### PR TITLE
Add coordinator tests

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,98 @@
+import importlib
+import os
+import sys
+import types
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Ensure repository root is on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+@pytest.fixture(autouse=True)
+def stub_homeassistant():
+    """Provide minimal stubs for Home Assistant modules used by coordinator."""
+    ha = types.ModuleType("homeassistant")
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    const = types.ModuleType("homeassistant.const")
+    core = types.ModuleType("homeassistant.core")
+    helpers = types.ModuleType("homeassistant.helpers.update_coordinator")
+
+    class ConfigEntry:
+        def __init__(self, data):
+            self.data = data
+    config_entries.ConfigEntry = ConfigEntry
+
+    const.CONF_HOST = "host"
+    const.CONF_PORT = "port"
+
+    class HomeAssistant:
+        pass
+    core.HomeAssistant = HomeAssistant
+
+    class DataUpdateCoordinator:
+        def __init__(self, hass, logger, name=None, update_interval=None):
+            self.hass = hass
+            self.logger = logger
+            self.name = name
+            self.update_interval = update_interval
+        def __class_getitem__(cls, item):
+            return cls
+        async def async_request_refresh(self):
+            pass
+    class UpdateFailed(Exception):
+        pass
+    helpers.DataUpdateCoordinator = DataUpdateCoordinator
+    helpers.UpdateFailed = UpdateFailed
+
+    modules = {
+        "homeassistant": ha,
+        "homeassistant.config_entries": config_entries,
+        "homeassistant.const": const,
+        "homeassistant.core": core,
+        "homeassistant.helpers.update_coordinator": helpers,
+    }
+    for name, module in modules.items():
+        sys.modules[name] = module
+    try:
+        yield
+    finally:
+        for name in modules:
+            sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def coordinator():
+    const_module = importlib.import_module("custom_components.thessla_green_modbus.const")
+    module = importlib.import_module("custom_components.thessla_green_modbus.coordinator")
+    ConfigEntry = sys.modules["homeassistant.config_entries"].ConfigEntry
+
+    entry = ConfigEntry({
+        const_module.CONF_HOST: "127.0.0.1",
+        const_module.CONF_PORT: 502,
+        const_module.CONF_SLAVE_ID: 1,
+    })
+    hass = MagicMock()
+    coord = module.TeslaGreenCoordinator(hass, entry)
+    coord._client = MagicMock()
+    return coord
+
+
+def test_async_write_invalid_register(coordinator):
+    result = asyncio.run(coordinator.async_write_register("invalid", 1))
+    assert result is False
+    coordinator._client.write_register.assert_not_called()
+
+
+def test_success_triggers_refresh(coordinator):
+    coordinator._client.connect.return_value = True
+    response = MagicMock()
+    response.isError.return_value = False
+    coordinator._client.write_register.return_value = response
+    coordinator.async_request_refresh = AsyncMock()
+
+    result = asyncio.run(coordinator.async_write_register("target_temperature", 20))
+    assert result is True
+    coordinator.async_request_refresh.assert_awaited_once()

--- a/validate.yaml
+++ b/validate.yaml
@@ -12,3 +12,11 @@ jobs:
     steps:
       - uses: "actions/checkout@v3"
       - uses: home-assistant/actions/helpers/hacs-validate@master
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest -ra


### PR DESCRIPTION
## Summary
- add `tests/test_coordinator.py`
- run tests with pytest in validation workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1efeddf4832687e9d83fd4b576cd