### PR TITLE
Replace TeslaGreen references with ThesslaGreen

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -2,8 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "Konfiguracja TeslaGreen Modbus",
-        "description": "Wprowadź dane połączenia z urządzeniem TeslaGreen",
+        "title": "Konfiguracja ThesslaGreen Modbus",
+        "description": "Wprowadź dane połączenia z urządzeniem ThesslaGreen",
         "data": {
           "host": "Adres IP",
           "port": "Port Modbus",
@@ -23,7 +23,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "Opcje TeslaGreen",
+        "title": "Opcje ThesslaGreen",
         "data": {
           "scan_interval": "Interwał skanowania (sekundy)"
         }

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -2,8 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "TeslaGreen Modbus Configuration",
-        "description": "Enter connection details for TeslaGreen device",
+        "title": "ThesslaGreen Modbus Configuration",
+        "description": "Enter connection details for ThesslaGreen device",
         "data": {
           "host": "IP Address",
           "port": "Modbus Port",
@@ -23,7 +23,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "TeslaGreen Options",
+        "title": "ThesslaGreen Options",
         "data": {
           "scan_interval": "Scan interval (seconds)"
         }
@@ -62,7 +62,7 @@
     },
     "climate": {
       "thessla_green_modbus": {
-        "name": "TeslaGreen Heat Recovery Unit"
+        "name": "ThesslaGreen Heat Recovery Unit"
       }
     },
     "fan": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -2,8 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "Konfiguracja TeslaGreen Modbus",
-        "description": "Wprowadź dane połączenia z urządzeniem TeslaGreen",
+        "title": "Konfiguracja ThesslaGreen Modbus",
+        "description": "Wprowadź dane połączenia z urządzeniem ThesslaGreen",
         "data": {
           "host": "Adres IP",
           "port": "Port Modbus",
@@ -23,7 +23,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "Opcje TeslaGreen",
+        "title": "Opcje ThesslaGreen",
         "data": {
           "scan_interval": "Interwał skanowania (sekundy)"
         }
@@ -62,7 +62,7 @@
     },
     "climate": {
       "thessla_green_modbus": {
-        "name": "Rekuperator TeslaGreen"
+        "name": "Rekuperator ThesslaGreen"
       }
     },
     "fan": {

--- a/info.md
+++ b/info.md
@@ -1,6 +1,6 @@
-# TeslaGreen Modbus Integration
+# ThesslaGreen Modbus Integration
 
-Integracja Home Assistant dla rekuperatorów TeslaGreen z komunikacją Modbus TCP.
+Integracja Home Assistant dla rekuperatorów ThesslaGreen z komunikacją Modbus TCP.
 
 ## Funkcje
 - Monitorowanie temperatury (4 czujniki)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -75,7 +75,7 @@ def coordinator():
         const_module.CONF_SLAVE_ID: 1,
     })
     hass = MagicMock()
-    coord = module.TeslaGreenCoordinator(hass, entry)
+    coord = module.ThesslaGreenCoordinator(hass, entry)
     coord._client = MagicMock()
     return coord
 


### PR DESCRIPTION
## Summary
- rename TeslaGreen references to ThesslaGreen in translations and docs
- update coordinator tests for ThesslaGreen naming

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_688f1d0bfda48326b1d2259f343dbfcc