### PR TITLE
Fix device scanner imports and update tests

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -24,7 +24,7 @@ from .const import (
     DEFAULT_TIMEOUT,
     DOMAIN,
 )
-from .device_scanner import ThesslaGreenDeviceScanner
+from .device_registry import ThesslaGreenDeviceScanner
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Final
 
+from homeassistant.const import CONF_HOST, CONF_PORT
+
 DOMAIN: Final = "thessla_green_modbus"
 
 # Default values

--- a/custom_components/thessla_green_modbus/device_registry.py
+++ b/custom_components/thessla_green_modbus/device_registry.py
@@ -221,15 +221,18 @@ class ThesslaGreenDeviceScanner:
 
     def _is_valid_register_value(self, register_name: str, value: int) -> bool:
         """Check if register value indicates the register is available."""
-        # Some registers return specific values when not available
-        if value == 0xFFFF or value == 65535:
-            # Temperature sensors return 0x8000 (32768) when not connected
-            if "temperature" in register_name and value == 32768:
-                return False
-            # Air flow sensors return 65535 when CF is not active
-            if "air_flow" in register_name and value == 65535:
-                return False
-        
+        # Temperature sensors return 0x8000 (32768) when not connected
+        if "temperature" in register_name and value == 32768:
+            return False
+
+        # Air flow sensors return 0xFFFF/65535 when CF is not active
+        if "air_flow" in register_name and value == 65535:
+            return False
+
+        # Generic values indicating unavailable registers
+        if value in (0xFFFF, 65535):
+            return False
+
         return True
 
     def _group_registers_by_range(self, registers: Dict[str, int], max_gap: int = 10) -> Dict[int, Dict[str, int]]:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -99,7 +99,7 @@ async def test_validate_input_success():
     }
     
     with patch(
-        "custom_components.thessla_green_modbus.device_scanner.ThesslaGreenDeviceScanner.scan_device",
+        "custom_components.thessla_green_modbus.device_registry.ThesslaGreenDeviceScanner.scan_device",
         return_value={
             "available_registers": {},
             "device_info": {"device_name": "ThesslaGreen AirPack"},
@@ -124,7 +124,7 @@ async def test_validate_input_no_data():
     }
     
     with patch(
-        "custom_components.thessla_green_modbus.device_scanner.ThesslaGreenDeviceScanner.scan_device",
+        "custom_components.thessla_green_modbus.device_registry.ThesslaGreenDeviceScanner.scan_device",
         return_value=None
     ):
         with pytest.raises(CannotConnect):

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -2,7 +2,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
-from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.device_registry import ThesslaGreenDeviceScanner
 
 
 @pytest.fixture
@@ -28,7 +28,7 @@ async def test_scan_device_success(mock_modbus_response):
     """Test successful device scan."""
     scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
     
-    with patch("pymodbus.client.ModbusTcpClient") as mock_client_class:
+    with patch("custom_components.thessla_green_modbus.device_registry.ModbusTcpClient") as mock_client_class:
         mock_client = MagicMock()
         mock_client.connect.return_value = True
         mock_client.read_input_registers.return_value = mock_modbus_response
@@ -49,7 +49,7 @@ async def test_scan_device_connection_failure():
     """Test device scan with connection failure."""
     scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
     
-    with patch("pymodbus.client.ModbusTcpClient") as mock_client_class:
+    with patch("custom_components.thessla_green_modbus.device_registry.ModbusTcpClient") as mock_client_class:
         mock_client = MagicMock()
         mock_client.connect.return_value = False
         mock_client_class.return_value = mock_client


### PR DESCRIPTION
## Summary
- point config flow at `device_registry` for device scanning
- update tests to use new module path and constants
- refine register validation and coordinator test helpers

## Testing
- `PYTHONPATH=/workspace/thesslagreen pytest --asyncio-mode=auto tests`

------
https://chatgpt.com/codex/tasks/task_e_688f7c9a2d0c8326b9c8c3622e42e39b