### PR TITLE
Use debug logging for device status and document enabling verbose logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ automation:
 
 ## 📝 Logi
 
-Włącz szczegółowe logi w `configuration.yaml`:
+Domyślnie integracja zapisuje tylko podstawowe ostrzeżenia. Aby włączyć rozszerzone logowanie diagnostyczne, w tym szczegółowe informacje o statusie urządzenia, dodaj w `configuration.yaml`:
 
 ```yaml
 logger:

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -117,7 +117,8 @@ class ThesslaGreenCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data.update(discrete_data)
 
             # Add debug info about device status
-            self._debug_device_status(data)
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                self._debug_device_status(data)
 
             return data
 
@@ -168,9 +169,9 @@ class ThesslaGreenCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         status_indicators.append(f"Operating mode: {mode} ({mode_name})")
         
         # Log all indicators
-        _LOGGER.warning("=== DEVICE STATUS INVESTIGATION ===")
+        _LOGGER.debug("=== DEVICE STATUS INVESTIGATION ===")
         for indicator in status_indicators:
-            _LOGGER.warning("  %s", indicator)
+            _LOGGER.debug("  %s", indicator)
         
         # Make a decision
         device_on_indicators = []
@@ -187,11 +188,14 @@ class ThesslaGreenCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             device_on_indicators.append("Fan voltages present")
         
         if device_on_indicators:
-            _LOGGER.warning("  DECISION: Device appears ON based on: %s", ", ".join(device_on_indicators))
+            _LOGGER.debug(
+                "  DECISION: Device appears ON based on: %s",
+                ", ".join(device_on_indicators),
+            )
         else:
-            _LOGGER.warning("  DECISION: Device appears OFF - no activity detected")
-        
-        _LOGGER.warning("=== END INVESTIGATION ===")
+            _LOGGER.debug("  DECISION: Device appears OFF - no activity detected")
+
+        _LOGGER.debug("=== END INVESTIGATION ===")
 
     def _read_input_registers(self, client: ModbusTcpClient) -> dict[str, Any]:
         """Read input registers efficiently."""

--- a/info.md
+++ b/info.md
@@ -14,3 +14,13 @@ Integracja Home Assistant dla rekuperatorów ThesslaGreen z komunikacją Modbus 
 2. Zainstaluj integrację
 3. Uruchom ponownie Home Assistant
 4. Dodaj integrację przez UI
+
+## Logi
+Aby włączyć rozszerzone logowanie, dodaj do `configuration.yaml`:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.thessla_green_modbus: debug
+```


### PR DESCRIPTION
## Summary
- log device status investigation only when debug logging is enabled
- document how to enable verbose logging

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: custom_components.thessla_green_modbus.device_scanner)*

------
https://chatgpt.com/codex/tasks/task_e_688f7ca10880832698614842ba2dd56c