### PR TITLE
Ensure rekuperator speed number entity exists

### DIFF
--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
             ThesslaGreenNumber(
                 coordinator,
                 "air_flow_rate_manual",
-                "Intensywność manualny",
+                "Rekuperator prędkość",
                 "mdi:fan",
                 10,
                 100,


### PR DESCRIPTION
## Summary
- rename manual air flow number to expose `number.rekuperator_predkosc`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'custom_components.thessla_green_modbus.device_scanner')*


------
https://chatgpt.com/codex/tasks/task_e_688f840c69508326ab5802b8bd110686