### PR TITLE
chore: sync HACS metadata

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,14 @@
   "name": "ThesslaGreen Modbus",
   "content_in_root": false,
   "render_readme": true,
-  "domains": ["climate", "sensor", "binary_sensor", "select", "number", "switch"],
-  "iot_class": "Local Polling",
-  "version": "1.0.0"
+  "domains": [
+    "climate",
+    "sensor",
+    "binary_sensor",
+    "select",
+    "number",
+    "switch"
+  ],
+  "iot_class": "local_polling",
+  "version": "2.0.0"
 }


### PR DESCRIPTION
## Summary
- update `hacs.json` version and iot_class

## Testing
- `pytest` *(fails: AttributeError: 'module' object has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_6890f517859c8326b47603ba356066a4