### PR TITLE
chore: bump homeassistant requirement

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -9,6 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/YOUR_USERNAME/thessla_green_modbus/issues",
   "loggers": ["custom_components.thessla_green_modbus"],
+  "homeassistant": "2025.7.0",
   "requirements": ["pymodbus>=3.5.0"],
   "version": "2.0.0",
   "quality_scale": "silver",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # ThesslaGreen Modbus Integration - Python Dependencies
 
 # Core Home Assistant (minimum version for compatibility)
-homeassistant>=2023.4.0
+homeassistant>=2025.7.0
 
 # Modbus communication library
 pymodbus>=3.5.0,<4.0.0


### PR DESCRIPTION
## Summary
- require Home Assistant 2025.7.0 in manifest and requirements

## Testing
- `pip install homeassistant==2025.7.0` *(fails: Could not find a version)*
- `python - <<'PY' ...` *(imported Home Assistant modules to verify availability)*
- `PYTHONPATH=. pytest` *(fails: AttributeError: 'module' object has no attribute)*

------
https://chatgpt.com/codex/tasks/task_e_6890f516f6e883269ef7208dd7173a0a