### PR TITLE
Run device scan before coordinator refresh

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -15,7 +15,7 @@ from pymodbus.client import ModbusTcpClient
 _LOGGER = logging.getLogger(__name__)
 
 class ThesslaGreenDataCoordinator(DataUpdateCoordinator):
-    """Poprawiony coordinator z nowym API pymodbus 3.x"""
+    """Coordinator handling Modbus data updates and register management."""
 
     def __init__(
         self,
@@ -24,7 +24,11 @@ class ThesslaGreenDataCoordinator(DataUpdateCoordinator):
         port: int,
         slave_id: int,
         scan_interval: int = 30,
-        available_registers: Dict[str, set] = None,
+        timeout: int = 10,
+        retry: int = 3,
+        available_registers: Dict[str, set] | None = None,
+        device_info: Dict[str, Any] | None = None,
+        capabilities: Dict[str, Any] | None = None,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -33,21 +37,44 @@ class ThesslaGreenDataCoordinator(DataUpdateCoordinator):
             name="thessla_green_modbus",
             update_interval=timedelta(seconds=scan_interval),
         )
-        
+
         self.host = host
         self.port = port
         self.slave_id = slave_id
-        self.timeout = 10
+        self.timeout = timeout
+        self.retry = retry
         self.available_registers = available_registers or {
             "input_registers": set(),
             "holding_registers": set(),
             "coil_registers": set(),
-            "discrete_inputs": set()
+            "discrete_inputs": set(),
         }
-        
+        self.device_info = device_info or {}
+        self.capabilities = capabilities or {}
+
         # Precompute optimized register groups for batch reading
+        self.rebuild_register_groups()
+
+    def rebuild_register_groups(self, available_registers: Dict[str, set] | None = None) -> None:
+        """Recalculate optimized register groups.
+
+        Optionally accepts a new mapping of available registers and updates
+        the coordinator before computing the groups. This method is exposed so
+        that a full device scan can rebuild the groups without reinstantiating
+        the coordinator.
+        """
+
+        if available_registers is not None:
+            self.available_registers = available_registers
+
         self._register_groups = self._compute_optimized_groups()
-        _LOGGER.debug("Precomputed %d optimized register groups", len(self._register_groups))
+        _LOGGER.debug(
+            "Precomputed %d optimized register groups", len(self._register_groups)
+        )
+
+    # Legacy method name for backward compatibility
+    def _precompute_register_groups(self, available_registers: Dict[str, set] | None = None) -> None:
+        self.rebuild_register_groups(available_registers)
 
     def _compute_optimized_groups(self) -> Dict[str, List[Tuple[int, int, Dict[str, int]]]]:
         """Pre-compute optimized register groups for efficient batch reading."""
@@ -349,3 +376,7 @@ class ThesslaGreenDataCoordinator(DataUpdateCoordinator):
         if self.data is None:
             return default
         return self.data.get(register_name, default)
+
+
+# Backwards compatibility
+ThesslaGreenCoordinator = ThesslaGreenDataCoordinator


### PR DESCRIPTION
## Summary
- scan device for registers and capabilities before first coordinator refresh
- allow coordinator to rebuild register groups using scanned data
- rescan service now rebuilds register groups via coordinator helper

## Testing
- `pip install --progress-bar off -r requirements.txt` *(failed: No matching distribution found for homeassistant>=2025.7.0)*
- `pytest` *(failed: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_6891220356d48326957979cdaa44bb86