### PR TITLE
Trigger refresh after writes

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -279,7 +279,7 @@ class ThesslaGreenDataCoordinator(DataUpdateCoordinator):
             try:
                 if not client.connect():
                     return False
-                
+
                 # Determine if it's a coil or holding register
                 if key in ["manual_mode", "fan_boost", "bypass_enable", "gwc_enable"]:
                     # Write coil (boolean)
@@ -295,21 +295,24 @@ class ThesslaGreenDataCoordinator(DataUpdateCoordinator):
                         value=value,
                         slave=self.slave_id
                     )
-                    
+
                 success = result and not result.isError()
                 if success:
                     _LOGGER.debug("Successfully wrote %s=%s to 0x%04X", key, value, address)
                 else:
                     _LOGGER.error("Failed to write %s=%s to 0x%04X: %s", key, value, address, result)
                 return success
-                
+
             except Exception as exc:
                 _LOGGER.error("Exception writing register %s: %s", key, exc)
                 return False
             finally:
                 client.close()
-        
-        return await asyncio.get_event_loop().run_in_executor(None, _write_sync)
+
+        success = await asyncio.get_event_loop().run_in_executor(None, _write_sync)
+        if success:
+            await self.async_request_refresh()
+        return success
 
     def _process_register_value(self, key: str, raw_value: Any) -> Any:
         """Process raw register value based on key type."""
@@ -349,3 +352,7 @@ class ThesslaGreenDataCoordinator(DataUpdateCoordinator):
         if self.data is None:
             return default
         return self.data.get(register_name, default)
+
+
+# Backwards compatibility alias
+ThesslaGreenCoordinator = ThesslaGreenDataCoordinator

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,98 +1,53 @@
-import importlib
+"""Tests for ThesslaGreen coordinator utilities."""
+
+import asyncio
 import os
 import sys
-import types
-import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 
 # Ensure repository root is on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-
-@pytest.fixture(autouse=True)
-def stub_homeassistant():
-    """Provide minimal stubs for Home Assistant modules used by coordinator."""
-    ha = types.ModuleType("homeassistant")
-    config_entries = types.ModuleType("homeassistant.config_entries")
-    const = types.ModuleType("homeassistant.const")
-    core = types.ModuleType("homeassistant.core")
-    helpers = types.ModuleType("homeassistant.helpers.update_coordinator")
-
-    class ConfigEntry:
-        def __init__(self, data):
-            self.data = data
-    config_entries.ConfigEntry = ConfigEntry
-
-    const.CONF_HOST = "host"
-    const.CONF_PORT = "port"
-
-    class HomeAssistant:
-        pass
-    core.HomeAssistant = HomeAssistant
-
-    class DataUpdateCoordinator:
-        def __init__(self, hass, logger, name=None, update_interval=None):
-            self.hass = hass
-            self.logger = logger
-            self.name = name
-            self.update_interval = update_interval
-        def __class_getitem__(cls, item):
-            return cls
-        async def async_request_refresh(self):
-            pass
-    class UpdateFailed(Exception):
-        pass
-    helpers.DataUpdateCoordinator = DataUpdateCoordinator
-    helpers.UpdateFailed = UpdateFailed
-
-    modules = {
-        "homeassistant": ha,
-        "homeassistant.config_entries": config_entries,
-        "homeassistant.const": const,
-        "homeassistant.core": core,
-        "homeassistant.helpers.update_coordinator": helpers,
-    }
-    for name, module in modules.items():
-        sys.modules[name] = module
-    try:
-        yield
-    finally:
-        for name in modules:
-            sys.modules.pop(name, None)
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenDataCoordinator,
+)
 
 
-@pytest.fixture
-def coordinator():
-    const_module = importlib.import_module("custom_components.thessla_green_modbus.const")
-    module = importlib.import_module("custom_components.thessla_green_modbus.coordinator")
-    ConfigEntry = sys.modules["homeassistant.config_entries"].ConfigEntry
-
-    entry = ConfigEntry({
-        const_module.CONF_HOST: "127.0.0.1",
-        const_module.CONF_PORT: 502,
-        const_module.CONF_SLAVE_ID: 1,
-    })
+@pytest.mark.asyncio
+async def test_async_write_invalid_register():
+    """Return False and do not refresh on unknown register."""
     hass = MagicMock()
-    coord = module.ThesslaGreenCoordinator(hass, entry)
-    coord._client = MagicMock()
-    return coord
-
-
-def test_async_write_invalid_register(coordinator):
-    result = asyncio.run(coordinator.async_write_register("invalid", 1))
-    assert result is False
-    coordinator._client.write_register.assert_not_called()
-
-
-def test_success_triggers_refresh(coordinator):
-    coordinator._client.connect.return_value = True
-    response = MagicMock()
-    response.isError.return_value = False
-    coordinator._client.write_register.return_value = response
+    coordinator = ThesslaGreenDataCoordinator(hass, "localhost", 502, 1)
     coordinator.async_request_refresh = AsyncMock()
 
-    result = asyncio.run(coordinator.async_write_register("target_temperature", 20))
+    result = await coordinator.async_write_register("invalid", 1)
+
+    assert result is False
+    coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_write_success_triggers_refresh():
+    """Ensure a successful write triggers a refresh request."""
+    hass = MagicMock()
+    coordinator = ThesslaGreenDataCoordinator(hass, "localhost", 502, 1)
+
+    with patch(
+        "custom_components.thessla_green_modbus.coordinator.ModbusTcpClient"
+    ) as mock_client_cls:
+        client = MagicMock()
+        client.connect.return_value = True
+        response = MagicMock()
+        response.isError.return_value = False
+        client.write_register.return_value = response
+        mock_client_cls.return_value = client
+
+        coordinator.async_request_refresh = AsyncMock()
+
+        result = await coordinator.async_write_register("mode", 1)
+
     assert result is True
     coordinator.async_request_refresh.assert_awaited_once()


### PR DESCRIPTION
## Summary
- refresh coordinator after a register write completes successfully
- add tests ensuring a successful write requests a refresh

## Testing
- `PYTHONPATH=$PWD pytest tests/test_coordinator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68912204eff4832697bfd5303abda881