### PR TITLE
Update dependency constraints

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/YOUR_USERNAME/thessla_green_modbus/issues",
   "loggers": ["custom_components.thessla_green_modbus"],
   "homeassistant": "2025.7.0",
-  "requirements": ["pymodbus>=3.5.0"],
+  "requirements": ["pymodbus>=3.5.0,<4.0.0"],
   "version": "2.0.0",
   "quality_scale": "silver",
   "dhcp": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "homeassistant>=2023.4.0",
+    "homeassistant>=2025.7.0",
     "pymodbus>=3.5.0,<4.0.0",
     "voluptuous>=0.13.1",
 ]


### PR DESCRIPTION
## Summary
- pin pymodbus to <4.0.0 in manifest
- require Home Assistant 2025.7.0 or newer

## Testing
- `pip install -r requirements.txt --progress-bar off` *(fails: No matching distribution found for homeassistant>=2025.7.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_689128aedec083269e1be3872c3d25b5