### PR TITLE
Refactor Modbus interactions for async

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from datetime import timedelta
 from typing import Any, Dict, List, Tuple
@@ -342,7 +341,8 @@ class ThesslaGreenCoordinator(DataUpdateCoordinator):
                 return False
             finally:
                 client.close()
-        success = await asyncio.get_event_loop().run_in_executor(None, _write_sync)
+
+        success = await self.hass.async_add_executor_job(_write_sync)
         if success:
             await self.async_request_refresh()
         return success

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -276,7 +276,7 @@ class ThesslaGreenDeviceScanner:
     async def scan_device(self) -> Dict[str, Any]:
         """Główna funkcja skanowania urządzenia"""
         import asyncio
-        return await asyncio.get_event_loop().run_in_executor(None, self._scan_device_sync)
+        return await asyncio.to_thread(self._scan_device_sync)
     
     def _scan_device_sync(self) -> Dict[str, Any]:
         """Synchroniczne skanowanie urządzenia"""

--- a/custom_components/thessla_green_modbus/modbus_client.py
+++ b/custom_components/thessla_green_modbus/modbus_client.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
-
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ModbusException
 
@@ -31,7 +29,7 @@ class ThesslaGreenModbusClient:
                 port=self.port,
                 timeout=self.timeout,
             )
-            return self._client.connect()
+            return await asyncio.to_thread(self._client.connect)
         except Exception as ex:
             _LOGGER.error("Failed to connect to Modbus device: %s", ex)
             return False
@@ -39,7 +37,7 @@ class ThesslaGreenModbusClient:
     async def disconnect(self) -> None:
         """Disconnect from Modbus device."""
         if self._client:
-            self._client.close()
+            await asyncio.to_thread(self._client.close)
             self._client = None
 
     async def read_holding_register(self, address: int) -> int | None:
@@ -51,10 +49,11 @@ class ThesslaGreenModbusClient:
                         return None
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.read_holding_registers(
+                result = await asyncio.to_thread(
+                    self._client.read_holding_registers,
                     address=address,
                     count=1,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():
@@ -81,10 +80,11 @@ class ThesslaGreenModbusClient:
                         return None
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.read_holding_registers(
+                result = await asyncio.to_thread(
+                    self._client.read_holding_registers,
                     address=address,
                     count=count,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():
@@ -114,10 +114,11 @@ class ThesslaGreenModbusClient:
                         return None
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.read_input_registers(
+                result = await asyncio.to_thread(
+                    self._client.read_input_registers,
                     address=address,
                     count=count,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():
@@ -145,10 +146,11 @@ class ThesslaGreenModbusClient:
                         return None
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.read_coils(
+                result = await asyncio.to_thread(
+                    self._client.read_coils,
                     address=address,
                     count=count,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():
@@ -176,10 +178,11 @@ class ThesslaGreenModbusClient:
                         return None
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.read_discrete_inputs(
+                result = await asyncio.to_thread(
+                    self._client.read_discrete_inputs,
                     address=address,
                     count=count,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():
@@ -207,10 +210,11 @@ class ThesslaGreenModbusClient:
                         return False
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.write_register(
+                result = await asyncio.to_thread(
+                    self._client.write_register,
                     address=address,
                     value=value,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():
@@ -236,10 +240,11 @@ class ThesslaGreenModbusClient:
                         return False
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.write_registers(
+                result = await asyncio.to_thread(
+                    self._client.write_registers,
                     address=address,
                     values=values,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():
@@ -269,10 +274,11 @@ class ThesslaGreenModbusClient:
                         return False
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.write_coil(
+                result = await asyncio.to_thread(
+                    self._client.write_coil,
                     address=address,
                     value=value,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():
@@ -298,10 +304,11 @@ class ThesslaGreenModbusClient:
                         return False
 
                 # POPRAWIONE API: keyword arguments
-                result = self._client.write_coils(
+                result = await asyncio.to_thread(
+                    self._client.write_coils,
                     address=address,
                     values=values,
-                    slave=self.slave_id
+                    slave=self.slave_id,
                 )
                 
                 if result.isError():


### PR DESCRIPTION
## Summary
- delegate modbus client connect, read and write calls to background threads
- offload device scanner work using `asyncio.to_thread`
- use Home Assistant executor to perform register writes

## Testing
- `pytest -q` *(fails: IndentationError in tests/test_coordinator.py)*

------
https://chatgpt.com/codex/tasks/task_e_689128b6f7708326ad2ea29eb17a8ffa