### PR TITLE
Clean coordinator tests

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,196 +1,140 @@
-"""Tests for ThesslaGreen coordinator utilities."""
+"""Tests for ThesslaGreenCoordinator."""
 
-import asyncio
 import os
 import sys
- codex/adjust-test-fixture-for-thesslagreencoordinator
 import types
-import asyncio
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# Stub minimal Home Assistant and pymodbus modules before importing the coordinator
+ha = types.ModuleType("homeassistant")
+const = types.ModuleType("homeassistant.const")
+core = types.ModuleType("homeassistant.core")
+helpers = types.ModuleType("homeassistant.helpers.update_coordinator")
+exceptions = types.ModuleType("homeassistant.exceptions")
+config_entries = types.ModuleType("homeassistant.config_entries")
+pymodbus = types.ModuleType("pymodbus")
+pymodbus_client = types.ModuleType("pymodbus.client")
+
+const.CONF_HOST = "host"
+const.CONF_PORT = "port"
+
+
+class HomeAssistant:
+    pass
+
+
+core.HomeAssistant = HomeAssistant
+
+
+class ConfigEntry:
+    def __init__(self, data):
+        self.data = data
+
+
+config_entries.ConfigEntry = ConfigEntry
+
+
+class DataUpdateCoordinator:
+    def __init__(self, hass, logger, name=None, update_interval=None):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+
+    async def async_request_refresh(self):
+        pass
+
+
+helpers.DataUpdateCoordinator = DataUpdateCoordinator
+
+
+class UpdateFailed(Exception):
+    pass
+
+
+helpers.UpdateFailed = UpdateFailed
+
+
+class ConfigEntryNotReady(Exception):
+    pass
+
+
+exceptions.ConfigEntryNotReady = ConfigEntryNotReady
+
+
+class ModbusTcpClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+pymodbus_client.ModbusTcpClient = ModbusTcpClient
+
+modules = {
+    "homeassistant": ha,
+    "homeassistant.const": const,
+    "homeassistant.core": core,
+    "homeassistant.helpers.update_coordinator": helpers,
+    "homeassistant.exceptions": exceptions,
+    "homeassistant.config_entries": config_entries,
+    "pymodbus": pymodbus,
+    "pymodbus.client": pymodbus_client,
+}
+
+sys.modules.update(modules)
 
 # Ensure repository root is on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from custom_components.thessla_green_modbus.coordinator import (
-    ThesslaGreenDataCoordinator,
-)
+from custom_components.thessla_green_modbus.coordinator import ThesslaGreenCoordinator
 
-codex/adjust-test-fixture-for-thesslagreencoordinator
-@pytest.fixture(autouse=True)
-def stub_homeassistant():
-    """Provide minimal stubs for Home Assistant and pymodbus modules."""
-    ha = types.ModuleType("homeassistant")
-    const = types.ModuleType("homeassistant.const")
-    core = types.ModuleType("homeassistant.core")
-    helpers = types.ModuleType("homeassistant.helpers.update_coordinator")
-    exceptions = types.ModuleType("homeassistant.exceptions")
-    pymodbus = types.ModuleType("pymodbus")
-    pymodbus_client = types.ModuleType("pymodbus.client")
-
-    const.CONF_HOST = "host"
-    const.CONF_PORT = "port"
-
-    class HomeAssistant:
-        pass
-    core.HomeAssistant = HomeAssistant
-
-    class DataUpdateCoordinator:
-        def __init__(self, hass, logger, name=None, update_interval=None):
-            self.hass = hass
-            self.logger = logger
-            self.name = name
-            self.update_interval = update_interval
-
-        def __class_getitem__(cls, item):
-            return cls
-
-        async def async_request_refresh(self):
-            pass
-
-    class UpdateFailed(Exception):
-        pass
-    helpers.DataUpdateCoordinator = DataUpdateCoordinator
-    helpers.UpdateFailed = UpdateFailed
-
-    class ConfigEntryNotReady(Exception):
-        pass
-    exceptions.ConfigEntryNotReady = ConfigEntryNotReady
-
-    class ModbusTcpClient:
-        pass
-    pymodbus_client.ModbusTcpClient = ModbusTcpClient
-
-    modules = {
-        "homeassistant": ha,
-        "homeassistant.const": const,
-        "homeassistant.core": core,
-        "homeassistant.helpers.update_coordinator": helpers,
-        "homeassistant.exceptions": exceptions,
-        "pymodbus": pymodbus,
-        "pymodbus.client": pymodbus_client,
-    }
-    for name, module in modules.items():
-        sys.modules[name] = module
-    try:
-        yield
-    finally:
-        for name in modules:
-            sys.modules.pop(name, None)
-=======
 
 @pytest.mark.asyncio
 async def test_async_write_invalid_register():
-    """Return False and do not refresh on unknown register."""
+    """Return False on unknown register and avoid executor call."""
     hass = MagicMock()
-    coordinator = ThesslaGreenDataCoordinator(hass, "localhost", 502, 1)
-    coordinator.async_request_refresh = AsyncMock()
-
-    result = await coordinator.async_write_register("invalid", 1)
- main
-
-    assert result is False
-    coordinator.async_request_refresh.assert_not_awaited()
- codex/adjust-test-fixture-for-thesslagreencoordinator
-@pytest.fixture
-def coordinator():
-    module = importlib.import_module("custom_components.thessla_green_modbus.coordinator")
- codex/replace-executor-calls-in-async-functions
-    hass = MagicMock()
-    coord = module.ThesslaGreenCoordinator(
+    hass.async_add_executor_job = AsyncMock(return_value=False)
+    coordinator = ThesslaGreenCoordinator(
         hass=hass,
-        host="127.0.0.1",
+        host="localhost",
         port=502,
         slave_id=1,
+        scan_interval=30,
+        timeout=10,
+        retry=3,
+        available_registers={
+            "input_registers": set(),
+            "holding_registers": set(),
+            "coil_registers": set(),
+            "discrete_inputs": set(),
+        },
     )
-=======
-    Coordinator = getattr(module, "ThesslaGreenCoordinator", None)
-    if Coordinator is None:
-        Coordinator = getattr(module, "ThesslaGreenDataCoordinator")
+    result = await coordinator.async_write_register("invalid", 1)
+    assert result is False
+    hass.async_add_executor_job.assert_not_awaited()
 
-codex/rename-thesslagreendatacoordinator
-    entry = ConfigEntry({
-        "host": "127.0.0.1",
-        "port": 502,
-        "slave_id": 1,
-    })
-    hass = MagicMock()
-    coord = module.ThesslaGreenCoordinator(
-        hass=hass,
-        host=entry.data["host"],
-        port=entry.data["port"],
-        slave_id=entry.data["slave_id"],
-    )
-    client_mock = MagicMock()
-    patcher = patch("custom_components.thessla_green_modbus.coordinator.ModbusTcpClient", return_value=client_mock)
-    patcher.start()
-    coord._client = client_mock
-    try:
-        yield coord
-    finally:
-        patcher.stop()
-=======
-    hass = MagicMock()
-    kwargs = {
-        "hass": hass,
-        "host": "127.0.0.1",
-        "port": 502,
-        "slave_id": 1,
-        "scan_interval": 30,
-        "timeout": 10,
-        "retry": 3,
-    }
-    import inspect
-    params = inspect.signature(Coordinator.__init__).parameters
-    accepted = {k: v for k, v in kwargs.items() if k in params}
-    coord = Coordinator(**accepted)
- main
-    return coord
-=======
-main
 
 @pytest.mark.asyncio
-async def test_async_write_success_triggers_refresh():
-    """Ensure a successful write triggers a refresh request."""
+async def test_async_write_success_triggers_executor():
+    """Successful write should call executor job."""
     hass = MagicMock()
-    coordinator = ThesslaGreenDataCoordinator(hass, "localhost", 502, 1)
- main
-
-    with patch(
-        "custom_components.thessla_green_modbus.coordinator.ModbusTcpClient"
-    ) as mock_client_cls:
-        client = MagicMock()
-        client.connect.return_value = True
-        response = MagicMock()
-        response.isError.return_value = False
-        client.write_register.return_value = response
-        mock_client_cls.return_value = client
-
- codex/adjust-test-fixture-for-thesslagreencoordinator
-def test_async_write_invalid_register(coordinator):
- codex/replace-executor-calls-in-async-functions
-    coordinator.hass.async_add_executor_job = AsyncMock()
-    result = asyncio.run(coordinator.async_write_register("invalid", 1))
-    assert result is False
-    coordinator.hass.async_add_executor_job.assert_not_called()
-
-
-def test_success_triggers_refresh(coordinator):
-    coordinator.hass.async_add_executor_job = AsyncMock(return_value=True)
-
-    result = asyncio.run(coordinator.async_write_register("mode", 1))
-=======
-    with patch("custom_components.thessla_green_modbus.coordinator.ModbusTcpClient") as mock_client:
-        result = asyncio.run(coordinator.async_write_register("invalid", 1))
-        assert result is False
-        mock_client.assert_not_called()
-
-
-def test_success_triggers_refresh(coordinator):
-    coordinator.async_request_refresh = AsyncMock()
+    hass.async_add_executor_job = AsyncMock(return_value=True)
+    coordinator = ThesslaGreenCoordinator(
+        hass=hass,
+        host="localhost",
+        port=502,
+        slave_id=1,
+        scan_interval=30,
+        timeout=10,
+        retry=3,
+        available_registers={
+            "input_registers": set(),
+            "holding_registers": {"mode"},
+            "coil_registers": set(),
+            "discrete_inputs": set(),
+        },
+    )
     with patch("custom_components.thessla_green_modbus.coordinator.ModbusTcpClient") as mock_client_cls:
         client = MagicMock()
         mock_client_cls.return_value = client
@@ -198,17 +142,7 @@ def test_success_triggers_refresh(coordinator):
         response = MagicMock()
         response.isError.return_value = False
         client.write_register.return_value = response
+        result = await coordinator.async_write_register("mode", 1)
 
-        result = asyncio.run(coordinator.async_write_register("mode", 1))
-=======
-        coordinator.async_request_refresh = AsyncMock()
-
-        result = await coordinator.async_write_register("mode", 1) main
-
- codex/rename-thesslagreendatacoordinator
-    result = asyncio.run(coordinator.async_write_register("mode", 1))
-=======
- main
- main
     assert result is True
-    coordinator.hass.async_add_executor_job.assert_awaited_once()
+    hass.async_add_executor_job.assert_awaited()


### PR DESCRIPTION
## Summary
- rewrite coordinator tests to use ThesslaGreenCoordinator with asyncio

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.data_entry_flow'; 'homeassistant' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68927521f7ec83269c569aa07f0d998e