### PR TITLE
docs: update GitHub links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,9 +198,9 @@ The integration automatically detects and enables only available features:
 ## Support
 
 For issues, questions, or contributions:
-- 🐛 [Bug Reports](https://github.com/YOUR_USERNAME/thessla_green_modbus/issues)
-- 💡 [Feature Requests](https://github.com/YOUR_USERNAME/thessla_green_modbus/discussions)
-- 📖 [Documentation](https://github.com/YOUR_USERNAME/thessla_green_modbus/wiki)
+- 🐛 [Bug Reports](https://github.com/thesslagreen/thessla-green-modbus-ha/issues)
+- 💡 [Feature Requests](https://github.com/thesslagreen/thessla-green-modbus-ha/discussions)
+- 📖 [Documentation](https://github.com/thesslagreen/thessla-green-modbus-ha/wiki)
 - 🤝 [Contributing](CONTRIBUTING.md)
 
 ## Credits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ We welcome contributions in these areas:
 
 ```bash
 # Fork the repository on GitHub first, then:
-git clone https://github.com/YOUR_USERNAME/thessla_green_modbus.git
+git clone https://github.com/thesslagreen/thessla-green-modbus-ha.git
 cd thessla_green_modbus
 ```
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,7 +19,7 @@
 1. **Dodaj repozytorium custom w HACS:**
    - Otwórz HACS → Integrations
    - Kliknij ⋮ → Custom repositories
-   - URL: `https://github.com/YOUR_USERNAME/thessla_green_modbus`
+   - URL: `https://github.com/thesslagreen/thessla-green-modbus-ha`
    - Category: Integration
    - Kliknij ADD
 
@@ -33,7 +33,7 @@
 1. **Pobierz pliki:**
    ```bash
    cd /config
-   git clone https://github.com/YOUR_USERNAME/thessla_green_modbus.git
+   git clone https://github.com/thesslagreen/thessla-green-modbus-ha.git
    ```
 
 2. **Skopiuj do custom_components:**
@@ -331,9 +331,9 @@ title: Temperatury
 
 ## 📞 Wsparcie
 
-- **GitHub Issues**: [Link do Issues]
-- **Community Forum**: [Link do Forum]
-- **Wiki**: [Link do Wiki]
+- **GitHub Issues**: https://github.com/thesslagreen/thessla-green-modbus-ha/issues
+- **Community Forum**: https://github.com/thesslagreen/thessla-green-modbus-ha/discussions
+- **Wiki**: https://github.com/thesslagreen/thessla-green-modbus-ha/wiki
 
 ## ⚠️ Uwagi Bezpieczeństwa
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -25,7 +25,7 @@ Before starting, make sure you have:
 ```
 1. Open HACS → Integrations
 2. Click ⋮ → Custom repositories  
-3. Add: https://github.com/YOUR_USERNAME/thessla_green_modbus
+3. Add: https://github.com/thesslagreen/thessla-green-modbus-ha
 4. Category: Integration
 5. Click ADD → Install "ThesslaGreen Modbus"
 6. Restart Home Assistant
@@ -223,8 +223,8 @@ automation:
 
 - 📖 **[Full Documentation](README.md)** - Complete setup guide
 - 🔧 **[Advanced Configuration](DEPLOYMENT.md)** - Detailed configuration options
-- 🤝 **[Get Help](https://github.com/YOUR_USERNAME/thessla_green_modbus/discussions)** - Community support
-- 🐛 **[Report Issues](https://github.com/YOUR_USERNAME/thessla_green_modbus/issues)** - Bug reports
+- 🤝 **[Get Help](https://github.com/thesslagreen/thessla-green-modbus-ha/discussions)** - Community support
+- 🐛 **[Report Issues](https://github.com/thesslagreen/thessla-green-modbus-ha/issues)** - Bug reports
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ThesslaGreen Modbus Integration for Home Assistant
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
-[![GitHub release](https://img.shields.io/github/release/YOUR_USERNAME/thessla_green_modbus.svg)](https://github.com/YOUR_USERNAME/thessla_green_modbus/releases)
+[![GitHub release](https://img.shields.io/github/release/thesslagreen/thessla-green-modbus-ha.svg)](https://github.com/thesslagreen/thessla-green-modbus-ha/releases)
 
 Inteligentna integracja dla Home Assistant umożliwiająca kontrolę rekuperatorów ThesslaGreen AirPack przez protokół Modbus RTU/TCP.
 
@@ -21,7 +21,7 @@ Inteligentna integracja dla Home Assistant umożliwiająca kontrolę rekuperator
 
 1. Dodaj to repozytorium jako custom repository w HACS:
    - HACS → Integrations → ⋮ → Custom repositories
-   - URL: `https://github.com/YOUR_USERNAME/thessla_green_modbus`
+   - URL: `https://github.com/thesslagreen/thessla-green-modbus-ha`
    - Category: Integration
 
 2. Znajdź "ThesslaGreen Modbus" w HACS i zainstaluj
@@ -30,7 +30,7 @@ Inteligentna integracja dla Home Assistant umożliwiająca kontrolę rekuperator
 
 ### Manualna instalacja
 
-1. Pobierz najnowszą wersję z [Releases](https://github.com/YOUR_USERNAME/thessla_green_modbus/releases)
+1. Pobierz najnowszą wersję z [Releases](https://github.com/thesslagreen/thessla-green-modbus-ha/releases)
 2. Wypakuj do `custom_components/thessla_green_modbus/`
 3. Zrestartuj Home Assistant
 
@@ -151,9 +151,9 @@ logger:
 
 ## 🤝 Wsparcie
 
-- [Issues](https://github.com/YOUR_USERNAME/thessla_green_modbus/issues)
-- [Discussions](https://github.com/YOUR_USERNAME/thessla_green_modbus/discussions)
-- [Wiki](https://github.com/YOUR_USERNAME/thessla_green_modbus/wiki)
+- [Issues](https://github.com/thesslagreen/thessla-green-modbus-ha/issues)
+- [Discussions](https://github.com/thesslagreen/thessla-green-modbus-ha/discussions)
+- [Wiki](https://github.com/thesslagreen/thessla-green-modbus-ha/wiki)
 
 ## 📄 Licencja
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,10 @@ docs = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/YOUR_USERNAME/thessla_green_modbus"
-"Bug Reports" = "https://github.com/YOUR_USERNAME/thessla_green_modbus/issues"
-"Source" = "https://github.com/YOUR_USERNAME/thessla_green_modbus"
-"Documentation" = "https://github.com/YOUR_USERNAME/thessla_green_modbus/wiki"
+"Homepage" = "https://github.com/thesslagreen/thessla-green-modbus-ha"
+"Bug Reports" = "https://github.com/thesslagreen/thessla-green-modbus-ha/issues"
+"Source" = "https://github.com/thesslagreen/thessla-green-modbus-ha"
+"Documentation" = "https://github.com/thesslagreen/thessla-green-modbus-ha/wiki"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- point project URLs to the thesslagreen/thessla-green-modbus-ha repository
- replace placeholder GitHub paths throughout docs and guides

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.data_entry_flow')*

------
https://chatgpt.com/codex/tasks/task_e_6892752534308326bd5747ebb66a2dc5