### PR TITLE
Fix coordinator update method for proper refresh

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -62,7 +62,7 @@ class ThesslaGreenCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=timedelta(seconds=scan_interval),
         )
 
-    async def async_update_data(self) -> dict[str, Any]:
+    async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the device."""
         data: dict[str, Any] = {}
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,14 +11,36 @@ import pytest
 ha = types.ModuleType("homeassistant")
 const = types.ModuleType("homeassistant.const")
 core = types.ModuleType("homeassistant.core")
+helpers_pkg = types.ModuleType("homeassistant.helpers")
 helpers = types.ModuleType("homeassistant.helpers.update_coordinator")
+helpers_cv = types.ModuleType("homeassistant.helpers.config_validation")
+helpers_dr = types.ModuleType("homeassistant.helpers.device_registry")
+helpers_pkg.update_coordinator = helpers
+helpers_pkg.config_validation = helpers_cv
+helpers_pkg.device_registry = helpers_dr
 exceptions = types.ModuleType("homeassistant.exceptions")
 config_entries = types.ModuleType("homeassistant.config_entries")
 pymodbus = types.ModuleType("pymodbus")
 pymodbus_client = types.ModuleType("pymodbus.client")
+pymodbus_exceptions = types.ModuleType("pymodbus.exceptions")
+pymodbus_exceptions = types.ModuleType("pymodbus.exceptions")
 
 const.CONF_HOST = "host"
 const.CONF_PORT = "port"
+const.CONF_SCAN_INTERVAL = "scan_interval"
+
+
+class Platform:
+    SENSOR = "sensor"
+    BINARY_SENSOR = "binary_sensor"
+    SELECT = "select"
+    NUMBER = "number"
+    SWITCH = "switch"
+    CLIMATE = "climate"
+    FAN = "fan"
+
+
+const.Platform = Platform
 
 
 class HomeAssistant:
@@ -26,6 +48,13 @@ class HomeAssistant:
 
 
 core.HomeAssistant = HomeAssistant
+
+
+class ServiceCall:
+    pass
+
+
+core.ServiceCall = ServiceCall
 
 
 class ConfigEntry:
@@ -45,6 +74,10 @@ class DataUpdateCoordinator:
 
     async def async_request_refresh(self):
         pass
+
+    @classmethod
+    def __class_getitem__(cls, item):
+        return cls
 
 
 helpers.DataUpdateCoordinator = DataUpdateCoordinator
@@ -71,15 +104,26 @@ class ModbusTcpClient:
 
 pymodbus_client.ModbusTcpClient = ModbusTcpClient
 
+
+class ModbusException(Exception):
+    pass
+
+
+pymodbus_exceptions.ModbusException = ModbusException
+
 modules = {
     "homeassistant": ha,
     "homeassistant.const": const,
     "homeassistant.core": core,
+    "homeassistant.helpers": helpers_pkg,
     "homeassistant.helpers.update_coordinator": helpers,
+    "homeassistant.helpers.config_validation": helpers_cv,
+    "homeassistant.helpers.device_registry": helpers_dr,
     "homeassistant.exceptions": exceptions,
     "homeassistant.config_entries": config_entries,
     "pymodbus": pymodbus,
     "pymodbus.client": pymodbus_client,
+    "pymodbus.exceptions": pymodbus_exceptions,
 }
 
 sys.modules.update(modules)
@@ -92,9 +136,8 @@ from custom_components.thessla_green_modbus.coordinator import ThesslaGreenCoord
 
 @pytest.mark.asyncio
 async def test_async_write_invalid_register():
-    """Return False on unknown register and avoid executor call."""
+    """Return False on unknown register and avoid client calls."""
     hass = MagicMock()
-    hass.async_add_executor_job = AsyncMock(return_value=False)
     coordinator = ThesslaGreenCoordinator(
         hass=hass,
         host="localhost",
@@ -110,16 +153,18 @@ async def test_async_write_invalid_register():
             "discrete_inputs": set(),
         },
     )
+    coordinator._client.write_register = AsyncMock(return_value=True)
+    coordinator._client.write_coil = AsyncMock(return_value=True)
     result = await coordinator.async_write_register("invalid", 1)
     assert result is False
-    hass.async_add_executor_job.assert_not_awaited()
+    coordinator._client.write_register.assert_not_awaited()
+    coordinator._client.write_coil.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_async_write_success_triggers_executor():
-    """Successful write should call executor job."""
+async def test_async_write_success_triggers_refresh():
+    """Successful write should refresh coordinator."""
     hass = MagicMock()
-    hass.async_add_executor_job = AsyncMock(return_value=True)
     coordinator = ThesslaGreenCoordinator(
         hass=hass,
         host="localhost",
@@ -135,14 +180,9 @@ async def test_async_write_success_triggers_executor():
             "discrete_inputs": set(),
         },
     )
-    with patch("custom_components.thessla_green_modbus.coordinator.ModbusTcpClient") as mock_client_cls:
-        client = MagicMock()
-        mock_client_cls.return_value = client
-        client.connect.return_value = True
-        response = MagicMock()
-        response.isError.return_value = False
-        client.write_register.return_value = response
+    coordinator._client.write_register = AsyncMock(return_value=True)
+    with patch.object(coordinator, "async_request_refresh", AsyncMock()) as mock_refresh:
         result = await coordinator.async_write_register("mode", 1)
 
     assert result is True
-    hass.async_add_executor_job.assert_awaited()
+    mock_refresh.assert_awaited_once()


### PR DESCRIPTION
## Summary
- rename `async_update_data` to `_async_update_data` for `DataUpdateCoordinator`
- update coordinator tests for refresh logic

## Testing
- `pytest tests/test_coordinator.py`

------
https://chatgpt.com/codex/tasks/task_e_6892794882688326ac5179a5e324b6eb