### PR TITLE
Add device scan result setter and update tests

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -525,5 +525,14 @@ class ThesslaGreenCoordinator(DataUpdateCoordinator):
         """Return device scan result - compatibility property."""
         return {
             "device_info": self.device_info,
-            "capabilities": self.capabilities
+            "capabilities": self.capabilities,
         }
+
+    @device_scan_result.setter
+    def device_scan_result(self, value: Dict[str, Any]) -> None:
+        """Update device scan result and related attributes."""
+        if not isinstance(value, dict):
+            raise ValueError("device_scan_result must be a dictionary")
+
+        self.device_info = value.get("device_info", {})
+        self.capabilities = value.get("capabilities", set())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,22 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
 DOMAIN = "thessla_green_modbus"
 
 
+class CoordinatorMock(MagicMock):
+    """MagicMock subclass with device_scan_result property."""
+
+    @property
+    def device_scan_result(self):  # type: ignore[override]
+        return {
+            "device_info": getattr(self, "device_info", {}),
+            "capabilities": getattr(self, "capabilities", {}),
+        }
+
+    @device_scan_result.setter
+    def device_scan_result(self, value):  # type: ignore[override]
+        self.device_info = value.get("device_info", {})
+        self.capabilities = value.get("capabilities", {})
+
+
 @pytest.fixture
 def hass():
     """Return a mock Home Assistant instance."""
@@ -98,7 +114,7 @@ def mock_config_entry():
 @pytest.fixture
 def mock_coordinator():
     """Return a mock coordinator."""
-    coordinator = MagicMock()
+    coordinator = CoordinatorMock()
     coordinator.host = "192.168.1.100"
     coordinator.port = 502
     coordinator.slave_id = 10
@@ -111,15 +127,17 @@ def mock_coordinator():
         "on_off_panel_mode": 1,
         "supply_percentage": 50,
     }
-    coordinator.device_info = {
-        "device_name": "ThesslaGreen AirPack",
-        "firmware": "4.85.0",
-        "serial_number": "S/N: 1234 5678 9abc",
-    }
-    coordinator.capabilities = {
-        "constant_flow": True,
+    coordinator.device_scan_result = {
+        "device_info": {
+            "device_name": "ThesslaGreen AirPack",
+            "firmware": "4.85.0",
+            "serial_number": "S/N: 1234 5678 9abc",
+        },
+        "capabilities": {
+            "constant_flow": True,
         "gwc_system": True,
-        "bypass_system": True,
+            "bypass_system": True,
+        },
     }
     coordinator.available_registers = {
         "input_registers": {"outside_temperature", "supply_temperature", "exhaust_temperature"},

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -5,6 +5,8 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch, call
 from datetime import timedelta
 
+from conftest import CoordinatorMock
+
 import voluptuous as vol
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -55,7 +57,7 @@ class TestThesslaGreenIntegration:
     @pytest.fixture
     def mock_coordinator(self):
         """Create a mock coordinator with realistic data."""
-        coordinator = MagicMock()
+        coordinator = CoordinatorMock()
         coordinator.host = "192.168.1.100"
         coordinator.port = 502
         coordinator.slave_id = 10
@@ -80,24 +82,24 @@ class TestThesslaGreenIntegration:
             "bypass_mode": 0,
         }
         
-        # Device info
-        coordinator.device_info = {
-            "device_name": "ThesslaGreen AirPack Test",
-            "firmware": "4.85.0",
-            "serial_number": "S/N: 1234 5678 9abc",
-            "processor": "ATmega2561",
-        }
-        
-        # Capabilities
-        coordinator.capabilities = {
-            "basic_control": True,
-            "constant_flow": True,
-            "gwc_system": True,
-            "bypass_system": True,
-            "comfort_mode": True,
-            "expansion_module": False,
-            "temperature_sensors_count": 7,
-            "model_type": "AirPack Home Energy+ with CF and GWC",
+        # Device scan result sets device_info and capabilities
+        coordinator.device_scan_result = {
+            "device_info": {
+                "device_name": "ThesslaGreen AirPack Test",
+                "firmware": "4.85.0",
+                "serial_number": "S/N: 1234 5678 9abc",
+                "processor": "ATmega2561",
+            },
+            "capabilities": {
+                "basic_control": True,
+                "constant_flow": True,
+                "gwc_system": True,
+                "bypass_system": True,
+                "comfort_mode": True,
+                "expansion_module": False,
+                "temperature_sensors_count": 7,
+                "model_type": "AirPack Home Energy+ with CF and GWC",
+            },
         }
         
         # Available registers
@@ -478,12 +480,14 @@ class TestThesslaGreenClimate:
     @pytest.fixture
     def mock_climate_coordinator(self):
         """Create a coordinator specifically for climate testing."""
-        coordinator = MagicMock()
+        coordinator = CoordinatorMock()
         coordinator.host = "192.168.1.100"
         coordinator.slave_id = 10
-        coordinator.device_info = {
-            "device_name": "Test AirPack",
-            "firmware": "4.85.0",
+        coordinator.device_scan_result = {
+            "device_info": {
+                "device_name": "Test AirPack",
+                "firmware": "4.85.0",
+            }
         }
         coordinator.available_registers = {
             "holding_registers": {"mode", "on_off_panel_mode", "air_flow_rate_manual"}


### PR DESCRIPTION
## Summary
- add `device_scan_result` setter to update `device_info` and `capabilities`
- use new property in tests via `CoordinatorMock`
- keep integration setup using `coordinator.device_scan_result`

## Testing
- `pytest -q` *(fails: No module named 'homeassistant.data_entry_flow'; No module named 'voluptuous')*

------
https://chatgpt.com/codex/tasks/task_e_689318f51dd4832695abfe65eb5cc58f