### PR TITLE
Retry individual Modbus registers on batch read failures

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -118,33 +118,63 @@ class ThesslaGreenDeviceScanner:
         
         # Group registers by address ranges for efficient batch reading
         register_groups = self._create_register_groups(INPUT_REGISTERS)
-        
+
         for start_addr, count, register_keys in register_groups:
+            self._scan_stats["total_attempts"] += 1
             try:
-                self._scan_stats["total_attempts"] += 1
                 # ✅ FIXED: pymodbus 3.5+ requires keyword arguments
                 response = client.read_input_registers(
-                    address=start_addr, 
-                    count=count, 
+                    address=start_addr,
+                    count=count,
                     slave=self.slave_id
                 )
-                
-                if not response.isError():
-                    self._scan_stats["successful_reads"] += 1
-                    # All registers in this batch are available
-                    available_registers.update(register_keys)
-                    _LOGGER.debug("Input register batch %s-%s: %d registers found", 
-                                start_addr, start_addr + count - 1, len(register_keys))
-                else:
-                    self._scan_stats["failed_reads"] += 1
-                    _LOGGER.debug("Input register batch %s-%s failed: %s", 
-                                start_addr, start_addr + count - 1, response)
-                    
             except Exception as exc:
                 self._scan_stats["failed_reads"] += 1
-                _LOGGER.debug("Input register batch %s failed: %s", start_addr, exc)
+                _LOGGER.debug(
+                    "Input register batch %s-%s failed: %s. Falling back to individual reads",
+                    start_addr,
+                    start_addr + count - 1,
+                    exc,
+                )
+                available_registers.update(
+                    self._fallback_read_registers(
+                        client,
+                        register_keys,
+                        INPUT_REGISTERS,
+                        "read_input_registers",
+                        "Input",
+                    )
+                )
                 continue
-        
+
+            if not response.isError():
+                self._scan_stats["successful_reads"] += 1
+                # All registers in this batch are available
+                available_registers.update(register_keys)
+                _LOGGER.debug(
+                    "Input register batch %s-%s: %d registers found",
+                    start_addr,
+                    start_addr + count - 1,
+                    len(register_keys),
+                )
+            else:
+                self._scan_stats["failed_reads"] += 1
+                _LOGGER.debug(
+                    "Input register batch %s-%s failed: %s. Falling back to individual reads",
+                    start_addr,
+                    start_addr + count - 1,
+                    response,
+                )
+                available_registers.update(
+                    self._fallback_read_registers(
+                        client,
+                        register_keys,
+                        INPUT_REGISTERS,
+                        "read_input_registers",
+                        "Input",
+                    )
+                )
+
         _LOGGER.info("Input registers scan: %d registers found", len(available_registers))
         return available_registers
 
@@ -155,28 +185,60 @@ class ThesslaGreenDeviceScanner:
         register_groups = self._create_register_groups(HOLDING_REGISTERS)
         
         for start_addr, count, register_keys in register_groups:
+            self._scan_stats["total_attempts"] += 1
             try:
-                self._scan_stats["total_attempts"] += 1
                 # ✅ FIXED: pymodbus 3.5+ requires keyword arguments
                 response = client.read_holding_registers(
-                    address=start_addr, 
-                    count=count, 
+                    address=start_addr,
+                    count=count,
                     slave=self.slave_id
                 )
-                
-                if not response.isError():
-                    self._scan_stats["successful_reads"] += 1
-                    available_registers.update(register_keys)
-                    _LOGGER.debug("Holding register batch %s-%s: %d registers found", 
-                                start_addr, start_addr + count - 1, len(register_keys))
-                else:
-                    self._scan_stats["failed_reads"] += 1
-                    
             except Exception as exc:
                 self._scan_stats["failed_reads"] += 1
-                _LOGGER.debug("Holding register batch %s failed: %s", start_addr, exc)
+                _LOGGER.debug(
+                    "Holding register batch %s-%s failed: %s. Falling back to individual reads",
+                    start_addr,
+                    start_addr + count - 1,
+                    exc,
+                )
+                available_registers.update(
+                    self._fallback_read_registers(
+                        client,
+                        register_keys,
+                        HOLDING_REGISTERS,
+                        "read_holding_registers",
+                        "Holding",
+                    )
+                )
                 continue
-        
+
+            if not response.isError():
+                self._scan_stats["successful_reads"] += 1
+                available_registers.update(register_keys)
+                _LOGGER.debug(
+                    "Holding register batch %s-%s: %d registers found",
+                    start_addr,
+                    start_addr + count - 1,
+                    len(register_keys),
+                )
+            else:
+                self._scan_stats["failed_reads"] += 1
+                _LOGGER.debug(
+                    "Holding register batch %s-%s failed: %s. Falling back to individual reads",
+                    start_addr,
+                    start_addr + count - 1,
+                    response,
+                )
+                available_registers.update(
+                    self._fallback_read_registers(
+                        client,
+                        register_keys,
+                        HOLDING_REGISTERS,
+                        "read_holding_registers",
+                        "Holding",
+                    )
+                )
+
         _LOGGER.info("Holding registers scan: %d registers found", len(available_registers))
         return available_registers
 
@@ -187,28 +249,60 @@ class ThesslaGreenDeviceScanner:
         register_groups = self._create_register_groups(COIL_REGISTERS)
         
         for start_addr, count, register_keys in register_groups:
+            self._scan_stats["total_attempts"] += 1
             try:
-                self._scan_stats["total_attempts"] += 1
                 # ✅ FIXED: pymodbus 3.5+ requires keyword arguments
                 response = client.read_coils(
-                    address=start_addr, 
-                    count=count, 
+                    address=start_addr,
+                    count=count,
                     slave=self.slave_id
                 )
-                
-                if not response.isError():
-                    self._scan_stats["successful_reads"] += 1
-                    available_registers.update(register_keys)
-                    _LOGGER.debug("Coil register batch %s-%s: %d registers found", 
-                                start_addr, start_addr + count - 1, len(register_keys))
-                else:
-                    self._scan_stats["failed_reads"] += 1
-                    
             except Exception as exc:
                 self._scan_stats["failed_reads"] += 1
-                _LOGGER.debug("Coil register batch %s failed: %s", start_addr, exc)
+                _LOGGER.debug(
+                    "Coil register batch %s-%s failed: %s. Falling back to individual reads",
+                    start_addr,
+                    start_addr + count - 1,
+                    exc,
+                )
+                available_registers.update(
+                    self._fallback_read_registers(
+                        client,
+                        register_keys,
+                        COIL_REGISTERS,
+                        "read_coils",
+                        "Coil",
+                    )
+                )
                 continue
-        
+
+            if not response.isError():
+                self._scan_stats["successful_reads"] += 1
+                available_registers.update(register_keys)
+                _LOGGER.debug(
+                    "Coil register batch %s-%s: %d registers found",
+                    start_addr,
+                    start_addr + count - 1,
+                    len(register_keys),
+                )
+            else:
+                self._scan_stats["failed_reads"] += 1
+                _LOGGER.debug(
+                    "Coil register batch %s-%s failed: %s. Falling back to individual reads",
+                    start_addr,
+                    start_addr + count - 1,
+                    response,
+                )
+                available_registers.update(
+                    self._fallback_read_registers(
+                        client,
+                        register_keys,
+                        COIL_REGISTERS,
+                        "read_coils",
+                        "Coil",
+                    )
+                )
+
         _LOGGER.info("Coil registers scan: %d registers found", len(available_registers))
         return available_registers
 
@@ -219,30 +313,112 @@ class ThesslaGreenDeviceScanner:
         register_groups = self._create_register_groups(DISCRETE_INPUTS)
         
         for start_addr, count, register_keys in register_groups:
+            self._scan_stats["total_attempts"] += 1
             try:
-                self._scan_stats["total_attempts"] += 1
                 # ✅ FIXED: pymodbus 3.5+ requires keyword arguments
                 response = client.read_discrete_inputs(
-                    address=start_addr, 
-                    count=count, 
+                    address=start_addr,
+                    count=count,
                     slave=self.slave_id
                 )
-                
-                if not response.isError():
-                    self._scan_stats["successful_reads"] += 1
-                    available_registers.update(register_keys)
-                    _LOGGER.debug("Discrete input batch %s-%s: %d registers found", 
-                                start_addr, start_addr + count - 1, len(register_keys))
-                else:
-                    self._scan_stats["failed_reads"] += 1
-                    
             except Exception as exc:
                 self._scan_stats["failed_reads"] += 1
-                _LOGGER.debug("Discrete input batch %s failed: %s", start_addr, exc)
+                _LOGGER.debug(
+                    "Discrete input batch %s-%s failed: %s. Falling back to individual reads",
+                    start_addr,
+                    start_addr + count - 1,
+                    exc,
+                )
+                available_registers.update(
+                    self._fallback_read_registers(
+                        client,
+                        register_keys,
+                        DISCRETE_INPUTS,
+                        "read_discrete_inputs",
+                        "Discrete input",
+                    )
+                )
                 continue
-        
+
+            if not response.isError():
+                self._scan_stats["successful_reads"] += 1
+                available_registers.update(register_keys)
+                _LOGGER.debug(
+                    "Discrete input batch %s-%s: %d registers found",
+                    start_addr,
+                    start_addr + count - 1,
+                    len(register_keys),
+                )
+            else:
+                self._scan_stats["failed_reads"] += 1
+                _LOGGER.debug(
+                    "Discrete input batch %s-%s failed: %s. Falling back to individual reads",
+                    start_addr,
+                    start_addr + count - 1,
+                    response,
+                )
+                available_registers.update(
+                    self._fallback_read_registers(
+                        client,
+                        register_keys,
+                        DISCRETE_INPUTS,
+                        "read_discrete_inputs",
+                        "Discrete input",
+                    )
+                )
+
         _LOGGER.info("Discrete inputs scan: %d registers found", len(available_registers))
         return available_registers
+
+    def _fallback_read_registers(
+        self,
+        client: ModbusTcpClient,
+        register_keys: list,
+        register_map: Dict[str, int],
+        method: str,
+        reg_type: str,
+    ) -> Set[str]:
+        """Attempt to read each register individually when a batch read fails."""
+        successful = set()
+        for reg in register_keys:
+            address = register_map.get(reg)
+            if address is None:
+                continue
+            try:
+                self._scan_stats["total_attempts"] += 1
+                response = getattr(client, method)(
+                    address=address,
+                    count=1,
+                    slave=self.slave_id,
+                )
+                if not response.isError():
+                    self._scan_stats["successful_reads"] += 1
+                    successful.add(reg)
+                    _LOGGER.debug(
+                        "%s register %s (%s) fallback succeeded",
+                        reg_type,
+                        reg,
+                        address,
+                    )
+                else:
+                    self._scan_stats["failed_reads"] += 1
+                    _LOGGER.debug(
+                        "%s register %s (%s) fallback failed: %s",
+                        reg_type,
+                        reg,
+                        address,
+                        response,
+                    )
+            except Exception as exc:
+                self._scan_stats["failed_reads"] += 1
+                _LOGGER.debug(
+                    "%s register %s (%s) fallback failed: %s",
+                    reg_type,
+                    reg,
+                    address,
+                    exc,
+                )
+        return successful
 
     def _create_register_groups(self, register_dict: Dict[str, int]) -> list:
         """Create groups of consecutive registers for batch reading."""


### PR DESCRIPTION
## Summary
- When a batch Modbus read fails, retry each register individually and merge successes
- Log successful and failed register reads during fallback
- Collect all successful registers across batch and fallback reads

## Testing
- `pytest` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_6893c80b6b4c8326afe150d203e7957c