### PR TITLE
Load config flow module on integration startup

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -33,6 +33,7 @@ from .const import (
 )
 from .coordinator import ThesslaGreenCoordinator
 from .device_scanner import ThesslaGreenDeviceScanner
+from . import config_flow  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Import `config_flow` when the ThesslaGreen Modbus integration loads so the configuration flow is registered at startup
- Reviewed `config_flow` and `device_scanner` to ensure they do not perform I/O at import time

## Testing
- `flake8 custom_components/thessla_green_modbus/__init__.py custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/device_scanner.py` *(fails: numerous pre-existing style violations)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous')*
- `pip install -r requirements.txt` *(fails: No matching distribution found for homeassistant>=2025.7.0)*

------
https://chatgpt.com/codex/tasks/task_e_6895b47cbdc08326af5ab0312b217809