### PR TITLE
Use validate_input in config flow and add confirm tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,16 +16,49 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     ha = types.ModuleType("homeassistant")
     core = types.ModuleType("homeassistant.core")
     config_entries = types.ModuleType("homeassistant.config_entries")
+    helpers_pkg = types.ModuleType("homeassistant.helpers")
     helpers = types.ModuleType("homeassistant.helpers.update_coordinator")
+    device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+    service_helper = types.ModuleType("homeassistant.helpers.service")
     exceptions = types.ModuleType("homeassistant.exceptions")
     const = types.ModuleType("homeassistant.const")
+    data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
+    cv = types.ModuleType("homeassistant.helpers.config_validation")
+    selector = types.ModuleType("homeassistant.helpers.selector")
+    pymodbus = types.ModuleType("pymodbus")
+    pymodbus_client = types.ModuleType("pymodbus.client")
+    pymodbus_client_tcp = types.ModuleType("pymodbus.client.tcp")
+    pymodbus_exceptions = types.ModuleType("pymodbus.exceptions")
+    pymodbus_pdu = types.ModuleType("pymodbus.pdu")
 
     class HomeAssistant:  # type: ignore[override]
         async def async_add_executor_job(self, func, *args):  # minimal stub
             return func(*args)
 
+    class ServiceCall:  # type: ignore[override]
+        pass
+
+    def callback(func):  # type: ignore[override]
+        return func
+
     class ConfigEntry:  # type: ignore[override]
         pass
+
+    class ConfigFlow:  # type: ignore[override]
+        def __init_subclass__(cls, **kwargs):
+            return
+
+        async def async_set_unique_id(self, *args, **kwargs):
+            return None
+
+        def _abort_if_unique_id_configured(self):
+            return None
+
+        def async_show_form(self, **kwargs):  # type: ignore[override]
+            return {"type": "form", **kwargs}
+
+        def async_create_entry(self, **kwargs):  # type: ignore[override]
+            return {"type": "create_entry", **kwargs}
 
     class DataUpdateCoordinator:  # type: ignore[override]
         def __init__(self, hass, logger, name=None, update_interval=None):
@@ -40,14 +73,85 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     class ConfigEntryNotReady(Exception):
         pass
 
+    class HomeAssistantError(Exception):
+        pass
+
     core.HomeAssistant = HomeAssistant
+    core.ServiceCall = ServiceCall
+    core.callback = callback
     config_entries.ConfigEntry = ConfigEntry
+    config_entries.ConfigFlow = ConfigFlow
+    config_entries.CONN_CLASS_LOCAL_POLL = "local_poll"
+
+    class OptionsFlow:  # type: ignore[override]
+        def __init_subclass__(cls, **kwargs):
+            return
+
+    config_entries.OptionsFlow = OptionsFlow
     helpers.DataUpdateCoordinator = DataUpdateCoordinator
     helpers.UpdateFailed = UpdateFailed
+    class DeviceInfo:  # type: ignore[override]
+        pass
+    device_registry.DeviceInfo = DeviceInfo
     exceptions.ConfigEntryNotReady = ConfigEntryNotReady
+    exceptions.HomeAssistantError = HomeAssistantError
     const.CONF_HOST = "host"
     const.CONF_PORT = "port"
     const.CONF_SCAN_INTERVAL = "scan_interval"
+    const.CONF_NAME = "name"
+    data_entry_flow.FlowResult = dict
+
+    # Minimal config validation helpers
+    cv.string = str
+    cv.port = int
+    cv.boolean = bool
+    cv.entity_ids = list
+    cv.time = str
+
+    # Minimal selector stubs
+    class SelectSelectorConfig:  # type: ignore[override]
+        def __init__(self, options=None, mode=None):
+            self.options = options
+            self.mode = mode
+
+    class SelectSelector:  # type: ignore[override]
+        def __init__(self, config):
+            self.config = config
+
+    class SelectSelectorMode:  # type: ignore[override]
+        DROPDOWN = "dropdown"
+
+    selector.SelectSelector = SelectSelector
+    selector.SelectSelectorConfig = SelectSelectorConfig
+    selector.SelectSelectorMode = SelectSelectorMode
+    async def async_extract_entity_ids(hass, service_call):
+        return set()
+    service_helper.async_extract_entity_ids = async_extract_entity_ids
+    helpers_pkg.update_coordinator = helpers
+    helpers_pkg.device_registry = device_registry
+    helpers_pkg.config_validation = cv
+    helpers_pkg.selector = selector
+    helpers_pkg.service = service_helper
+
+    # Minimal pymodbus stubs
+    class ModbusTcpClient:  # type: ignore[override]
+        pass
+
+    class ModbusException(Exception):
+        pass
+
+    class ConnectionException(Exception):
+        pass
+
+    class ExceptionResponse:  # type: ignore[override]
+        pass
+
+    pymodbus_client_tcp.ModbusTcpClient = ModbusTcpClient
+    pymodbus_client.tcp = pymodbus_client_tcp
+    pymodbus.client = pymodbus_client
+    pymodbus_exceptions.ModbusException = ModbusException
+    pymodbus_exceptions.ConnectionException = ConnectionException
+    pymodbus_pdu.ExceptionResponse = ExceptionResponse
 
     class Platform:
         SENSOR = "sensor"
@@ -57,15 +161,27 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
         SWITCH = "switch"
         CLIMATE = "climate"
         FAN = "fan"
+        DIAGNOSTICS = "diagnostics"
 
     const.Platform = Platform
 
     sys.modules["homeassistant"] = ha
     sys.modules["homeassistant.core"] = core
     sys.modules["homeassistant.config_entries"] = config_entries
+    sys.modules["homeassistant.helpers"] = helpers_pkg
     sys.modules["homeassistant.helpers.update_coordinator"] = helpers
+    sys.modules["homeassistant.helpers.device_registry"] = device_registry
+    sys.modules["homeassistant.helpers.service"] = service_helper
     sys.modules["homeassistant.exceptions"] = exceptions
     sys.modules["homeassistant.const"] = const
+    sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
+    sys.modules["homeassistant.helpers.config_validation"] = cv
+    sys.modules["homeassistant.helpers.selector"] = selector
+    sys.modules["pymodbus"] = pymodbus
+    sys.modules["pymodbus.client"] = pymodbus_client
+    sys.modules["pymodbus.client.tcp"] = pymodbus_client_tcp
+    sys.modules["pymodbus.exceptions"] = pymodbus_exceptions
+    sys.modules["pymodbus.pdu"] = pymodbus_pdu
 
 DOMAIN = "thessla_green_modbus"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,131 +1,185 @@
 """Test config flow for ThesslaGreen Modbus integration."""
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
-from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.data_entry_flow import FlowResultType
 
-from custom_components.thessla_green_modbus.config_flow import ConfigFlow, CannotConnect
-from custom_components.thessla_green_modbus.const import DOMAIN
+CONF_NAME = "name"
+
+from custom_components.thessla_green_modbus.config_flow import (
+    ConfigFlow,
+    CannotConnect,
+    InvalidAuth,
+)
+
+
+pytestmark = pytest.mark.asyncio
 
 
 async def test_form_user():
-    """Test we get the form."""
+    """Test we get the initial form."""
     flow = ConfigFlow()
     flow.hass = None
-    
+
     result = await flow.async_step_user()
-    
-    assert result["type"] == FlowResultType.FORM
+
+    assert result["type"] == "form"
     assert result["errors"] == {}
 
 
 async def test_form_user_success():
-    """Test successful configuration."""
+    """Test successful configuration with confirm step."""
     flow = ConfigFlow()
     flow.hass = None
-    
+
+    validation_result = {
+        "title": "ThesslaGreen 192.168.1.100",
+        "device_info": {"device_name": "ThesslaGreen AirPack", "firmware": "1.0", "serial_number": "123"},
+        "scan_result": {
+            "device_info": {"device_name": "ThesslaGreen AirPack", "firmware": "1.0", "serial_number": "123"},
+            "capabilities": {"fan": True},
+            "register_count": 5,
+        },
+    }
+
     with patch(
         "custom_components.thessla_green_modbus.config_flow.validate_input",
-        return_value={"title": "ThesslaGreen 192.168.1.100"},
+        return_value=validation_result,
     ), patch(
         "custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"
     ), patch(
         "custom_components.thessla_green_modbus.config_flow.ConfigFlow._abort_if_unique_id_configured"
     ):
-        result = await flow.async_step_user({
-            CONF_HOST: "192.168.1.100",
-            CONF_PORT: 502,
-            "slave_id": 10,
-        })
-        
-        assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == "ThesslaGreen 192.168.1.100"
-        assert result["data"] == {
-            CONF_HOST: "192.168.1.100",
-            CONF_PORT: 502,
-            "slave_id": 10,
-        }
+        result = await flow.async_step_user(
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 502,
+                "slave_id": 10,
+                CONF_NAME: "My Device",
+            }
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "confirm"
+
+    result2 = await flow.async_step_confirm({})
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "My Device"
+    assert result2["data"] == {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "My Device",
+    }
 
 
 async def test_form_user_cannot_connect():
     """Test we handle cannot connect error."""
     flow = ConfigFlow()
     flow.hass = None
-    
+
     with patch(
         "custom_components.thessla_green_modbus.config_flow.validate_input",
         side_effect=CannotConnect,
     ):
-        result = await flow.async_step_user({
-            CONF_HOST: "192.168.1.100",
-            CONF_PORT: 502,
-            "slave_id": 10,
-        })
-        
-        assert result["type"] == FlowResultType.FORM
-        assert result["errors"] == {"base": "cannot_connect"}
+        result = await flow.async_step_user(
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 502,
+                "slave_id": 10,
+                CONF_NAME: "My Device",
+            }
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_user_invalid_auth():
+    """Test we handle invalid auth error."""
+    flow = ConfigFlow()
+    flow.hass = None
+
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow.validate_input",
+        side_effect=InvalidAuth,
+    ):
+        result = await flow.async_step_user(
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 502,
+                "slave_id": 10,
+                CONF_NAME: "My Device",
+            }
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_auth"}
 
 
 async def test_form_user_unexpected_exception():
     """Test we handle unexpected exception."""
     flow = ConfigFlow()
     flow.hass = None
-    
+
     with patch(
         "custom_components.thessla_green_modbus.config_flow.validate_input",
         side_effect=Exception,
     ):
-        result = await flow.async_step_user({
-            CONF_HOST: "192.168.1.100",
-            CONF_PORT: 502,
-            "slave_id": 10,
-        })
-        
-        assert result["type"] == FlowResultType.FORM
-        assert result["errors"] == {"base": "unknown"}
+        result = await flow.async_step_user(
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 502,
+                "slave_id": 10,
+                CONF_NAME: "My Device",
+            }
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "unknown"}
 
 
 async def test_validate_input_success():
     """Test validate_input with successful connection."""
     from custom_components.thessla_green_modbus.config_flow import validate_input
-    
+
     hass = None
     data = {
         CONF_HOST: "192.168.1.100",
         CONF_PORT: 502,
         "slave_id": 10,
+        CONF_NAME: "Test",
     }
-    
+
     with patch(
         "custom_components.thessla_green_modbus.device_scanner.ThesslaGreenDeviceScanner.scan_device",
         return_value={
             "available_registers": {},
-            "device_info": {"device_name": "ThesslaGreen AirPack"},
+            "device_info": {"device_name": "ThesslaGreen AirPack", "firmware": "1.0", "serial_number": "123"},
             "capabilities": {},
-        }
+        },
     ):
         result = await validate_input(hass, data)
-        
-        assert result["title"] == "ThesslaGreen 192.168.1.100"
-        assert "device_info" in result
+
+    assert result["title"] == "Test"
+    assert "device_info" in result
 
 
 async def test_validate_input_no_data():
     """Test validate_input with no device data."""
     from custom_components.thessla_green_modbus.config_flow import validate_input
-    
+
     hass = None
     data = {
         CONF_HOST: "192.168.1.100",
         CONF_PORT: 502,
         "slave_id": 10,
+        CONF_NAME: "Test",
     }
-    
+
     with patch(
         "custom_components.thessla_green_modbus.device_scanner.ThesslaGreenDeviceScanner.scan_device",
-        return_value=None
+        return_value=None,
     ):
         with pytest.raises(CannotConnect):
             await validate_input(hass, data)


### PR DESCRIPTION
## Summary
- Refactor config flow to validate input via helper and handle confirm step errors
- Add comprehensive config flow tests for success, CannotConnect, and InvalidAuth cases
- Extend test stubs for Home Assistant modules

## Testing
- `pytest tests/test_config_flow.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'ThesslaGreenCoordinator' from 'custom_components.thessla_green_modbus.coordinator')*


------
https://chatgpt.com/codex/tasks/task_e_68987aea7a288326a0f7174145209f5c