### PR TITLE
Simplify services module docstring

### DIFF
--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -1,8 +1,4 @@
-"""COMPLETE Services implementation for ThesslaGreen Modbus Integration - SILVER STANDARD.
-Compatibility: Home Assistant 2025.* + pymodbus 3.5.*+
-All models: thessla green AirPack Home series 4
-COMPLETE: All 13 services from documentation
-"""
+"""Service handlers for the ThesslaGreen Modbus integration."""
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
## Summary
- replace verbose module docstring in services with concise description

## Testing
- `pytest -q` *(fails: cannot import name 'AsyncModbusTcpClient'; cannot import name 'CONF_NAME'; ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_689a522e77088326a17096086126cd5b