### PR TITLE
Expose client setup helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -223,7 +223,23 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             except Exception as exc:
                 _LOGGER.error("Connection test failed: %s", exc)
                 raise
-    
+
+    async def _async_setup_client(self) -> bool:
+        """Set up the Modbus client if needed.
+
+        Returns True on success, False otherwise.
+        """
+        try:
+            await self._ensure_connection()
+            return True
+        except Exception as exc:
+            _LOGGER.error("Failed to set up Modbus client: %s", exc)
+            return False
+
+    async def async_ensure_client(self) -> bool:
+        """Public wrapper ensuring the Modbus client is connected."""
+        return await self._async_setup_client()
+
     async def _ensure_connection(self) -> None:
         """Ensure Modbus connection is established."""
         if self.client is None or not self.client.connected:

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -194,7 +194,7 @@ class ThesslaGreenFan(CoordinatorEntity, FanEntity):
         
         # Ensure client is connected
         if not self.coordinator.client or not self.coordinator.client.connected:
-            if not await self.coordinator._async_setup_client():
+            if not await self.coordinator.async_ensure_client():
                 raise RuntimeError("Failed to connect to device")
         
         # Write register - pymodbus 3.5+ compatible

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -236,7 +236,7 @@ class ThesslaGreenNumber(CoordinatorEntity, NumberEntity):
         
         # Ensure client is connected
         if not self.coordinator.client or not self.coordinator.client.connected:
-            if not await self.coordinator._async_setup_client():
+            if not await self.coordinator.async_ensure_client():
                 raise RuntimeError("Failed to connect to device")
         
         # Write register - pymodbus 3.5+ compatible

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -195,7 +195,7 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
         
         # Ensure client is connected
         if not self.coordinator.client or not self.coordinator.client.connected:
-            if not await self.coordinator._async_setup_client():
+            if not await self.coordinator.async_ensure_client():
                 raise RuntimeError("Failed to connect to device")
         
         # Write register - pymodbus 3.5+ compatible


### PR DESCRIPTION
## Summary
- add public async_ensure_client wrapper for Modbus client setup
- use async_ensure_client in entity write helpers

## Testing
- `pytest` *(fails: ImportError: cannot import name 'AsyncModbusTcpClient' from 'pymodbus.client')*


------
https://chatgpt.com/codex/tasks/task_e_689a523f286c8326988772d267a13a70