### PR TITLE
chore: remove unused typing imports

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -1,5 +1,4 @@
 """Constants and register definitions for the ThesslaGreen Modbus integration."""
-from typing import Dict, List, Set
 
 # Integration constants
 DOMAIN = "thessla_green_modbus"


### PR DESCRIPTION
## Summary
- remove unused typing imports from constant definitions

## Testing
- `flake8 --select=F401 custom_components/thessla_green_modbus/const.py`
- `pytest` *(fails: ImportError: cannot import name 'AsyncModbusTcpClient' from 'pymodbus.client'; ModuleNotFoundError: No module named 'voluptuous')*

------
https://chatgpt.com/codex/tasks/task_e_689a52b7a8ac832681670f4a292c0b58