### PR TITLE
Use translation keys for entity names

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -22,49 +22,49 @@ _LOGGER = logging.getLogger(__name__)
 BINARY_SENSOR_DEFINITIONS = {
     # System status (from coil registers)
     "duct_water_heater_pump": {
-        "name": "Pompa obiegowa nagrzewnicy",
+        "translation_key": "duct_water_heater_pump",
         "icon": "mdi:pump",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "coil_registers",
     },
     "bypass": {
-        "name": "Bypass",
+        "translation_key": "bypass",
         "icon": "mdi:pipe-leak",
         "device_class": BinarySensorDeviceClass.OPENING,
         "register_type": "coil_registers",
     },
     "info": {
-        "name": "Potwierdzenie pracy centrali",
+        "translation_key": "info",
         "icon": "mdi:information",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "coil_registers",
     },
     "power_supply_fans": {
-        "name": "Zasilanie wentylatorów",
+        "translation_key": "power_supply_fans",
         "icon": "mdi:fan",
         "device_class": BinarySensorDeviceClass.POWER,
         "register_type": "coil_registers",
     },
     "heating_cable": {
-        "name": "Kabel grzejny",
+        "translation_key": "heating_cable",
         "icon": "mdi:heating-coil",
         "device_class": BinarySensorDeviceClass.HEAT,
         "register_type": "coil_registers",
     },
     "work_permit": {
-        "name": "Potwierdzenie pracy (Expansion)",
+        "translation_key": "work_permit",
         "icon": "mdi:check-circle",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "coil_registers",
     },
     "gwc": {
-        "name": "GWC",
+        "translation_key": "gwc",
         "icon": "mdi:pipe",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "coil_registers",
     },
     "hood": {
-        "name": "Okap",
+        "translation_key": "hood",
         "icon": "mdi:stove",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "coil_registers",
@@ -72,37 +72,37 @@ BINARY_SENSOR_DEFINITIONS = {
     
     # System status (from discrete inputs)
     "expansion": {
-        "name": "Moduł Expansion",
+        "translation_key": "expansion",
         "icon": "mdi:expansion-card",
         "device_class": BinarySensorDeviceClass.CONNECTIVITY,
         "register_type": "discrete_inputs",
     },
     "contamination_sensor": {
-        "name": "Czujnik zanieczyszczenia",
+        "translation_key": "contamination_sensor",
         "icon": "mdi:air-filter",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
     "external_contact_1": {
-        "name": "Kontakt zewnętrzny 1",
+        "translation_key": "external_contact_1",
         "icon": "mdi:electric-switch",
         "device_class": BinarySensorDeviceClass.OPENING,
         "register_type": "discrete_inputs",
     },
     "external_contact_2": {
-        "name": "Kontakt zewnętrzny 2",
+        "translation_key": "external_contact_2",
         "icon": "mdi:electric-switch",
         "device_class": BinarySensorDeviceClass.OPENING,
         "register_type": "discrete_inputs",
     },
     "external_contact_3": {
-        "name": "Kontakt zewnętrzny 3",
+        "translation_key": "external_contact_3",
         "icon": "mdi:electric-switch",
         "device_class": BinarySensorDeviceClass.OPENING,
         "register_type": "discrete_inputs",
     },
     "external_contact_4": {
-        "name": "Kontakt zewnętrzny 4",
+        "translation_key": "external_contact_4",
         "icon": "mdi:electric-switch",
         "device_class": BinarySensorDeviceClass.OPENING,
         "register_type": "discrete_inputs",
@@ -110,73 +110,73 @@ BINARY_SENSOR_DEFINITIONS = {
     
     # Alarms and errors (from discrete inputs)
     "fire_alarm": {
-        "name": "Alarm pożarowy",
+        "translation_key": "fire_alarm",
         "icon": "mdi:fire",
         "device_class": BinarySensorDeviceClass.SAFETY,
         "register_type": "discrete_inputs",
     },
     "frost_alarm": {
-        "name": "Alarm przeciwmrozowy",
+        "translation_key": "frost_alarm",
         "icon": "mdi:snowflake-alert",
         "device_class": BinarySensorDeviceClass.COLD,
         "register_type": "discrete_inputs",
     },
     "filter_alarm": {
-        "name": "Alarm filtra",
+        "translation_key": "filter_alarm",
         "icon": "mdi:filter-variant-remove",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
     "maintenance_alarm": {
-        "name": "Alarm konserwacji",
+        "translation_key": "maintenance_alarm",
         "icon": "mdi:wrench-clock",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
     "sensor_error": {
-        "name": "Błąd czujnika",
+        "translation_key": "sensor_error",
         "icon": "mdi:sensor-off",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
     "communication_error": {
-        "name": "Błąd komunikacji",
+        "translation_key": "communication_error",
         "icon": "mdi:wifi-off",
         "device_class": BinarySensorDeviceClass.CONNECTIVITY,
         "register_type": "discrete_inputs",
     },
     "fan_error": {
-        "name": "Błąd wentylatora",
+        "translation_key": "fan_error",
         "icon": "mdi:fan-off",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
     "heater_error": {
-        "name": "Błąd grzałki",
+        "translation_key": "heater_error",
         "icon": "mdi:heating-coil",
         "device_class": BinarySensorDeviceClass.HEAT,
         "register_type": "discrete_inputs",
     },
     "cooler_error": {
-        "name": "Błąd chłodnicy",
+        "translation_key": "cooler_error",
         "icon": "mdi:snowflake-off",
         "device_class": BinarySensorDeviceClass.COLD,
         "register_type": "discrete_inputs",
     },
     "bypass_error": {
-        "name": "Błąd bypass",
+        "translation_key": "bypass_error",
         "icon": "mdi:pipe-disconnected",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
     "gwc_error": {
-        "name": "Błąd GWC",
+        "translation_key": "gwc_error",
         "icon": "mdi:pipe-wrench",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
     "expansion_error": {
-        "name": "Błąd modułu Expansion",
+        "translation_key": "expansion_error",
         "icon": "mdi:expansion-card-variant",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
@@ -184,73 +184,73 @@ BINARY_SENSOR_DEFINITIONS = {
     
     # Active protection systems (from input registers)
     "frost_protection_active": {
-        "name": "Ochrona przeciwmrozowa",
+        "translation_key": "frost_protection_active",
         "icon": "mdi:snowflake-check",
         "device_class": BinarySensorDeviceClass.COLD,
         "register_type": "input_registers",
     },
     "defrost_cycle_active": {
-        "name": "Cykl odszraniania",
+        "translation_key": "defrost_cycle_active",
         "icon": "mdi:snowflake-thermometer",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
     },
     "summer_bypass_active": {
-        "name": "Letni bypass",
+        "translation_key": "summer_bypass_active",
         "icon": "mdi:weather-sunny",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
     },
     "winter_heating_active": {
-        "name": "Zimowe grzanie",
+        "translation_key": "winter_heating_active",
         "icon": "mdi:weather-snowy",
         "device_class": BinarySensorDeviceClass.HEAT,
         "register_type": "input_registers",
     },
     "night_cooling_active": {
-        "name": "Nocne chłodzenie",
+        "translation_key": "night_cooling_active",
         "icon": "mdi:weather-night",
         "device_class": BinarySensorDeviceClass.COLD,
         "register_type": "input_registers",
     },
     "constant_flow_active": {
-        "name": "Stały przepływ",
+        "translation_key": "constant_flow_active",
         "icon": "mdi:waves",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
     },
     "air_quality_control_active": {
-        "name": "Kontrola jakości powietrza",
+        "translation_key": "air_quality_control_active",
         "icon": "mdi:air-filter",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
     },
     "humidity_control_active": {
-        "name": "Kontrola wilgotności",
+        "translation_key": "humidity_control_active",
         "icon": "mdi:water-percent",
         "device_class": BinarySensorDeviceClass.MOISTURE,
         "register_type": "input_registers",
     },
     "temperature_control_active": {
-        "name": "Kontrola temperatury",
+        "translation_key": "temperature_control_active",
         "icon": "mdi:thermometer-auto",
         "device_class": BinarySensorDeviceClass.HEAT,
         "register_type": "input_registers",
     },
     "demand_control_active": {
-        "name": "Kontrola na żądanie",
+        "translation_key": "demand_control_active",
         "icon": "mdi:hand-extended",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
     },
     "schedule_control_active": {
-        "name": "Kontrola harmonogramu",
+        "translation_key": "schedule_control_active",
         "icon": "mdi:calendar-clock",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
     },
     "manual_control_active": {
-        "name": "Kontrola manualna",
+        "translation_key": "manual_control_active",
         "icon": "mdi:hand-pointing-up",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
@@ -258,7 +258,7 @@ BINARY_SENSOR_DEFINITIONS = {
     
     # Device main status (from holding registers)
     "on_off_panel_mode": {
-        "name": "Zasilanie główne",
+        "translation_key": "on_off_panel_mode",
         "icon": "mdi:power",
         "device_class": BinarySensorDeviceClass.POWER,
         "register_type": "holding_registers",
@@ -283,7 +283,7 @@ async def async_setup_entry(
         # Check if this register is available on the device
         if register_name in coordinator.available_registers.get(register_type, set()):
             entities.append(ThesslaGreenBinarySensor(coordinator, register_name, sensor_def))
-            _LOGGER.debug("Created binary sensor: %s", sensor_def["name"])
+            _LOGGER.debug("Created binary sensor: %s", sensor_def["translation_key"])
     
     if entities:
         async_add_entities(entities, True)
@@ -309,14 +309,21 @@ class ThesslaGreenBinarySensor(CoordinatorEntity, BinarySensorEntity):
         
         # Entity attributes
         self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
-        self._attr_name = f"{coordinator.device_name} {sensor_definition['name']}"
         self._attr_device_info = coordinator.device_info_dict
-        
+
         # Binary sensor specific attributes
         self._attr_icon = sensor_definition.get("icon")
         self._attr_device_class = sensor_definition.get("device_class")
-        
-        _LOGGER.debug("Binary sensor initialized: %s (%s)", self._attr_name, register_name)
+
+        # Translation setup
+        self._attr_translation_key = sensor_definition.get("translation_key")
+        self._attr_has_entity_name = True
+
+        _LOGGER.debug(
+            "Binary sensor initialized: %s (%s)",
+            sensor_definition.get("translation_key"),
+            register_name,
+        )
 
     @property
     def is_on(self) -> Optional[bool]:

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -44,7 +44,7 @@ _LOGGER = logging.getLogger(__name__)
 SENSOR_DEFINITIONS = {
     # Temperature sensors
     "outside_temperature": {
-        "name": "Temperatura zewnętrzna",
+        "translation_key": "outside_temperature",
         "icon": "mdi:thermometer",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -52,7 +52,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "supply_temperature": {
-        "name": "Temperatura nawiewu",
+        "translation_key": "supply_temperature",
         "icon": "mdi:thermometer-plus",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -60,7 +60,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "exhaust_temperature": {
-        "name": "Temperatura wywiewu",
+        "translation_key": "exhaust_temperature",
         "icon": "mdi:thermometer-minus",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -68,7 +68,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "fpx_temperature": {
-        "name": "Temperatura FPX",
+        "translation_key": "fpx_temperature",
         "icon": "mdi:thermometer",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -76,7 +76,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "duct_supply_temperature": {
-        "name": "Temperatura kanałowa",
+        "translation_key": "duct_supply_temperature",
         "icon": "mdi:thermometer-lines",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -84,7 +84,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "gwc_temperature": {
-        "name": "Temperatura GWC",
+        "translation_key": "gwc_temperature",
         "icon": "mdi:thermometer-low",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -92,7 +92,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "ambient_temperature": {
-        "name": "Temperatura otoczenia",
+        "translation_key": "ambient_temperature",
         "icon": "mdi:home-thermometer",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -100,7 +100,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "heating_temperature": {
-        "name": "Temperatura grzania",
+        "translation_key": "heating_temperature",
         "icon": "mdi:thermometer-high",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -110,7 +110,7 @@ SENSOR_DEFINITIONS = {
     
     # Heat exchanger temperatures
     "heat_exchanger_temperature_1": {
-        "name": "Temperatura wymiennika 1",
+        "translation_key": "heat_exchanger_temperature_1",
         "icon": "mdi:heat-pump",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -118,7 +118,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "heat_exchanger_temperature_2": {
-        "name": "Temperatura wymiennika 2",
+        "translation_key": "heat_exchanger_temperature_2",
         "icon": "mdi:heat-pump",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -126,7 +126,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "heat_exchanger_temperature_3": {
-        "name": "Temperatura wymiennika 3",
+        "translation_key": "heat_exchanger_temperature_3",
         "icon": "mdi:heat-pump",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -134,7 +134,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "heat_exchanger_temperature_4": {
-        "name": "Temperatura wymiennika 4",
+        "translation_key": "heat_exchanger_temperature_4",
         "icon": "mdi:heat-pump",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -144,63 +144,63 @@ SENSOR_DEFINITIONS = {
     
     # Flow sensors
     "supply_flowrate": {
-        "name": "Przepływ nawiewu",
+        "translation_key": "supply_flowrate",
         "icon": "mdi:fan",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "exhaust_flowrate": {
-        "name": "Przepływ wywiewu",
+        "translation_key": "exhaust_flowrate",
         "icon": "mdi:fan-clock",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "outdoor_flowrate": {
-        "name": "Przepływ zewnętrzny",
+        "translation_key": "outdoor_flowrate",
         "icon": "mdi:weather-windy",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "inside_flowrate": {
-        "name": "Przepływ wewnętrzny",
+        "translation_key": "inside_flowrate",
         "icon": "mdi:home-circle",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "gwc_flowrate": {
-        "name": "Przepływ GWC",
+        "translation_key": "gwc_flowrate",
         "icon": "mdi:pipe",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "heat_recovery_flowrate": {
-        "name": "Przepływ rekuperatora",
+        "translation_key": "heat_recovery_flowrate",
         "icon": "mdi:heat-pump",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "bypass_flowrate": {
-        "name": "Przepływ bypass",
+        "translation_key": "bypass_flowrate",
         "icon": "mdi:pipe-leak",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "supply_air_flow": {
-        "name": "Strumień nawiewu",
+        "translation_key": "supply_air_flow",
         "icon": "mdi:fan",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "exhaust_air_flow": {
-        "name": "Strumień wywiewu",
+        "translation_key": "exhaust_air_flow",
         "icon": "mdi:fan-clock",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
@@ -209,7 +209,7 @@ SENSOR_DEFINITIONS = {
     
     # Air quality sensors
     "co2_level": {
-        "name": "Poziom CO2",
+        "translation_key": "co2_level",
         "icon": "mdi:molecule-co2",
         "device_class": SensorDeviceClass.CO2,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -217,7 +217,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "humidity_indoor": {
-        "name": "Wilgotność wewnętrzna",
+        "translation_key": "humidity_indoor",
         "icon": "mdi:water-percent",
         "device_class": SensorDeviceClass.HUMIDITY,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -225,7 +225,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "humidity_outdoor": {
-        "name": "Wilgotność zewnętrzna",
+        "translation_key": "humidity_outdoor",
         "icon": "mdi:water-percent",
         "device_class": SensorDeviceClass.HUMIDITY,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -233,7 +233,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "pm1_level": {
-        "name": "PM1.0",
+        "translation_key": "pm1_level",
         "icon": "mdi:air-filter",
         "device_class": SensorDeviceClass.PM1,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -241,7 +241,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "pm25_level": {
-        "name": "PM2.5",
+        "translation_key": "pm25_level",
         "icon": "mdi:air-filter",
         "device_class": SensorDeviceClass.PM25,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -249,7 +249,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "pm10_level": {
-        "name": "PM10",
+        "translation_key": "pm10_level",
         "icon": "mdi:air-filter",
         "device_class": SensorDeviceClass.PM10,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -257,7 +257,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "voc_level": {
-        "name": "VOC",
+        "translation_key": "voc_level",
         "icon": "mdi:air-filter",
         "device_class": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -265,7 +265,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "air_quality_index": {
-        "name": "Indeks jakości powietrza",
+        "translation_key": "air_quality_index",
         "icon": "mdi:air-filter",
         "device_class": SensorDeviceClass.AQI,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -275,14 +275,14 @@ SENSOR_DEFINITIONS = {
     
     # System efficiency and status
     "heat_recovery_efficiency": {
-        "name": "Sprawność rekuperacji",
+        "translation_key": "heat_recovery_efficiency",
         "icon": "mdi:percent",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": PERCENTAGE,
         "register_type": "input_registers",
     },
     "filter_lifetime_remaining": {
-        "name": "Pozostały czas życia filtra",
+        "translation_key": "filter_lifetime_remaining",
         "icon": "mdi:filter-variant",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfTime.DAYS,
@@ -291,7 +291,7 @@ SENSOR_DEFINITIONS = {
     
     # Power and energy sensors
     "preheater_power": {
-        "name": "Moc wstępnego grzania",
+        "translation_key": "preheater_power",
         "icon": "mdi:heating-coil",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -299,7 +299,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "main_heater_power": {
-        "name": "Moc głównego grzania",
+        "translation_key": "main_heater_power",
         "icon": "mdi:heating-coil",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -307,7 +307,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "cooler_power": {
-        "name": "Moc chłodzenia",
+        "translation_key": "cooler_power",
         "icon": "mdi:snowflake",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -315,7 +315,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "supply_fan_power": {
-        "name": "Moc wentylatora nawiewnego",
+        "translation_key": "supply_fan_power",
         "icon": "mdi:fan",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -323,7 +323,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "exhaust_fan_power": {
-        "name": "Moc wentylatora wywiewnego",
+        "translation_key": "exhaust_fan_power",
         "icon": "mdi:fan-clock",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -331,7 +331,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "total_power_consumption": {
-        "name": "Całkowite zużycie energii",
+        "translation_key": "total_power_consumption",
         "icon": "mdi:lightning-bolt",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -339,7 +339,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "daily_energy_consumption": {
-        "name": "Dzienne zużycie energii",
+        "translation_key": "daily_energy_consumption",
         "icon": "mdi:counter",
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
@@ -347,7 +347,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "annual_energy_consumption": {
-        "name": "Roczne zużycie energii",
+        "translation_key": "annual_energy_consumption",
         "icon": "mdi:counter",
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
@@ -355,7 +355,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "annual_energy_savings": {
-        "name": "Roczne oszczędności energii",
+        "translation_key": "annual_energy_savings",
         "icon": "mdi:leaf",
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
@@ -363,7 +363,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "co2_reduction": {
-        "name": "Redukcja CO2",
+        "translation_key": "co2_reduction",
         "icon": "mdi:tree",
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "unit": "kg/rok",
@@ -372,28 +372,28 @@ SENSOR_DEFINITIONS = {
     
     # System diagnostics
     "system_uptime": {
-        "name": "Czas pracy systemu",
+        "translation_key": "system_uptime",
         "icon": "mdi:clock-outline",
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "unit": UnitOfTime.HOURS,
         "register_type": "input_registers",
     },
     "fault_counter": {
-        "name": "Licznik błędów",
+        "translation_key": "fault_counter",
         "icon": "mdi:alert-circle",
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "unit": None,
         "register_type": "input_registers",
     },
     "maintenance_counter": {
-        "name": "Licznik konserwacji",
+        "translation_key": "maintenance_counter",
         "icon": "mdi:wrench",
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "unit": None,
         "register_type": "input_registers",
     },
     "filter_replacement_counter": {
-        "name": "Licznik wymian filtra",
+        "translation_key": "filter_replacement_counter",
         "icon": "mdi:filter-variant",
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "unit": None,
@@ -402,7 +402,7 @@ SENSOR_DEFINITIONS = {
     
     # Pressure sensors
     "supply_pressure": {
-        "name": "Ciśnienie nawiewu",
+        "translation_key": "supply_pressure",
         "icon": "mdi:gauge",
         "device_class": SensorDeviceClass.PRESSURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -410,7 +410,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "exhaust_pressure": {
-        "name": "Ciśnienie wywiewu",
+        "translation_key": "exhaust_pressure",
         "icon": "mdi:gauge",
         "device_class": SensorDeviceClass.PRESSURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -418,7 +418,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "differential_pressure": {
-        "name": "Ciśnienie różnicowe",
+        "translation_key": "differential_pressure",
         "icon": "mdi:gauge",
         "device_class": SensorDeviceClass.PRESSURE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -428,21 +428,21 @@ SENSOR_DEFINITIONS = {
     
     # Motor diagnostics
     "motor_supply_rpm": {
-        "name": "Obroty silnika nawiewnego",
+        "translation_key": "motor_supply_rpm",
         "icon": "mdi:fan",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": REVOLUTIONS_PER_MINUTE,
         "register_type": "input_registers",
     },
     "motor_exhaust_rpm": {
-        "name": "Obroty silnika wywiewnego",
+        "translation_key": "motor_exhaust_rpm",
         "icon": "mdi:fan-clock",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": REVOLUTIONS_PER_MINUTE,
         "register_type": "input_registers",
     },
     "motor_supply_current": {
-        "name": "Prąd silnika nawiewnego",
+        "translation_key": "motor_supply_current",
         "icon": "mdi:current-ac",
         "device_class": SensorDeviceClass.CURRENT,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -450,7 +450,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "motor_exhaust_current": {
-        "name": "Prąd silnika wywiewnego",
+        "translation_key": "motor_exhaust_current",
         "icon": "mdi:current-ac",
         "device_class": SensorDeviceClass.CURRENT,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -458,7 +458,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "motor_supply_voltage": {
-        "name": "Napięcie silnika nawiewnego",
+        "translation_key": "motor_supply_voltage",
         "icon": "mdi:lightning-bolt",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -466,7 +466,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "motor_exhaust_voltage": {
-        "name": "Napięcie silnika wywiewnego",
+        "translation_key": "motor_exhaust_voltage",
         "icon": "mdi:lightning-bolt",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -476,7 +476,7 @@ SENSOR_DEFINITIONS = {
     
     # PWM control values
     "dac_supply": {
-        "name": "Sterowanie wentylatorem nawiewnym",
+        "translation_key": "dac_supply",
         "icon": "mdi:sine-wave",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -484,7 +484,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "dac_exhaust": {
-        "name": "Sterowanie wentylatorem wywiewnym",
+        "translation_key": "dac_exhaust",
         "icon": "mdi:sine-wave",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -492,7 +492,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "dac_heater": {
-        "name": "Sterowanie nagrzewnicą",
+        "translation_key": "dac_heater",
         "icon": "mdi:sine-wave",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -500,7 +500,7 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     "dac_cooler": {
-        "name": "Sterowanie chłodnicą",
+        "translation_key": "dac_cooler",
         "icon": "mdi:sine-wave",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
@@ -510,21 +510,21 @@ SENSOR_DEFINITIONS = {
     
     # Damper positions
     "damper_position_bypass": {
-        "name": "Pozycja przepustnicy bypass",
+        "translation_key": "damper_position_bypass",
         "icon": "mdi:valve",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": PERCENTAGE,
         "register_type": "input_registers",
     },
     "damper_position_gwc": {
-        "name": "Pozycja przepustnicy GWC",
+        "translation_key": "damper_position_gwc",
         "icon": "mdi:valve",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": PERCENTAGE,
         "register_type": "input_registers",
     },
     "damper_position_mix": {
-        "name": "Pozycja przepustnicy mieszającej",
+        "translation_key": "damper_position_mix",
         "icon": "mdi:valve",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": PERCENTAGE,
@@ -533,25 +533,25 @@ SENSOR_DEFINITIONS = {
     
     # Firmware and version info
     "firmware_major": {
-        "name": "Wersja firmware (główna)",
+        "translation_key": "firmware_major",
         "icon": "mdi:chip",
         "unit": None,
         "register_type": "input_registers",
     },
     "firmware_minor": {
-        "name": "Wersja firmware (podrzędna)",
+        "translation_key": "firmware_minor",
         "icon": "mdi:chip",
         "unit": None,
         "register_type": "input_registers",
     },
     "firmware_patch": {
-        "name": "Wersja firmware (poprawka)",
+        "translation_key": "firmware_patch",
         "icon": "mdi:chip",
         "unit": None,
         "register_type": "input_registers",
     },
     "expansion_version": {
-        "name": "Wersja modułu Expansion",
+        "translation_key": "expansion_version",
         "icon": "mdi:expansion-card",
         "unit": None,
         "register_type": "input_registers",
@@ -576,7 +576,7 @@ async def async_setup_entry(
         # Check if this register is available on the device
         if register_name in coordinator.available_registers.get(register_type, set()):
             entities.append(ThesslaGreenSensor(coordinator, register_name, sensor_def))
-            _LOGGER.debug("Created sensor: %s", sensor_def["name"])
+            _LOGGER.debug("Created sensor: %s", sensor_def["translation_key"])
     
     if entities:
         async_add_entities(entities, True)
@@ -602,16 +602,23 @@ class ThesslaGreenSensor(CoordinatorEntity, SensorEntity):
         
         # Entity attributes
         self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
-        self._attr_name = f"{coordinator.device_name} {sensor_definition['name']}"
         self._attr_device_info = coordinator.device_info_dict
-        
+
         # Sensor specific attributes
         self._attr_icon = sensor_definition.get("icon")
         self._attr_native_unit_of_measurement = sensor_definition.get("unit")
         self._attr_device_class = sensor_definition.get("device_class")
         self._attr_state_class = sensor_definition.get("state_class")
-        
-        _LOGGER.debug("Sensor initialized: %s (%s)", self._attr_name, register_name)
+
+        # Translation setup
+        self._attr_translation_key = sensor_definition.get("translation_key")
+        self._attr_has_entity_name = True
+
+        _LOGGER.debug(
+            "Sensor initialized: %s (%s)",
+            sensor_definition.get("translation_key"),
+            register_name,
+        )
 
     @property
     def native_value(self) -> Optional[float | int | str]:

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -121,6 +121,132 @@
       },
       "system_uptime": {
         "name": "System Uptime"
+      },
+      "heat_exchanger_temperature_1": {
+        "name": "Heat Exchanger Temperature 1"
+      },
+      "heat_exchanger_temperature_2": {
+        "name": "Heat Exchanger Temperature 2"
+      },
+      "heat_exchanger_temperature_3": {
+        "name": "Heat Exchanger Temperature 3"
+      },
+      "heat_exchanger_temperature_4": {
+        "name": "Heat Exchanger Temperature 4"
+      },
+      "outdoor_flowrate": {
+        "name": "Outdoor Airflow"
+      },
+      "inside_flowrate": {
+        "name": "Indoor Airflow"
+      },
+      "gwc_flowrate": {
+        "name": "GWC Airflow"
+      },
+      "heat_recovery_flowrate": {
+        "name": "Heat Recovery Airflow"
+      },
+      "bypass_flowrate": {
+        "name": "Bypass Airflow"
+      },
+      "supply_air_flow": {
+        "name": "Supply Air Flow"
+      },
+      "exhaust_air_flow": {
+        "name": "Exhaust Air Flow"
+      },
+      "pm1_level": {
+        "name": "PM1"
+      },
+      "preheater_power": {
+        "name": "Preheater Power"
+      },
+      "main_heater_power": {
+        "name": "Main Heater Power"
+      },
+      "cooler_power": {
+        "name": "Cooler Power"
+      },
+      "supply_fan_power": {
+        "name": "Supply Fan Power"
+      },
+      "exhaust_fan_power": {
+        "name": "Exhaust Fan Power"
+      },
+      "annual_energy_savings": {
+        "name": "Annual Energy Savings"
+      },
+      "co2_reduction": {
+        "name": "CO2 Reduction"
+      },
+      "fault_counter": {
+        "name": "Fault Counter"
+      },
+      "maintenance_counter": {
+        "name": "Maintenance Counter"
+      },
+      "filter_replacement_counter": {
+        "name": "Filter Replacement Counter"
+      },
+      "supply_pressure": {
+        "name": "Supply Pressure"
+      },
+      "exhaust_pressure": {
+        "name": "Exhaust Pressure"
+      },
+      "differential_pressure": {
+        "name": "Differential Pressure"
+      },
+      "motor_supply_rpm": {
+        "name": "Supply Fan RPM"
+      },
+      "motor_exhaust_rpm": {
+        "name": "Exhaust Fan RPM"
+      },
+      "motor_supply_current": {
+        "name": "Supply Fan Current"
+      },
+      "motor_exhaust_current": {
+        "name": "Exhaust Fan Current"
+      },
+      "motor_supply_voltage": {
+        "name": "Supply Fan Voltage"
+      },
+      "motor_exhaust_voltage": {
+        "name": "Exhaust Fan Voltage"
+      },
+      "dac_supply": {
+        "name": "Supply DAC"
+      },
+      "dac_exhaust": {
+        "name": "Exhaust DAC"
+      },
+      "dac_heater": {
+        "name": "Heater DAC"
+      },
+      "dac_cooler": {
+        "name": "Cooler DAC"
+      },
+      "damper_position_bypass": {
+        "name": "Bypass Damper Position"
+      },
+      "damper_position_gwc": {
+        "name": "GWC Damper Position"
+      },
+      "damper_position_mix": {
+        "name": "Mix Damper Position"
+      },
+      "firmware_major": {
+        "name": "Firmware Major"
+      },
+      "firmware_minor": {
+        "name": "Firmware Minor"
+      },
+      "firmware_patch": {
+        "name": "Firmware Patch"
+      },
+      "expansion_version": {
+        "name": "Expansion Version"
       }
     },
     "binary_sensor": {
@@ -162,6 +288,84 @@
       },
       "communication_error": {
         "name": "Communication Error"
+      },
+      "duct_water_heater_pump": {
+        "name": "Water Heater Pump"
+      },
+      "info": {
+        "name": "Unit Operation Confirmation"
+      },
+      "work_permit": {
+        "name": "Work Permit"
+      },
+      "hood": {
+        "name": "Hood"
+      },
+      "expansion": {
+        "name": "Expansion Module"
+      },
+      "contamination_sensor": {
+        "name": "Contamination Sensor"
+      },
+      "external_contact_1": {
+        "name": "External Contact 1"
+      },
+      "external_contact_2": {
+        "name": "External Contact 2"
+      },
+      "external_contact_3": {
+        "name": "External Contact 3"
+      },
+      "external_contact_4": {
+        "name": "External Contact 4"
+      },
+      "fire_alarm": {
+        "name": "Fire Alarm"
+      },
+      "frost_alarm": {
+        "name": "Frost Alarm"
+      },
+      "fan_error": {
+        "name": "Fan Error"
+      },
+      "heater_error": {
+        "name": "Heater Error"
+      },
+      "cooler_error": {
+        "name": "Cooler Error"
+      },
+      "bypass_error": {
+        "name": "Bypass Error"
+      },
+      "gwc_error": {
+        "name": "GWC Error"
+      },
+      "expansion_error": {
+        "name": "Expansion Module Error"
+      },
+      "night_cooling_active": {
+        "name": "Night Cooling Active"
+      },
+      "air_quality_control_active": {
+        "name": "Air Quality Control Active"
+      },
+      "humidity_control_active": {
+        "name": "Humidity Control Active"
+      },
+      "temperature_control_active": {
+        "name": "Temperature Control Active"
+      },
+      "demand_control_active": {
+        "name": "Demand Control Active"
+      },
+      "schedule_control_active": {
+        "name": "Schedule Control Active"
+      },
+      "manual_control_active": {
+        "name": "Manual Control Active"
+      },
+      "on_off_panel_mode": {
+        "name": "Panel Power"
       }
     },
     "climate": {
@@ -182,7 +386,7 @@
         "name": "Bypass Mode",
         "state": {
           "auto": "Auto",
-          "open": "Open", 
+          "open": "Open",
           "closed": "Closed"
         }
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -103,6 +103,171 @@
       },
       "warning_code": {
         "name": "Kod ostrzeżenia"
+      },
+      "heating_temperature": {
+        "name": "Temperatura grzania"
+      },
+      "heat_exchanger_temperature_1": {
+        "name": "Temperatura wymiennika 1"
+      },
+      "heat_exchanger_temperature_2": {
+        "name": "Temperatura wymiennika 2"
+      },
+      "heat_exchanger_temperature_3": {
+        "name": "Temperatura wymiennika 3"
+      },
+      "heat_exchanger_temperature_4": {
+        "name": "Temperatura wymiennika 4"
+      },
+      "outdoor_flowrate": {
+        "name": "Przepływ zewnętrzny"
+      },
+      "inside_flowrate": {
+        "name": "Przepływ wewnętrzny"
+      },
+      "gwc_flowrate": {
+        "name": "Przepływ GWC"
+      },
+      "heat_recovery_flowrate": {
+        "name": "Przepływ rekuperatora"
+      },
+      "bypass_flowrate": {
+        "name": "Przepływ bypass"
+      },
+      "supply_air_flow": {
+        "name": "Strumień nawiewu"
+      },
+      "exhaust_air_flow": {
+        "name": "Strumień wywiewu"
+      },
+      "co2_level": {
+        "name": "Poziom CO2"
+      },
+      "humidity_indoor": {
+        "name": "Wilgotność wewnętrzna"
+      },
+      "humidity_outdoor": {
+        "name": "Wilgotność zewnętrzna"
+      },
+      "pm1_level": {
+        "name": "PM1.0"
+      },
+      "pm25_level": {
+        "name": "PM2.5"
+      },
+      "pm10_level": {
+        "name": "PM10"
+      },
+      "voc_level": {
+        "name": "VOC"
+      },
+      "air_quality_index": {
+        "name": "Indeks jakości powietrza"
+      },
+      "filter_lifetime_remaining": {
+        "name": "Pozostały czas życia filtra"
+      },
+      "preheater_power": {
+        "name": "Moc wstępnego grzania"
+      },
+      "main_heater_power": {
+        "name": "Moc głównego grzania"
+      },
+      "cooler_power": {
+        "name": "Moc chłodzenia"
+      },
+      "supply_fan_power": {
+        "name": "Moc wentylatora nawiewnego"
+      },
+      "exhaust_fan_power": {
+        "name": "Moc wentylatora wywiewnego"
+      },
+      "total_power_consumption": {
+        "name": "Całkowite zużycie energii"
+      },
+      "daily_energy_consumption": {
+        "name": "Dzienne zużycie energii"
+      },
+      "annual_energy_consumption": {
+        "name": "Roczne zużycie energii"
+      },
+      "annual_energy_savings": {
+        "name": "Roczne oszczędności energii"
+      },
+      "co2_reduction": {
+        "name": "Redukcja CO2"
+      },
+      "system_uptime": {
+        "name": "Czas pracy systemu"
+      },
+      "fault_counter": {
+        "name": "Licznik błędów"
+      },
+      "maintenance_counter": {
+        "name": "Licznik konserwacji"
+      },
+      "filter_replacement_counter": {
+        "name": "Licznik wymian filtra"
+      },
+      "supply_pressure": {
+        "name": "Ciśnienie nawiewu"
+      },
+      "exhaust_pressure": {
+        "name": "Ciśnienie wywiewu"
+      },
+      "differential_pressure": {
+        "name": "Ciśnienie różnicowe"
+      },
+      "motor_supply_rpm": {
+        "name": "Obroty silnika nawiewnego"
+      },
+      "motor_exhaust_rpm": {
+        "name": "Obroty silnika wywiewnego"
+      },
+      "motor_supply_current": {
+        "name": "Prąd silnika nawiewnego"
+      },
+      "motor_exhaust_current": {
+        "name": "Prąd silnika wywiewnego"
+      },
+      "motor_supply_voltage": {
+        "name": "Napięcie silnika nawiewnego"
+      },
+      "motor_exhaust_voltage": {
+        "name": "Napięcie silnika wywiewnego"
+      },
+      "dac_supply": {
+        "name": "Sterowanie wentylatorem nawiewnym"
+      },
+      "dac_exhaust": {
+        "name": "Sterowanie wentylatorem wywiewnym"
+      },
+      "dac_heater": {
+        "name": "Sterowanie nagrzewnicą"
+      },
+      "dac_cooler": {
+        "name": "Sterowanie chłodnicą"
+      },
+      "damper_position_bypass": {
+        "name": "Pozycja przepustnicy bypass"
+      },
+      "damper_position_gwc": {
+        "name": "Pozycja przepustnicy GWC"
+      },
+      "damper_position_mix": {
+        "name": "Pozycja przepustnicy mieszającej"
+      },
+      "firmware_major": {
+        "name": "Wersja firmware (główna)"
+      },
+      "firmware_minor": {
+        "name": "Wersja firmware (podrzędna)"
+      },
+      "firmware_patch": {
+        "name": "Wersja firmware (poprawka)"
+      },
+      "expansion_version": {
+        "name": "Wersja modułu Expansion"
       }
     },
     "binary_sensor": {
@@ -129,6 +294,105 @@
       },
       "expansion": {
         "name": "Moduł rozszerzający"
+      },
+      "duct_water_heater_pump": {
+        "name": "Pompa obiegowa nagrzewnicy"
+      },
+      "info": {
+        "name": "Potwierdzenie pracy centrali"
+      },
+      "work_permit": {
+        "name": "Potwierdzenie pracy (Expansion)"
+      },
+      "hood": {
+        "name": "Okap"
+      },
+      "contamination_sensor": {
+        "name": "Czujnik zanieczyszczenia"
+      },
+      "external_contact_1": {
+        "name": "Kontakt zewnętrzny 1"
+      },
+      "external_contact_2": {
+        "name": "Kontakt zewnętrzny 2"
+      },
+      "external_contact_3": {
+        "name": "Kontakt zewnętrzny 3"
+      },
+      "external_contact_4": {
+        "name": "Kontakt zewnętrzny 4"
+      },
+      "frost_alarm": {
+        "name": "Alarm przeciwmrozowy"
+      },
+      "filter_alarm": {
+        "name": "Alarm filtra"
+      },
+      "maintenance_alarm": {
+        "name": "Alarm konserwacji"
+      },
+      "sensor_error": {
+        "name": "Błąd czujnika"
+      },
+      "communication_error": {
+        "name": "Błąd komunikacji"
+      },
+      "fan_error": {
+        "name": "Błąd wentylatora"
+      },
+      "heater_error": {
+        "name": "Błąd grzałki"
+      },
+      "cooler_error": {
+        "name": "Błąd chłodnicy"
+      },
+      "bypass_error": {
+        "name": "Błąd bypass"
+      },
+      "gwc_error": {
+        "name": "Błąd GWC"
+      },
+      "expansion_error": {
+        "name": "Błąd modułu Expansion"
+      },
+      "frost_protection_active": {
+        "name": "Ochrona przeciwmrozowa"
+      },
+      "defrost_cycle_active": {
+        "name": "Cykl odszraniania"
+      },
+      "summer_bypass_active": {
+        "name": "Letni bypass"
+      },
+      "winter_heating_active": {
+        "name": "Zimowe grzanie"
+      },
+      "night_cooling_active": {
+        "name": "Nocne chłodzenie"
+      },
+      "constant_flow_active": {
+        "name": "Stały przepływ"
+      },
+      "air_quality_control_active": {
+        "name": "Kontrola jakości powietrza"
+      },
+      "humidity_control_active": {
+        "name": "Kontrola wilgotności"
+      },
+      "temperature_control_active": {
+        "name": "Kontrola temperatury"
+      },
+      "demand_control_active": {
+        "name": "Kontrola na żądanie"
+      },
+      "schedule_control_active": {
+        "name": "Kontrola harmonogramu"
+      },
+      "manual_control_active": {
+        "name": "Kontrola manualna"
+      },
+      "on_off_panel_mode": {
+        "name": "Zasilanie główne"
       }
     },
     "climate": {


### PR DESCRIPTION
## Summary
- replace hard-coded `name` values in sensors and binary sensors with `translation_key`
- add English and Polish translation entries for new keys
- initialize entities using translation-based names

## Testing
- `pytest` *(fails: ImportError: cannot import name 'AsyncModbusTcpClient')*

------
https://chatgpt.com/codex/tasks/task_e_689a52321344832697cf80ac5b485ac4