### PR TITLE
Bump config flow version and refine migration

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -157,32 +157,35 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug("Migrating ThesslaGreen Modbus from version %s", config_entry.version)
-    
-    if config_entry.version == 1:
-        # Migration from version 1 to 2
-        new_data = {**config_entry.data}
-        new_options = {**config_entry.options}
-        
-        # Migrate "unit" to CONF_SLAVE_ID if needed
-        if "unit" in new_data and CONF_SLAVE_ID not in new_data:
-            new_data[CONF_SLAVE_ID] = new_data["unit"]
-            _LOGGER.info("Migrated 'unit' to '%s'", CONF_SLAVE_ID)
-        
-        # Add new fields with defaults if missing
-        if CONF_SCAN_INTERVAL not in new_options:
-            new_options[CONF_SCAN_INTERVAL] = DEFAULT_SCAN_INTERVAL
-        if CONF_TIMEOUT not in new_options:
-            new_options[CONF_TIMEOUT] = DEFAULT_TIMEOUT
-        if CONF_RETRY not in new_options:
-            new_options[CONF_RETRY] = DEFAULT_RETRY
-        if CONF_FORCE_FULL_REGISTER_LIST not in new_options:
-            new_options[CONF_FORCE_FULL_REGISTER_LIST] = False
-        
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(
-            config_entry, data=new_data, options=new_options
-        )
-    
+    _LOGGER.debug(
+        "Migrating ThesslaGreen Modbus from version %s", config_entry.version
+    )
+
+    if config_entry.version != 1:
+        return True
+
+    new_data = {**config_entry.data}
+    new_options = {**config_entry.options}
+
+    # Migrate "unit" to CONF_SLAVE_ID if needed
+    if "unit" in new_data and CONF_SLAVE_ID not in new_data:
+        new_data[CONF_SLAVE_ID] = new_data["unit"]
+        _LOGGER.info("Migrated 'unit' to '%s'", CONF_SLAVE_ID)
+
+    # Add new fields with defaults if missing
+    if CONF_SCAN_INTERVAL not in new_options:
+        new_options[CONF_SCAN_INTERVAL] = DEFAULT_SCAN_INTERVAL
+    if CONF_TIMEOUT not in new_options:
+        new_options[CONF_TIMEOUT] = DEFAULT_TIMEOUT
+    if CONF_RETRY not in new_options:
+        new_options[CONF_RETRY] = DEFAULT_RETRY
+    if CONF_FORCE_FULL_REGISTER_LIST not in new_options:
+        new_options[CONF_FORCE_FULL_REGISTER_LIST] = False
+
+    config_entry.version = 2
+    hass.config_entries.async_update_entry(
+        config_entry, data=new_data, options=new_options
+    )
+
     _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -78,7 +78,7 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ThesslaGreen Modbus."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self):
         """Initialize config flow."""


### PR DESCRIPTION
## Summary
- Set config flow version to 2
- Handle only version 1 to 2 config entry migrations and always return success

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for homeassistant>=2025.7.0)*
- `pytest` *(fails: ImportError: cannot import name 'CONF_NAME' from 'homeassistant.const')*

------
https://chatgpt.com/codex/tasks/task_e_689a56cde4408326ba035889ab1c9b73