### PR TITLE
chore: add newline to services spec

### DIFF
--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -63,7 +63,7 @@ set_airflow_schedule:
         select:
           options:
             - "monday"
-            - "tuesday" 
+            - "tuesday"
             - "wednesday"
             - "thursday"
             - "friday"


### PR DESCRIPTION
## Summary
- add newline at end of `services.yaml`
- fix stray trailing whitespace in services list

## Testing
- `python -m yamllint custom_components/thessla_green_modbus/services.yaml`
- `pytest` *(fails: No matching distribution found for homeassistant>=2025.7.0)*

------
https://chatgpt.com/codex/tasks/task_e_689a56d4cc648326bf428ce1f01a3520