### PR TITLE
Replace device_info_dict usage with get_device_info

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -306,10 +306,10 @@ class ThesslaGreenBinarySensor(CoordinatorEntity, BinarySensorEntity):
         
         self._register_name = register_name
         self._sensor_def = sensor_definition
-        
+
         # Entity attributes
         self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
-        self._attr_device_info = coordinator.device_info_dict
+        self._attr_device_info = coordinator.get_device_info()
 
         # Binary sensor specific attributes
         self._attr_icon = sensor_definition.get("icon")

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -77,7 +77,7 @@ class ThesslaGreenClimate(CoordinatorEntity, ClimateEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_climate"
         self._attr_name = f"{coordinator.device_name} Rekuperator"
-        self._attr_device_info = coordinator.device_info_dict
+        self._attr_device_info = coordinator.get_device_info()
         
         # Climate features
         self._attr_supported_features = (

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -77,7 +77,7 @@ class ThesslaGreenSelect(CoordinatorEntity, SelectEntity):
 
         self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
         self._attr_name = f"{coordinator.device_name} {definition['name']}"
-        self._attr_device_info = coordinator.device_info_dict
+        self._attr_device_info = coordinator.get_device_info()
         self._attr_icon = definition.get("icon")
         self._attr_options = definition["options"]
 

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -599,10 +599,10 @@ class ThesslaGreenSensor(CoordinatorEntity, SensorEntity):
         
         self._register_name = register_name
         self._sensor_def = sensor_definition
-        
+
         # Entity attributes
         self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
-        self._attr_device_info = coordinator.device_info_dict
+        self._attr_device_info = coordinator.get_device_info()
 
         # Sensor specific attributes
         self._attr_icon = sensor_definition.get("icon")

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -403,10 +403,10 @@ def _get_coordinator_from_entity_id(hass: HomeAssistant, entity_id: str):
     """Get coordinator from entity ID."""
     # Find the config entry that matches this entity
     for entry_id, coordinator in hass.data.get(DOMAIN, {}).items():
-        if hasattr(coordinator, 'device_info_dict'):
+        if hasattr(coordinator, "get_device_info"):
             # Check if this entity belongs to this coordinator
-            device_identifiers = coordinator.device_info_dict.get("identifiers", set())
-            for domain, identifier in device_identifiers:
+            device_info = coordinator.get_device_info()
+            for domain, identifier in getattr(device_info, "identifiers", set()):
                 if domain == DOMAIN and identifier in entity_id:
                     return coordinator
     return None


### PR DESCRIPTION
## Summary
- replace outdated `device_info_dict` lookups with `get_device_info`
- assign `DeviceInfo` directly to `_attr_device_info` for all entities
- align service helper with new coordinator API

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689a56eb89b88326bb0e19af6ba1a83f