### PR TITLE
chore: pin pymodbus dependency upper bound

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",
   "requirements": [
-    "pymodbus>=3.5.0"
+    "pymodbus>=3.5.0,<4.0.0"
   ],
   "version": "2.1.1",
   "integration_type": "device",


### PR DESCRIPTION
## Summary
- align manifest's pymodbus requirement with pyproject by adding <4.0.0 upper bound

## Testing
- `pytest` *(fails: ImportError cannot import name 'ModbusIOException' from 'pymodbus.exceptions')*


------
https://chatgpt.com/codex/tasks/task_e_689a572bd33883269d845cd92b96aad2