### PR TITLE
Await Modbus client close in coordinator

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -515,7 +515,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         """Disconnect from Modbus device."""
         if self.client:
             try:
-                self.client.close()
+                await self.client.close()
                 _LOGGER.debug("Disconnected from Modbus device")
             except Exception as exc:
                 _LOGGER.debug("Error disconnecting: %s", exc)


### PR DESCRIPTION
## Summary
- await Modbus client close operation

## Testing
- `pytest` *(fails: cannot import name 'ModbusIOException', cannot import name 'CONF_NAME' from 'homeassistant.const')*

------
https://chatgpt.com/codex/tasks/task_e_689a58d319808326ac9255c3a669f0c2