### PR TITLE
Refactor entity naming to use translations

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -1,4 +1,5 @@
 """Fan platform for the ThesslaGreen Modbus integration."""
+
 from __future__ import annotations
 
 import logging
@@ -19,6 +20,7 @@ from .coordinator import ThesslaGreenModbusCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -26,20 +28,29 @@ async def async_setup_entry(
 ) -> None:
     """Set up ThesslaGreen fan from config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    
+
     # Check if fan control is available
-    fan_registers = ["air_flow_rate_manual", "air_flow_rate_auto", "supply_percentage", "exhaust_percentage"]
-    
+    fan_registers = [
+        "air_flow_rate_manual",
+        "air_flow_rate_auto",
+        "supply_percentage",
+        "exhaust_percentage",
+    ]
+
     has_fan_registers = False
     for register in fan_registers:
-        if register in coordinator.available_registers.get("holding", {}) or register in coordinator.available_registers.get("input", {}):
+        if register in coordinator.available_registers.get(
+            "holding", {}
+        ) or register in coordinator.available_registers.get("input", {}):
             has_fan_registers = True
             break
-    
+
     # If force full register list, assume fan is available
     if not has_fan_registers and coordinator.force_full_register_list:
-        has_fan_registers = any(register in HOLDING_REGISTERS for register in fan_registers[:2])  # Only check writable registers
-    
+        has_fan_registers = any(
+            register in HOLDING_REGISTERS for register in fan_registers[:2]
+        )  # Only check writable registers
+
     if has_fan_registers:
         async_add_entities([ThesslaGreenFan(coordinator)])
         _LOGGER.info("Added fan entity")
@@ -49,24 +60,25 @@ async def async_setup_entry(
 
 class ThesslaGreenFan(CoordinatorEntity, FanEntity):
     """ThesslaGreen fan entity."""
-    
+
     def __init__(self, coordinator: ThesslaGreenModbusCoordinator) -> None:
         """Initialize the fan entity."""
         super().__init__(coordinator)
-        
+
         # Entity configuration
-        self._attr_name = f"{coordinator.device_name} Ventilation"
         self._attr_unique_id = f"{coordinator.device_name}_fan"
+        self._attr_translation_key = "thessla_green_fan"
+        self._attr_has_entity_name = True
         self._attr_device_info = coordinator.get_device_info()
-        
+
         # Fan configuration
         self._attr_supported_features = FanEntityFeature.SET_SPEED
-        
+
         # Speed range (10-100% as per ThesslaGreen specs)
         self._attr_speed_count = 9  # 10%, 20%, ..., 90%, 100%
-        
+
         _LOGGER.debug("Initialized fan entity")
-    
+
     @property
     def is_on(self) -> bool | None:
         """Return true if fan is on."""
@@ -74,42 +86,42 @@ class ThesslaGreenFan(CoordinatorEntity, FanEntity):
         if "on_off_panel_mode" in self.coordinator.data:
             if not self.coordinator.data["on_off_panel_mode"]:
                 return False
-        
+
         # Check current flow rate
         flow_rate = self._get_current_flow_rate()
         if flow_rate is None:
             return None
-        
+
         return flow_rate > 0
-    
+
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
         flow_rate = self._get_current_flow_rate()
         if flow_rate is None:
             return None
-        
+
         # Convert to percentage (clamp to 0-100)
         return max(0, min(100, int(flow_rate)))
-    
+
     def _get_current_flow_rate(self) -> float | None:
         """Get current flow rate from available registers."""
         # Priority order for reading current flow rate
         flow_registers = [
-            "air_flow_rate",           # Current overall flow rate
-            "supply_percentage",       # Supply air percentage 
-            "air_flow_rate_manual",    # Manual flow rate setting
-            "air_flow_rate_auto",      # Auto flow rate setting
+            "air_flow_rate",  # Current overall flow rate
+            "supply_percentage",  # Supply air percentage
+            "air_flow_rate_manual",  # Manual flow rate setting
+            "air_flow_rate_auto",  # Auto flow rate setting
         ]
-        
+
         for register in flow_registers:
             if register in self.coordinator.data:
                 value = self.coordinator.data[register]
                 if value is not None and isinstance(value, (int, float)):
                     return float(value)
-        
+
         return None
-    
+
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -121,19 +133,19 @@ class ThesslaGreenFan(CoordinatorEntity, FanEntity):
             # First ensure system is on
             if "on_off_panel_mode" in HOLDING_REGISTERS:
                 await self._write_register("on_off_panel_mode", 1)
-            
+
             # Set flow rate
             if percentage is not None:
                 await self.async_set_percentage(percentage)
             else:
                 # Default to 50% if no percentage specified
                 await self.async_set_percentage(50)
-            
+
             _LOGGER.info("Turned on fan")
-            
+
         except Exception as exc:
             _LOGGER.error("Failed to turn on fan: %s", exc)
-    
+
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         try:
@@ -159,20 +171,20 @@ class ThesslaGreenFan(CoordinatorEntity, FanEntity):
 
         except Exception as exc:
             _LOGGER.error("Failed to turn off fan: %s", exc)
-    
+
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         if percentage < 0 or percentage > 100:
             _LOGGER.error("Invalid percentage %d (must be 0-100)", percentage)
             return
-        
+
         try:
             # Ensure minimum flow rate (ThesslaGreen typically requires 10% minimum)
             actual_percentage = max(10, percentage) if percentage > 0 else 10
-            
+
             # Determine which register to write based on current mode
             current_mode = self._get_current_mode()
-            
+
             if current_mode == "manual" or not current_mode:
                 # Set manual mode and flow rate
                 if "mode" in HOLDING_REGISTERS:
@@ -183,12 +195,12 @@ class ThesslaGreenFan(CoordinatorEntity, FanEntity):
                 # Auto mode - set auto flow rate
                 if "air_flow_rate_auto" in HOLDING_REGISTERS:
                     await self._write_register("air_flow_rate_auto", actual_percentage)
-            
+
             _LOGGER.info("Set fan speed to %d%%", actual_percentage)
-            
+
         except Exception as exc:
             _LOGGER.error("Failed to set fan speed to %d%%: %s", percentage, exc)
-    
+
     def _get_current_mode(self) -> str | None:
         """Get current system mode."""
         if "mode" in self.coordinator.data:
@@ -200,67 +212,68 @@ class ThesslaGreenFan(CoordinatorEntity, FanEntity):
             elif mode_value == 2:
                 return "temporary"
         return None
-    
+
     async def _write_register(self, register_name: str, value: int) -> None:
         """Write value to register."""
         if register_name not in HOLDING_REGISTERS:
             raise ValueError(f"Register {register_name} is not writable")
-        
+
         register_address = HOLDING_REGISTERS[register_name]
-        
+
         # Ensure client is connected
         if not self.coordinator.client or not self.coordinator.client.connected:
             if not await self.coordinator.async_ensure_client():
                 raise RuntimeError("Failed to connect to device")
-        
+
         # Write register - pymodbus 3.5+ compatible
         response = await self.coordinator.client.write_register(
-            address=register_address, 
-            value=value, 
-            slave=self.coordinator.slave_id
+            address=register_address, value=value, slave=self.coordinator.slave_id
         )
-        
+
         if response.isError():
             raise RuntimeError(f"Failed to write register {register_name}: {response}")
-        
+
         # Request immediate data update
         await self.coordinator.async_request_refresh()
-    
+
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         """Return additional state attributes."""
         attributes = {}
-        
+
         # Add flow information
         if "supply_flowrate" in self.coordinator.data:
             attributes["supply_flow"] = self.coordinator.data["supply_flowrate"]
-        
+
         if "exhaust_flowrate" in self.coordinator.data:
             attributes["exhaust_flow"] = self.coordinator.data["exhaust_flowrate"]
-        
+
         if "supply_percentage" in self.coordinator.data:
             attributes["supply_percentage"] = self.coordinator.data["supply_percentage"]
-        
+
         if "exhaust_percentage" in self.coordinator.data:
             attributes["exhaust_percentage"] = self.coordinator.data["exhaust_percentage"]
-        
+
         # Add current mode
         current_mode = self._get_current_mode()
         if current_mode:
             attributes["operating_mode"] = current_mode
-        
+
         # Add system status
         system_status = []
-        if "power_supply_fans" in self.coordinator.data and self.coordinator.data["power_supply_fans"]:
+        if (
+            "power_supply_fans" in self.coordinator.data
+            and self.coordinator.data["power_supply_fans"]
+        ):
             system_status.append("fans_powered")
         if "boost_mode" in self.coordinator.data and self.coordinator.data["boost_mode"]:
             system_status.append("boost_active")
         if "eco_mode" in self.coordinator.data and self.coordinator.data["eco_mode"]:
             system_status.append("eco_active")
-        
+
         if system_status:
             attributes["system_status"] = system_status
-        
+
         # Add last update time
         if self.coordinator.last_successful_update:
             attributes["last_updated"] = self.coordinator.last_successful_update.isoformat()

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -1,4 +1,5 @@
 """Number platform for the ThesslaGreen Modbus integration."""
+
 from __future__ import annotations
 
 import logging
@@ -25,6 +26,7 @@ UNIT_MAPPINGS = {
     "h": UnitOfTime.HOURS,
 }
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -32,29 +34,29 @@ async def async_setup_entry(
 ) -> None:
     """Set up ThesslaGreen number entities from config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    
+
     entities = []
-    
+
     # Get number entity mappings
     number_mappings = ENTITY_MAPPINGS.get("number", {})
-    
+
     # Create number entities for available writable registers
     for register_name, entity_config in number_mappings.items():
         # Check if this register is available and writable
         is_available = False
         register_type = None
-        
+
         # Only check holding registers as they are writable
         if register_name in coordinator.available_registers.get("holding", {}):
             is_available = True
             register_type = "holding"
-        
+
         # If force full register list, check against holding registers
         if not is_available and coordinator.force_full_register_list:
             if register_name in HOLDING_REGISTERS:
                 is_available = True
                 register_type = "holding"
-        
+
         if is_available:
             entities.append(
                 ThesslaGreenNumber(
@@ -65,7 +67,7 @@ async def async_setup_entry(
                 )
             )
             _LOGGER.debug("Created number entity: %s", register_name)
-    
+
     if entities:
         async_add_entities(entities)
         _LOGGER.info("Added %d number entities", len(entities))
@@ -75,7 +77,7 @@ async def async_setup_entry(
 
 class ThesslaGreenNumber(CoordinatorEntity, NumberEntity):
     """ThesslaGreen number entity."""
-    
+
     def __init__(
         self,
         coordinator: ThesslaGreenModbusCoordinator,
@@ -85,95 +87,42 @@ class ThesslaGreenNumber(CoordinatorEntity, NumberEntity):
     ) -> None:
         """Initialize the number entity."""
         super().__init__(coordinator)
-        
+
         self.register_name = register_name
         self.entity_config = entity_config
         self.register_type = register_type
-        
+
         # Entity configuration
-        self._attr_name = self._generate_entity_name()
         self._attr_unique_id = f"{coordinator.device_name}_{register_name}"
+        self._attr_translation_key = register_name
+        self._attr_has_entity_name = True
         self._attr_device_info = coordinator.get_device_info()
-        
+
         # Number configuration
         self._setup_number_attributes()
-        
-        _LOGGER.debug("Initialized number entity: %s (register: %s)", self._attr_name, register_name)
-    
-    def _generate_entity_name(self) -> str:
-        """Generate human-readable entity name."""
-        # Convert register name to human readable
-        name_parts = self.register_name.split("_")
-        
-        # Common replacements for better readability
-        replacements = {
-            "supply": "Supply",
-            "temperature": "Temperature", 
-            "manual": "Manual",
-            "auto": "Auto",
-            "heating": "Heating",
-            "cooling": "Cooling",
-            "comfort": "Comfort",
-            "eco": "Eco",
-            "anti": "Anti",
-            "freeze": "Freeze",
-            "hysteresis": "Hysteresis",
-            "sensor": "Sensor",
-            "correction": "Correction",
-            "temp": "Temperature",
-            "max": "Max",
-            "min": "Min",
-            "gwc": "GWC",
-            "switch": "Switch",
-            "air": "Air",
-            "flow": "Flow",
-            "rate": "Rate",
-            "temporary": "Temporary",
-            "boost": "Boost",
-            "minimum": "Minimum",
-            "night": "Night",
-            "okap": "Hood",
-            "intensity": "Intensity",
-            "duration": "Duration",
-            "party": "Party",
-            "fireplace": "Fireplace",
-            "reduction": "Reduction",
-            "vacation": "Vacation",
-            "mode": "Mode",
-            "balance": "Balance",
-            "correction": "Correction",
-        }
-        
-        # Apply replacements and capitalize
-        processed_parts = []
-        for part in name_parts:
-            if part in replacements:
-                processed_parts.append(replacements[part])
-            else:
-                processed_parts.append(part.capitalize())
-        
-        return " ".join(processed_parts)
-    
+
+        _LOGGER.debug("Initialized number entity for register: %s", register_name)
+
     def _setup_number_attributes(self) -> None:
         """Setup number attributes based on entity configuration."""
         # Unit of measurement
         if "unit" in self.entity_config:
             unit = self.entity_config["unit"]
             self._attr_native_unit_of_measurement = UNIT_MAPPINGS.get(unit, unit)
-        
+
         # Min/max values
         self._attr_native_min_value = self.entity_config.get("min", 0)
         self._attr_native_max_value = self.entity_config.get("max", 100)
-        
+
         # Step size
         self._attr_native_step = self.entity_config.get("step", 1)
-        
+
         # Mode - slider for temperatures and durations, box for others
         if "temperature" in self.register_name or "duration" in self.register_name:
             self._attr_mode = NumberMode.SLIDER
         else:
             self._attr_mode = NumberMode.BOX
-        
+
         # Icon
         if "temperature" in self.register_name:
             self._attr_icon = "mdi:thermometer"
@@ -185,112 +134,111 @@ class ThesslaGreenNumber(CoordinatorEntity, NumberEntity):
             self._attr_icon = "mdi:gauge"
         else:
             self._attr_icon = "mdi:numeric"
-        
+
         # Entity category for configuration parameters
-        if any(keyword in self.register_name for keyword in [
-            "hysteresis", "correction", "max", "min", "balance"
-        ]):
+        if any(
+            keyword in self.register_name
+            for keyword in ["hysteresis", "correction", "max", "min", "balance"]
+        ):
             self._attr_entity_category = EntityCategory.CONFIG
-    
+
     @property
     def native_value(self) -> float | None:
         """Return the current value."""
         if self.register_name not in self.coordinator.data:
             return None
-            
+
         raw_value = self.coordinator.data[self.register_name]
-        
+
         # Handle None values
         if raw_value is None:
             return None
-        
+
         # Apply scale factor if configured
         scale = self.entity_config.get("scale", 1)
         if scale != 1 and isinstance(raw_value, (int, float)):
             return round(float(raw_value) * scale, 2)
-        
+
         return float(raw_value) if isinstance(raw_value, (int, float)) else None
-    
+
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         try:
             # Apply inverse scale factor if configured
             scale = self.entity_config.get("scale", 1)
             scaled_value = value / scale if scale != 1 else value
-            
+
             await self._write_register(self.register_name, scaled_value)
             _LOGGER.info("Set %s to %.2f", self.register_name, value)
-            
+
         except Exception as exc:
             _LOGGER.error("Failed to set %s to %.2f: %s", self.register_name, value, exc)
-    
+
     async def _write_register(self, register_name: str, value: float) -> None:
         """Write value to register."""
         if register_name not in HOLDING_REGISTERS:
             raise ValueError(f"Register {register_name} is not writable")
-        
+
         register_address = HOLDING_REGISTERS[register_name]
-        
+
         # Convert to integer for Modbus
         int_value = int(round(value))
-        
+
         # Ensure client is connected
         if not self.coordinator.client or not self.coordinator.client.connected:
             if not await self.coordinator.async_ensure_client():
                 raise RuntimeError("Failed to connect to device")
-        
+
         # Write register - pymodbus 3.5+ compatible
         response = await self.coordinator.client.write_register(
-            address=register_address, 
-            value=int_value, 
-            slave=self.coordinator.slave_id
+            address=register_address, value=int_value, slave=self.coordinator.slave_id
         )
-        
+
         if response.isError():
             raise RuntimeError(f"Failed to write register {register_name}: {response}")
-        
+
         # Request immediate data update
         await self.coordinator.async_request_refresh()
-    
+
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         """Return additional state attributes."""
         attributes = {}
-        
+
         # Add register information
         attributes["register_name"] = self.register_name
         attributes["register_address"] = f"0x{HOLDING_REGISTERS.get(self.register_name, 0):04X}"
-        
+
         # Add raw value for debugging
         if self.register_name in self.coordinator.data:
             raw_value = self.coordinator.data[self.register_name]
             if raw_value is not None:
                 attributes["raw_value"] = raw_value
-        
+
         # Add scale information if applicable
         if "scale" in self.entity_config:
             attributes["scale_factor"] = self.entity_config["scale"]
-        
+
         # Add valid range
         attributes["valid_range"] = {
             "min": self._attr_native_min_value,
             "max": self._attr_native_max_value,
-            "step": self._attr_native_step
+            "step": self._attr_native_step,
         }
-        
+
         # Add last update time
         if self.coordinator.last_successful_update:
             attributes["last_updated"] = self.coordinator.last_successful_update.isoformat()
-        
+
         return attributes
-    
+
     @property
     def available(self) -> bool:
         """Return if entity is available."""
         # Entity is available if coordinator is available
         if not self.coordinator.last_update_success:
             return False
-            
+
         # For number entities, we don't require the register to be in current data
         # as they are primarily for control, not just display
         return True

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -18,28 +18,24 @@ _LOGGER = logging.getLogger(__name__)
 # Select entity definitions
 SELECT_DEFINITIONS = {
     "mode": {
-        "name": "Tryb pracy",
         "icon": "mdi:cog",
         "options": ["Automatyczny", "Manualny", "Chwilowy"],
         "values": [0, 1, 2],
         "register_type": "holding_registers",
     },
     "bypass_mode": {
-        "name": "Tryb bypass",
         "icon": "mdi:pipe-leak",
         "options": ["Auto", "Otwarty", "Zamknięty"],
         "values": [0, 1, 2],
         "register_type": "holding_registers",
     },
     "gwc_mode": {
-        "name": "Tryb GWC",
         "icon": "mdi:pipe",
         "options": ["Wyłączony", "Auto", "Wymuszony"],
         "values": [0, 1, 2],
         "register_type": "holding_registers",
     },
     "filter_change": {
-        "name": "Typ filtra",
         "icon": "mdi:filter-variant",
         "options": ["Presostat", "Filtry płaskie", "CleanPad", "CleanPad Pure"],
         "values": [1, 2, 3, 4],
@@ -76,7 +72,8 @@ class ThesslaGreenSelect(CoordinatorEntity, SelectEntity):
         self._definition = definition
 
         self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
-        self._attr_name = f"{coordinator.device_name} {definition['name']}"
+        self._attr_translation_key = register_name
+        self._attr_has_entity_name = True
         self._attr_device_info = coordinator.get_device_info()
         self._attr_icon = definition.get("icon")
         self._attr_options = definition["options"]
@@ -104,4 +101,3 @@ class ThesslaGreenSelect(CoordinatorEntity, SelectEntity):
                 await self.coordinator.async_request_refresh()
         except ValueError:
             _LOGGER.error("Invalid option: %s", option)
-

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -1,4 +1,5 @@
 """Switch platform for the ThesslaGreen Modbus integration."""
+
 from __future__ import annotations
 
 import logging
@@ -19,61 +20,17 @@ _LOGGER = logging.getLogger(__name__)
 # Switch entities that can be controlled
 SWITCH_ENTITIES = {
     # System control switches from holding registers
-    "on_off_panel_mode": {
-        "name": "System Power",
-        "icon": "mdi:power",
-        "register_type": "holding",
-        "category": None
-    },
-    "boost_mode": {
-        "name": "Boost Mode",
-        "icon": "mdi:rocket-launch",
-        "register_type": "holding",
-        "category": None
-    },
-    "eco_mode": {
-        "name": "Eco Mode", 
-        "icon": "mdi:leaf",
-        "register_type": "holding",
-        "category": None
-    },
-    "night_mode": {
-        "name": "Night Mode",
-        "icon": "mdi:weather-night",
-        "register_type": "holding",
-        "category": None
-    },
-    "party_mode": {
-        "name": "Party Mode",
-        "icon": "mdi:party-popper",
-        "register_type": "holding",
-        "category": None
-    },
-    "fireplace_mode": {
-        "name": "Fireplace Mode",
-        "icon": "mdi:fireplace",
-        "register_type": "holding",
-        "category": None
-    },
-    "vacation_mode": {
-        "name": "Vacation Mode",
-        "icon": "mdi:airplane",
-        "register_type": "holding",
-        "category": None
-    },
-    "okap_mode": {
-        "name": "Hood Mode",
-        "icon": "mdi:range-hood",
-        "register_type": "holding",
-        "category": None
-    },
-    "silent_mode": {
-        "name": "Silent Mode",
-        "icon": "mdi:volume-off",
-        "register_type": "holding",
-        "category": None
-    },
+    "on_off_panel_mode": {"icon": "mdi:power", "register_type": "holding", "category": None},
+    "boost_mode": {"icon": "mdi:rocket-launch", "register_type": "holding", "category": None},
+    "eco_mode": {"icon": "mdi:leaf", "register_type": "holding", "category": None},
+    "night_mode": {"icon": "mdi:weather-night", "register_type": "holding", "category": None},
+    "party_mode": {"icon": "mdi:party-popper", "register_type": "holding", "category": None},
+    "fireplace_mode": {"icon": "mdi:fireplace", "register_type": "holding", "category": None},
+    "vacation_mode": {"icon": "mdi:airplane", "register_type": "holding", "category": None},
+    "okap_mode": {"icon": "mdi:range-hood", "register_type": "holding", "category": None},
+    "silent_mode": {"icon": "mdi:volume-off", "register_type": "holding", "category": None},
 }
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -82,14 +39,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up ThesslaGreen switch entities from config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    
+
     entities = []
-    
+
     # Create switch entities for available writable registers
     for register_name, config in SWITCH_ENTITIES.items():
         # Check if this register is available and writable
         is_available = False
-        
+
         if config["register_type"] == "holding":
             if register_name in coordinator.available_registers.get("holding", {}):
                 is_available = True
@@ -100,7 +57,7 @@ async def async_setup_entry(
                 is_available = True
             elif coordinator.force_full_register_list and register_name in COIL_REGISTERS:
                 is_available = True
-        
+
         if is_available:
             entities.append(
                 ThesslaGreenSwitch(
@@ -110,7 +67,7 @@ async def async_setup_entry(
                 )
             )
             _LOGGER.debug("Created switch entity: %s", register_name)
-    
+
     if entities:
         async_add_entities(entities)
         _LOGGER.info("Added %d switch entities", len(entities))
@@ -120,7 +77,7 @@ async def async_setup_entry(
 
 class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
     """ThesslaGreen switch entity."""
-    
+
     def __init__(
         self,
         coordinator: ThesslaGreenModbusCoordinator,
@@ -129,59 +86,60 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
     ) -> None:
         """Initialize the switch entity."""
         super().__init__(coordinator)
-        
+
         self.register_name = register_name
         self.entity_config = entity_config
-        
+
         # Entity configuration
-        self._attr_name = entity_config["name"]
         self._attr_unique_id = f"{coordinator.device_name}_{register_name}"
+        self._attr_translation_key = register_name
+        self._attr_has_entity_name = True
         self._attr_device_info = coordinator.get_device_info()
         self._attr_icon = entity_config["icon"]
-        
+
         # Set entity category if specified
         if entity_config.get("category"):
             self._attr_entity_category = entity_config["category"]
-        
-        _LOGGER.debug("Initialized switch entity: %s (register: %s)", self._attr_name, register_name)
-    
+
+        _LOGGER.debug("Initialized switch entity for register: %s", register_name)
+
     @property
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         if self.register_name not in self.coordinator.data:
             return None
-            
+
         raw_value = self.coordinator.data[self.register_name]
-        
+
         # Handle None values
         if raw_value is None:
             return None
-        
+
         # Convert to boolean
         return bool(raw_value)
-    
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         try:
             await self._write_register(self.register_name, 1)
             _LOGGER.info("Turned on %s", self.register_name)
-            
+
         except Exception as exc:
             _LOGGER.error("Failed to turn on %s: %s", self.register_name, exc)
-    
+
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         try:
             await self._write_register(self.register_name, 0)
             _LOGGER.info("Turned off %s", self.register_name)
-            
+
         except Exception as exc:
             _LOGGER.error("Failed to turn off %s: %s", self.register_name, exc)
-    
+
     async def _write_register(self, register_name: str, value: int) -> None:
         """Write value to register."""
         register_type = self.entity_config["register_type"]
-        
+
         if register_type == "holding":
             if register_name not in HOLDING_REGISTERS:
                 raise ValueError(f"Register {register_name} is not a holding register")
@@ -192,59 +150,55 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
             register_address = COIL_REGISTERS[register_name]
         else:
             raise ValueError(f"Invalid register type: {register_type}")
-        
+
         # Ensure client is connected
         if not self.coordinator.client or not self.coordinator.client.connected:
             if not await self.coordinator.async_ensure_client():
                 raise RuntimeError("Failed to connect to device")
-        
+
         # Write register - pymodbus 3.5+ compatible
         if register_type == "holding":
             response = await self.coordinator.client.write_register(
-                address=register_address, 
-                value=value, 
-                slave=self.coordinator.slave_id
+                address=register_address, value=value, slave=self.coordinator.slave_id
             )
         else:  # coil
             response = await self.coordinator.client.write_coil(
-                address=register_address, 
-                value=bool(value), 
-                slave=self.coordinator.slave_id
+                address=register_address, value=bool(value), slave=self.coordinator.slave_id
             )
-        
+
         if response.isError():
             raise RuntimeError(f"Failed to write register {register_name}: {response}")
-        
+
         # Request immediate data update
         await self.coordinator.async_request_refresh()
-    
+
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         """Return additional state attributes."""
         attributes = {}
-        
+
         # Add register information
         attributes["register_name"] = self.register_name
         register_type = self.entity_config["register_type"]
-        
+
         if register_type == "holding":
             register_address = HOLDING_REGISTERS.get(self.register_name, 0)
         else:
             register_address = COIL_REGISTERS.get(self.register_name, 0)
-            
+
         attributes["register_address"] = f"0x{register_address:04X}"
         attributes["register_type"] = register_type
-        
+
         # Add raw value for debugging
         if self.register_name in self.coordinator.data:
             raw_value = self.coordinator.data[self.register_name]
             if raw_value is not None:
                 attributes["raw_value"] = raw_value
-        
+
         # Add last update time
         if self.coordinator.last_successful_update:
             attributes["last_updated"] = self.coordinator.last_successful_update.isoformat()
-        
+
         # Add mode-specific information
         if "mode" in self.register_name:
             attributes["control_type"] = "operating_mode"
@@ -254,16 +208,16 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
             attributes["control_type"] = "special_mode"
         elif self.register_name == "on_off_panel_mode":
             attributes["control_type"] = "system_power"
-        
+
         return attributes
-    
+
     @property
     def available(self) -> bool:
         """Return if entity is available."""
         # Entity is available if coordinator is available
         if not self.coordinator.last_update_success:
             return False
-            
+
         # For switch entities, we don't require the register to be in current data
         # as they are primarily for control, not just display
         return True

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -396,8 +396,13 @@
       }
     },
     "climate": {
-      "climate": {
+      "thessla_green_climate": {
         "name": "Sterowanie klimatem"
+      }
+    },
+    "fan": {
+      "thessla_green_fan": {
+        "name": "Wentylacja"
       }
     },
     "switch": {


### PR DESCRIPTION
## Summary
- remove explicit entity names and rely on translation keys
- add Polish translations for climate and fan entities

## Testing
- `pytest` *(fails: cannot import name 'ModbusIOException' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_689a58d56c6883269f594b6aa9cc2828