### PR TITLE
feat: use device model from coordinator info

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MODEL
 from .coordinator import ThesslaGreenCoordinator
 
 
@@ -25,7 +25,7 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenCoordinator]):
             identifiers={(DOMAIN, f"{coordinator.host}_{coordinator.slave_id}")},
             name=device_name,
             manufacturer="ThesslaGreen",
-            model="AirPack",
+            model=coordinator.device_info.get("model", MODEL),
             sw_version=device_info.get("firmware", "Unknown"),
         )
 


### PR DESCRIPTION
## Summary
- import MODEL constant for entity device info
- default to MODEL when coordinator.device_info lacks a model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'voluptuous'; ImportError: cannot import name 'CONF_NAME' from 'homeassistant.const'; ImportError: cannot import name 'ModbusIOException' from 'pymodbus.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_689a5a8b91c48326bcd0e6bd76f3043a