### PR TITLE
Add number entity mappings

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -31,6 +31,64 @@ PLATFORMS = [
     "switch",
 ]
 
+# Entity mappings for various platforms
+ENTITY_MAPPINGS = {
+    "number": {
+        "required_temperature": {
+            "unit": "°C",
+            "min": 16,
+            "max": 26,
+            "step": 0.5,
+            "scale": 0.5,
+        },
+        "max_supply_temperature": {
+            "unit": "°C",
+            "min": 15,
+            "max": 45,
+            "step": 0.5,
+            "scale": 0.5,
+        },
+        "min_supply_temperature": {
+            "unit": "°C",
+            "min": 5,
+            "max": 30,
+            "step": 0.5,
+            "scale": 0.5,
+        },
+        "heating_curve_slope": {
+            "min": 0,
+            "max": 10,
+            "step": 0.1,
+            "scale": 0.1,
+        },
+        "heating_curve_offset": {
+            "unit": "°C",
+            "min": -10,
+            "max": 10,
+            "step": 0.5,
+            "scale": 0.5,
+        },
+        "boost_air_flow_rate": {
+            "unit": "%",
+            "min": 0,
+            "max": 100,
+            "step": 1,
+        },
+        "boost_duration": {
+            "unit": "min",
+            "min": 0,
+            "max": 240,
+            "step": 1,
+        },
+        "humidity_target": {
+            "unit": "%",
+            "min": 0,
+            "max": 100,
+            "step": 1,
+        },
+    }
+}
+
 # ============================================================================
 # Complete register mapping from MODBUS_USER_AirPack_Home_08.2021.01 PDF
 # ============================================================================


### PR DESCRIPTION
## Summary
- define `ENTITY_MAPPINGS` with configuration for number entities
- use the new mapping in `number.py` to generate number entities

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ModbusIOException' from 'pymodbus.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_689a5a7266308326975012fd9ed2330d