### PR TITLE
Rename register keys and operate on sets

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -168,17 +168,17 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         # Group Input Registers
         if self.available_registers["input_registers"]:
             input_addrs = [INPUT_REGISTERS[reg] for reg in self.available_registers["input_registers"]]
-            self._register_groups["input"] = self._group_registers_for_batch_read(sorted(input_addrs))
+            self._register_groups["input_registers"] = self._group_registers_for_batch_read(sorted(input_addrs))
         
         # Group Holding Registers  
         if self.available_registers["holding_registers"]:
             holding_addrs = [HOLDING_REGISTERS[reg] for reg in self.available_registers["holding_registers"]]
-            self._register_groups["holding"] = self._group_registers_for_batch_read(sorted(holding_addrs))
+            self._register_groups["holding_registers"] = self._group_registers_for_batch_read(sorted(holding_addrs))
         
         # Group Coil Registers
         if self.available_registers["coil_registers"]:
             coil_addrs = [COIL_REGISTERS[reg] for reg in self.available_registers["coil_registers"]]
-            self._register_groups["coil"] = self._group_registers_for_batch_read(sorted(coil_addrs))
+            self._register_groups["coil_registers"] = self._group_registers_for_batch_read(sorted(coil_addrs))
         
         # Group Discrete Input Registers
         if self.available_registers["discrete_inputs"]:
@@ -321,10 +321,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         """Read input registers using optimized batch reading."""
         data = {}
         
-        if "input" not in self._register_groups:
+        if "input_registers" not in self._register_groups:
             return data
-        
-        for start_addr, count in self._register_groups["input"]:
+
+        for start_addr, count in self._register_groups["input_registers"]:
             try:
                 response = await self.client.read_input_registers(start_addr, count)
                 if response.isError():
@@ -351,10 +351,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         """Read holding registers using optimized batch reading."""
         data = {}
         
-        if "holding" not in self._register_groups:
+        if "holding_registers" not in self._register_groups:
             return data
-        
-        for start_addr, count in self._register_groups["holding"]:
+
+        for start_addr, count in self._register_groups["holding_registers"]:
             try:
                 response = await self.client.read_holding_registers(start_addr, count)
                 if response.isError():
@@ -381,10 +381,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         """Read coil registers using optimized batch reading."""
         data = {}
         
-        if "coil" not in self._register_groups:
+        if "coil_registers" not in self._register_groups:
             return data
-        
-        for start_addr, count in self._register_groups["coil"]:
+
+        for start_addr, count in self._register_groups["coil_registers"]:
             try:
                 response = await self.client.read_coils(start_addr, count)
                 if response.isError():

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -358,7 +358,7 @@ class ThesslaGreenDeviceScanner:
                     self.available_registers["coil_registers"].add(reg_name)
             
             if len(self.available_registers["coil_registers"]) > 0:
-                present_blocks["coil"] = (0x0000, 0x0005)
+                present_blocks["coil_registers"] = (0x0000, 0x0005)
             
             # Scan discrete inputs
             discrete_registers = [

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -40,8 +40,8 @@ async def async_setup_entry(
     has_fan_registers = False
     for register in fan_registers:
         if register in coordinator.available_registers.get(
-            "holding", {}
-        ) or register in coordinator.available_registers.get("input", {}):
+            "holding_registers", set()
+        ) or register in coordinator.available_registers.get("input_registers", set()):
             has_fan_registers = True
             break
 

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -47,15 +47,15 @@ async def async_setup_entry(
         register_type = None
 
         # Only check holding registers as they are writable
-        if register_name in coordinator.available_registers.get("holding", {}):
+        if register_name in coordinator.available_registers.get("holding_registers", set()):
             is_available = True
-            register_type = "holding"
+            register_type = "holding_registers"
 
         # If force full register list, check against holding registers
         if not is_available and coordinator.force_full_register_list:
             if register_name in HOLDING_REGISTERS:
                 is_available = True
-                register_type = "holding"
+                register_type = "holding_registers"
 
         if is_available:
             entities.append(

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -20,15 +20,15 @@ _LOGGER = logging.getLogger(__name__)
 # Switch entities that can be controlled
 SWITCH_ENTITIES = {
     # System control switches from holding registers
-    "on_off_panel_mode": {"icon": "mdi:power", "register_type": "holding", "category": None},
-    "boost_mode": {"icon": "mdi:rocket-launch", "register_type": "holding", "category": None},
-    "eco_mode": {"icon": "mdi:leaf", "register_type": "holding", "category": None},
-    "night_mode": {"icon": "mdi:weather-night", "register_type": "holding", "category": None},
-    "party_mode": {"icon": "mdi:party-popper", "register_type": "holding", "category": None},
-    "fireplace_mode": {"icon": "mdi:fireplace", "register_type": "holding", "category": None},
-    "vacation_mode": {"icon": "mdi:airplane", "register_type": "holding", "category": None},
-    "okap_mode": {"icon": "mdi:range-hood", "register_type": "holding", "category": None},
-    "silent_mode": {"icon": "mdi:volume-off", "register_type": "holding", "category": None},
+    "on_off_panel_mode": {"icon": "mdi:power", "register_type": "holding_registers", "category": None},
+    "boost_mode": {"icon": "mdi:rocket-launch", "register_type": "holding_registers", "category": None},
+    "eco_mode": {"icon": "mdi:leaf", "register_type": "holding_registers", "category": None},
+    "night_mode": {"icon": "mdi:weather-night", "register_type": "holding_registers", "category": None},
+    "party_mode": {"icon": "mdi:party-popper", "register_type": "holding_registers", "category": None},
+    "fireplace_mode": {"icon": "mdi:fireplace", "register_type": "holding_registers", "category": None},
+    "vacation_mode": {"icon": "mdi:airplane", "register_type": "holding_registers", "category": None},
+    "okap_mode": {"icon": "mdi:range-hood", "register_type": "holding_registers", "category": None},
+    "silent_mode": {"icon": "mdi:volume-off", "register_type": "holding_registers", "category": None},
 }
 
 
@@ -47,13 +47,13 @@ async def async_setup_entry(
         # Check if this register is available and writable
         is_available = False
 
-        if config["register_type"] == "holding":
-            if register_name in coordinator.available_registers.get("holding", {}):
+        if config["register_type"] == "holding_registers":
+            if register_name in coordinator.available_registers.get("holding_registers", set()):
                 is_available = True
             elif coordinator.force_full_register_list and register_name in HOLDING_REGISTERS:
                 is_available = True
-        elif config["register_type"] == "coil":
-            if register_name in coordinator.available_registers.get("coil", {}):
+        elif config["register_type"] == "coil_registers":
+            if register_name in coordinator.available_registers.get("coil_registers", set()):
                 is_available = True
             elif coordinator.force_full_register_list and register_name in COIL_REGISTERS:
                 is_available = True
@@ -140,11 +140,11 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
         """Write value to register."""
         register_type = self.entity_config["register_type"]
 
-        if register_type == "holding":
+        if register_type == "holding_registers":
             if register_name not in HOLDING_REGISTERS:
                 raise ValueError(f"Register {register_name} is not a holding register")
             register_address = HOLDING_REGISTERS[register_name]
-        elif register_type == "coil":
+        elif register_type == "coil_registers":
             if register_name not in COIL_REGISTERS:
                 raise ValueError(f"Register {register_name} is not a coil register")
             register_address = COIL_REGISTERS[register_name]
@@ -157,11 +157,11 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
                 raise RuntimeError("Failed to connect to device")
 
         # Write register - pymodbus 3.5+ compatible
-        if register_type == "holding":
+        if register_type == "holding_registers":
             response = await self.coordinator.client.write_register(
                 address=register_address, value=value, slave=self.coordinator.slave_id
             )
-        else:  # coil
+        else:  # coil register
             response = await self.coordinator.client.write_coil(
                 address=register_address, value=bool(value), slave=self.coordinator.slave_id
             )
@@ -181,7 +181,7 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
         attributes["register_name"] = self.register_name
         register_type = self.entity_config["register_type"]
 
-        if register_type == "holding":
+        if register_type == "holding_registers":
             register_address = HOLDING_REGISTERS.get(self.register_name, 0)
         else:
             register_address = COIL_REGISTERS.get(self.register_name, 0)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -292,7 +292,7 @@ async def test_write_register_sync_pymodbus_api(coordinator):
         client.write_register.return_value = response
         
         # Test holding register write
-        result = coordinator._write_register_sync(100, 50, "holding")
+        result = coordinator._write_register_sync(100, 50, "holding_registers")
         
         # ✅ VERIFY: Should use keyword arguments (pymodbus 3.5+ compatible)
         client.write_register.assert_called_once()


### PR DESCRIPTION
## Summary
- rename register groups and config to `*_registers`
- use sets when checking coordinator `available_registers`
- adjust tests for updated register type names

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ModbusIOException' from 'pymodbus.exceptions'; ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_689a5a6c7a448326acb4d85f1912a776