### PR TITLE
Use kg unit for CO₂ reduction sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Przepływy**: Nawiew, wywiew, rzeczywisty, min/max zakresy
 - **Ciśnienia**: Nawiew, wywiew, różnicowe, alarmy
 - **Jakość powietrza**: CO2, VOC, indeks jakości, wilgotność
-- **Energie**: Zużycie, odzysk, moc szczytowa, średnia
+- **Energie**: Zużycie, odzysk, moc szczytowa, średnia, roczna redukcja CO2 (kg)
 - **System**: Sprawność, godziny pracy, status filtrów, błędy
 - **Diagnostyka**: Czas aktualizacji, jakość danych, statystyki
 

--- a/README_en.md
+++ b/README_en.md
@@ -91,7 +91,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Flows**: supply, exhaust, actual, min/max range
 - **Pressures**: supply, exhaust, differential, alarms
 - **Air quality**: CO₂, VOC, air quality index, humidity
-- **Energy**: consumption, recovery, peak power, average
+- **Energy**: consumption, recovery, peak power, average, annual CO₂ reduction (kg)
 - **System**: efficiency, operating hours, filter status, errors
 - **Diagnostics**: update time, data quality, statistics
 

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -487,9 +487,9 @@ REGISTER_UNITS = {
     "air_quality_response_delay": "min",
     "air_quality_boost_duration": "min",
     "display_timeout": "s",
-    
+
     # Misc
-    "co2_reduction": "kg/year",
+    "co2_reduction": "kg",
     "air_quality_index": "",
     "fault_counter": "",
     "maintenance_counter": "",
@@ -577,7 +577,10 @@ DEVICE_CLASSES = {
     "daily_energy_consumption": "energy",
     "annual_energy_consumption": "energy",
     "annual_energy_savings": "energy",
-    
+
+    # Mass
+    "co2_reduction": "weight",
+
     # Pressure
     "supply_pressure": "pressure",
     "exhaust_pressure": "pressure",

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     UnitOfEnergy,
+    UnitOfMass,
     UnitOfPower,
     UnitOfPressure,
     UnitOfTemperature,
@@ -365,8 +366,9 @@ SENSOR_DEFINITIONS = {
     "co2_reduction": {
         "translation_key": "co2_reduction",
         "icon": "mdi:tree",
+        "device_class": SensorDeviceClass.WEIGHT,
         "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": "kg/rok",
+        "unit": UnitOfMass.KILOGRAMS,
         "register_type": "input_registers",
     },
     

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -177,7 +177,7 @@
         "name": "Annual Energy Savings"
       },
       "co2_reduction": {
-        "name": "CO2 Reduction"
+        "name": "Annual CO2 Reduction"
       },
       "fault_counter": {
         "name": "Fault Counter"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -195,7 +195,7 @@
         "name": "Roczne oszczędności energii"
       },
       "co2_reduction": {
-        "name": "Redukcja CO2"
+        "name": "Roczna redukcja CO2"
       },
       "system_uptime": {
         "name": "Czas pracy systemu"


### PR DESCRIPTION
## Summary
- replace custom `kg/rok` value with standard `UnitOfMass.KILOGRAMS` and `SensorDeviceClass.WEIGHT`
- document annual CO₂ reduction sensor in README files
- update English and Polish translations for annual CO₂ reduction

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement homeassistant>=2025.7.0)*
- `pytest` *(failed: ImportError: cannot import name 'AsyncModbusTcpClient' from 'pymodbus.client')*

------
https://chatgpt.com/codex/tasks/task_e_689a5935aa7c8326947c9b5c301dd62b