### PR TITLE
refactor: drop diagnostics platform

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -20,7 +20,8 @@ CONF_TIMEOUT = "timeout"
 CONF_RETRY = "retry"
 CONF_FORCE_FULL_REGISTER_LIST = "force_full_register_list"
 
-# Platforms
+# Platforms supported by the integration
+# Diagnostics is handled separately and therefore not listed here
 PLATFORMS = [
     "sensor",
     "binary_sensor",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,6 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
         SWITCH = "switch"
         CLIMATE = "climate"
         FAN = "fan"
-        DIAGNOSTICS = "diagnostics"
 
     const.Platform = Platform
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -77,7 +77,6 @@ class Platform:
     SWITCH = "switch"
     CLIMATE = "climate"
     FAN = "fan"
-    DIAGNOSTICS = "diagnostics"
 
 const.Platform = Platform
 


### PR DESCRIPTION
## Summary
- clarify supported platforms without diagnostics
- adjust tests to align with platform list

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ModbusIOException' from 'pymodbus.exceptions'; ImportError: cannot import name 'CONF_NAME' from 'homeassistant.const'; ModuleNotFoundError: No module named 'voluptuous'; ImportError: cannot import name 'AsyncModbusTcpClient' from 'pymodbus.client')*


------
https://chatgpt.com/codex/tasks/task_e_689a5931f9908326b341020693e7fef6