### PR TITLE
Use translation keys for switch and select entities

### DIFF
--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -19,26 +19,31 @@ _LOGGER = logging.getLogger(__name__)
 SELECT_DEFINITIONS = {
     "mode": {
         "icon": "mdi:cog",
-        "options": ["Automatyczny", "Manualny", "Chwilowy"],
-        "values": [0, 1, 2],
+        "translation_key": "mode",
+        "states": {"auto": 0, "manual": 1, "temporary": 2},
         "register_type": "holding_registers",
     },
     "bypass_mode": {
         "icon": "mdi:pipe-leak",
-        "options": ["Auto", "Otwarty", "Zamknięty"],
-        "values": [0, 1, 2],
+        "translation_key": "bypass_mode",
+        "states": {"auto": 0, "open": 1, "closed": 2},
         "register_type": "holding_registers",
     },
     "gwc_mode": {
         "icon": "mdi:pipe",
-        "options": ["Wyłączony", "Auto", "Wymuszony"],
-        "values": [0, 1, 2],
+        "translation_key": "gwc_mode",
+        "states": {"off": 0, "auto": 1, "forced": 2},
         "register_type": "holding_registers",
     },
     "filter_change": {
         "icon": "mdi:filter-variant",
-        "options": ["Presostat", "Filtry płaskie", "CleanPad", "CleanPad Pure"],
-        "values": [1, 2, 3, 4],
+        "translation_key": "filter_change",
+        "states": {
+            "presostat": 1,
+            "flat_filters": 2,
+            "cleanpad": 3,
+            "cleanpad_pure": 4,
+        },
         "register_type": "holding_registers",
     },
 }
@@ -69,14 +74,15 @@ class ThesslaGreenSelect(CoordinatorEntity, SelectEntity):
     def __init__(self, coordinator, register_name, definition):
         super().__init__(coordinator)
         self._register_name = register_name
-        self._definition = definition
 
         self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
-        self._attr_translation_key = register_name
+        self._attr_translation_key = definition["translation_key"]
         self._attr_has_entity_name = True
         self._attr_device_info = coordinator.get_device_info()
         self._attr_icon = definition.get("icon")
-        self._attr_options = definition["options"]
+        self._states = definition["states"]
+        self._reverse_states = {v: k for k, v in self._states.items()}
+        self._attr_options = list(self._states.keys())
 
     @property
     def current_option(self) -> Optional[str]:
@@ -85,19 +91,15 @@ class ThesslaGreenSelect(CoordinatorEntity, SelectEntity):
         if value is None:
             return None
 
-        try:
-            index = self._definition["values"].index(value)
-            return self._definition["options"][index]
-        except (ValueError, IndexError):
-            return None
+        return self._reverse_states.get(value)
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        try:
-            index = self._definition["options"].index(option)
-            value = self._definition["values"][index]
-            success = await self.coordinator.async_write_register(self._register_name, value)
-            if success:
-                await self.coordinator.async_request_refresh()
-        except ValueError:
+        if option not in self._states:
             _LOGGER.error("Invalid option: %s", option)
+            return
+
+        value = self._states[option]
+        success = await self.coordinator.async_write_register(self._register_name, value)
+        if success:
+            await self.coordinator.async_request_refresh()

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -20,15 +20,60 @@ _LOGGER = logging.getLogger(__name__)
 # Switch entities that can be controlled
 SWITCH_ENTITIES = {
     # System control switches from holding registers
-    "on_off_panel_mode": {"icon": "mdi:power", "register_type": "holding_registers", "category": None},
-    "boost_mode": {"icon": "mdi:rocket-launch", "register_type": "holding_registers", "category": None},
-    "eco_mode": {"icon": "mdi:leaf", "register_type": "holding_registers", "category": None},
-    "night_mode": {"icon": "mdi:weather-night", "register_type": "holding_registers", "category": None},
-    "party_mode": {"icon": "mdi:party-popper", "register_type": "holding_registers", "category": None},
-    "fireplace_mode": {"icon": "mdi:fireplace", "register_type": "holding_registers", "category": None},
-    "vacation_mode": {"icon": "mdi:airplane", "register_type": "holding_registers", "category": None},
-    "okap_mode": {"icon": "mdi:range-hood", "register_type": "holding_registers", "category": None},
-    "silent_mode": {"icon": "mdi:volume-off", "register_type": "holding_registers", "category": None},
+    "on_off_panel_mode": {
+        "icon": "mdi:power",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "on_off_panel_mode",
+    },
+    "boost_mode": {
+        "icon": "mdi:rocket-launch",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "boost_mode",
+    },
+    "eco_mode": {
+        "icon": "mdi:leaf",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "eco_mode",
+    },
+    "night_mode": {
+        "icon": "mdi:weather-night",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "night_mode",
+    },
+    "party_mode": {
+        "icon": "mdi:party-popper",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "party_mode",
+    },
+    "fireplace_mode": {
+        "icon": "mdi:fireplace",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "fireplace_mode",
+    },
+    "vacation_mode": {
+        "icon": "mdi:airplane",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "vacation_mode",
+    },
+    "okap_mode": {
+        "icon": "mdi:range-hood",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "okap_mode",
+    },
+    "silent_mode": {
+        "icon": "mdi:volume-off",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "silent_mode",
+    },
 }
 
 
@@ -92,7 +137,7 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
 
         # Entity configuration
         self._attr_unique_id = f"{coordinator.device_name}_{register_name}"
-        self._attr_translation_key = register_name
+        self._attr_translation_key = entity_config["translation_key"]
         self._attr_has_entity_name = True
         self._attr_device_info = coordinator.get_device_info()
         self._attr_icon = entity_config["icon"]

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -367,6 +367,52 @@
       "on_off_panel_mode": {
         "name": "Panel Power"
       }
+    },
+    "switch": {
+      "on_off_panel_mode": { "name": "Panel Power" },
+      "boost_mode": { "name": "Boost Mode" },
+      "eco_mode": { "name": "Eco Mode" },
+      "night_mode": { "name": "Night Mode" },
+      "party_mode": { "name": "Party Mode" },
+      "fireplace_mode": { "name": "Fireplace Mode" },
+      "vacation_mode": { "name": "Vacation Mode" },
+      "okap_mode": { "name": "Hood Mode" },
+      "silent_mode": { "name": "Silent Mode" }
+    },
+    "select": {
+      "mode": {
+        "name": "Mode",
+        "state": {
+          "auto": "Automatic",
+          "manual": "Manual",
+          "temporary": "Temporary"
+        }
+      },
+      "bypass_mode": {
+        "name": "Bypass Mode",
+        "state": {
+          "auto": "Auto",
+          "open": "Open",
+          "closed": "Closed"
+        }
+      },
+      "gwc_mode": {
+        "name": "GWC Mode",
+        "state": {
+          "off": "Off",
+          "auto": "Auto",
+          "forced": "Forced"
+        }
+      },
+      "filter_change": {
+        "name": "Filter Type",
+        "state": {
+          "presostat": "Presostat",
+          "flat_filters": "Flat Filters",
+          "cleanpad": "CleanPad",
+          "cleanpad_pure": "CleanPad Pure"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -34,13 +34,8 @@
   "options": {
     "step": {
       "init": {
- codex/audit-and-clean-translation-files
         "title": "Opcje ThesslaGreen Modbus",
-        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Interwał skanowania: {current_scan_interval}s\n- Timeout: {current_timeout}s\n- Liczba prób: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
-=======
-          "title": "Opcje ThesslaGreen Modbus",
-          "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Interwał skanowania: {current_scan_interval}s\n- Limit czasu: {current_timeout}s\n- Liczba prób: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
- main
+        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Interwał skanowania: {current_scan_interval}s\n- Limit czasu: {current_timeout}s\n- Liczba prób: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
         "data": {
           "scan_interval": "Interwał skanowania (sekundy)",
           "timeout": "Limit czasu połączenia (sekundy)",
@@ -85,15 +80,12 @@
       "exhaust_flowrate": {
         "name": "Przepływ wywiewu"
       },
- codex/audit-and-clean-translation-files
-=======
       "supply_percentage": {
         "name": "Prędkość wentylatora nawiewnego"
       },
       "exhaust_percentage": {
         "name": "Prędkość wentylatora wywiewnego"
       },
-main
       "heat_recovery_efficiency": {
         "name": "Sprawność rekuperacji"
       },
@@ -381,8 +373,6 @@ main
       "on_off_panel_mode": {
         "name": "Zasilanie główne"
       }
- codex/audit-and-clean-translation-files
-=======
     },
     "climate": {
       "thessla_green_climate": {
@@ -395,66 +385,23 @@ main
       }
     },
     "switch": {
-      "on_off_panel_mode": {
-        "name": "Główne zasilanie"
-      },
-      "auto_mode": {
-        "name": "Tryb automatyczny"
-      },
-      "manual_mode": {
-        "name": "Tryb manualny"
-      },
-      "summer_mode": {
-        "name": "Tryb letni"
-      },
-      "winter_mode": {
-        "name": "Tryb zimowy"
-      },
-      "boost_mode": {
-        "name": "Tryb boost"
-      },
-      "night_mode": {
-        "name": "Tryb nocny"
-      },
-      "bypass_control": {
-        "name": "Sterowanie bypassem"
-      },
-      "gwc_control": {
-        "name": "Sterowanie GWC"
-      }
+      "on_off_panel_mode": { "name": "Główne zasilanie" },
+      "boost_mode": { "name": "Tryb boost" },
+      "eco_mode": { "name": "Tryb eco" },
+      "night_mode": { "name": "Tryb nocny" },
+      "party_mode": { "name": "Tryb party" },
+      "fireplace_mode": { "name": "Tryb kominkowy" },
+      "vacation_mode": { "name": "Tryb wakacyjny" },
+      "okap_mode": { "name": "Tryb okapu" },
+      "silent_mode": { "name": "Tryb cichy" }
     },
     "select": {
       "mode": {
         "name": "Tryb pracy",
         "state": {
-          "off": "Wyłączony",
+          "auto": "Automatyczny",
           "manual": "Manualny",
-          "auto": "Automatyczny",
           "temporary": "Tymczasowy"
-        }
-      },
-      "season_mode": {
-        "name": "Tryb sezonowy",
-        "state": {
-          "auto": "Automatyczny",
-          "winter": "Zimowy",
-          "summer": "Letni"
-        }
-      },
-      "special_mode": {
-        "name": "Tryb specjalny",
-        "state": {
-          "none": "Brak",
-          "okap": "Okap",
-          "kominek": "Kominek",
-          "wietrzenie": "Wietrzenie",
-          "pusty_dom": "Pusty dom",
-          "boost": "Boost",
-          "night": "Nocny",
-          "party": "Party",
-          "vacation": "Wakacyjny",
-          "economy": "Ekonomiczny",
-          "comfort": "Komfort"
         }
       },
       "bypass_mode": {
@@ -468,12 +415,12 @@ main
       "gwc_mode": {
         "name": "Tryb GWC",
         "state": {
-          "auto": "Automatyczny",
-          "on": "Włączony",
-          "off": "Wyłączony"
+          "off": "Wyłączony",
+          "auto": "Auto",
+          "forced": "Wymuszony"
         }
       },
-      "filter_type": {
+      "filter_change": {
         "name": "Typ filtrów",
         "state": {
           "presostat": "Presostat",
@@ -511,7 +458,6 @@ main
       "filter_change_interval": {
         "name": "Interwał wymiany filtrów"
       }
- main
     }
   },
   "services": {


### PR DESCRIPTION
## Summary
- use translation keys for switch and select entities
- move names and option labels into en/pl translation files
- clean up Polish translation file remnants

## Testing
- `pytest` *(fails: cannot import name 'ModbusIOException' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689a5d826e9083269279d6c10909e0b9