### PR TITLE
Use translation keys for select and climate entities

### DIFF
--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -19,25 +19,25 @@ _LOGGER = logging.getLogger(__name__)
 SELECT_DEFINITIONS = {
     "mode": {
         "icon": "mdi:cog",
-        "options": ["Automatyczny", "Manualny", "Chwilowy"],
+        "options": ["auto", "manual", "temporary"],
         "values": [0, 1, 2],
         "register_type": "holding_registers",
     },
     "bypass_mode": {
         "icon": "mdi:pipe-leak",
-        "options": ["Auto", "Otwarty", "Zamknięty"],
+        "options": ["auto", "open", "closed"],
         "values": [0, 1, 2],
         "register_type": "holding_registers",
     },
     "gwc_mode": {
         "icon": "mdi:pipe",
-        "options": ["Wyłączony", "Auto", "Wymuszony"],
+        "options": ["off", "auto", "forced"],
         "values": [0, 1, 2],
         "register_type": "holding_registers",
     },
     "filter_change": {
         "icon": "mdi:filter-variant",
-        "options": ["Presostat", "Filtry płaskie", "CleanPad", "CleanPad Pure"],
+        "options": ["presostat", "flat_filters", "cleanpad", "cleanpad_pure"],
         "values": [1, 2, 3, 4],
         "register_type": "holding_registers",
     },

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -367,6 +367,46 @@
       "on_off_panel_mode": {
         "name": "Panel Power"
       }
+    },
+    "climate": {
+      "thessla_green_climate": {
+        "name": "Climate Control"
+      }
+    },
+    "select": {
+      "mode": {
+        "name": "Operating Mode",
+        "state": {
+          "auto": "Automatic",
+          "manual": "Manual",
+          "temporary": "Temporary"
+        }
+      },
+      "bypass_mode": {
+        "name": "Bypass Mode",
+        "state": {
+          "auto": "Automatic",
+          "open": "Open",
+          "closed": "Closed"
+        }
+      },
+      "gwc_mode": {
+        "name": "GWC Mode",
+        "state": {
+          "off": "Off",
+          "auto": "Automatic",
+          "forced": "Forced"
+        }
+      },
+      "filter_change": {
+        "name": "Filter Type",
+        "state": {
+          "presostat": "Presostat",
+          "flat_filters": "Flat Filters",
+          "cleanpad": "CleanPad",
+          "cleanpad_pure": "CleanPad Pure"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -34,13 +34,8 @@
   "options": {
     "step": {
       "init": {
- codex/audit-and-clean-translation-files
         "title": "Opcje ThesslaGreen Modbus",
-        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Interwał skanowania: {current_scan_interval}s\n- Timeout: {current_timeout}s\n- Liczba prób: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
-=======
-          "title": "Opcje ThesslaGreen Modbus",
-          "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Interwał skanowania: {current_scan_interval}s\n- Limit czasu: {current_timeout}s\n- Liczba prób: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
- main
+        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Interwał skanowania: {current_scan_interval}s\n- Limit czasu: {current_timeout}s\n- Liczba prób: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
         "data": {
           "scan_interval": "Interwał skanowania (sekundy)",
           "timeout": "Limit czasu połączenia (sekundy)",
@@ -85,15 +80,12 @@
       "exhaust_flowrate": {
         "name": "Przepływ wywiewu"
       },
- codex/audit-and-clean-translation-files
-=======
       "supply_percentage": {
         "name": "Prędkość wentylatora nawiewnego"
       },
       "exhaust_percentage": {
         "name": "Prędkość wentylatora wywiewnego"
       },
-main
       "heat_recovery_efficiency": {
         "name": "Sprawność rekuperacji"
       },
@@ -381,8 +373,6 @@ main
       "on_off_panel_mode": {
         "name": "Zasilanie główne"
       }
- codex/audit-and-clean-translation-files
-=======
     },
     "climate": {
       "thessla_green_climate": {
@@ -427,9 +417,8 @@ main
       "mode": {
         "name": "Tryb pracy",
         "state": {
-          "off": "Wyłączony",
-          "manual": "Manualny",
           "auto": "Automatyczny",
+          "manual": "Manualny",
           "temporary": "Tymczasowy"
         }
       },
@@ -468,12 +457,12 @@ main
       "gwc_mode": {
         "name": "Tryb GWC",
         "state": {
+          "off": "Wyłączony",
           "auto": "Automatyczny",
-          "on": "Włączony",
-          "off": "Wyłączony"
+          "forced": "Wymuszony"
         }
       },
-      "filter_type": {
+      "filter_change": {
         "name": "Typ filtrów",
         "state": {
           "presostat": "Presostat",
@@ -511,7 +500,6 @@ main
       "filter_change_interval": {
         "name": "Interwał wymiany filtrów"
       }
- main
     }
   },
   "services": {


### PR DESCRIPTION
## Summary
- replace hardcoded select labels with translation keys
- add English and Polish translations for select options and climate entity

## Testing
- `pytest` *(fails: ModbusIOException and other imports; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689a5db58d2c8326a370281a40c7bd74