### PR TITLE
Remove unused imports

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -1,16 +1,12 @@
 """ThesslaGreen Modbus integration for Home Assistant."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from datetime import timedelta
-from typing import Any, Dict, Optional
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import (
     DOMAIN,
@@ -25,8 +21,6 @@ from .const import (
     DEFAULT_RETRY,
     DEFAULT_SLAVE_ID,
     DEFAULT_NAME,
-    MANUFACTURER,
-    MODEL,
 )
 from .coordinator import ThesslaGreenModbusCoordinator
 from .services import async_setup_services, async_unload_services

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from homeassistant.components.climate import (
     ClimateEntity,

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -5,11 +5,9 @@ import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Set, List, Tuple
-import struct
 
 from pymodbus.client import AsyncModbusTcpClient
-from pymodbus.exceptions import ModbusException, ConnectionException
-from pymodbus.pdu import ExceptionResponse
+from pymodbus.exceptions import ConnectionException
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -23,10 +21,7 @@ from .const import (
     HOLDING_REGISTERS,
     COIL_REGISTERS,
     DISCRETE_INPUT_REGISTERS,
-    REGISTER_UNITS,
     REGISTER_MULTIPLIERS,
-    DEVICE_CLASSES,
-    STATE_CLASSES,
 )
 from .device_scanner import ThesslaGreenDeviceScanner, DeviceCapabilities
 

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -1,13 +1,12 @@
 """Device scanner for ThesslaGreen Modbus integration."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass, asdict
 from typing import Dict, List, Optional, Tuple, Set
 
 from pymodbus.client import AsyncModbusTcpClient
-from pymodbus.exceptions import ModbusIOException, ConnectionException
+from pymodbus.exceptions import ConnectionException
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.percentage import (
-    percentage_to_ranged_value,
-    ranged_value_to_percentage,
-)
 
 from .const import DOMAIN, HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -33,9 +33,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DOMAIN,
-    REGISTER_UNITS,
-    DEVICE_CLASSES,
-    STATE_CLASSES,
 )
 from .coordinator import ThesslaGreenModbusCoordinator
 

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -1,9 +1,7 @@
 """Service handlers for the ThesslaGreen Modbus integration."""
 from __future__ import annotations
 
-import asyncio
 import logging
-from typing import Any, Dict
 
 import voluptuous as vol
 

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Test configuration for ThesslaGreen Modbus integration."""
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 import os
 import sys
 import types

--- a/tests/run_optimization_tests.py
+++ b/tests/run_optimization_tests.py
@@ -124,7 +124,7 @@ async def validate_register_coverage():
     
     try:
         from custom_components.thessla_green_modbus.const import (
-            INPUT_REGISTERS, HOLDING_REGISTERS, COIL_REGISTERS, DISCRETE_INPUTS
+            INPUT_REGISTERS, HOLDING_REGISTERS, COIL_REGISTERS
         )
         
         # Critical registers that must be present

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -1,13 +1,10 @@
 """Comprehensive test suite for ThesslaGreen Modbus integration - OPTIMIZED VERSION."""
 import pytest
-import asyncio
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch, call
-from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from conftest import CoordinatorMock
 
-import voluptuous as vol
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT

--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -1,7 +1,6 @@
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
-import pytest
 
 # Stub minimal Home Assistant and pymodbus modules before importing the coordinator
 ha = types.ModuleType("homeassistant")


### PR DESCRIPTION
## Summary
- drop unused imports across integration modules and tests
- clean import blocks in services, device scanner, sensors, coordinator and more

## Testing
- `ruff check --select F401 custom_components/thessla_green_modbus/__init__.py custom_components/thessla_green_modbus/climate.py custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/fan.py custom_components/thessla_green_modbus/sensor.py custom_components/thessla_green_modbus/services.py custom_components/thessla_green_modbus/switch.py tests/conftest.py tests/run_optimization_tests.py tests/test_optimized_integration.py tests/test_scanner_close.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_689a605ac9dc8326a7e3974e3614eba2