### PR TITLE
refactor: use base entity

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -15,10 +15,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, SPECIAL_FUNCTION_MAP
 from .coordinator import ThesslaGreenModbusCoordinator
+from .entity import ThesslaGreenEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,16 +70,13 @@ async def async_setup_entry(
         _LOGGER.warning("Basic control not available, climate entity not created")
 
 
-class ThesslaGreenClimate(CoordinatorEntity, ClimateEntity):
+class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
     """Enhanced climate entity for ThesslaGreen AirPack."""
 
     def __init__(self, coordinator: ThesslaGreenModbusCoordinator) -> None:
         """Initialize the climate entity."""
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_climate"
+        super().__init__(coordinator, "climate")
         self._attr_translation_key = "thessla_green_climate"
-        self._attr_has_entity_name = True
-        self._attr_device_info = coordinator.get_device_info()
 
         # Climate features
         self._attr_supported_features = (

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -1,4 +1,3 @@
-# Select entities for the ThesslaGreen Modbus integration
 """Select platform for the ThesslaGreen Modbus integration."""
 from __future__ import annotations
 
@@ -9,9 +8,9 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .entity import ThesslaGreenEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,43 +18,24 @@ _LOGGER = logging.getLogger(__name__)
 SELECT_DEFINITIONS = {
     "mode": {
         "icon": "mdi:cog",
- codex/replace-hard-coded-strings-with-translation-keys
-        "options": ["auto", "manual", "temporary"],
-        "values": [0, 1, 2],
-=======
         "translation_key": "mode",
         "states": {"auto": 0, "manual": 1, "temporary": 2},
- main
         "register_type": "holding_registers",
     },
     "bypass_mode": {
         "icon": "mdi:pipe-leak",
- codex/replace-hard-coded-strings-with-translation-keys
-        "options": ["auto", "open", "closed"],
-        "values": [0, 1, 2],
-=======
         "translation_key": "bypass_mode",
         "states": {"auto": 0, "open": 1, "closed": 2},
- main
         "register_type": "holding_registers",
     },
     "gwc_mode": {
         "icon": "mdi:pipe",
- codex/replace-hard-coded-strings-with-translation-keys
-        "options": ["off", "auto", "forced"],
-        "values": [0, 1, 2],
-=======
         "translation_key": "gwc_mode",
         "states": {"off": 0, "auto": 1, "forced": 2},
- main
         "register_type": "holding_registers",
     },
     "filter_change": {
         "icon": "mdi:filter-variant",
- codex/replace-hard-coded-strings-with-translation-keys
-        "options": ["presostat", "flat_filters", "cleanpad", "cleanpad_pure"],
-        "values": [1, 2, 3, 4],
-=======
         "translation_key": "filter_change",
         "states": {
             "presostat": 1,
@@ -63,7 +43,6 @@ SELECT_DEFINITIONS = {
             "cleanpad": 3,
             "cleanpad_pure": 4,
         },
- main
         "register_type": "holding_registers",
     },
 }
@@ -88,17 +67,14 @@ async def async_setup_entry(
         _LOGGER.info("Created %d select entities", len(entities))
 
 
-class ThesslaGreenSelect(CoordinatorEntity, SelectEntity):
+class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
     """Select entity for ThesslaGreen device."""
 
     def __init__(self, coordinator, register_name, definition):
-        super().__init__(coordinator)
+        super().__init__(coordinator, register_name)
         self._register_name = register_name
 
-        self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
         self._attr_translation_key = definition["translation_key"]
-        self._attr_has_entity_name = True
-        self._attr_device_info = coordinator.get_device_info()
         self._attr_icon = definition.get("icon")
         self._states = definition["states"]
         self._reverse_states = {v: k for k, v in self._states.items()}

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -29,7 +29,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DOMAIN,
@@ -38,6 +37,7 @@ from .const import (
     STATE_CLASSES,
 )
 from .coordinator import ThesslaGreenModbusCoordinator
+from .entity import ThesslaGreenEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -587,7 +587,7 @@ async def async_setup_entry(
         _LOGGER.warning("No sensor entities created - no compatible registers found")
 
 
-class ThesslaGreenSensor(CoordinatorEntity, SensorEntity):
+class ThesslaGreenSensor(ThesslaGreenEntity, SensorEntity):
     """Sensor entity for ThesslaGreen device."""
 
     def __init__(
@@ -597,14 +597,10 @@ class ThesslaGreenSensor(CoordinatorEntity, SensorEntity):
         sensor_definition: Dict[str, Any],
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        
+        super().__init__(coordinator, register_name)
+
         self._register_name = register_name
         self._sensor_def = sensor_definition
-
-        # Entity attributes
-        self._attr_unique_id = f"{coordinator.host}_{coordinator.slave_id}_{register_name}"
-        self._attr_device_info = coordinator.get_device_info()
 
         # Sensor specific attributes
         self._attr_icon = sensor_definition.get("icon")
@@ -614,7 +610,6 @@ class ThesslaGreenSensor(CoordinatorEntity, SensorEntity):
 
         # Translation setup
         self._attr_translation_key = sensor_definition.get("translation_key")
-        self._attr_has_entity_name = True
 
         _LOGGER.debug(
             "Sensor initialized: %s (%s)",
@@ -641,14 +636,6 @@ class ThesslaGreenSensor(CoordinatorEntity, SensorEntity):
             return f"{major}.{minor:02d}"
         
         return value
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return (
-            self.coordinator.last_update_success and
-            self._register_name in self.coordinator.data
-        )
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- use ThesslaGreenEntity base class for sensors
- use ThesslaGreenEntity base class for binary sensors, climate, and selects
- clean up select definitions

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement homeassistant>=2025.7.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_689a6065e520832697b9e79614e3755a