### PR TITLE
Expose coordinator device info dictionary

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -557,6 +557,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             configuration_url=f"http://{self.host}",
         )
 
+    @property
+    def device_info_dict(self) -> Dict[str, Any]:
+        """Return device information as a plain dictionary."""
+        return self.get_device_info().as_dict()
+
 
 # Legacy compatibility - ThesslaGreenCoordinator alias
 ThesslaGreenCoordinator = ThesslaGreenModbusCoordinator


### PR DESCRIPTION
## Summary
- add `device_info_dict` property to the coordinator to expose Home Assistant `DeviceInfo` as a dict

## Testing
- `pytest` *(fails: cannot import name 'ModbusIOException'; Home Assistant const 'CONF_NAME' missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a606076708326abefb1346c465c4e