### PR TITLE
refactor: annotate entity mappings for numbers

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -1,5 +1,7 @@
 """Constants and register definitions for the ThesslaGreen Modbus integration."""
 
+from typing import Any, Dict
+
 # Integration constants
 DOMAIN = "thessla_green_modbus"
 MANUFACTURER = "ThesslaGreen"
@@ -33,7 +35,7 @@ PLATFORMS = [
 ]
 
 # Entity mappings for various platforms
-ENTITY_MAPPINGS = {
+ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
     "number": {
         "required_temperature": {
             "unit": "°C",

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
     entities = []
 
     # Get number entity mappings
-    number_mappings = ENTITY_MAPPINGS.get("number", {})
+    number_mappings: Dict[str, Dict[str, Any]] = ENTITY_MAPPINGS.get("number", {})
 
     # Create number entities for available writable registers
     for register_name, entity_config in number_mappings.items():


### PR DESCRIPTION
## Summary
- type annotate ENTITY_MAPPINGS in const module and map number entity configs
- consume typed ENTITY_MAPPINGS in number platform setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymodbus')*


------
https://chatgpt.com/codex/tasks/task_e_689a620377c4832683021c602cf33749