### PR TITLE
Ensure clean shutdown in ThesslaGreen coordinator

### DIFF
--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -169,3 +169,31 @@ def test_async_setup_closes_scanner():
 
     import asyncio
     asyncio.run(run_test())
+
+
+def test_disconnect_closes_client():
+    """Ensure _disconnect awaits client.close."""
+
+    async def run_test():
+        hass = MagicMock()
+        coordinator = ThesslaGreenCoordinator(
+            hass=hass,
+            host="localhost",
+            port=502,
+            slave_id=1,
+            name="Test",
+            scan_interval=30,
+            timeout=10,
+            retry=3,
+        )
+
+        client = AsyncMock()
+        coordinator.client = client
+
+        await coordinator._disconnect()
+
+        client.close.assert_awaited_once()
+        assert coordinator.client is None
+
+    import asyncio
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Add unit test verifying `_disconnect` awaits closing the Modbus client
- Confirm coordinator setup closes the device scanner

## Testing
- `pytest tests/test_scanner_close.py -q`
- `pytest -k 'not scanner_close' -q` *(fails: ImportError: cannot import name 'AIR_QUALITY_REGISTER_MAP' from 'custom_components.thessla_green_modbus.services')*


------
https://chatgpt.com/codex/tasks/task_e_689a620821b48326b6be0c08bc53fe3c