### PR TITLE
refactor: move switch and select names to translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -368,16 +368,11 @@
         "name": "Panel Power"
       }
     },
- codex/replace-hard-coded-strings-with-translation-keys
     "climate": {
       "thessla_green_climate": {
         "name": "Climate Control"
       }
     },
-    "select": {
-      "mode": {
-        "name": "Operating Mode",
-=======
     "switch": {
       "on_off_panel_mode": { "name": "Panel Power" },
       "boost_mode": { "name": "Boost Mode" },
@@ -392,7 +387,6 @@
     "select": {
       "mode": {
         "name": "Mode",
- main
         "state": {
           "auto": "Automatic",
           "manual": "Manual",
@@ -402,11 +396,7 @@
       "bypass_mode": {
         "name": "Bypass Mode",
         "state": {
- codex/replace-hard-coded-strings-with-translation-keys
           "auto": "Automatic",
-=======
-          "auto": "Auto",
- main
           "open": "Open",
           "closed": "Closed"
         }
@@ -415,11 +405,7 @@
         "name": "GWC Mode",
         "state": {
           "off": "Off",
- codex/replace-hard-coded-strings-with-translation-keys
           "auto": "Automatic",
-=======
-          "auto": "Auto",
- main
           "forced": "Forced"
         }
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -416,11 +416,7 @@
         "name": "Tryb GWC",
         "state": {
           "off": "Wyłączony",
- codex/replace-hard-coded-strings-with-translation-keys
           "auto": "Automatyczny",
-=======
-          "auto": "Auto",
- main
           "forced": "Wymuszony"
         }
       },


### PR DESCRIPTION
## Summary
- clean translation entries for switch and select entities
- use translation keys for naming and options

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for homeassistant>=2025.7.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_689a63e6589883268e56ef9fe2d473ea