### PR TITLE
Use coordinator get_device_info for entities

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -1,10 +1,9 @@
 """Base entity for ThesslaGreen Modbus Integration."""
 from __future__ import annotations
 
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MODEL
+from .const import DOMAIN
 from .coordinator import ThesslaGreenCoordinator
 
 
@@ -17,17 +16,9 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenCoordinator]):
         """Initialize the entity."""
         super().__init__(coordinator)
         self._key = key
-        
-        device_info = coordinator.device_info
-        device_name = device_info.get("device_name", "ThesslaGreen")
-        
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{coordinator.host}_{coordinator.slave_id}")},
-            name=device_name,
-            manufacturer="ThesslaGreen",
-            model=coordinator.device_info.get("model", MODEL),
-            sw_version=device_info.get("firmware", "Unknown"),
-        )
+
+        # Retrieve fully populated DeviceInfo from the coordinator
+        self._attr_device_info = coordinator.get_device_info()
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -401,10 +401,8 @@ def _get_coordinator_from_entity_id(hass: HomeAssistant, entity_id: str):
     """Get coordinator from entity ID."""
     # Find the config entry that matches this entity
     for coordinator in hass.data.get(DOMAIN, {}).values():
-        if hasattr(coordinator, "get_device_info"):
-            # Check if this entity belongs to this coordinator
-            device_info = coordinator.get_device_info()
-            for domain, identifier in getattr(device_info, "identifiers", set()):
-                if domain == DOMAIN and identifier in entity_id:
-                    return coordinator
+        # Check if this entity belongs to this coordinator
+        for domain, identifier in coordinator.get_device_info().identifiers:
+            if domain == DOMAIN and identifier in entity_id:
+                return coordinator
     return None


### PR DESCRIPTION
## Summary
- retrieve DeviceInfo objects directly from coordinator
- inspect coordinator.get_device_info().identifiers when resolving services

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous'; ImportError: cannot import name 'CONF_NAME' from 'homeassistant.const')*


------
https://chatgpt.com/codex/tasks/task_e_689a655032c8832680ea40b273a8d36e