### PR TITLE
refactor: use translation keys for entity names

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -77,6 +77,7 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
         """Initialize the climate entity."""
         super().__init__(coordinator, "climate")
         self._attr_translation_key = "thessla_green_climate"
+        self._attr_has_entity_name = True
 
         # Climate features
         self._attr_supported_features = (

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -76,6 +76,7 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
 
         self._attr_translation_key = definition["translation_key"]
         self._attr_icon = definition.get("icon")
+        self._attr_has_entity_name = True
         self._states = definition["states"]
         self._reverse_states = {v: k for k, v in self._states.items()}
         self._attr_options = list(self._states.keys())

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -368,16 +368,16 @@
         "name": "Panel Power"
       }
     },
- codex/replace-hard-coded-strings-with-translation-keys
     "climate": {
       "thessla_green_climate": {
         "name": "Climate Control"
       }
     },
-    "select": {
-      "mode": {
-        "name": "Operating Mode",
-=======
+    "fan": {
+      "thessla_green_fan": {
+        "name": "Ventilation"
+      }
+    },
     "switch": {
       "on_off_panel_mode": { "name": "Panel Power" },
       "boost_mode": { "name": "Boost Mode" },
@@ -392,9 +392,8 @@
     "select": {
       "mode": {
         "name": "Mode",
- main
         "state": {
-          "auto": "Automatic",
+          "auto": "Auto",
           "manual": "Manual",
           "temporary": "Temporary"
         }
@@ -402,11 +401,7 @@
       "bypass_mode": {
         "name": "Bypass Mode",
         "state": {
- codex/replace-hard-coded-strings-with-translation-keys
-          "auto": "Automatic",
-=======
           "auto": "Auto",
- main
           "open": "Open",
           "closed": "Closed"
         }
@@ -415,11 +410,7 @@
         "name": "GWC Mode",
         "state": {
           "off": "Off",
- codex/replace-hard-coded-strings-with-translation-keys
-          "auto": "Automatic",
-=======
           "auto": "Auto",
- main
           "forced": "Forced"
         }
       },
@@ -432,6 +423,16 @@
           "cleanpad_pure": "CleanPad Pure"
         }
       }
+    },
+    "number": {
+      "required_temperature": { "name": "Required Temperature" },
+      "max_supply_temperature": { "name": "Max Supply Temperature" },
+      "min_supply_temperature": { "name": "Min Supply Temperature" },
+      "heating_curve_slope": { "name": "Heating Curve Slope" },
+      "heating_curve_offset": { "name": "Heating Curve Offset" },
+      "boost_air_flow_rate": { "name": "Boost Air Flow Rate" },
+      "boost_duration": { "name": "Boost Duration" },
+      "humidity_target": { "name": "Humidity Target" }
     }
   },
   "services": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -416,11 +416,7 @@
         "name": "Tryb GWC",
         "state": {
           "off": "Wyłączony",
- codex/replace-hard-coded-strings-with-translation-keys
-          "auto": "Automatyczny",
-=======
           "auto": "Auto",
- main
           "forced": "Wymuszony"
         }
       },
@@ -459,11 +455,19 @@
       "wietrzenie_intensity": {
         "name": "Intensywność wietrzenia"
       },
-      "filter_change_interval": {
-        "name": "Interwał wymiany filtrów"
+        "filter_change_interval": {
+          "name": "Interwał wymiany filtrów"
+        },
+        "required_temperature": { "name": "Wymagana temperatura" },
+        "max_supply_temperature": { "name": "Maksymalna temperatura nawiewu" },
+        "min_supply_temperature": { "name": "Minimalna temperatura nawiewu" },
+        "heating_curve_slope": { "name": "Nachylenie krzywej grzewczej" },
+        "heating_curve_offset": { "name": "Przesunięcie krzywej grzewczej" },
+        "boost_air_flow_rate": { "name": "Prędkość nawiewu w trybie boost" },
+        "boost_duration": { "name": "Czas trwania trybu boost" },
+        "humidity_target": { "name": "Docelowa wilgotność" }
       }
-    }
-  },
+    },
   "services": {
     "set_mode": {
       "name": "Ustaw tryb pracy",


### PR DESCRIPTION
## Summary
- localize select and climate entities using translation keys
- add English and Polish entries for fan and number entities

## Testing
- `pytest` *(fails: No module named 'voluptuous'; ImportError: cannot import name 'CONF_NAME'; ImportError: AIR_QUALITY_REGISTER_MAP)*

------
https://chatgpt.com/codex/tasks/task_e_689a6554bc6c8326ba9f44ca0e378b2f