### PR TITLE
Use coordinator device info helper

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -303,6 +303,7 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
     ) -> None:
         """Initialize the binary sensor."""
         super().__init__(coordinator, register_name)
+        self._attr_device_info = coordinator.get_device_info()
 
         self._register_name = register_name
         self._sensor_def = sensor_definition

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -76,6 +76,7 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
     def __init__(self, coordinator: ThesslaGreenModbusCoordinator) -> None:
         """Initialize the climate entity."""
         super().__init__(coordinator, "climate")
+        self._attr_device_info = coordinator.get_device_info()
         self._attr_translation_key = "thessla_green_climate"
 
         # Climate features

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -554,7 +554,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
     @property
     def device_info_dict(self) -> Dict[str, Any]:
-        """Return device information as a plain dictionary."""
+        """Return device information as a plain dictionary for legacy use."""
         return self.get_device_info().as_dict()
 
 

--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -1,10 +1,9 @@
 """Base entity for ThesslaGreen Modbus Integration."""
 from __future__ import annotations
 
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MODEL
+from .const import DOMAIN
 from .coordinator import ThesslaGreenCoordinator
 
 
@@ -18,16 +17,7 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenCoordinator]):
         super().__init__(coordinator)
         self._key = key
         
-        device_info = coordinator.device_info
-        device_name = device_info.get("device_name", "ThesslaGreen")
-        
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{coordinator.host}_{coordinator.slave_id}")},
-            name=device_name,
-            manufacturer="ThesslaGreen",
-            model=coordinator.device_info.get("model", MODEL),
-            sw_version=device_info.get("firmware", "Unknown"),
-        )
+        self._attr_device_info = coordinator.get_device_info()
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -72,6 +72,7 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
 
     def __init__(self, coordinator, register_name, definition):
         super().__init__(coordinator, register_name)
+        self._attr_device_info = coordinator.get_device_info()
         self._register_name = register_name
 
         self._attr_translation_key = definition["translation_key"]

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -595,6 +595,7 @@ class ThesslaGreenSensor(ThesslaGreenEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, register_name)
+        self._attr_device_info = coordinator.get_device_info()
 
         self._register_name = register_name
         self._sensor_def = sensor_definition


### PR DESCRIPTION
## Summary
- expose device info helper for entity platforms
- use `get_device_info()` across entity implementations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous'; ImportError: cannot import name 'CONF_NAME' from 'homeassistant.const'; ImportError: cannot import name 'AIR_QUALITY_REGISTER_MAP' from 'custom_components.thessla_green_modbus.services`*

------
https://chatgpt.com/codex/tasks/task_e_689a653608348326af99885cbda8b92f