### PR TITLE
Use translation keys for climate presets and select options

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -370,17 +370,31 @@
     },
     "climate": {
       "thessla_green_climate": {
-        "name": "Climate Control"
+        "name": "Climate Control",
+        "state_attributes": {
+          "preset_mode": {
+            "none": "None",
+            "eco": "Eco",
+            "boost": "Boost",
+            "comfort": "Comfort",
+            "away": "Away",
+            "sleep": "Sleep",
+            "fireplace": "Fireplace",
+            "hood": "Hood",
+            "party": "Party",
+            "bathroom": "Bathroom",
+            "kitchen": "Kitchen",
+            "summer": "Summer",
+            "winter": "Winter"
+          }
+        }
       }
     },
- codex/add-entity-translation-keys-and-update-json
     "fan": {
       "thessla_green_fan": {
         "name": "Ventilation"
       }
     },
-=======
- main
     "switch": {
       "on_off_panel_mode": { "name": "Panel Power" },
       "boost_mode": { "name": "Boost Mode" },
@@ -404,11 +418,7 @@
       "bypass_mode": {
         "name": "Bypass Mode",
         "state": {
- codex/add-entity-translation-keys-and-update-json
-          "auto": "Auto",
-=======
           "auto": "Automatic",
- main
           "open": "Open",
           "closed": "Closed"
         }
@@ -417,11 +427,7 @@
         "name": "GWC Mode",
         "state": {
           "off": "Off",
- codex/add-entity-translation-keys-and-update-json
-          "auto": "Auto",
-=======
           "auto": "Automatic",
- main
           "forced": "Forced"
         }
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -376,7 +376,24 @@
     },
     "climate": {
       "thessla_green_climate": {
-        "name": "Sterowanie klimatem"
+        "name": "Sterowanie klimatem",
+        "state_attributes": {
+          "preset_mode": {
+            "none": "Brak",
+            "eco": "Eco",
+            "boost": "Boost",
+            "comfort": "Komfort",
+            "away": "Nieobecność",
+            "sleep": "Sen",
+            "fireplace": "Kominek",
+            "hood": "Okap",
+            "party": "Impreza",
+            "bathroom": "Łazienka",
+            "kitchen": "Kuchnia",
+            "summer": "Lato",
+            "winter": "Zima"
+          }
+        }
       }
     },
     "fan": {
@@ -416,11 +433,7 @@
         "name": "Tryb GWC",
         "state": {
           "off": "Wyłączony",
- codex/add-entity-translation-keys-and-update-json
-          "auto": "Auto",
-=======
           "auto": "Automatyczny",
- main
           "forced": "Wymuszony"
         }
       },


### PR DESCRIPTION
## Summary
- add climate preset mode translations
- clean up select option translations

## Testing
- `pytest` *(fails: Platform() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_689a67551c2c83269213aff05943ad34