### PR TITLE
Clean entity initializer

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -16,12 +16,7 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenCoordinator]):
         """Initialize the entity."""
         super().__init__(coordinator)
         self._key = key
- codex/add-device-info-property-and-update-entities
-        
-=======
-
         # Retrieve fully populated DeviceInfo from the coordinator
- main
         self._attr_device_info = coordinator.get_device_info()
 
     @property


### PR DESCRIPTION
## Summary
- remove stray merge markers in ThesslaGreenEntity initializer
- keep device info retrieval

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_689a6be80bdc832699fb766084146c12