### PR TITLE
chore: align minimum Home Assistant version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example configuration file
 - Contributing guidelines
 
+### Changed
+- Bumped minimum Home Assistant version to 2025.7.0
+
 ### Removed
 - Custom Modbus client in favor of native AsyncModbusTcpClient
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 - ✅ **Firmware v3.x - v5.x** z automatyczną detekcją
 
 ### Home Assistant
-- ✅ **Home Assistant 2025.7.0+** - najnowsza kompatybilność
+- ✅ **Wymagany Home Assistant 2025.7.0 lub nowszy** - najnowsza kompatybilność
 - ✅ **pymodbus 3.5.0+** - najnowsza biblioteka Modbus
 - ✅ **Python 3.11+** - nowoczesne standardy
 - ✅ **Standardowy AsyncModbusTcpClient** – brak potrzeby własnego klienta Modbus

--- a/README_en.md
+++ b/README_en.md
@@ -32,7 +32,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 - ✅ **Firmware v3.x – v5.x** with automatic detection
 
 ### Home Assistant
-- ✅ **Home Assistant 2025.7.0+** – latest compatibility
+- ✅ **Requires Home Assistant 2025.7.0 or later** – latest compatibility
 - ✅ **pymodbus 3.5.0+** – latest Modbus library
 - ✅ **Python 3.11+** – modern standards
 - ✅ **Standard AsyncModbusTcpClient** – no custom Modbus client required

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.1.0",
+  "homeassistant": "2025.7.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",


### PR DESCRIPTION
## Summary
- bump minimum Home Assistant version to 2025.7.0
- document new minimum requirement
- note version bump in changelog

## Testing
- `pytest` *(fails: ImportError: cannot import name 'AIR_QUALITY_REGISTER_MAP')*


------
https://chatgpt.com/codex/tasks/task_e_689a6c031e948326aff47460fc88c484