### PR TITLE
Clarify device ID wording and localize bypass terms

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -7,13 +7,13 @@
         "data": {
           "host": "IP Address",
           "port": "Port",
-          "slave_id": "Slave ID",
+          "slave_id": "Device ID (Slave ID)",
           "name": "Name"
         },
         "data_description": {
           "host": "IP address of the AirPack device on your local network",
           "port": "Modbus TCP port (default 502)",
-          "slave_id": "Modbus device identifier (default 10)",
+          "slave_id": "Modbus device ID (Slave ID, default 10)",
           "name": "Device name in Home Assistant"
         }
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -7,13 +7,13 @@
         "data": {
           "host": "Adres IP",
           "port": "Port",
-          "slave_id": "Identyfikator Slave",
+          "slave_id": "ID urządzenia (Slave ID)",
           "name": "Nazwa"
         },
         "data_description": {
           "host": "Adres IP urządzenia AirPack w sieci lokalnej",
           "port": "Port Modbus TCP (domyślnie 502)",
-          "slave_id": "Identyfikator urządzenia Modbus (domyślnie 10)",
+          "slave_id": "ID urządzenia Modbus (Slave ID, domyślnie 10)",
           "name": "Nazwa urządzenia w Home Assistant"
         }
       },
@@ -117,7 +117,7 @@
         "name": "Przepływ rekuperatora"
       },
       "bypass_flowrate": {
-        "name": "Przepływ bypassu"
+        "name": "Przepływ obejścia (bypassu)"
       },
       "supply_air_flow": {
         "name": "Strumień nawiewu"
@@ -234,7 +234,7 @@
         "name": "Sterowanie chłodnicą"
       },
       "damper_position_bypass": {
-        "name": "Pozycja przepustnicy bypassu"
+        "name": "Pozycja przepustnicy obejścia (bypassu)"
       },
       "damper_position_gwc": {
         "name": "Pozycja przepustnicy GWC"
@@ -260,7 +260,7 @@
         "name": "Zasilanie wentylatorów"
       },
       "bypass": {
-        "name": "Bypass"
+        "name": "Obejście (bypass)"
       },
       "gwc": {
         "name": "System GWC"
@@ -326,7 +326,7 @@
         "name": "Błąd chłodnicy"
       },
       "bypass_error": {
-        "name": "Błąd bypassu"
+        "name": "Błąd obejścia (bypassu)"
       },
       "gwc_error": {
         "name": "Błąd GWC"
@@ -341,7 +341,7 @@
         "name": "Cykl odszraniania"
       },
       "summer_bypass_active": {
-        "name": "Letni bypass"
+        "name": "Letnie obejście (bypass)"
       },
       "winter_heating_active": {
         "name": "Zimowe grzanie"
@@ -422,7 +422,7 @@
         }
       },
       "bypass_mode": {
-        "name": "Tryb bypassu",
+        "name": "Tryb obejścia (bypass)",
         "state": {
           "auto": "Automatyczny",
           "open": "Otwarty",
@@ -503,8 +503,8 @@
       "description": "Kontroluje prędkość wentylatorów nawiewnego i wywiewnego oraz balans przepływów."
     },
     "control_bypass": {
-      "name": "Steruj bypassem",
-      "description": "Kontroluje tryb pracy systemu bypassu."
+      "name": "Steruj obejściem (bypass)",
+      "description": "Kontroluje tryb pracy systemu obejścia (bypassu)."
     },
     "control_gwc": {
       "name": "Steruj GWC",


### PR DESCRIPTION
## Summary
- Clarify device ID wording in English and Polish translations
- Localize Polish bypass terminology and ensure capitalization consistency

## Testing
- `python -m script.translations develop` *(fails: No module named 'script')*
- `python -m json.tool custom_components/thessla_green_modbus/translations/en.json`
- `python -m json.tool custom_components/thessla_green_modbus/translations/pl.json`
- `pytest` *(fails: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_689a6bf32d3c83268d6147a8e0714f6a