### PR TITLE
Include slave id in Modbus write operations

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -486,10 +486,14 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Determine register type and address
                 if register_name in HOLDING_REGISTERS:
                     address = HOLDING_REGISTERS[register_name]
-                    response = await self.client.write_register(address, value)
+                    response = await self.client.write_register(
+                        address=address, value=value, slave=self.slave_id
+                    )
                 elif register_name in COIL_REGISTERS:
                     address = COIL_REGISTERS[register_name]
-                    response = await self.client.write_coil(address, bool(value))
+                    response = await self.client.write_coil(
+                        address=address, value=bool(value), slave=self.slave_id
+                    )
                 else:
                     _LOGGER.error("Unknown register for writing: %s", register_name)
                     return False


### PR DESCRIPTION
## Summary
- pass `slave=self.slave_id` when writing registers or coils

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'voluptuous'; ImportError: cannot import name 'CONF_NAME' from 'homeassistant.const')*


------
https://chatgpt.com/codex/tasks/task_e_689a6ddca2d88326af442abe10c3b5af