### PR TITLE
Use existing air quality register constants

### DIFF
--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -15,10 +15,10 @@ _LOGGER = logging.getLogger(__name__)
 
 # Map service parameters to corresponding register names
 AIR_QUALITY_REGISTER_MAP = {
-    "co2_low": "co2_low_threshold",
-    "co2_medium": "co2_medium_threshold",
-    "co2_high": "co2_high_threshold",
-    "humidity_target": "humidity_target_threshold",
+    "co2_low": "co2_threshold_low",
+    "co2_medium": "co2_threshold_medium",
+    "co2_high": "co2_threshold_high",
+    "humidity_target": "humidity_target",
 }
 
 # Service schemas
@@ -229,7 +229,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     if value is not None:
                         register_name = AIR_QUALITY_REGISTER_MAP[param]
                         await coordinator.async_write_register(register_name, value)
-                
+
                 await coordinator.async_request_refresh()
                 _LOGGER.info("Set air quality thresholds for %s", entity_id)
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -187,7 +187,7 @@ from custom_components.thessla_green_modbus.services import AIR_QUALITY_REGISTER
 
 def test_air_quality_register_map():
     """Verify correct mapping of air quality parameters to register names."""
-    assert AIR_QUALITY_REGISTER_MAP["co2_low"] == "co2_low_threshold"
-    assert AIR_QUALITY_REGISTER_MAP["co2_medium"] == "co2_medium_threshold"
-    assert AIR_QUALITY_REGISTER_MAP["co2_high"] == "co2_high_threshold"
-    assert AIR_QUALITY_REGISTER_MAP["humidity_target"] == "humidity_target_threshold"
+    assert AIR_QUALITY_REGISTER_MAP["co2_low"] == "co2_threshold_low"
+    assert AIR_QUALITY_REGISTER_MAP["co2_medium"] == "co2_threshold_medium"
+    assert AIR_QUALITY_REGISTER_MAP["co2_high"] == "co2_threshold_high"
+    assert AIR_QUALITY_REGISTER_MAP["humidity_target"] == "humidity_target"


### PR DESCRIPTION
## Summary
- align service register map with defined Modbus register constants
- update service tests for new constant names

## Testing
- `pytest tests/test_services.py::test_air_quality_register_map -q`
- `pytest -q` *(fails: ImportError: cannot import name 'AIR_QUALITY_REGISTER_MAP' from 'custom_components.thessla_green_modbus.services')*


------
https://chatgpt.com/codex/tasks/task_e_689ad7c6a44c8326a93bc58dc2445466