### PR TITLE
Align versions and Home Assistant requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributing guidelines
 
 ### Changed
-- Bumped minimum Home Assistant version to 2025.7.0
+- Bumped minimum Home Assistant version to 2025.7.1
 
 ### Removed
 - Custom Modbus client in favor of native AsyncModbusTcpClient
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ New Features
 
-#### Enhanced Climate Entity (HA 2025.7+ Compatible)
+#### Enhanced Climate Entity (HA 2025.7.1+ Compatible)
 - **Preset Modes**: Eco, Comfort, Boost, Sleep, Away
 - **Custom ThesslaGreen Presets**: OKAP, KOMINEK, WIETRZENIE, GOTOWANIE, PRANIE, ŁAZIENKA
 - **Advanced Temperature Control**: Manual/temporary/comfort temperature settings
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Comprehensive Device Scanner** - Intelligent capability detection with 60+ capabilities
 - **Enhanced Error Handling** - Smart retry logic and graceful error recovery
 
-#### Complete Entity Coverage (HA 2025.7+)
+#### Complete Entity Coverage (HA 2025.7.1+)
 - **Temperature Sensors** (11): All temperature measurement points
 - **Flow Sensors** (8): Complete air flow monitoring including Constant Flow
 - **Performance Sensors** (7): Efficiency and performance indicators
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Technical Improvements
 
-#### Optimized Coordinator (HA 2025.7+)
+#### Optimized Coordinator (HA 2025.7.1+)
 - **Pre-computed Register Groups** - Efficient batch reading with intelligent grouping
 - **Enhanced Error Handling** - Smart retry logic with exponential backoff
 - **Memory Optimization** - Reduced memory usage through efficient data structures
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Numbers**: Smart validation with range checking and recommendations
 - **Select**: Enhanced mode selection with context information
 
-#### Services Integration (HA 2025.7+)
+#### Services Integration (HA 2025.7.1+)
 - **Basic Control**: Set mode, intensity, special functions
 - **Advanced Functions**: Boost mode, comfort temperature, quick ventilation
 - **System Management**: Emergency stop, alarm reset, device rescan
@@ -97,8 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Coil Registers | 25+ | Output controls and system switches |
 | Discrete Inputs | 35+ | Input status and sensor health |
 
-### 🏠 Home Assistant Compatibility (HA 2025.7+)
-- **HA 2025.7.0+** - Latest Home Assistant compatibility
+### 🏠 Home Assistant Compatibility (HA 2025.7.1+)
+- **HA 2025.7.1+** - Latest Home Assistant compatibility
 - **Modern Standards** - Follows latest HA development guidelines
 - **Device Registry** - Proper device registration with enhanced info
 - **Entity Categories** - Proper categorization for better UI organization

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub release](https://img.shields.io/github/release/thesslagreen/thessla-green-modbus-ha.svg)](https://github.com/thesslagreen/thessla-green-modbus-ha/releases)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7%2B-blue.svg)](https://home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7.1%2B-blue.svg)](https://home-assistant.io/)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://python.org/)
 
 ## ✨ Kompletna integracja ThesslaGreen AirPack z Home Assistant
@@ -32,7 +32,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 - ✅ **Firmware v3.x - v5.x** z automatyczną detekcją
 
 ### Home Assistant
-- ✅ **Wymagany Home Assistant 2025.7.0 lub nowszy** - najnowsza kompatybilność
+- ✅ **Wymagany Home Assistant 2025.7.1 lub nowszy** - najnowsza kompatybilność
 - ✅ **pymodbus 3.5.0+** - najnowsza biblioteka Modbus
 - ✅ **Python 3.11+** - nowoczesne standardy
 - ✅ **Standardowy AsyncModbusTcpClient** – brak potrzeby własnego klienta Modbus

--- a/README_en.md
+++ b/README_en.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub release](https://img.shields.io/github/release/thesslagreen/thessla-green-modbus-ha.svg)](https://github.com/thesslagreen/thessla-green-modbus-ha/releases)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7%2B-blue.svg)](https://home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7.1%2B-blue.svg)](https://home-assistant.io/)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://python.org/)
 
 ## ✨ Complete ThesslaGreen AirPack integration for Home Assistant
@@ -32,7 +32,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 - ✅ **Firmware v3.x – v5.x** with automatic detection
 
 ### Home Assistant
-- ✅ **Requires Home Assistant 2025.7.0 or later** – latest compatibility
+- ✅ **Requires Home Assistant 2025.7.1 or later** – latest compatibility
 - ✅ **pymodbus 3.5.0+** – latest Modbus library
 - ✅ **Python 3.11+** – modern standards
 - ✅ **Standard AsyncModbusTcpClient** – no custom Modbus client required

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.7.0",
+  "homeassistant": "2025.7.1",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",

--- a/hacs.json
+++ b/hacs.json
@@ -12,5 +12,5 @@
     "switch"
   ],
   "iot_class": "local_polling",
-  "version": "2.0.0"
+  "version": "2.1.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thessla-green-modbus"
-version = "2.0.0"
+version = "2.1.1"
 description = "ThesslaGreen Modbus integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.10"
 # Core dependencies
 dependencies = [
-    "homeassistant>=2025.7.0",
+    "homeassistant>=2025.7.1",
     "pymodbus>=3.5.0,<4.0.0",
     "voluptuous>=0.13.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Updated core requirements
 
 # Core Home Assistant (minimum version for compatibility)
-homeassistant>=2025.7.0
+homeassistant>=2025.7.1
 
 # Modbus communication library
 pymodbus>=3.5.0,<4.0.0

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,4 +1,4 @@
-"""Tests for ThesslaGreenCoordinator - HA 2025.7+ & pymodbus 3.5+ Compatible."""
+"""Tests for ThesslaGreenCoordinator - HA 2025.7.1+ & pymodbus 3.5+ Compatible."""
 
 import os
 import sys


### PR DESCRIPTION
## Summary
- Bump package to v2.1.1
- Require Home Assistant 2025.7.1 across metadata, docs, and tests

## Testing
- `python -m pip install -r requirements.txt` *(fails: No matching distribution found for homeassistant>=2025.7.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous')*

------
https://chatgpt.com/codex/tasks/task_e_689ad906d1f88326b0369665964edc7e