### PR TITLE
Use ThesslaGreenEntity for core entities

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -9,10 +9,10 @@ from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
+from .entity import ThesslaGreenEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,18 +54,15 @@ async def async_setup_entry(
         _LOGGER.debug("No fan control registers available - skipping fan entity")
 
 
-class ThesslaGreenFan(CoordinatorEntity, FanEntity):
+class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
     """ThesslaGreen fan entity."""
 
     def __init__(self, coordinator: ThesslaGreenModbusCoordinator) -> None:
         """Initialize the fan entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, "fan")
 
         # Entity configuration
-        self._attr_unique_id = f"{coordinator.device_name}_fan"
         self._attr_translation_key = "thessla_green_fan"
-        self._attr_has_entity_name = True
-        self._attr_device_info = coordinator.get_device_info()
 
         # Fan configuration
         self._attr_supported_features = FanEntityFeature.SET_SPEED

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -11,7 +11,6 @@ from homeassistant.const import UnitOfTemperature, PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, HOLDING_REGISTERS
 
@@ -20,6 +19,7 @@ try:  # Newer versions expose metadata through ENTITY_MAPPINGS
 except ImportError:  # pragma: no cover - fall back when not available
     ENTITY_MAPPINGS = {}
 from .coordinator import ThesslaGreenModbusCoordinator
+from .entity import ThesslaGreenEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ async def async_setup_entry(
         _LOGGER.debug("No number entities were created")
 
 
-class ThesslaGreenNumber(CoordinatorEntity, NumberEntity):
+class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
     """ThesslaGreen number entity."""
 
     def __init__(
@@ -94,17 +94,14 @@ class ThesslaGreenNumber(CoordinatorEntity, NumberEntity):
         register_type: Optional[str] = None,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, register_name)
 
         self.register_name = register_name
         self.entity_config = entity_config
         self.register_type = register_type
 
         # Entity configuration
-        self._attr_unique_id = f"{coordinator.device_name}_{register_name}"
         self._attr_translation_key = register_name
-        self._attr_has_entity_name = True
-        self._attr_device_info = coordinator.get_device_info()
 
         # Number configuration
         self._setup_number_attributes()

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -9,10 +9,10 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, HOLDING_REGISTERS, COIL_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
+from .entity import ThesslaGreenEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ async def async_setup_entry(
         _LOGGER.debug("No switch entities were created")
 
 
-class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
+class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
     """ThesslaGreen switch entity."""
 
     def __init__(
@@ -129,16 +129,13 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
         entity_config: Dict[str, Any],
     ) -> None:
         """Initialize the switch entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, register_name)
 
         self.register_name = register_name
         self.entity_config = entity_config
 
         # Entity configuration
-        self._attr_unique_id = f"{coordinator.device_name}_{register_name}"
         self._attr_translation_key = entity_config["translation_key"]
-        self._attr_has_entity_name = True
-        self._attr_device_info = coordinator.get_device_info()
         self._attr_icon = entity_config["icon"]
 
         # Set entity category if specified


### PR DESCRIPTION
## Summary
- Derive fan, number, and switch entities from `ThesslaGreenEntity`
- Let base entity provide device info and unique IDs from host/port/slave ID

## Testing
- `pytest` *(fails: cannot import name 'AIR_QUALITY_REGISTER_MAP' from 'custom_components.thessla_green_modbus.services')*


------
https://chatgpt.com/codex/tasks/task_e_689adc5e3fe08326a0ad7cf825b083a9