### PR TITLE
Scale writes using register multipliers

### DIFF
--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -162,51 +162,16 @@ class ThesslaGreenNumber(CoordinatorEntity, NumberEntity):
         if raw_value is None:
             return None
 
-        # Apply scale factor if configured
-        scale = self.entity_config.get("scale", 1)
-        if scale != 1 and isinstance(raw_value, (int, float)):
-            return round(float(raw_value) * scale, 2)
-
         return float(raw_value) if isinstance(raw_value, (int, float)) else None
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         try:
-            # Apply inverse scale factor if configured
-            scale = self.entity_config.get("scale", 1)
-            scaled_value = value / scale if scale != 1 else value
-
-            await self._write_register(self.register_name, scaled_value)
+            await self.coordinator.async_write_register(self.register_name, value)
             _LOGGER.info("Set %s to %.2f", self.register_name, value)
 
         except Exception as exc:
             _LOGGER.error("Failed to set %s to %.2f: %s", self.register_name, value, exc)
-
-    async def _write_register(self, register_name: str, value: float) -> None:
-        """Write value to register."""
-        if register_name not in HOLDING_REGISTERS:
-            raise ValueError(f"Register {register_name} is not writable")
-
-        register_address = HOLDING_REGISTERS[register_name]
-
-        # Convert to integer for Modbus
-        int_value = int(round(value))
-
-        # Ensure client is connected
-        if not self.coordinator.client or not self.coordinator.client.connected:
-            if not await self.coordinator.async_ensure_client():
-                raise RuntimeError("Failed to connect to device")
-
-        # Write register - pymodbus 3.5+ compatible
-        response = await self.coordinator.client.write_register(
-            address=register_address, value=int_value, slave=self.coordinator.slave_id
-        )
-
-        if response.isError():
-            raise RuntimeError(f"Failed to write register {register_name}: {response}")
-
-        # Request immediate data update
-        await self.coordinator.async_request_refresh()
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_extract_entity_ids
 
-from .const import DOMAIN, SPECIAL_FUNCTION_MAP, REGISTER_MULTIPLIERS
+from .const import DOMAIN, SPECIAL_FUNCTION_MAP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -244,29 +244,18 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for entity_id in entity_ids:
             coordinator = _get_coordinator_from_entity_id(hass, entity_id)
             if coordinator:
-                slope_raw = int(round(slope / REGISTER_MULTIPLIERS.get("heating_curve_slope", 1)))
-                offset_raw = int(round(offset / REGISTER_MULTIPLIERS.get("heating_curve_offset", 1)))
-
-                await coordinator.async_write_register("heating_curve_slope", slope_raw)
-                await coordinator.async_write_register("heating_curve_offset", offset_raw)
+                await coordinator.async_write_register("heating_curve_slope", slope)
+                await coordinator.async_write_register("heating_curve_offset", offset)
 
                 if max_supply_temp is not None:
-                    max_raw = int(
-                        round(
-                            max_supply_temp
-                            / REGISTER_MULTIPLIERS.get("max_supply_temperature", 1)
-                        )
+                    await coordinator.async_write_register(
+                        "max_supply_temperature", max_supply_temp
                     )
-                    await coordinator.async_write_register("max_supply_temperature", max_raw)
 
                 if min_supply_temp is not None:
-                    min_raw = int(
-                        round(
-                            min_supply_temp
-                            / REGISTER_MULTIPLIERS.get("min_supply_temperature", 1)
-                        )
+                    await coordinator.async_write_register(
+                        "min_supply_temperature", min_supply_temp
                     )
-                    await coordinator.async_write_register("min_supply_temperature", min_raw)
 
                 await coordinator.async_request_refresh()
                 _LOGGER.info("Set temperature curve for %s", entity_id)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,166 @@
+"""Tests for climate entity scaling when writing registers."""
+
+import sys
+import types
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal Home Assistant stubs for required modules
+# ---------------------------------------------------------------------------
+
+# homeassistant.const
+const = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+
+
+class UnitOfTemperature:
+    CELSIUS = "°C"
+
+
+const.UnitOfTemperature = UnitOfTemperature
+const.ATTR_TEMPERATURE = "temperature"
+
+# homeassistant.components.climate
+climate_mod = types.ModuleType("homeassistant.components.climate")
+
+
+class ClimateEntity:  # pragma: no cover - simple stub
+    pass
+
+
+class ClimateEntityFeature:  # pragma: no cover - simple stub
+    TARGET_TEMPERATURE = 1
+    FAN_MODE = 2
+    PRESET_MODE = 4
+    TURN_ON = 8
+    TURN_OFF = 16
+
+
+class HVACMode:  # pragma: no cover - simple stub
+    OFF = "off"
+    AUTO = "auto"
+    FAN_ONLY = "fan_only"
+
+
+class HVACAction:  # pragma: no cover - simple stub
+    pass
+
+
+climate_mod.ClimateEntity = ClimateEntity
+climate_mod.ClimateEntityFeature = ClimateEntityFeature
+climate_mod.HVACMode = HVACMode
+climate_mod.HVACAction = HVACAction
+sys.modules["homeassistant.components.climate"] = climate_mod
+
+# homeassistant.helpers.update_coordinator.CoordinatorEntity
+helpers_uc = sys.modules.setdefault(
+    "homeassistant.helpers.update_coordinator", types.ModuleType("hass.helpers.uc")
+)
+
+
+class CoordinatorEntity:  # pragma: no cover - simple stub
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+    @classmethod
+    def __class_getitem__(cls, item):  # pragma: no cover - allow subscripting
+        return cls
+
+
+helpers_uc.CoordinatorEntity = CoordinatorEntity
+
+# homeassistant.helpers.entity_platform.AddEntitiesCallback
+entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+
+
+class AddEntitiesCallback:  # pragma: no cover - simple stub
+    pass
+
+
+entity_platform.AddEntitiesCallback = AddEntitiesCallback
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+# homeassistant.helpers.device_registry.DeviceInfo
+device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+
+
+class DeviceInfo(dict):  # pragma: no cover - simple dict-based stub
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+device_registry.DeviceInfo = DeviceInfo
+sys.modules["homeassistant.helpers.device_registry"] = device_registry
+
+
+# ---------------------------------------------------------------------------
+# Actual imports after stubbing
+# ---------------------------------------------------------------------------
+
+from custom_components.thessla_green_modbus.climate import ThesslaGreenClimate
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+)
+from custom_components.thessla_green_modbus.const import (
+    DOMAIN,
+    HOLDING_REGISTERS,
+    REGISTER_MULTIPLIERS,
+)
+
+
+class DummyClient:
+    """Simple Modbus client stub capturing written values."""
+
+    def __init__(self):
+        self.writes = []
+
+    async def write_register(self, address, value, slave):
+        self.writes.append((address, value, slave))
+
+        class Response:
+            def isError(self):
+                return False
+
+        return Response()
+
+    async def write_coil(self, address, value, slave):  # pragma: no cover - not used
+        self.writes.append((address, value, slave))
+
+        class Response:
+            def isError(self):
+                return False
+
+        return Response()
+
+
+@pytest.mark.asyncio
+async def test_set_temperature_scaling():
+    """Ensure temperatures are scaled before writing to Modbus."""
+
+    hass = SimpleNamespace()
+    coordinator = ThesslaGreenModbusCoordinator(
+        hass, "host", 502, 1, "dev", timedelta(seconds=1)
+    )
+    coordinator.client = DummyClient()
+    coordinator._ensure_connection = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.available_registers["holding_registers"].update(
+        {"comfort_temperature", "required_temperature"}
+    )
+    coordinator.capabilities.basic_control = True
+
+    climate = ThesslaGreenClimate(coordinator)
+
+    await climate.async_set_temperature(**{const.ATTR_TEMPERATURE: 21.5})
+
+    addr_comfort = HOLDING_REGISTERS["comfort_temperature"]
+    addr_required = HOLDING_REGISTERS["required_temperature"]
+    expected = int(round(21.5 / REGISTER_MULTIPLIERS["comfort_temperature"]))
+
+    assert coordinator.client.writes == [
+        (addr_comfort, expected, coordinator.slave_id),
+        (addr_required, expected, coordinator.slave_id),
+    ]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -182,7 +182,12 @@ for name, module in modules.items():
 # Ensure repository root on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from custom_components.thessla_green_modbus.services import AIR_QUALITY_REGISTER_MAP
+import importlib
+
+services_module = importlib.reload(
+    importlib.import_module("custom_components.thessla_green_modbus.services")
+)
+AIR_QUALITY_REGISTER_MAP = services_module.AIR_QUALITY_REGISTER_MAP
 
 
 def test_air_quality_register_map():

--- a/tests/test_services_scaling.py
+++ b/tests/test_services_scaling.py
@@ -1,0 +1,108 @@
+"""Tests for service helpers ensuring values are scaled when written."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+)
+from custom_components.thessla_green_modbus.const import (
+    HOLDING_REGISTERS,
+    REGISTER_MULTIPLIERS,
+)
+import custom_components.thessla_green_modbus.services as services
+
+
+class DummyClient:
+    """Simple Modbus client stub capturing written values."""
+
+    def __init__(self):
+        self.writes = []
+
+    async def write_register(self, address, value, slave):
+        self.writes.append((address, value, slave))
+
+        class Response:
+            def isError(self):
+                return False
+
+        return Response()
+
+
+class Services:
+    """Minimal service registry for tests."""
+
+    def __init__(self):
+        self.handlers = {}
+
+    def async_register(self, domain, service, handler, schema):  # pragma: no cover
+        self.handlers[service] = handler
+
+
+@pytest.mark.asyncio
+async def test_temperature_curve_service_scaling(monkeypatch):
+    """Ensure set_temperature_curve writes scaled values to Modbus."""
+
+    hass = SimpleNamespace()
+    hass.services = Services()
+
+    coordinator = ThesslaGreenModbusCoordinator(
+        hass, "host", 502, 1, "dev", timedelta(seconds=1)
+    )
+    coordinator.client = DummyClient()
+    coordinator._ensure_connection = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+
+    # Patch service helpers to return our coordinator and entity IDs
+    monkeypatch.setattr(
+        services, "_get_coordinator_from_entity_id", lambda h, e: coordinator
+    )
+    monkeypatch.setattr(
+        services, "async_extract_entity_ids", lambda h, call: call.data["entity_id"]
+    )
+
+    await services.async_setup_services(hass)
+    handler = hass.services.handlers["set_temperature_curve"]
+
+    call = SimpleNamespace(
+        data={
+            "entity_id": ["climate.device"],
+            "slope": 2.5,
+            "offset": 1.0,
+            "max_supply_temp": 45.0,
+            "min_supply_temp": 20.0,
+        }
+    )
+
+    await handler(call)
+
+    client_writes = coordinator.client.writes
+
+    expected_slope = int(round(2.5 / REGISTER_MULTIPLIERS["heating_curve_slope"]))
+    expected_offset = int(round(1.0 / REGISTER_MULTIPLIERS["heating_curve_offset"]))
+    expected_max = int(round(45.0 / REGISTER_MULTIPLIERS["max_supply_temperature"]))
+    expected_min = int(round(20.0 / REGISTER_MULTIPLIERS["min_supply_temperature"]))
+
+    assert client_writes[0] == (
+        HOLDING_REGISTERS["heating_curve_slope"],
+        expected_slope,
+        coordinator.slave_id,
+    )
+    assert client_writes[1] == (
+        HOLDING_REGISTERS["heating_curve_offset"],
+        expected_offset,
+        coordinator.slave_id,
+    )
+    assert client_writes[2] == (
+        HOLDING_REGISTERS["max_supply_temperature"],
+        expected_max,
+        coordinator.slave_id,
+    )
+    assert client_writes[3] == (
+        HOLDING_REGISTERS["min_supply_temperature"],
+        expected_min,
+        coordinator.slave_id,
+    )


### PR DESCRIPTION
## Summary
- scale values in `async_write_register` using `REGISTER_MULTIPLIERS`
- pass user-unit values from services and numbers
- add tests verifying climate and service write scaling

## Testing
- `pytest tests/test_climate.py::test_set_temperature_scaling tests/test_services_scaling.py::test_temperature_curve_service_scaling -q`


------
https://chatgpt.com/codex/tasks/task_e_689adc3e4eec83268479c9fc09440c3d