### PR TITLE
Normalize translation keys and add missing entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ data:
 # Aktywuj tryb specjalny
 service: thessla_green_modbus.set_special_mode
 data:
-  special_mode: "okap"
+  special_mode: "hood"
   intensity: 100
   duration: 30
 
@@ -197,7 +197,7 @@ data:
 ### Auto boost podczas gotowania
 ```yaml
 automation:
-  - alias: "Kuchnia - tryb OKAP"
+  - alias: "Kuchnia - tryb HOOD"
     trigger:
       - platform: state
         entity_id: binary_sensor.kuchnia_ruch
@@ -205,7 +205,7 @@ automation:
     action:
       - service: thessla_green_modbus.set_special_mode
         data:
-          special_mode: "okap"
+          special_mode: "hood"
           intensity: 120
           duration: 45
 ```

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -61,11 +61,11 @@ SWITCH_ENTITIES = {
         "category": None,
         "translation_key": "vacation_mode",
     },
-    "okap_mode": {
+    "hood_mode": {
         "icon": "mdi:range-hood",
         "register_type": "holding_registers",
         "category": None,
-        "translation_key": "okap_mode",
+        "translation_key": "hood_mode",
     },
     "silent_mode": {
         "icon": "mdi:volume-off",
@@ -248,7 +248,7 @@ class ThesslaGreenSwitch(CoordinatorEntity, SwitchEntity):
             attributes["control_type"] = "operating_mode"
         elif self.register_name in ["boost_mode", "eco_mode", "night_mode"]:
             attributes["control_type"] = "performance_mode"
-        elif self.register_name in ["party_mode", "fireplace_mode", "vacation_mode", "okap_mode"]:
+        elif self.register_name in ["party_mode", "fireplace_mode", "vacation_mode", "hood_mode"]:
             attributes["control_type"] = "special_mode"
         elif self.register_name == "on_off_panel_mode":
             attributes["control_type"] = "system_power"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -83,6 +83,12 @@
       "exhaust_flowrate": {
         "name": "Exhaust Airflow"
       },
+      "supply_percentage": {
+        "name": "Supply Fan Speed"
+      },
+      "exhaust_percentage": {
+        "name": "Exhaust Fan Speed"
+      },
       "heat_recovery_efficiency": {
         "name": "Heat Recovery Efficiency"
       },
@@ -403,7 +409,7 @@
       "party_mode": { "name": "Party Mode" },
       "fireplace_mode": { "name": "Fireplace Mode" },
       "vacation_mode": { "name": "Vacation Mode" },
-      "okap_mode": { "name": "Hood Mode" },
+      "hood_mode": { "name": "Hood Mode" },
       "silent_mode": { "name": "Silent Mode" }
     },
     "select": {
@@ -442,6 +448,15 @@
       }
     },
     "number": {
+      "supply_temperature_manual": { "name": "Supply Temperature (Manual)" },
+      "supply_temperature_auto": { "name": "Supply Temperature (Auto)" },
+      "comfort_temperature": { "name": "Comfort Temperature" },
+      "air_flow_rate_manual": { "name": "Manual Air Flow Rate" },
+      "air_flow_rate_auto": { "name": "Automatic Air Flow Rate" },
+      "hood_intensity": { "name": "Hood Intensity" },
+      "fireplace_intensity": { "name": "Fireplace Intensity" },
+      "venting_intensity": { "name": "Venting Intensity" },
+      "filter_change_interval": { "name": "Filter Change Interval" },
       "required_temperature": { "name": "Required Temperature" },
       "max_supply_temperature": { "name": "Max Supply Temperature" },
       "min_supply_temperature": { "name": "Min Supply Temperature" },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -409,7 +409,7 @@
       "party_mode": { "name": "Tryb party" },
       "fireplace_mode": { "name": "Tryb kominkowy" },
       "vacation_mode": { "name": "Tryb wakacyjny" },
-      "okap_mode": { "name": "Tryb okapu" },
+      "hood_mode": { "name": "Tryb okapu" },
       "silent_mode": { "name": "Tryb cichy" }
     },
     "select": {
@@ -463,13 +463,13 @@
       "air_flow_rate_auto": {
         "name": "Intensywność automatyczna"
       },
-      "okap_intensity": {
+      "hood_intensity": {
         "name": "Intensywność okapu"
       },
-      "kominek_intensity": {
+      "fireplace_intensity": {
         "name": "Intensywność kominka"
       },
-      "wietrzenie_intensity": {
+      "venting_intensity": {
         "name": "Intensywność wietrzenia"
       },
         "filter_change_interval": {


### PR DESCRIPTION
## Summary
- add missing English translations and new keys
- replace Polish key names with English equivalents
- update docs and code references for hood mode

## Testing
- `pytest` *(fails: ImportError: cannot import name 'AIR_QUALITY_REGISTER_MAP')*

------
https://chatgpt.com/codex/tasks/task_e_689adc33c34c8326b85c989b7f0f5974