### PR TITLE
Clean unused translation entries

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -83,12 +83,6 @@
       "exhaust_flowrate": {
         "name": "Exhaust Airflow"
       },
-      "supply_percentage": {
-        "name": "Supply Fan Speed"
-      },
-      "exhaust_percentage": {
-        "name": "Exhaust Fan Speed"
-      },
       "heat_recovery_efficiency": {
         "name": "Heat Recovery Efficiency"
       },
@@ -402,15 +396,33 @@
       }
     },
     "switch": {
-      "on_off_panel_mode": { "name": "Panel Power" },
-      "boost_mode": { "name": "Boost Mode" },
-      "eco_mode": { "name": "Eco Mode" },
-      "night_mode": { "name": "Night Mode" },
-      "party_mode": { "name": "Party Mode" },
-      "fireplace_mode": { "name": "Fireplace Mode" },
-      "vacation_mode": { "name": "Vacation Mode" },
-      "hood_mode": { "name": "Hood Mode" },
-      "silent_mode": { "name": "Silent Mode" }
+      "on_off_panel_mode": {
+        "name": "Panel Power"
+      },
+      "boost_mode": {
+        "name": "Boost Mode"
+      },
+      "eco_mode": {
+        "name": "Eco Mode"
+      },
+      "night_mode": {
+        "name": "Night Mode"
+      },
+      "party_mode": {
+        "name": "Party Mode"
+      },
+      "fireplace_mode": {
+        "name": "Fireplace Mode"
+      },
+      "vacation_mode": {
+        "name": "Vacation Mode"
+      },
+      "hood_mode": {
+        "name": "Hood Mode"
+      },
+      "silent_mode": {
+        "name": "Silent Mode"
+      }
     },
     "select": {
       "mode": {
@@ -448,23 +460,30 @@
       }
     },
     "number": {
-      "supply_temperature_manual": { "name": "Supply Temperature (Manual)" },
-      "supply_temperature_auto": { "name": "Supply Temperature (Auto)" },
-      "comfort_temperature": { "name": "Comfort Temperature" },
-      "air_flow_rate_manual": { "name": "Manual Air Flow Rate" },
-      "air_flow_rate_auto": { "name": "Automatic Air Flow Rate" },
-      "hood_intensity": { "name": "Hood Intensity" },
-      "fireplace_intensity": { "name": "Fireplace Intensity" },
-      "venting_intensity": { "name": "Venting Intensity" },
-      "filter_change_interval": { "name": "Filter Change Interval" },
-      "required_temperature": { "name": "Required Temperature" },
-      "max_supply_temperature": { "name": "Max Supply Temperature" },
-      "min_supply_temperature": { "name": "Min Supply Temperature" },
-      "heating_curve_slope": { "name": "Heating Curve Slope" },
-      "heating_curve_offset": { "name": "Heating Curve Offset" },
-      "boost_air_flow_rate": { "name": "Boost Air Flow Rate" },
-      "boost_duration": { "name": "Boost Duration" },
-      "humidity_target": { "name": "Humidity Target" }
+      "required_temperature": {
+        "name": "Required Temperature"
+      },
+      "max_supply_temperature": {
+        "name": "Max Supply Temperature"
+      },
+      "min_supply_temperature": {
+        "name": "Min Supply Temperature"
+      },
+      "heating_curve_slope": {
+        "name": "Heating Curve Slope"
+      },
+      "heating_curve_offset": {
+        "name": "Heating Curve Offset"
+      },
+      "boost_air_flow_rate": {
+        "name": "Boost Air Flow Rate"
+      },
+      "boost_duration": {
+        "name": "Boost Duration"
+      },
+      "humidity_target": {
+        "name": "Humidity Target"
+      }
     }
   },
   "services": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -80,12 +80,6 @@
       "exhaust_flowrate": {
         "name": "Przepływ wywiewu"
       },
-      "supply_percentage": {
-        "name": "Prędkość wentylatora nawiewnego"
-      },
-      "exhaust_percentage": {
-        "name": "Prędkość wentylatora wywiewnego"
-      },
       "heat_recovery_efficiency": {
         "name": "Sprawność rekuperacji"
       },
@@ -402,15 +396,33 @@
       }
     },
     "switch": {
-      "on_off_panel_mode": { "name": "Główne zasilanie" },
-      "boost_mode": { "name": "Tryb boost" },
-      "eco_mode": { "name": "Tryb eco" },
-      "night_mode": { "name": "Tryb nocny" },
-      "party_mode": { "name": "Tryb party" },
-      "fireplace_mode": { "name": "Tryb kominkowy" },
-      "vacation_mode": { "name": "Tryb wakacyjny" },
-      "hood_mode": { "name": "Tryb okapu" },
-      "silent_mode": { "name": "Tryb cichy" }
+      "on_off_panel_mode": {
+        "name": "Główne zasilanie"
+      },
+      "boost_mode": {
+        "name": "Tryb boost"
+      },
+      "eco_mode": {
+        "name": "Tryb eco"
+      },
+      "night_mode": {
+        "name": "Tryb nocny"
+      },
+      "party_mode": {
+        "name": "Tryb party"
+      },
+      "fireplace_mode": {
+        "name": "Tryb kominkowy"
+      },
+      "vacation_mode": {
+        "name": "Tryb wakacyjny"
+      },
+      "hood_mode": {
+        "name": "Tryb okapu"
+      },
+      "silent_mode": {
+        "name": "Tryb cichy"
+      }
     },
     "select": {
       "mode": {
@@ -448,43 +460,32 @@
       }
     },
     "number": {
-      "supply_temperature_manual": {
-        "name": "Temperatura nawiewu (manual)"
+      "required_temperature": {
+        "name": "Wymagana temperatura"
       },
-      "supply_temperature_auto": {
-        "name": "Temperatura nawiewu (auto)"
+      "max_supply_temperature": {
+        "name": "Maksymalna temperatura nawiewu"
       },
-      "comfort_temperature": {
-        "name": "Temperatura komfortu"
+      "min_supply_temperature": {
+        "name": "Minimalna temperatura nawiewu"
       },
-      "air_flow_rate_manual": {
-        "name": "Intensywność ręczna"
+      "heating_curve_slope": {
+        "name": "Nachylenie krzywej grzewczej"
       },
-      "air_flow_rate_auto": {
-        "name": "Intensywność automatyczna"
+      "heating_curve_offset": {
+        "name": "Przesunięcie krzywej grzewczej"
       },
-      "hood_intensity": {
-        "name": "Intensywność okapu"
+      "boost_air_flow_rate": {
+        "name": "Prędkość nawiewu w trybie boost"
       },
-      "fireplace_intensity": {
-        "name": "Intensywność kominka"
+      "boost_duration": {
+        "name": "Czas trwania trybu boost"
       },
-      "venting_intensity": {
-        "name": "Intensywność wietrzenia"
-      },
-        "filter_change_interval": {
-          "name": "Interwał wymiany filtrów"
-        },
-        "required_temperature": { "name": "Wymagana temperatura" },
-        "max_supply_temperature": { "name": "Maksymalna temperatura nawiewu" },
-        "min_supply_temperature": { "name": "Minimalna temperatura nawiewu" },
-        "heating_curve_slope": { "name": "Nachylenie krzywej grzewczej" },
-        "heating_curve_offset": { "name": "Przesunięcie krzywej grzewczej" },
-        "boost_air_flow_rate": { "name": "Prędkość nawiewu w trybie boost" },
-        "boost_duration": { "name": "Czas trwania trybu boost" },
-        "humidity_target": { "name": "Docelowa wilgotność" }
+      "humidity_target": {
+        "name": "Docelowa wilgotność"
       }
-    },
+    }
+  },
   "services": {
     "set_special_mode": {
       "name": "Ustaw tryb specjalny",


### PR DESCRIPTION
## Summary
- remove translation entries for non-existent entities
- align Polish and English translation key sets

## Testing
- `pytest -q` *(fails: SyntaxError in coordinator.py and missing async plugin)*

------
https://chatgpt.com/codex/tasks/task_e_689ae11c5078832682f06067655ff4cd