### PR TITLE
Reorder imports in cleanup script

### DIFF
--- a/custom_components/thessla_green_modbus/cleanup_old_entities.py
+++ b/custom_components/thessla_green_modbus/cleanup_old_entities.py
@@ -9,12 +9,12 @@ integration:
     python3 cleanup_old_entities.py
 """
 
-import json
 import logging
+import json
 import shutil
 import sys
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- reorder import section in cleanup_old_entities to include logging, json, shutil, and sys at top

## Testing
- `pytest` (fails: SyntaxError in coordinator.py and missing module voluptuous)


------
https://chatgpt.com/codex/tasks/task_e_689ae35bcaec8326819ad06ae422a19b