### PR TITLE
Fix typing for scan_device

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 try:  # pragma: no cover
     from pymodbus.exceptions import ConnectionException
@@ -427,7 +427,7 @@ class ThesslaGreenDeviceScanner:
                 pass
             _LOGGER.debug("Disconnected from ThesslaGreen device")
 
-    async def scan_device(self) -> Dict[str, any]:
+    async def scan_device(self) -> Dict[str, Any]:
         """Scan device and return formatted result - compatible with coordinator."""
         try:
             info, caps, blocks = await self.scan()


### PR DESCRIPTION
## Summary
- use `typing.Any` for `scan_device` return type

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for homeassistant>=2025.7.1)*
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689ae35e34c883269f1bbef0b577c027