### PR TITLE
Rename Hood Mode to Range Hood Mode

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -418,7 +418,7 @@
         "name": "Vacation Mode"
       },
       "hood_mode": {
-        "name": "Hood Mode"
+        "name": "Range Hood Mode"
       },
       "silent_mode": {
         "name": "Silent Mode"


### PR DESCRIPTION
## Summary
- Rename Hood Mode to Range Hood Mode in English translations

## Testing
- `pytest` (fails: SyntaxError in `coordinator.py` and missing `homeassistant` dependency)
- `pip install homeassistant==2025.7.1` (fails: No matching distribution found)


------
https://chatgpt.com/codex/tasks/task_e_689ae3664554832692fa3af6fc5323b7