### PR TITLE
Remove comfort preset option

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -40,7 +40,6 @@ PRESET_MODES = [
     "none",
     "eco",
     "boost",
-    "comfort",
     "away",
     "sleep",
     "fireplace",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -376,7 +376,6 @@
             "none": "None",
             "eco": "Eco",
             "boost": "Boost",
-            "comfort": "Comfort",
             "away": "Away",
             "sleep": "Sleep",
             "fireplace": "Fireplace",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -376,7 +376,6 @@
             "none": "Brak",
             "eco": "Eco",
             "boost": "Boost",
-            "comfort": "Komfort",
             "away": "Nieobecność",
             "sleep": "Sen",
             "fireplace": "Kominek",


### PR DESCRIPTION
## Summary
- drop unused `comfort` preset from climate entity
- sync English and Polish translations with updated preset list

## Testing
- `pytest` *(fails: SyntaxError in custom_components/thessla_green_modbus/coordinator.py)*

------
https://chatgpt.com/codex/tasks/task_e_689ae36094448326bd75baa73cce4edc