### PR TITLE
chore: harmonize hood terminology

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -417,7 +417,7 @@
         "name": "Vacation Mode"
       },
       "hood_mode": {
-        "name": "Range Hood Mode"
+        "name": "Hood Mode"
       },
       "silent_mode": {
         "name": "Silent Mode"


### PR DESCRIPTION
## Summary
- Harmonize hood terminology by updating English translations to use "Hood Mode"
- Verified translation keys and service names for en/pl translations

## Testing
- `hass --script translations custom_components/thessla_green_modbus` *(fails: Invalid script specified)*

------
https://chatgpt.com/codex/tasks/task_e_689ae55d7b308326aabcfc3dca702a65