### PR TITLE
Ensure numbers added all at once

### DIFF
--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -77,7 +77,7 @@ async def async_setup_entry(
             _LOGGER.debug("Created number entity: %s", register_name)
 
     if entities:
-        async_add_entities(entities)
+        async_add_entities(entities, True)
         _LOGGER.info("Added %d number entities", len(entities))
     else:
         _LOGGER.debug("No number entities were created")


### PR DESCRIPTION
## Summary
- Ensure `async_add_entities` adds all collected number entities at once, enabling `update_before_add`

## Testing
- `python -m pytest` *(fails: ThesslaGreenModbusCoordinator.__init__() missing 1 required positional argument: 'name')*


------
https://chatgpt.com/codex/tasks/task_e_689aeb0d39a48326be04afa0ce43eebf