### PR TITLE
refactor: remove legacy coordinator alias

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -756,7 +756,3 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
     def device_info_dict(self) -> Dict[str, Any]:
         """Return device information as a plain dictionary for legacy use."""
         return self.get_device_info().as_dict()
-
-
-# Legacy compatibility - ThesslaGreenCoordinator alias
-ThesslaGreenCoordinator = ThesslaGreenModbusCoordinator

--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import ThesslaGreenCoordinator
+from .coordinator import ThesslaGreenModbusCoordinator
 
 
-class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenCoordinator]):
+class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     """Base entity for ThesslaGreen devices."""
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: ThesslaGreenCoordinator, key: str) -> None:
+    def __init__(self, coordinator: ThesslaGreenModbusCoordinator, key: str) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
         self._key = key

--- a/tests/run_optimization_tests.py
+++ b/tests/run_optimization_tests.py
@@ -36,11 +36,11 @@ async def validate_optimization_metrics():
     try:
         # Test 1: Register Grouping Efficiency
         print("🔍 Testing register grouping optimization...")
-        from custom_components.thessla_green_modbus.coordinator import ThesslaGreenCoordinator
+        from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
         from unittest.mock import MagicMock
         
         hass = MagicMock()
-        coordinator = ThesslaGreenCoordinator(
+        coordinator = ThesslaGreenModbusCoordinator(
             hass=hass, host="192.168.1.100", port=502, slave_id=10,
             scan_interval=30, timeout=10, retry=3
         )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,4 +1,4 @@
-"""Tests for ThesslaGreenCoordinator - HA 2025.7.1+ & pymodbus 3.5+ Compatible."""
+"""Tests for ThesslaGreenModbusCoordinator - HA 2025.7.1+ & pymodbus 3.5+ Compatible."""
 
 import os
 import sys
@@ -132,7 +132,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 # ✅ FIXED: Import correct coordinator class name
 from custom_components.thessla_green_modbus.coordinator import (
-    ThesslaGreenCoordinator,
+    ThesslaGreenModbusCoordinator,
 )
 
 
@@ -146,7 +146,7 @@ def coordinator():
         "coil_registers": {"system_on_off"},
         "discrete_inputs": set(),
     }
-    coordinator = ThesslaGreenCoordinator(
+    coordinator = ThesslaGreenModbusCoordinator(
         hass=hass,
         host="localhost",
         port=502,
@@ -244,7 +244,7 @@ def test_coordinator_initialization():
     hass = MagicMock()
     available_registers = {"holding_registers": set(), "input_registers": set()}
 
-    coordinator = ThesslaGreenCoordinator(
+    coordinator = ThesslaGreenModbusCoordinator(
         hass=hass,
         host="192.168.1.100",
         port=502,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,7 +28,7 @@ async def test_async_setup_entry_success():
     entry.async_on_unload = MagicMock()
     
     with patch(
-        "custom_components.thessla_green_modbus.ThesslaGreenCoordinator"
+        "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator"
     ) as mock_coordinator_class:
         mock_coordinator = MagicMock()
         mock_coordinator.async_config_entry_first_refresh = AsyncMock()
@@ -57,7 +57,7 @@ async def test_async_setup_entry_failure():
     entry.options = {}
     
     with patch(
-        "custom_components.thessla_green_modbus.ThesslaGreenCoordinator"
+        "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator"
     ) as mock_coordinator_class:
         mock_coordinator = MagicMock()
         mock_coordinator.async_config_entry_first_refresh = AsyncMock(

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -123,7 +123,7 @@ class TestThesslaGreenIntegration:
         from custom_components.thessla_green_modbus.const import DOMAIN
         
         with patch(
-            "custom_components.thessla_green_modbus.ThesslaGreenCoordinator",
+            "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator",
             return_value=mock_coordinator
         ):
             result = await async_setup_entry(mock_hass, mock_config_entry)
@@ -145,7 +145,7 @@ class TestThesslaGreenIntegration:
         )
         
         with patch(
-            "custom_components.thessla_green_modbus.ThesslaGreenCoordinator",
+            "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator",
             return_value=mock_coordinator
         ):
             with pytest.raises(ConfigEntryNotReady):
@@ -172,7 +172,7 @@ class TestThesslaGreenIntegration:
         from custom_components.thessla_green_modbus import async_setup_entry
         
         with patch(
-            "custom_components.thessla_green_modbus.ThesslaGreenCoordinator",
+            "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator",
             return_value=mock_coordinator
         ):
             await async_setup_entry(mock_hass, mock_config_entry)
@@ -186,16 +186,16 @@ class TestThesslaGreenIntegration:
                 assert service in service_names
 
 
-class TestThesslaGreenCoordinator:
+class TestThesslaGreenModbusCoordinator:
     """Test the data coordinator functionality."""
 
     @pytest.fixture
     def coordinator_data(self):
         """Create coordinator with test data."""
-        from custom_components.thessla_green_modbus.coordinator import ThesslaGreenCoordinator
+        from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
         
         hass = MagicMock()
-        coordinator = ThesslaGreenCoordinator(
+        coordinator = ThesslaGreenModbusCoordinator(
             hass=hass,
             host="192.168.1.100",
             port=502,
@@ -563,11 +563,11 @@ class TestPerformanceOptimizations:
     @pytest.mark.asyncio
     async def test_register_grouping_performance(self):
         """Test that register grouping reduces Modbus calls."""
-        from custom_components.thessla_green_modbus.coordinator import ThesslaGreenCoordinator
+        from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
         
         # Create coordinator with many registers
         hass = MagicMock()
-        coordinator = ThesslaGreenCoordinator(
+        coordinator = ThesslaGreenModbusCoordinator(
             hass=hass, host="192.168.1.100", port=502, slave_id=10,
             scan_interval=30, timeout=10, retry=3
         )

--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -126,14 +126,14 @@ async def async_unload_services(hass):
 cc_services.async_setup_services = async_setup_services
 cc_services.async_unload_services = async_unload_services
 
-from custom_components.thessla_green_modbus.coordinator import ThesslaGreenCoordinator
+from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
 
 
 def test_async_setup_closes_scanner():
     """Ensure scanner is closed after async_setup."""
     async def run_test():
         hass = MagicMock()
-        coordinator = ThesslaGreenCoordinator(
+        coordinator = ThesslaGreenModbusCoordinator(
             hass=hass,
             host="localhost",
             port=502,
@@ -176,7 +176,7 @@ def test_disconnect_closes_client():
 
     async def run_test():
         hass = MagicMock()
-        coordinator = ThesslaGreenCoordinator(
+        coordinator = ThesslaGreenModbusCoordinator(
             hass=hass,
             host="localhost",
             port=502,


### PR DESCRIPTION
## Summary
- replace `ThesslaGreenCoordinator` import with `ThesslaGreenModbusCoordinator`
- drop old `ThesslaGreenCoordinator` alias
- update tests to reference `ThesslaGreenModbusCoordinator`

## Testing
- `pytest` *(fails: 42 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689aeb174a888326909d88de879dfed2