### PR TITLE
Ensure switch entities update before adding

### DIFF
--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -113,7 +113,9 @@ async def async_setup_entry(
             _LOGGER.debug("Created switch entity: %s", register_name)
 
     if entities:
-        async_add_entities(entities)
+        # Coordinator already holds initial data from setup, so update entities before add
+        # to populate their state without triggering another refresh
+        async_add_entities(entities, True)
         _LOGGER.info("Added %d switch entities", len(entities))
     else:
         _LOGGER.debug("No switch entities were created")


### PR DESCRIPTION
## Summary
- Update switch entity setup to use async_add_entities(..., True) and document preloaded coordinator state

## Testing
- `pytest` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689aeb0ee460832694e02c641cc8c433