### PR TITLE
Remove Home Assistant from requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ This project adheres to a simple code of conduct:
 ### Prerequisites
 
 - Python 3.10+ 
-- Home Assistant 2023.4.0+
+- Home Assistant 2025.7.1+ (managed outside `requirements.txt`)
 - Git
 - A ThesslaGreen AirPack device (for testing)
 
@@ -75,13 +75,15 @@ cd thessla_green_modbus
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 
-# Install dependencies
+# Install dependencies (Home Assistant core excluded)
 pip install -r requirements.txt
 pip install pre-commit pytest black isort flake8 mypy
 
 # Install pre-commit hooks
 pre-commit install
 ```
+
+> **Note:** The `homeassistant` package is not included in `requirements.txt`; ensure your environment provides a compatible Home Assistant version as declared in `custom_components/thessla_green_modbus/manifest.json`.
 
 ### 3. Verify Setup
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,7 +8,7 @@
 - Połączenie sieciowe między HA a rekuperatorem
 
 ### Oprogramowanie
-- Home Assistant 2023.4.0 lub nowszy
+- Home Assistant 2025.7.1 lub nowszy (minimalna wersja zadeklarowana w `manifest.json`, brak pakietu `homeassistant` w `requirements.txt`)
 - Python 3.10 lub nowszy
 - Biblioteka `pymodbus>=3.0.0`
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 - ✅ **Firmware v3.x - v5.x** z automatyczną detekcją
 
 ### Home Assistant
-- ✅ **Wymagany Home Assistant 2025.7.1 lub nowszy** - najnowsza kompatybilność
+- ✅ **Wymagany Home Assistant 2025.7.1 lub nowszy** – minimalna wersja określona w `manifest.json` (pakiet `homeassistant` nie jest częścią `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** - najnowsza biblioteka Modbus
 - ✅ **Python 3.11+** - nowoczesne standardy
 - ✅ **Standardowy AsyncModbusTcpClient** – brak potrzeby własnego klienta Modbus

--- a/README_en.md
+++ b/README_en.md
@@ -32,7 +32,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 - ✅ **Firmware v3.x – v5.x** with automatic detection
 
 ### Home Assistant
-- ✅ **Requires Home Assistant 2025.7.1 or later** – latest compatibility
+- ✅ **Requires Home Assistant 2025.7.1 or later** – minimum version declared in `manifest.json` (the `homeassistant` package is not part of `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** – latest Modbus library
 - ✅ **Python 3.11+** – modern standards
 - ✅ **Standard AsyncModbusTcpClient** – no custom Modbus client required

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # ThesslaGreen Modbus Integration - Python Dependencies
 # Updated core requirements
 
-# Core Home Assistant (minimum version for compatibility)
-homeassistant>=2025.7.1
+# Core Home Assistant provided by host environment
+# (minimum version declared in manifest.json)
 
 # Modbus communication library
 pymodbus>=3.5.0,<4.0.0


### PR DESCRIPTION
## Summary
- drop `homeassistant` from `requirements.txt`
- document that Home Assistant is provided by the host environment

## Testing
- `pytest` *(fails: AttributeError module homeassistant.util has no attribute 'location')*

------
https://chatgpt.com/codex/tasks/task_e_689aeb21f04883269afcae5a808ddaed