### PR TITLE
refactor discrete input grouping key

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -231,7 +231,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             discrete_addrs = [
                 DISCRETE_INPUT_REGISTERS[reg] for reg in self.available_registers["discrete_inputs"]
             ]
-            self._register_groups["discrete"] = self._group_registers_for_batch_read(
+            self._register_groups["discrete_inputs"] = self._group_registers_for_batch_read(
                 sorted(discrete_addrs)
             )
 
@@ -522,10 +522,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         """Read discrete input registers using optimized batch reading."""
         data = {}
 
-        if "discrete" not in self._register_groups:
+        if "discrete_inputs" not in self._register_groups:
             return data
 
-        for start_addr, count in self._register_groups["discrete"]:
+        for start_addr, count in self._register_groups["discrete_inputs"]:
             try:
                 response = await self.client.read_discrete_inputs(
                     start_addr, count, unit=self.slave_id


### PR DESCRIPTION
## Summary
- ensure discrete input register groups use `discrete_inputs` key
- align optimized discrete input reader with new register group key

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for homeassistant>=2025.7.1)*
- `pip install voluptuous`
- `pytest tests/test_coordinator.py::test_async_write_invalid_register -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689aeb32e10c832695e42f0c24a4f6cf