### PR TITLE
Remove unused air_flow_rate references

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -101,7 +101,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         """Get current flow rate from available registers."""
         # Priority order for reading current flow rate
         flow_registers = [
-            "air_flow_rate",  # Current overall flow rate
+            "supply_air_flow",  # Supply air flow rate
             "supply_percentage",  # Supply air percentage
             "air_flow_rate_manual",  # Manual flow rate setting
             "air_flow_rate_auto",  # Auto flow rate setting
@@ -158,8 +158,6 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                     await self._write_register(register, 0)
                     self.coordinator.data[register] = 0
 
-            # Ensure current flow rate reflects the off state for properties
-            self.coordinator.data["air_flow_rate"] = 0
             _LOGGER.info("Turned off fan")
 
         except Exception as exc:


### PR DESCRIPTION
## Summary
- Stop referencing deprecated `air_flow_rate` register in fan entity
- Remove manual `air_flow_rate` state updates when turning the fan off

## Testing
- `pytest -q` *(fails: ThesslaGreenModbusCoordinator.__init__() missing 1 required positional argument: 'name')*


------
https://chatgpt.com/codex/tasks/task_e_689aeb2d2bd8832686d4feac11514d38