### PR TITLE
Ensure old Modbus client is closed before reconnect

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -303,6 +303,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
     async def _ensure_connection(self) -> None:
         """Ensure Modbus connection is established."""
         if self.client is None or not self.client.connected:
+            if self.client is not None:
+                await self._disconnect()
             try:
                 from pymodbus.client import AsyncModbusTcpClient
 


### PR DESCRIPTION
## Summary
- close existing Modbus client when reconnecting
- add regression test to ensure repeated reconnections do not leak connections

## Testing
- `pytest tests/test_coordinator.py::test_reconfigure_does_not_leak_connections -q`
- `pytest tests/test_coordinator.py -q`
- `pytest -q` *(fails: 26 failed, 29 passed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689aeb14d04c832695c889d6d1aae928