### PR TITLE
fix: unify GWC translation

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -257,7 +257,7 @@
         "name": "Obejście (bypass)"
       },
       "gwc": {
-        "name": "System GWC"
+        "name": "GWC"
       },
       "heating_cable": {
         "name": "Kabel grzejny"


### PR DESCRIPTION
## Summary
- ensure Polish translation uses "GWC" for gwc entity, matching English terminology

## Testing
- `pytest` *(fails: module 'homeassistant' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_689aed3115bc83269cdde7b68f52cc6c