### PR TITLE
Use explicit newline in configuration description

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "ThesslaGreen Modbus Configuration",
-        "description": "Configure connection to ThesslaGreen AirPack via Modbus TCP. The integration will automatically detect available device functions and registers.",
+        "description": "Configure connection to ThesslaGreen AirPack via Modbus TCP.\nThe integration will automatically detect available device functions and registers.",
         "data": {
           "host": "IP Address",
           "port": "Port",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfiguracja ThesslaGreen Modbus",
-        "description": "Skonfiguruj połączenie z ThesslaGreen AirPack przez Modbus TCP. Integracja automatycznie wykryje dostępne funkcje i rejestry urządzenia.",
+        "description": "Skonfiguruj połączenie z ThesslaGreen AirPack przez Modbus TCP.\nIntegracja automatycznie wykryje dostępne funkcje i rejestry urządzenia.",
         "data": {
           "host": "Adres IP",
           "port": "Port",


### PR DESCRIPTION
## Summary
- add explicit `\n` in configuration descriptions for English and Polish translations

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/en.json`
- `python -m json.tool custom_components/thessla_green_modbus/translations/pl.json`
- `pytest` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute 'dt')*


------
https://chatgpt.com/codex/tasks/task_e_689aed2e690c832688b12e2d7531a8c7