### PR TITLE
Use DISCRETE_INPUT_REGISTERS constant in integration test

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -128,7 +128,7 @@ async def test_register_constants():
     """Test that register constants are properly defined."""
     from custom_components.thessla_green_modbus.const import (
         COIL_REGISTERS,
-        DISCRETE_INPUTS,
+        DISCRETE_INPUT_REGISTERS,
         INPUT_REGISTERS,
         HOLDING_REGISTERS,
     )
@@ -137,7 +137,7 @@ async def test_register_constants():
     assert "power_supply_fans" in COIL_REGISTERS
     assert "outside_temperature" in INPUT_REGISTERS
     assert "mode" in HOLDING_REGISTERS
-    assert "expansion" in DISCRETE_INPUTS
+    assert "expansion" in DISCRETE_INPUT_REGISTERS
     
     # Test address ranges
     assert COIL_REGISTERS["power_supply_fans"] == 0x000B


### PR DESCRIPTION
## Summary
- update integration test to use `DISCRETE_INPUT_REGISTERS` constant

## Testing
- `pytest tests/test_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_689af06222a08326a746c517cbcc5b3d