### PR TITLE
Clarify supply duct temperature translation

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -66,7 +66,7 @@
         "name": "FPX Temperature"
       },
       "duct_supply_temperature": {
-        "name": "Duct Temperature"
+        "name": "Supply Duct Temperature"
       },
       "gwc_temperature": {
         "name": "GWC Temperature"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -66,7 +66,7 @@
         "name": "Temperatura FPX"
       },
       "duct_supply_temperature": {
-        "name": "Temperatura kanałowa"
+        "name": "Temperatura kanału nawiewu"
       },
       "gwc_temperature": {
         "name": "Temperatura GWC"


### PR DESCRIPTION
## Summary
- clarify sensor name for duct supply temperature in English and Polish translations

## Testing
- `python -m script.translations develop` *(fails: No module named 'script')*
- `pytest` *(fails: module 'homeassistant' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_689af05ff004832682621ac53d814644