### PR TITLE
fix: update HA requirement version

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.7.1",
+  "homeassistant": "2025.1.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",


### PR DESCRIPTION
## Summary
- update `homeassistant` version in manifest

## Testing
- `pytest` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689af45f5fe48326a155f17f755d6f67