### PR TITLE
Handle missing target temperature register

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -128,15 +128,15 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
 
     @property
     def target_temperature(self) -> Optional[float]:
-        """Return target temperature."""
+        """Return target temperature if available."""
         # Try comfort temperature first, then required temperature
         if "comfort_temperature" in self.coordinator.data:
             return self.coordinator.data["comfort_temperature"]
-        elif "required_temperature" in self.coordinator.data:
+        if "required_temperature" in self.coordinator.data:
             return self.coordinator.data["required_temperature"]
-        elif "required_temp" in self.coordinator.data:
+        if "required_temp" in self.coordinator.data:
             return self.coordinator.data["required_temp"]
-        return 22.0  # Default
+        return None
 
     @property
     def hvac_mode(self) -> HVACMode:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,17 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
 
     const.Platform = Platform
 
+    # Minimal util.logging stub for pytest plugin compatibility
+    util = types.ModuleType("homeassistant.util")
+    util_logging = types.ModuleType("homeassistant.util.logging")
+
+    def log_exception(*args, **kwargs):  # pragma: no cover - simple no-op
+        return None
+
+    util_logging.log_exception = log_exception
+    util.logging = util_logging
+    ha.util = util
+
     sys.modules["homeassistant"] = ha
     sys.modules["homeassistant.core"] = core
     sys.modules["homeassistant.config_entries"] = config_entries
@@ -184,6 +195,8 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
     sys.modules["homeassistant.exceptions"] = exceptions
     sys.modules["homeassistant.const"] = const
+    sys.modules["homeassistant.util"] = util
+    sys.modules["homeassistant.util.logging"] = util_logging
     sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
     sys.modules["homeassistant.helpers.config_validation"] = cv
     sys.modules["homeassistant.helpers.selector"] = selector
@@ -194,6 +207,9 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["pymodbus.pdu"] = pymodbus_pdu
 
 DOMAIN = "thessla_green_modbus"
+
+# Ensure util.logging is importable for pytest plugin
+import homeassistant.util.logging  # type: ignore
 
 
 class CoordinatorMock(MagicMock):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -164,3 +164,20 @@ async def test_set_temperature_scaling():
         (addr_comfort, expected, coordinator.slave_id),
         (addr_required, expected, coordinator.slave_id),
     ]
+
+
+def test_target_temperature_none_when_unavailable():
+    """Return None when no target temperature register is present."""
+    hass = SimpleNamespace()
+    coordinator = ThesslaGreenModbusCoordinator(
+        hass, "host", 502, 1, "dev", timedelta(seconds=1)
+    )
+    coordinator.capabilities.basic_control = True
+    coordinator.data = {}
+
+    climate = ThesslaGreenClimate(coordinator)
+
+    assert climate.target_temperature is None
+
+    coordinator.data["comfort_temperature"] = 20.0
+    assert climate.target_temperature == 20.0


### PR DESCRIPTION
## Summary
- Return `None` from `target_temperature` when no register is present
- Add regression test for missing temperature register
- Provide `homeassistant.util` stubs in tests to satisfy pytest plugin

## Testing
- `pytest tests/test_climate.py::test_target_temperature_none_when_unavailable -q`
- `pytest -q` *(fails: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689af46ee25c832697a71b410d384c96