### PR TITLE
chore: split development requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,7 @@ python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 
 # Install dependencies (Home Assistant core excluded)
-pip install -r requirements.txt
-pip install pre-commit pytest black isort flake8 mypy
+pip install -r requirements.txt -r requirements-dev.txt
 
 # Install pre-commit hooks
 pre-commit install

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,17 @@
+# ThesslaGreen Modbus Integration - Development Dependencies
+
+# Testing
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+pytest-homeassistant-custom-component>=0.13.0
+
+# Code quality tools
+black>=22.0.0
+isort>=5.10.0
+flake8>=4.0.0
+mypy>=0.990
+pre-commit>=3.0.0
+
+# Documentation
+sphinx>=4.0.0
+sphinx-rtd-theme>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# ThesslaGreen Modbus Integration - Python Dependencies
-# Updated core requirements
+# ThesslaGreen Modbus Integration - Runtime Dependencies
 
 # Core Home Assistant provided by host environment
 # (minimum version declared in manifest.json)
@@ -7,20 +6,5 @@
 # Modbus communication library
 pymodbus>=3.5.0,<4.0.0
 
-# Data validation and schemas  
+# Data validation and schemas
 voluptuous>=0.13.1
-
-# Testing dependencies (development)
-pytest>=7.0.0
-pytest-asyncio>=0.21.0
-pytest-homeassistant-custom-component>=0.13.0
-
-# Code quality tools (development)
-black>=22.0.0
-isort>=5.10.0
-flake8>=4.0.0
-mypy>=0.990
-
-# Documentation (development)
-sphinx>=4.0.0
-sphinx-rtd-theme>=1.0.0


### PR DESCRIPTION
## Summary
- move test and tooling packages into requirements-dev.txt
- keep runtime dependencies only in requirements.txt
- update contributing docs to install both runtime and dev requirements

## Testing
- `pytest`
- `pre-commit run --files requirements.txt requirements-dev.txt CONTRIBUTING.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689af4a29ae88326911d34a36f16ea84