### PR TITLE
Clarify Polish retry wording

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -35,11 +35,11 @@
     "step": {
       "init": {
         "title": "Opcje ThesslaGreen Modbus",
-        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Częstotliwość odczytu: {current_scan_interval}s\n- Limit czasu połączenia: {current_timeout}s\n- Liczba ponowień: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
+        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Częstotliwość odczytu: {current_scan_interval}s\n- Limit czasu połączenia: {current_timeout}s\n- Liczba prób: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
         "data": {
           "scan_interval": "Interwał skanowania (sekundy)",
           "timeout": "Limit czasu połączenia (sekundy)",
-          "retry": "Liczba prób ponowienia",
+          "retry": "Liczba prób",
           "force_full_register_list": "Wymuś pełną listę rejestrów (bez skanowania)"
         },
         "data_description": {


### PR DESCRIPTION
## Summary
- clarify retry field label in Polish translation
- update advanced options description to use "Liczba prób"

## Testing
- `pytest` *(fails: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689af4a0cb3c8326a8faf9345c33d2b3