### PR TITLE
chore: update maintainer email

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "ThesslaGreen Modbus integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
-    {name = "ThesslaGreen Modbus Integration", email = "contact@example.com"}
+    {name = "ThesslaGreen Modbus Integration", email = "blakinio@o2.pl"}
 ]
 keywords = ["home-assistant", "modbus", "hvac", "thesslagreen", "airpack"]
 classifiers = [
@@ -26,7 +26,6 @@ classifiers = [
 requires-python = ">=3.10"
 # Core dependencies
 dependencies = [
-    "homeassistant>=2025.7.1",
     "pymodbus>=3.5.0,<4.0.0",
     "voluptuous>=0.13.1",
 ]


### PR DESCRIPTION
## Summary
- replace placeholder maintainer email with current address
- rely on manifest for Home Assistant version by removing direct dependency

## Testing
- `pytest` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689af49dbf348326b609abfd035ca2fd