### PR TITLE
style: move deferred test imports to top

### DIFF
--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -2,6 +2,10 @@ import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+)
+
 # Stub minimal Home Assistant and pymodbus modules before importing the coordinator
 ha = types.ModuleType("homeassistant")
 const = types.ModuleType("homeassistant.const")
@@ -18,6 +22,18 @@ pymodbus_exceptions = types.ModuleType("pymodbus.exceptions")
 pymodbus_pdu = types.ModuleType("pymodbus.pdu")
 vol = types.ModuleType("voluptuous")
 cc_services = types.ModuleType("custom_components.thessla_green_modbus.services")
+
+
+async def async_setup_services(hass):
+    pass
+
+
+async def async_unload_services(hass):
+    pass
+
+
+cc_services.async_setup_services = async_setup_services
+cc_services.async_unload_services = async_unload_services
 
 # Minimal util.logging module required by pytest_homeassistant_custom_component
 util = types.ModuleType("homeassistant.util")
@@ -143,17 +159,6 @@ sys.modules.update({
     "voluptuous": vol,
     "custom_components.thessla_green_modbus.services": cc_services,
 })
-
-async def async_setup_services(hass):
-    pass
-
-async def async_unload_services(hass):
-    pass
-
-cc_services.async_setup_services = async_setup_services
-cc_services.async_unload_services = async_unload_services
-
-from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
 
 
 def test_async_setup_closes_scanner():

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,5 +1,6 @@
 """Tests for service helper mappings."""
 
+import importlib
 import os
 import sys
 import types
@@ -193,8 +194,6 @@ for name, module in modules.items():
 
 # Ensure repository root on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-import importlib
 
 services_module = importlib.reload(
     importlib.import_module("custom_components.thessla_green_modbus.services")


### PR DESCRIPTION
## Summary
- move coordinator import to start of `test_scanner_close.py`
- relocate `importlib` import to top of `test_services.py`

## Testing
- `ruff check tests`


------
https://chatgpt.com/codex/tasks/task_e_689af4753e348326b807fe03a5b9944d