### PR TITLE
docs: clarify legacy temperature register

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -134,8 +134,8 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
             return self.coordinator.data["comfort_temperature"]
         elif "required_temperature" in self.coordinator.data:
             return self.coordinator.data["required_temperature"]
-        elif "required_temp" in self.coordinator.data:
-            return self.coordinator.data["required_temp"]
+        elif "required_temperature_legacy" in self.coordinator.data:
+            return self.coordinator.data["required_temperature_legacy"]
         return 22.0  # Default
 
     @property

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -376,7 +376,8 @@ HOLDING_REGISTERS = {
     "lock_pass1": 0x1FFB,
     "lock_pass2": 0x1FFC,
     "lock_flag": 0x1FFD,
-    "required_temp": 0x1FFE,
+    # Legacy location for required temperature used by older firmware
+    "required_temperature_legacy": 0x1FFE,
     "filter_change": 0x1FFF,
 }
 
@@ -569,7 +570,8 @@ REGISTER_MULTIPLIERS = {
     "night_cooling_temperature": 0.5,
     "supply_air_temperature_manual": 0.5,
     "supply_air_temperature_temporary": 0.5,
-    "required_temp": 0.5,
+    # Legacy register shares the same scaling as required_temperature
+    "required_temperature_legacy": 0.5,
     # Voltage/Current conversions
     "dac_supply": 0.00244,  # 0-4095 -> 0-10V
     "dac_exhaust": 0.00244,


### PR DESCRIPTION
## Summary
- clarify that register 0x1FFE represents a legacy required temperature
- handle new constant in climate fallback logic

## Testing
- `pytest` *(fails: module 'homeassistant' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_689af4611c7c8326b4da0f83b49c48c1