### PR TITLE
Add basic entity tests for ThesslaGreen Modbus

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,18 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
     sys.modules["homeassistant.helpers.config_validation"] = cv
     sys.modules["homeassistant.helpers.selector"] = selector
+    # Minimal util logging stub required by pytest_homeassistant_custom_component
+    util = types.ModuleType("homeassistant.util")
+    util_logging = types.ModuleType("homeassistant.util.logging")
+
+    def log_exception(format_err, *args):  # pragma: no cover - simple stub
+        return None
+
+    util_logging.log_exception = log_exception
+    util.logging = util_logging
+    ha.util = util
+    sys.modules["homeassistant.util"] = util
+    sys.modules["homeassistant.util.logging"] = util_logging
     sys.modules["pymodbus"] = pymodbus
     sys.modules["pymodbus.client"] = pymodbus_client
     sys.modules["pymodbus.client.tcp"] = pymodbus_client_tcp

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -4,10 +4,11 @@ norecursedirs = .git testing_config
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = 
+addopts =
     --strict-markers
     --disable-warnings
     --tb=short
     -ra
     -q
+    -p no:pytest_homeassistant_custom_component
 asyncio_mode = auto

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,67 @@
+"""Tests for ThesslaGreenBinarySensor entity."""
+import sys
+import types
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal Home Assistant stubs
+# ---------------------------------------------------------------------------
+
+const = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+
+binary_sensor_mod = types.ModuleType("homeassistant.components.binary_sensor")
+
+
+class BinarySensorEntity:  # pragma: no cover - simple stub
+    pass
+
+
+class BinarySensorDeviceClass:  # pragma: no cover - enum stubs
+    RUNNING = "running"
+    OPENING = "opening"
+    POWER = "power"
+    HEAT = "heat"
+    CONNECTIVITY = "connectivity"
+    PROBLEM = "problem"
+    SAFETY = "safety"
+    COLD = "cold"
+    MOISTURE = "moisture"
+
+
+binary_sensor_mod.BinarySensorEntity = BinarySensorEntity
+binary_sensor_mod.BinarySensorDeviceClass = BinarySensorDeviceClass
+sys.modules["homeassistant.components.binary_sensor"] = binary_sensor_mod
+
+entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+
+
+class AddEntitiesCallback:  # pragma: no cover - simple stub
+    pass
+
+
+entity_platform.AddEntitiesCallback = AddEntitiesCallback
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+# ---------------------------------------------------------------------------
+# Actual tests
+# ---------------------------------------------------------------------------
+
+from custom_components.thessla_green_modbus.binary_sensor import (
+    BINARY_SENSOR_DEFINITIONS,
+    ThesslaGreenBinarySensor,
+)
+
+
+def test_binary_sensor_creation_and_state(mock_coordinator):
+    """Test creation and state changes of binary sensor."""
+    # Prepare coordinator data
+    mock_coordinator.data["bypass"] = 0
+
+    sensor = ThesslaGreenBinarySensor(
+        mock_coordinator, "bypass", BINARY_SENSOR_DEFINITIONS["bypass"]
+    )
+    assert sensor.is_on is False
+
+    # Update coordinator data to trigger state change
+    mock_coordinator.data["bypass"] = 1
+    assert sensor.is_on is True

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,54 @@
+"""Tests for ThesslaGreenFan entity."""
+import sys
+import types
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal Home Assistant stubs
+# ---------------------------------------------------------------------------
+
+const = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+
+fan_mod = types.ModuleType("homeassistant.components.fan")
+
+
+class FanEntity:  # pragma: no cover - simple stub
+    pass
+
+
+class FanEntityFeature:  # pragma: no cover - simple stub
+    SET_SPEED = 1
+
+
+fan_mod.FanEntity = FanEntity
+fan_mod.FanEntityFeature = FanEntityFeature
+sys.modules["homeassistant.components.fan"] = fan_mod
+
+entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+
+
+class AddEntitiesCallback:  # pragma: no cover - simple stub
+    pass
+
+
+entity_platform.AddEntitiesCallback = AddEntitiesCallback
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+# ---------------------------------------------------------------------------
+# Actual tests
+# ---------------------------------------------------------------------------
+
+from custom_components.thessla_green_modbus.fan import ThesslaGreenFan
+
+
+def test_fan_creation_and_state(mock_coordinator):
+    """Test creation and basic state reporting of fan entity."""
+    mock_coordinator.data["supply_percentage"] = 50
+    mock_coordinator.data["on_off_panel_mode"] = 1
+    fan = ThesslaGreenFan(mock_coordinator)
+    assert fan.is_on is True
+    assert fan.percentage == 50
+
+    mock_coordinator.data["supply_percentage"] = 0
+    assert fan.is_on is False
+    assert fan.percentage == 0

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,84 @@
+"""Tests for ThesslaGreenNumber entity."""
+import sys
+import types
+import asyncio
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal Home Assistant stubs
+# ---------------------------------------------------------------------------
+
+const = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+
+# Units and constants
+class UnitOfTemperature:  # pragma: no cover - simple stub
+    CELSIUS = "°C"
+
+
+class UnitOfTime:  # pragma: no cover - simple stub
+    MINUTES = "min"
+    HOURS = "h"
+
+
+const.UnitOfTemperature = UnitOfTemperature
+const.UnitOfTime = UnitOfTime
+const.PERCENTAGE = "%"
+
+number_mod = types.ModuleType("homeassistant.components.number")
+
+
+class NumberEntity:  # pragma: no cover - simple stub
+    pass
+
+
+class NumberMode:  # pragma: no cover - simple stub
+    SLIDER = "slider"
+    BOX = "box"
+
+
+number_mod.NumberEntity = NumberEntity
+number_mod.NumberMode = NumberMode
+sys.modules["homeassistant.components.number"] = number_mod
+
+entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+
+
+class AddEntitiesCallback:  # pragma: no cover - simple stub
+    pass
+
+
+entity_platform.AddEntitiesCallback = AddEntitiesCallback
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+# ---------------------------------------------------------------------------
+# Actual tests
+# ---------------------------------------------------------------------------
+
+from custom_components.thessla_green_modbus.number import (
+    ENTITY_MAPPINGS,
+    ThesslaGreenNumber,
+)
+
+
+def test_number_creation_and_state(mock_coordinator):
+    """Test creation and state changes of number entity."""
+    mock_coordinator.data["required_temperature"] = 20
+    entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
+    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
+    assert number.native_value == 20
+
+    mock_coordinator.data["required_temperature"] = 21.5
+    assert number.native_value == 21.5
+
+
+def test_number_set_value(mock_coordinator):
+    """Test setting a new value on the number entity."""
+    mock_coordinator.data["required_temperature"] = 20
+    entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
+    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
+
+    asyncio.run(number.async_set_native_value(22))
+    mock_coordinator.async_write_register.assert_awaited_with(
+        "required_temperature", 22, refresh=False
+    )
+    mock_coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,58 @@
+"""Tests for ThesslaGreenSelect entity."""
+import sys
+import types
+import asyncio
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal Home Assistant stubs
+# ---------------------------------------------------------------------------
+
+const = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+
+select_mod = types.ModuleType("homeassistant.components.select")
+
+
+class SelectEntity:  # pragma: no cover - simple stub
+    pass
+
+
+select_mod.SelectEntity = SelectEntity
+sys.modules["homeassistant.components.select"] = select_mod
+
+entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+
+
+class AddEntitiesCallback:  # pragma: no cover - simple stub
+    pass
+
+
+entity_platform.AddEntitiesCallback = AddEntitiesCallback
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+# ---------------------------------------------------------------------------
+# Actual tests
+# ---------------------------------------------------------------------------
+
+from custom_components.thessla_green_modbus.select import (
+    SELECT_DEFINITIONS,
+    ThesslaGreenSelect,
+)
+
+
+def test_select_creation_and_state(mock_coordinator):
+    """Test creation and state changes of select entity."""
+    mock_coordinator.data["mode"] = 0
+    select = ThesslaGreenSelect(mock_coordinator, "mode", SELECT_DEFINITIONS["mode"])
+    assert select.current_option == "auto"
+
+    mock_coordinator.data["mode"] = 1
+    assert select.current_option == "manual"
+
+
+def test_select_option_change(mock_coordinator):
+    mock_coordinator.data["mode"] = 0
+    select = ThesslaGreenSelect(mock_coordinator, "mode", SELECT_DEFINITIONS["mode"])
+    asyncio.run(select.async_select_option("manual"))
+    mock_coordinator.async_write_register.assert_awaited_with("mode", 1)
+    mock_coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,72 @@
+"""Tests for ThesslaGreenSwitch entity."""
+import sys
+import types
+import asyncio
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal Home Assistant stubs
+# ---------------------------------------------------------------------------
+
+const = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
+
+switch_mod = types.ModuleType("homeassistant.components.switch")
+
+
+class SwitchEntity:  # pragma: no cover - simple stub
+    pass
+
+
+switch_mod.SwitchEntity = SwitchEntity
+sys.modules["homeassistant.components.switch"] = switch_mod
+
+entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+
+
+class AddEntitiesCallback:  # pragma: no cover - simple stub
+    pass
+
+
+entity_platform.AddEntitiesCallback = AddEntitiesCallback
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+# ---------------------------------------------------------------------------
+# Actual tests
+# ---------------------------------------------------------------------------
+
+from custom_components.thessla_green_modbus.switch import (
+    SWITCH_ENTITIES,
+    ThesslaGreenSwitch,
+)
+
+
+def test_switch_creation_and_state(mock_coordinator):
+    """Test creation and state changes of switch entity."""
+    mock_coordinator.data["on_off_panel_mode"] = 1
+    switch = ThesslaGreenSwitch(
+        mock_coordinator, "on_off_panel_mode", SWITCH_ENTITIES["on_off_panel_mode"]
+    )
+    assert switch.is_on is True
+
+    mock_coordinator.data["on_off_panel_mode"] = 0
+    assert switch.is_on is False
+
+
+def test_switch_turn_on_off(mock_coordinator):
+    mock_coordinator.data["on_off_panel_mode"] = 0
+    switch = ThesslaGreenSwitch(
+        mock_coordinator, "on_off_panel_mode", SWITCH_ENTITIES["on_off_panel_mode"]
+    )
+    asyncio.run(switch.async_turn_on())
+    mock_coordinator.async_write_register.assert_awaited_with(
+        "on_off_panel_mode", 1, refresh=False
+    )
+    mock_coordinator.async_request_refresh.assert_awaited_once()
+    mock_coordinator.async_write_register.reset_mock()
+    mock_coordinator.async_request_refresh.reset_mock()
+
+    asyncio.run(switch.async_turn_off())
+    mock_coordinator.async_write_register.assert_awaited_with(
+        "on_off_panel_mode", 0, refresh=False
+    )
+    mock_coordinator.async_request_refresh.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add minimal Home Assistant util stub and disable HA plugin in test config
- add unit tests for binary sensor, number, select, switch and fan entities

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_binary_sensor.py tests/test_number.py tests/test_select.py tests/test_switch.py tests/test_fan.py`

------
https://chatgpt.com/codex/tasks/task_e_689af4a82f048326b08094359660b5e4