### PR TITLE
refactor: drop unused sys import

### DIFF
--- a/custom_components/thessla_green_modbus/cleanup_old_entities.py
+++ b/custom_components/thessla_green_modbus/cleanup_old_entities.py
@@ -12,7 +12,6 @@ integration:
 import logging
 import json
 import shutil
-import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -236,7 +235,7 @@ def main():
     if not config_dir:
         _LOGGER.error("Cannot find Home Assistant configuration directory")
         _LOGGER.error("Ensure you are in the correct directory or Home Assistant is installed")
-        sys.exit(1)
+        raise SystemExit(1)
 
     _LOGGER.info("Found HA configuration: %s", config_dir)
     _LOGGER.info("")
@@ -281,7 +280,7 @@ if __name__ == "__main__":
         main()
     except KeyboardInterrupt:
         _LOGGER.warning("\n\nInterrupted by user")
-        sys.exit(1)
+        raise SystemExit(1)
     except Exception as exc:
         _LOGGER.error("\nUnexpected error: %s", exc)
-        sys.exit(1)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- remove unnecessary `sys` import from cleanup utility
- replace `sys.exit` calls with `SystemExit`

## Testing
- `ruff check custom_components/thessla_green_modbus/cleanup_old_entities.py`
- `pytest` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute 'asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_689af476c45c8326894195bf82d12123