### PR TITLE
Handle failed register writes for select entities

### DIFF
--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -98,6 +98,10 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
             return
 
         value = self._states[option]
-        success = await self.coordinator.async_write_register(self._register_name, value)
+        success = await self.coordinator.async_write_register(
+            self._register_name, value, refresh=False
+        )
         if success:
             await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error("Failed to set %s to %s", self._register_name, option)


### PR DESCRIPTION
## Summary
- Check `async_write_register` result in select options
- Log an error instead of refreshing when a write fails

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/select.py` *(fails: `.pre-commit-config.yaml` is not a file)*
- `pytest` *(fails: IndentationError: unindent does not match any outer indentation level)*

------
https://chatgpt.com/codex/tasks/task_e_689af748cb408326ace17dace3f0b4bc