### PR TITLE
Add translations for temperature setpoints

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -482,6 +482,18 @@
       },
       "humidity_target": {
         "name": "Humidity Target"
+      },
+      "economy_temperature": {
+        "name": "Economy Temperature"
+      },
+      "night_temperature": {
+        "name": "Night Temperature"
+      },
+      "away_temperature": {
+        "name": "Away Temperature"
+      },
+      "frost_protection_temperature": {
+        "name": "Frost Protection Temperature"
       }
     }
   },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -35,11 +35,7 @@
     "step": {
       "init": {
         "title": "Opcje ThesslaGreen Modbus",
- codex/update-translation-strings-for-clarity
         "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Częstotliwość odczytu: {current_scan_interval}s\n- Limit czasu połączenia: {current_timeout}s\n- Liczba powtórzeń nieudanych odczytów: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
-=======
-        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Częstotliwość odczytu: {current_scan_interval}s\n- Limit czasu połączenia: {current_timeout}s\n- Liczba prób: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
- main
         "data": {
           "scan_interval": "Interwał skanowania (sekundy)",
           "timeout": "Limit czasu połączenia (sekundy)",
@@ -486,6 +482,18 @@
       },
       "humidity_target": {
         "name": "Docelowa wilgotność"
+      },
+      "economy_temperature": {
+        "name": "Temperatura ekonomiczna"
+      },
+      "night_temperature": {
+        "name": "Temperatura nocna"
+      },
+      "away_temperature": {
+        "name": "Temperatura nieobecności"
+      },
+      "frost_protection_temperature": {
+        "name": "Temperatura przeciwmrozowa"
       }
     }
   },


### PR DESCRIPTION
## Summary
- add economy, night, away, and frost protection temperature labels in English and Polish translations
- clean up stray merge artifacts in Polish translations

## Testing
- `pytest` *(fails: missing Home Assistant components and indentation errors)*

------
https://chatgpt.com/codex/tasks/task_e_689af7474190832681d1bb73ee813d96