### PR TITLE
Use DEFAULT_PORT constant for modbus port

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_TIMEOUT,
     DEFAULT_RETRY,
+    DEFAULT_PORT,
     DEFAULT_SLAVE_ID,
     DEFAULT_NAME,
 )
@@ -45,7 +46,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     
     # Get configuration - support both new and legacy keys
     host = entry.data[CONF_HOST]
-    port = entry.data.get(CONF_PORT, 8899)  # Default to 8899 for legacy
+    port = entry.data.get(
+        CONF_PORT, DEFAULT_PORT
+    )  # Default to DEFAULT_PORT (8899 was used in legacy versions)
     
     # Try to get slave_id from multiple possible keys for compatibility
     slave_id = None


### PR DESCRIPTION
## Summary
- import DEFAULT_PORT and use it when reading config entries
- note legacy default port 8899 in comment

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator')*

------
https://chatgpt.com/codex/tasks/task_e_689af74498bc8326b44a58d23ff145e1