### PR TITLE
Handle missing Modbus bits safely

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -498,6 +498,12 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                     )
                     continue
 
+                if response.bits is None:
+                    _LOGGER.error(
+                        "No bits returned reading coil registers at 0x%04X", start_addr
+                    )
+                    continue
+
                 # Process each bit in the batch
                 for i in range(min(count, len(response.bits))):
                     addr = start_addr + i
@@ -535,6 +541,12 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read discrete inputs at 0x%04X: %s", start_addr, response
+                    )
+                    continue
+
+                if response.bits is None:
+                    _LOGGER.error(
+                        "No bits returned reading discrete inputs at 0x%04X", start_addr
                     )
                     continue
 


### PR DESCRIPTION
## Summary
- safeguard coil and discrete input reads when `response.bits` is None

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator')*

------
https://chatgpt.com/codex/tasks/task_e_689af73e79108326b12c0e94f69d72f2