### PR TITLE
Log Modbus exceptions directly

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -64,13 +64,13 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
         return {"title": name, "device_info": device_info, "scan_result": scan_result}
 
     except ConnectionException as exc:
-        _LOGGER.error("Connection error: %s", exc)
+        _LOGGER.exception("Connection error")
         raise CannotConnect from exc
     except ModbusException as exc:
-        _LOGGER.error("Modbus error: %s", exc)
+        _LOGGER.exception("Modbus error")
         raise InvalidAuth from exc
     except (OSError, asyncio.TimeoutError) as exc:
-        _LOGGER.error("Unexpected error during device validation: %s", exc)
+        _LOGGER.exception("Unexpected error during device validation")
         raise CannotConnect from exc
     finally:
         await scanner.close()
@@ -114,11 +114,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
-            except (ConnectionException, ModbusException) as exc:
-                _LOGGER.error("Modbus communication error: %s", exc)
+            except (ConnectionException, ModbusException):
+                _LOGGER.exception("Modbus communication error")
                 errors["base"] = "cannot_connect"
-            except (OSError, asyncio.TimeoutError, ValueError) as exc:
-                _LOGGER.error("Unexpected exception: %s", exc)
+            except (OSError, asyncio.TimeoutError, ValueError):
+                _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
         # Show form

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -157,11 +157,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                     self.device_info.get("model", "Unknown"),
                     self.device_info.get("firmware", "Unknown"),
                 )
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.error("Device scan failed: %s", exc)
+            except (ModbusException, ConnectionException):
+                _LOGGER.exception("Device scan failed")
                 raise
-            except (OSError, asyncio.TimeoutError, ValueError) as exc:
-                _LOGGER.error("Unexpected error during device scan: %s", exc)
+            except (OSError, asyncio.TimeoutError, ValueError):
+                _LOGGER.exception("Unexpected error during device scan")
                 raise
             finally:
                 await scanner.close()
@@ -274,11 +274,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
                 _LOGGER.debug("Connection test successful")
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.error("Connection test failed: %s", exc)
+            except (ModbusException, ConnectionException):
+                _LOGGER.exception("Connection test failed")
                 raise
-            except (OSError, asyncio.TimeoutError) as exc:
-                _LOGGER.error("Unexpected error during connection test: %s", exc)
+            except (OSError, asyncio.TimeoutError):
+                _LOGGER.exception("Unexpected error during connection test")
                 raise
 
     async def _async_setup_client(self) -> bool:
@@ -289,11 +289,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         try:
             await self._ensure_connection()
             return True
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.error("Failed to set up Modbus client: %s", exc)
+        except (ModbusException, ConnectionException):
+            _LOGGER.exception("Failed to set up Modbus client")
             return False
-        except (OSError, asyncio.TimeoutError) as exc:
-            _LOGGER.error("Unexpected error setting up Modbus client: %s", exc)
+        except (OSError, asyncio.TimeoutError):
+            _LOGGER.exception("Unexpected error setting up Modbus client")
             return False
 
     async def async_ensure_client(self) -> bool:
@@ -317,13 +317,13 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 if not connected:
                     raise ConnectionException(f"Could not connect to {self.host}:{self.port}")
                 _LOGGER.debug("Modbus connection established")
-            except (ModbusException, ConnectionException) as exc:
+            except (ModbusException, ConnectionException):
                 self.statistics["connection_errors"] += 1
-                _LOGGER.error("Failed to establish connection: %s", exc)
+                _LOGGER.exception("Failed to establish connection")
                 raise
-            except (OSError, asyncio.TimeoutError) as exc:
+            except (OSError, asyncio.TimeoutError):
                 self.statistics["connection_errors"] += 1
-                _LOGGER.error("Unexpected error establishing connection: %s", exc)
+                _LOGGER.exception("Unexpected error establishing connection")
                 raise
 
     async def _async_update_data(self) -> Dict[str, Any]:
@@ -429,12 +429,16 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                             data[register_name] = processed_value
                             self.statistics["total_registers_read"] += 1
 
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.debug("Error reading input registers at 0x%04X: %s", start_addr, exc)
+            except (ModbusException, ConnectionException):
+                _LOGGER.debug(
+                    "Error reading input registers at 0x%04X", start_addr, exc_info=True
+                )
                 continue
-            except (OSError, asyncio.TimeoutError, ValueError) as exc:
+            except (OSError, asyncio.TimeoutError, ValueError):
                 _LOGGER.error(
-                    "Unexpected error reading input registers at 0x%04X: %s", start_addr, exc
+                    "Unexpected error reading input registers at 0x%04X",
+                    start_addr,
+                    exc_info=True,
                 )
                 continue
 
@@ -471,12 +475,16 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                             data[register_name] = processed_value
                             self.statistics["total_registers_read"] += 1
 
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.debug("Error reading holding registers at 0x%04X: %s", start_addr, exc)
+            except (ModbusException, ConnectionException):
+                _LOGGER.debug(
+                    "Error reading holding registers at 0x%04X", start_addr, exc_info=True
+                )
                 continue
-            except (OSError, asyncio.TimeoutError, ValueError) as exc:
+            except (OSError, asyncio.TimeoutError, ValueError):
                 _LOGGER.error(
-                    "Unexpected error reading holding registers at 0x%04X: %s", start_addr, exc
+                    "Unexpected error reading holding registers at 0x%04X",
+                    start_addr,
+                    exc_info=True,
                 )
                 continue
 
@@ -509,12 +517,16 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                         data[register_name] = response.bits[i]
                         self.statistics["total_registers_read"] += 1
 
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.debug("Error reading coil registers at 0x%04X: %s", start_addr, exc)
+            except (ModbusException, ConnectionException):
+                _LOGGER.debug(
+                    "Error reading coil registers at 0x%04X", start_addr, exc_info=True
+                )
                 continue
-            except (OSError, asyncio.TimeoutError, ValueError) as exc:
+            except (OSError, asyncio.TimeoutError, ValueError):
                 _LOGGER.error(
-                    "Unexpected error reading coil registers at 0x%04X: %s", start_addr, exc
+                    "Unexpected error reading coil registers at 0x%04X",
+                    start_addr,
+                    exc_info=True,
                 )
                 continue
 
@@ -549,12 +561,16 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                         data[register_name] = response.bits[i]
                         self.statistics["total_registers_read"] += 1
 
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.debug("Error reading discrete inputs at 0x%04X: %s", start_addr, exc)
+            except (ModbusException, ConnectionException):
+                _LOGGER.debug(
+                    "Error reading discrete inputs at 0x%04X", start_addr, exc_info=True
+                )
                 continue
-            except (OSError, asyncio.TimeoutError, ValueError) as exc:
+            except (OSError, asyncio.TimeoutError, ValueError):
                 _LOGGER.error(
-                    "Unexpected error reading discrete inputs at 0x%04X: %s", start_addr, exc
+                    "Unexpected error reading discrete inputs at 0x%04X",
+                    start_addr,
+                    exc_info=True,
                 )
                 continue
 
@@ -667,12 +683,12 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                     await self.async_request_refresh()
                 return True
 
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.error("Failed to write register %s: %s", register_name, exc)
+            except (ModbusException, ConnectionException):
+                _LOGGER.exception("Failed to write register %s", register_name)
                 return False
-            except (OSError, asyncio.TimeoutError, ValueError) as exc:
-                _LOGGER.error(
-                    "Unexpected error writing register %s: %s", register_name, exc
+            except (OSError, asyncio.TimeoutError, ValueError):
+                _LOGGER.exception(
+                    "Unexpected error writing register %s", register_name
                 )
                 return False
 
@@ -682,10 +698,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self.client.close()
                 _LOGGER.debug("Disconnected from Modbus device")
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.debug("Error disconnecting: %s", exc)
-            except OSError as exc:
-                _LOGGER.error("Unexpected error disconnecting: %s", exc)
+            except (ModbusException, ConnectionException):
+                _LOGGER.debug("Error disconnecting", exc_info=True)
+            except OSError:
+                _LOGGER.exception("Unexpected error disconnecting")
             finally:
                 self.client = None
 

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -99,10 +99,12 @@ class ThesslaGreenDeviceScanner:
             response = await client.read_input_registers(address, count, unit=self.slave_id)
             if not response.isError():
                 return response.registers
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.debug("Failed to read input 0x%04X: %s", address, exc)
-        except (OSError, asyncio.TimeoutError) as exc:
-            _LOGGER.error("Unexpected error reading input 0x%04X: %s", address, exc)
+        except (ModbusException, ConnectionException):
+            _LOGGER.debug(f"Failed to read input 0x{address:04X}", exc_info=True)
+        except (OSError, asyncio.TimeoutError):
+            _LOGGER.error(
+                f"Unexpected error reading input 0x{address:04X}", exc_info=True
+            )
         return None
 
     async def _read_holding(
@@ -113,10 +115,12 @@ class ThesslaGreenDeviceScanner:
             response = await client.read_holding_registers(address, count, unit=self.slave_id)
             if not response.isError():
                 return response.registers
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.debug("Failed to read holding 0x%04X: %s", address, exc)
-        except (OSError, asyncio.TimeoutError) as exc:
-            _LOGGER.error("Unexpected error reading holding 0x%04X: %s", address, exc)
+        except (ModbusException, ConnectionException):
+            _LOGGER.debug(f"Failed to read holding 0x{address:04X}", exc_info=True)
+        except (OSError, asyncio.TimeoutError):
+            _LOGGER.error(
+                f"Unexpected error reading holding 0x{address:04X}", exc_info=True
+            )
         return None
 
     async def _read_coil(
@@ -127,10 +131,12 @@ class ThesslaGreenDeviceScanner:
             response = await client.read_coils(address, count, unit=self.slave_id)
             if not response.isError():
                 return response.bits[:count]
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.debug("Failed to read coil 0x%04X: %s", address, exc)
-        except (OSError, asyncio.TimeoutError) as exc:
-            _LOGGER.error("Unexpected error reading coil 0x%04X: %s", address, exc)
+        except (ModbusException, ConnectionException):
+            _LOGGER.debug(f"Failed to read coil 0x{address:04X}", exc_info=True)
+        except (OSError, asyncio.TimeoutError):
+            _LOGGER.error(
+                f"Unexpected error reading coil 0x{address:04X}", exc_info=True
+            )
         return None
 
     async def _read_discrete(
@@ -141,10 +147,12 @@ class ThesslaGreenDeviceScanner:
             response = await client.read_discrete_inputs(address, count, unit=self.slave_id)
             if not response.isError():
                 return response.bits[:count]
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.debug("Failed to read discrete 0x%04X: %s", address, exc)
-        except (OSError, asyncio.TimeoutError) as exc:
-            _LOGGER.error("Unexpected error reading discrete 0x%04X: %s", address, exc)
+        except (ModbusException, ConnectionException):
+            _LOGGER.debug(f"Failed to read discrete 0x{address:04X}", exc_info=True)
+        except (OSError, asyncio.TimeoutError):
+            _LOGGER.error(
+                f"Unexpected error reading discrete 0x{address:04X}", exc_info=True
+            )
         return None
 
     def _is_valid_register_value(self, register_name: str, value: int) -> bool:
@@ -434,11 +442,11 @@ class ThesslaGreenDeviceScanner:
 
             return info, caps, present_blocks
 
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.error("Device scan failed: %s", exc)
+        except (ModbusException, ConnectionException):
+            _LOGGER.exception("Device scan failed")
             raise
-        except (OSError, asyncio.TimeoutError, ValueError) as exc:
-            _LOGGER.error("Unexpected error during device scan: %s", exc)
+        except (OSError, asyncio.TimeoutError, ValueError):
+            _LOGGER.exception("Unexpected error during device scan")
             raise
 
     async def scan_device(self) -> Dict[str, Any]:
@@ -474,11 +482,11 @@ class ThesslaGreenDeviceScanner:
 
             return result
 
-        except (ConnectionException, ModbusException) as exc:
-            _LOGGER.error("Connection failed during device scan: %s", exc)
+        except (ConnectionException, ModbusException):
+            _LOGGER.exception("Connection failed during device scan")
             raise
-        except (OSError, asyncio.TimeoutError, ValueError) as exc:
-            _LOGGER.error("Device scan failed: %s", exc)
+        except (OSError, asyncio.TimeoutError, ValueError):
+            _LOGGER.exception("Device scan failed")
             raise
 
     async def close(self):
@@ -488,10 +496,10 @@ class ThesslaGreenDeviceScanner:
 
         try:
             await self._client.close()
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.debug("Error closing Modbus client: %s", exc)
-        except OSError as exc:
-            _LOGGER.debug("Unexpected error closing Modbus client: %s", exc)
+        except (ModbusException, ConnectionException):
+            _LOGGER.debug("Error closing Modbus client", exc_info=True)
+        except OSError:
+            _LOGGER.debug("Unexpected error closing Modbus client", exc_info=True)
         finally:
             self._client = None
             _LOGGER.debug("Disconnected from ThesslaGreen device")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -10,14 +10,19 @@ def run_tests():
     
     try:
         # Run pytest with coverage
-        result = subprocess.run([
-            sys.executable, "-m", "pytest",
-            "tests/",
-            "-v",
-            "--tb=short",
-            "-ra"
-        ], check=True)
-        
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "tests/",
+                "-v",
+                "--tb=short",
+                "-ra",
+            ],
+            check=True,
+        )
+
         print("✅ All tests passed!")
         return 0
         


### PR DESCRIPTION
## Summary
- use `_LOGGER.exception` instead of storing unused exception variables in config flow, coordinator and device scanner
- drop unused variable in test runner

## Testing
- `ruff check --select F841 --exclude custom_components/thessla_green_modbus/climate.py .`
- `ruff check --fix custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/device_scanner.py tests/run_tests.py`
- `pytest` *(fails: PytestUnknownMarkWarning and 6 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689af73991f8832696c01e2ecd48f350