### PR TITLE
Log caught exceptions in config flow and coordinator

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -64,13 +64,13 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
         return {"title": name, "device_info": device_info, "scan_result": scan_result}
 
     except ConnectionException as exc:
-        _LOGGER.exception("Connection error")
+        _LOGGER.exception("Connection error: %s", exc)
         raise CannotConnect from exc
     except ModbusException as exc:
-        _LOGGER.exception("Modbus error")
+        _LOGGER.exception("Modbus error: %s", exc)
         raise InvalidAuth from exc
     except (OSError, asyncio.TimeoutError) as exc:
-        _LOGGER.exception("Unexpected error during device validation")
+        _LOGGER.exception("Unexpected error during device validation: %s", exc)
         raise CannotConnect from exc
     finally:
         await scanner.close()

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -157,11 +157,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                     self.device_info.get("model", "Unknown"),
                     self.device_info.get("firmware", "Unknown"),
                 )
-            except (ModbusException, ConnectionException):
-                _LOGGER.exception("Device scan failed")
+            except (ModbusException, ConnectionException) as exc:
+                _LOGGER.exception("Device scan failed: %s", exc)
                 raise
-            except (OSError, asyncio.TimeoutError, ValueError):
-                _LOGGER.exception("Unexpected error during device scan")
+            except (OSError, asyncio.TimeoutError, ValueError) as exc:
+                _LOGGER.exception("Unexpected error during device scan: %s", exc)
                 raise
             finally:
                 await scanner.close()
@@ -274,11 +274,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
                 _LOGGER.debug("Connection test successful")
-            except (ModbusException, ConnectionException):
-                _LOGGER.exception("Connection test failed")
+            except (ModbusException, ConnectionException) as exc:
+                _LOGGER.exception("Connection test failed: %s", exc)
                 raise
-            except (OSError, asyncio.TimeoutError):
-                _LOGGER.exception("Unexpected error during connection test")
+            except (OSError, asyncio.TimeoutError) as exc:
+                _LOGGER.exception("Unexpected error during connection test: %s", exc)
                 raise
 
     async def _async_setup_client(self) -> bool:
@@ -289,11 +289,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         try:
             await self._ensure_connection()
             return True
-        except (ModbusException, ConnectionException):
-            _LOGGER.exception("Failed to set up Modbus client")
+        except (ModbusException, ConnectionException) as exc:
+            _LOGGER.exception("Failed to set up Modbus client: %s", exc)
             return False
-        except (OSError, asyncio.TimeoutError):
-            _LOGGER.exception("Unexpected error setting up Modbus client")
+        except (OSError, asyncio.TimeoutError) as exc:
+            _LOGGER.exception("Unexpected error setting up Modbus client: %s", exc)
             return False
 
     async def async_ensure_client(self) -> bool:
@@ -317,13 +317,13 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 if not connected:
                     raise ConnectionException(f"Could not connect to {self.host}:{self.port}")
                 _LOGGER.debug("Modbus connection established")
-            except (ModbusException, ConnectionException):
+            except (ModbusException, ConnectionException) as exc:
                 self.statistics["connection_errors"] += 1
-                _LOGGER.exception("Failed to establish connection")
+                _LOGGER.exception("Failed to establish connection: %s", exc)
                 raise
-            except (OSError, asyncio.TimeoutError):
+            except (OSError, asyncio.TimeoutError) as exc:
                 self.statistics["connection_errors"] += 1
-                _LOGGER.exception("Unexpected error establishing connection")
+                _LOGGER.exception("Unexpected error establishing connection: %s", exc)
                 raise
 
     async def _async_update_data(self) -> Dict[str, Any]:

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -99,11 +99,13 @@ class ThesslaGreenDeviceScanner:
             response = await client.read_input_registers(address, count, unit=self.slave_id)
             if not response.isError():
                 return response.registers
-        except (ModbusException, ConnectionException):
-            _LOGGER.debug(f"Failed to read input 0x{address:04X}", exc_info=True)
-        except (OSError, asyncio.TimeoutError):
+        except (ModbusException, ConnectionException) as exc:
+            _LOGGER.debug(
+                "Failed to read input 0x%04X: %s", address, exc, exc_info=True
+            )
+        except (OSError, asyncio.TimeoutError) as exc:
             _LOGGER.error(
-                f"Unexpected error reading input 0x{address:04X}", exc_info=True
+                "Unexpected error reading input 0x%04X: %s", address, exc, exc_info=True
             )
         return None
 
@@ -115,11 +117,13 @@ class ThesslaGreenDeviceScanner:
             response = await client.read_holding_registers(address, count, unit=self.slave_id)
             if not response.isError():
                 return response.registers
-        except (ModbusException, ConnectionException):
-            _LOGGER.debug(f"Failed to read holding 0x{address:04X}", exc_info=True)
-        except (OSError, asyncio.TimeoutError):
+        except (ModbusException, ConnectionException) as exc:
+            _LOGGER.debug(
+                "Failed to read holding 0x%04X: %s", address, exc, exc_info=True
+            )
+        except (OSError, asyncio.TimeoutError) as exc:
             _LOGGER.error(
-                f"Unexpected error reading holding 0x{address:04X}", exc_info=True
+                "Unexpected error reading holding 0x%04X: %s", address, exc, exc_info=True
             )
         return None
 
@@ -131,11 +135,13 @@ class ThesslaGreenDeviceScanner:
             response = await client.read_coils(address, count, unit=self.slave_id)
             if not response.isError():
                 return response.bits[:count]
-        except (ModbusException, ConnectionException):
-            _LOGGER.debug(f"Failed to read coil 0x{address:04X}", exc_info=True)
-        except (OSError, asyncio.TimeoutError):
+        except (ModbusException, ConnectionException) as exc:
+            _LOGGER.debug(
+                "Failed to read coil 0x%04X: %s", address, exc, exc_info=True
+            )
+        except (OSError, asyncio.TimeoutError) as exc:
             _LOGGER.error(
-                f"Unexpected error reading coil 0x{address:04X}", exc_info=True
+                "Unexpected error reading coil 0x%04X: %s", address, exc, exc_info=True
             )
         return None
 
@@ -147,11 +153,13 @@ class ThesslaGreenDeviceScanner:
             response = await client.read_discrete_inputs(address, count, unit=self.slave_id)
             if not response.isError():
                 return response.bits[:count]
-        except (ModbusException, ConnectionException):
-            _LOGGER.debug(f"Failed to read discrete 0x{address:04X}", exc_info=True)
-        except (OSError, asyncio.TimeoutError):
+        except (ModbusException, ConnectionException) as exc:
+            _LOGGER.debug(
+                "Failed to read discrete 0x%04X: %s", address, exc, exc_info=True
+            )
+        except (OSError, asyncio.TimeoutError) as exc:
             _LOGGER.error(
-                f"Unexpected error reading discrete 0x{address:04X}", exc_info=True
+                "Unexpected error reading discrete 0x%04X: %s", address, exc, exc_info=True
             )
         return None
 
@@ -442,11 +450,11 @@ class ThesslaGreenDeviceScanner:
 
             return info, caps, present_blocks
 
-        except (ModbusException, ConnectionException):
-            _LOGGER.exception("Device scan failed")
+        except (ModbusException, ConnectionException) as exc:
+            _LOGGER.exception("Device scan failed: %s", exc)
             raise
-        except (OSError, asyncio.TimeoutError, ValueError):
-            _LOGGER.exception("Unexpected error during device scan")
+        except (OSError, asyncio.TimeoutError, ValueError) as exc:
+            _LOGGER.exception("Unexpected error during device scan: %s", exc)
             raise
 
     async def scan_device(self) -> Dict[str, Any]:
@@ -482,11 +490,11 @@ class ThesslaGreenDeviceScanner:
 
             return result
 
-        except (ConnectionException, ModbusException):
-            _LOGGER.exception("Connection failed during device scan")
+        except (ConnectionException, ModbusException) as exc:
+            _LOGGER.exception("Connection failed during device scan: %s", exc)
             raise
-        except (OSError, asyncio.TimeoutError, ValueError):
-            _LOGGER.exception("Device scan failed")
+        except (OSError, asyncio.TimeoutError, ValueError) as exc:
+            _LOGGER.exception("Device scan failed: %s", exc)
             raise
 
     async def close(self):
@@ -496,10 +504,10 @@ class ThesslaGreenDeviceScanner:
 
         try:
             await self._client.close()
-        except (ModbusException, ConnectionException):
-            _LOGGER.debug("Error closing Modbus client", exc_info=True)
-        except OSError:
-            _LOGGER.debug("Unexpected error closing Modbus client", exc_info=True)
+        except (ModbusException, ConnectionException) as exc:
+            _LOGGER.debug("Error closing Modbus client: %s", exc, exc_info=True)
+        except OSError as exc:
+            _LOGGER.debug("Unexpected error closing Modbus client: %s", exc, exc_info=True)
         finally:
             self._client = None
             _LOGGER.debug("Disconnected from ThesslaGreen device")


### PR DESCRIPTION
## Summary
- log caught exceptions in `config_flow` validation
- surface connection and scan errors in coordinator and device scanner

## Testing
- `ruff check custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/device_scanner.py --fix`
- `ruff check custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/device_scanner.py --select F841`


------
https://chatgpt.com/codex/tasks/task_e_689af9734e30832682193fb0f0d20fb7