### PR TITLE
Handle missing Modbus response bits

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -506,10 +506,12 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                     )
                     continue
 
-                if response.bits is None:
-                    _LOGGER.error(
-                        "No bits returned reading coil registers at 0x%04X", start_addr
-                    )
+                if not response.bits:
+                    if response.bits is None:
+                        _LOGGER.error(
+                            "No bits returned reading coil registers at 0x%04X",
+                            start_addr,
+                        )
                     continue
 
                 # Process each bit in the batch
@@ -556,10 +558,12 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                     )
                     continue
 
-                if response.bits is None:
-                    _LOGGER.error(
-                        "No bits returned reading discrete inputs at 0x%04X", start_addr
-                    )
+                if not response.bits:
+                    if response.bits is None:
+                        _LOGGER.error(
+                            "No bits returned reading discrete inputs at 0x%04X",
+                            start_addr,
+                        )
                     continue
 
                 # Process each bit in the batch


### PR DESCRIPTION
## Summary
- Safely handle missing `response.bits` when reading coil and discrete input registers
- Log a helpful error when Modbus responses lack bit data

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator')*


------
https://chatgpt.com/codex/tasks/task_e_689af96ff0008326b11ebed7158a60b9