### PR TITLE
Use Home Assistant datetime utilities

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+
+from homeassistant.util import dt as dt_util
 
 try:  # pragma: no cover - handle missing pymodbus during tests
     from pymodbus.exceptions import ConnectionException, ModbusException
@@ -90,7 +92,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         # Connection management
         self.client: Optional["AsyncModbusTcpClient"] = None
         self._connection_lock = asyncio.Lock()
-        self._last_successful_read = datetime.now()
+        self._last_successful_read = dt_util.utcnow()
 
         # Device info and capabilities
         self.device_info: Dict[str, Any] = {}
@@ -328,7 +330,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> Dict[str, Any]:
         """Fetch data from the device with optimized batch reading."""
-        start_time = datetime.now()
+        start_time = dt_util.utcnow()
 
         async with self._connection_lock:
             try:
@@ -358,11 +360,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
                 # Update statistics
                 self.statistics["successful_reads"] += 1
-                self.statistics["last_successful_update"] = datetime.now()
+                self.statistics["last_successful_update"] = dt_util.utcnow()
                 self._consecutive_failures = 0
 
                 # Calculate response time
-                response_time = (datetime.now() - start_time).total_seconds()
+                response_time = (dt_util.utcnow() - start_time).total_seconds()
                 self.statistics["average_response_time"] = (
                     self.statistics["average_response_time"]
                     * (self.statistics["successful_reads"] - 1)

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.service import async_extract_entity_ids
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, REGISTER_MULTIPLIERS, SPECIAL_FUNCTION_MAP
 
@@ -384,13 +385,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     async def start_pressure_test(call: ServiceCall) -> None:
         """Service to start pressure test."""
         entity_ids = async_extract_entity_ids(hass, call)
-        
+
         for entity_id in entity_ids:
             coordinator = _get_coordinator_from_entity_id(hass, entity_id)
             if coordinator:
                 # Trigger pressure test by setting current day and time
-                import datetime
-                now = datetime.datetime.now()
+                now = dt_util.now()
                 day_of_week = now.weekday()  # 0 = Monday
                 time_hhmm = now.hour * 100 + now.minute
                 


### PR DESCRIPTION
## Summary
- replace datetime.now usage with Home Assistant dt utilities in coordinator
- use dt_util.now in pressure test service and remove inline datetime import

## Testing
- `pytest` *(fails: ImportError: cannot import name 'dt' from 'homeassistant.util')*


------
https://chatgpt.com/codex/tasks/task_e_689afd9795c4832691c0c636a8921b53