### PR TITLE
Align Home Assistant minimum version in manifest and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 - ✅ **Firmware v3.x - v5.x** z automatyczną detekcją
 
 ### Home Assistant
-- ✅ **Wymagany Home Assistant 2025.7.1 lub nowszy** – minimalna wersja określona w `manifest.json` (pakiet `homeassistant` nie jest częścią `requirements.txt`)
+- ✅ **Wymagany Home Assistant 2025.7.1+** – minimalna wersja określona w `manifest.json` (pakiet `homeassistant` nie jest częścią `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** - najnowsza biblioteka Modbus
 - ✅ **Python 3.11+** - nowoczesne standardy
 - ✅ **Standardowy AsyncModbusTcpClient** – brak potrzeby własnego klienta Modbus

--- a/README_en.md
+++ b/README_en.md
@@ -32,7 +32,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 - ✅ **Firmware v3.x – v5.x** with automatic detection
 
 ### Home Assistant
-- ✅ **Requires Home Assistant 2025.7.1 or later** – minimum version declared in `manifest.json` (the `homeassistant` package is not part of `requirements.txt`)
+- ✅ **Requires Home Assistant 2025.7.1+** – minimum version declared in `manifest.json` (the `homeassistant` package is not part of `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** – latest Modbus library
 - ✅ **Python 3.11+** – modern standards
 - ✅ **Standard AsyncModbusTcpClient** – no custom Modbus client required

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.1.0",
+  "homeassistant": "2025.7.1",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",


### PR DESCRIPTION
## Summary
- Require Home Assistant 2025.7.1 in manifest
- Update README badges and compatibility notes to 2025.7.1+

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator')*

------
https://chatgpt.com/codex/tasks/task_e_689afd9137f08326bc5c368d3081bcaf