### PR TITLE
chore: require Python 3.12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This project adheres to a simple code of conduct:
 
 ### Prerequisites
 
-- Python 3.10+ 
+- Python 3.12+
 - Home Assistant 2025.7.1+ (managed outside `requirements.txt`)
 - Git
 - A ThesslaGreen AirPack device (for testing)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,7 +9,7 @@
 
 ### Oprogramowanie
 - Home Assistant 2025.7.1 lub nowszy (minimalna wersja zadeklarowana w `manifest.json`, brak pakietu `homeassistant` w `requirements.txt`)
-- Python 3.10 lub nowszy
+- Python 3.12 lub nowszy
 - Biblioteka `pymodbus>=3.0.0`
 
 ## 🚀 Instalacja

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub release](https://img.shields.io/github/release/thesslagreen/thessla-green-modbus-ha.svg)](https://github.com/thesslagreen/thessla-green-modbus-ha/releases)
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7.1%2B-blue.svg)](https://home-assistant.io/)
-[![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://python.org/)
 
 ## ✨ Kompletna integracja ThesslaGreen AirPack z Home Assistant
 
@@ -34,7 +34,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 ### Home Assistant
 - ✅ **Wymagany Home Assistant 2025.7.1 lub nowszy** – minimalna wersja określona w `manifest.json` (pakiet `homeassistant` nie jest częścią `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** - najnowsza biblioteka Modbus
-- ✅ **Python 3.11+** - nowoczesne standardy
+- ✅ **Python 3.12+** - nowoczesne standardy
 - ✅ **Standardowy AsyncModbusTcpClient** – brak potrzeby własnego klienta Modbus
 
 ## 🚀 Instalacja

--- a/README_en.md
+++ b/README_en.md
@@ -3,7 +3,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub release](https://img.shields.io/github/release/thesslagreen/thessla-green-modbus-ha.svg)](https://github.com/thesslagreen/thessla-green-modbus-ha/releases)
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7.1%2B-blue.svg)](https://home-assistant.io/)
-[![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://python.org/)
 
 ## ✨ Complete ThesslaGreen AirPack integration for Home Assistant
 
@@ -34,7 +34,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 ### Home Assistant
 - ✅ **Requires Home Assistant 2025.7.1 or later** – minimum version declared in `manifest.json` (the `homeassistant` package is not part of `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** – latest Modbus library
-- ✅ **Python 3.11+** – modern standards
+- ✅ **Python 3.12+** – modern standards
 - ✅ **Standard AsyncModbusTcpClient** – no custom Modbus client required
 
 ## 🚀 Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11", 
     "Programming Language :: Python :: 3.12",
     "Topic :: Home Automation",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 # Core dependencies
 dependencies = [
     "pymodbus>=3.5.0,<4.0.0",
@@ -56,7 +54,7 @@ where = ["."]
 include = ["custom_components*"]
 
 [tool.black]
-target-version = ["py310"]
+target-version = ["py312"]
 line-length = 100
 extend-exclude = '''
 /(
@@ -84,7 +82,7 @@ use_parentheses = true
 ensure_newline_before_comments = true
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/validate.yaml
+++ b/validate.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: pip install pytest
       - name: Run tests


### PR DESCRIPTION
## Summary
- raise minimum supported Python to 3.12
- align tooling and documentation with Python 3.12

## Testing
- `python -m black --check .` *(fails: unindent does not match any outer indentation level)*
- `flake8` *(fails: E305, E501, F401, E402, W391, etc.)*
- `python -m isort --check-only .` *(fails: imports are incorrectly sorted)*
- `mypy custom_components/thessla_green_modbus` *(fails: indentation error in climate.py)*
- `pytest` *(fails: IndentationError in climate.py)*

------
https://chatgpt.com/codex/tasks/task_e_689afd8c569083268e04747f95b01d10