### PR TITLE
refactor: centralize regex import for diagnostics

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Dict
 
 from homeassistant.config_entries import ConfigEntry
@@ -17,16 +18,18 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> Dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: ThesslaGreenModbusCoordinator = hass.data[DOMAIN][entry.entry_id]
-    
+    coordinator: ThesslaGreenModbusCoordinator = hass.data[DOMAIN][
+        entry.entry_id
+    ]
+
     # Gather comprehensive diagnostic data from the coordinator
     diagnostics = coordinator.get_diagnostic_data()
-    
+
     # Redact sensitive information
     diagnostics_safe = _redact_sensitive_data(diagnostics)
-    
+
     _LOGGER.debug("Generated diagnostics for ThesslaGreen device")
-    
+
     return diagnostics_safe
 
 
@@ -34,7 +37,7 @@ def _redact_sensitive_data(data: Dict[str, Any]) -> Dict[str, Any]:
     """Redact sensitive information from diagnostics."""
     # Create a copy to avoid modifying original data
     safe_data = data.copy()
-    
+
     # Redact sensitive connection information
     if "connection" in safe_data:
         connection = safe_data["connection"].copy()
@@ -45,22 +48,30 @@ def _redact_sensitive_data(data: Dict[str, Any]) -> Dict[str, Any]:
                 # Redact middle parts of IP: 192.xxx.xxx.17
                 connection["host"] = f"{host_parts[0]}.xxx.xxx.{host_parts[3]}"
         safe_data["connection"] = connection
-    
+
     # Redact serial number if present
-    if "device_info" in safe_data and "serial_number" in safe_data["device_info"]:
+    if (
+        "device_info" in safe_data
+        and "serial_number" in safe_data["device_info"]
+    ):
         serial = safe_data["device_info"]["serial_number"]
         if serial and len(serial) > 4:
             # Show only first and last 2 characters
-            safe_data["device_info"]["serial_number"] = f"{serial[:2]}***{serial[-2:]}"
-    
+            safe_data["device_info"]["serial_number"] = (
+                f"{serial[:2]}***{serial[-2:]}"
+            )
+
     # Keep error logs but redact any IP addresses in messages
     if "recent_errors" in safe_data:
         for error in safe_data["recent_errors"]:
             if "message" in error:
                 # Simple IP redaction
                 message = error["message"]
-                import re
-                message = re.sub(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', 'xxx.xxx.xxx.xxx', message)
+                message = re.sub(
+                    r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b",
+                    "xxx.xxx.xxx.xxx",
+                    message,
+                )
                 error["message"] = message
 
     return safe_data


### PR DESCRIPTION
## Summary
- centralize regex import in diagnostics
- remove local regex import and reformat for line length

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/diagnostics.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `flake8 custom_components/thessla_green_modbus/diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_689b002c61d48326843e12c64178cca9