### PR TITLE
chore: enforce Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Topic :: Home Automation",
 ]


### PR DESCRIPTION
## Summary
- ensure package metadata declares Python 3 only
- keep minimum Python version aligned at 3.12

## Testing
- `black --check .`
- `flake8`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_689b001ca8a48326874e2deb62b29dd7