### PR TITLE
Fix climate target temperature and resolve merge artifacts

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -134,28 +134,13 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
         data = self.coordinator.data
         for key in (
             "comfort_temperature",
-=======
-        # Try comfort temperature first, then required temperature
-        if "comfort_temperature" in self.coordinator.data:
-            return self.coordinator.data["comfort_temperature"]
-
-        for key in (
- main
             "required_temperature",
             "required_temperature_legacy",
-            "required_temp",
         ):
- codex/clean-up-climate.py-and-implement-target_temperature
             value = data.get(key)
             if isinstance(value, (int, float)):
                 return float(value)
-        return 22.0  # Default
-=======
-            if key in self.coordinator.data:
-                return self.coordinator.data[key]
-
         return None
- main
 
     @property
     def hvac_mode(self) -> HVACMode:
@@ -262,10 +247,6 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
                 "on_off_panel_mode", 0, refresh=False
             )
         else:
- codex/clean-up-climate.py-and-implement-target_temperature
-            # Turn on device first
-            await self.coordinator.async_write_register("on_off_panel_mode", 1, refresh=False)
-=======
             # Turn on device first and capture result
             power_on_success = await self.coordinator.async_write_register(
                 "on_off_panel_mode", 1, refresh=False
@@ -286,7 +267,6 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
                 )
                 return
 
- main
             # Set mode
             device_mode = HVAC_MODE_REVERSE_MAP.get(hvac_mode, 0)
             success = await self.coordinator.async_write_register(


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers
- ensure target temperature checks comfort, required and legacy values and falls back to None
- tidy hvac mode update with power-on retry

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/climate.py`


------
https://chatgpt.com/codex/tasks/task_e_689b001835a0832689be5f1d6becd15a