### PR TITLE
Fix Thessla Green fan availability check

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -73,6 +73,14 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         _LOGGER.debug("Initialized fan entity")
 
     @property
+    def available(self) -> bool:
+        """Return if the fan entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("on_off_panel_mode") is not None
+        )
+
+    @property
     def is_on(self) -> bool | None:
         """Return true if fan is on."""
         # Check if system is powered on


### PR DESCRIPTION
## Summary
- ensure fan entity availability checks for on/off panel register

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/fan.py`
- `pytest` *(fails: ImportError: cannot import name 'dt' from 'homeassistant.util')*

------
https://chatgpt.com/codex/tasks/task_e_689b001384f48326acb88d580b814f73