### PR TITLE
feat: improve Polish filter lifetime wording

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -144,7 +144,7 @@
         "name": "Indeks jakości powietrza"
       },
       "filter_lifetime_remaining": {
-        "name": "Pozostały czas życia filtra"
+        "name": "Pozostały czas pracy filtra"
       },
       "preheater_power": {
         "name": "Moc wstępnego grzania"
@@ -612,7 +612,7 @@
     },
     "reset_filters": {
       "name": "Resetuj licznik filtrów",
-      "description": "Resetuje licznik żywotności filtrów",
+      "description": "Resetuje licznik czasu pracy filtrów",
       "fields": {
         "filter_type": {
           "name": "Typ filtra",


### PR DESCRIPTION
## Summary
- use more natural phrase "Pozostały czas pracy filtra"
- align filter reset description with same terminology

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.helpers.entity'; 'homeassistant.helpers' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689b001036008326bf2dcae5b264b3e0