### PR TITLE
Fix target temperature fallback and update tests

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -132,14 +132,19 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
     def target_temperature(self) -> Optional[float]:
         """Return target temperature if available."""
         data = self.coordinator.data
-        for key in (
-            "comfort_temperature",
-            "required_temperature",
-            "required_temperature_legacy",
-        ):
-            value = data.get(key)
-            if isinstance(value, (int, float)):
-                return float(value)
+
+        value = data.get("comfort_temperature")
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        value = data.get("required_temperature")
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        value = data.get("required_temperature_legacy")
+        if isinstance(value, (int, float)):
+            return float(value)
+
         return None
 
     @property
@@ -254,17 +259,13 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
 
             # Retry once if power on failed
             if not power_on_success:
-                _LOGGER.warning(
-                    "Power-on failed when setting HVAC mode to %s, retrying", hvac_mode
-                )
+                _LOGGER.warning("Power-on failed when setting HVAC mode to %s, retrying", hvac_mode)
                 power_on_success = await self.coordinator.async_write_register(
                     "on_off_panel_mode", 1, refresh=False
                 )
 
             if not power_on_success:
-                _LOGGER.error(
-                    "Failed to enable device before setting HVAC mode to %s", hvac_mode
-                )
+                _LOGGER.error("Failed to enable device before setting HVAC mode to %s", hvac_mode)
                 return
 
             # Set mode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 """Test configuration for ThesslaGreen Modbus integration."""
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 import os
 import sys
 import types
+from datetime import datetime
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -91,8 +93,10 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     config_entries.OptionsFlow = OptionsFlow
     helpers.DataUpdateCoordinator = DataUpdateCoordinator
     helpers.UpdateFailed = UpdateFailed
+
     class DeviceInfo:  # type: ignore[override]
         pass
+
     device_registry.DeviceInfo = DeviceInfo
     exceptions.ConfigEntryNotReady = ConfigEntryNotReady
     exceptions.HomeAssistantError = HomeAssistantError
@@ -125,11 +129,15 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     selector.SelectSelector = SelectSelector
     selector.SelectSelectorConfig = SelectSelectorConfig
     selector.SelectSelectorMode = SelectSelectorMode
+
     async def async_extract_entity_ids(hass, service_call):
         return set()
+
     service_helper.async_extract_entity_ids = async_extract_entity_ids
+
     def er_async_get(hass):
         return getattr(hass, "entity_registry", None)
+
     entity_registry.async_get = er_async_get
     helpers_pkg.update_coordinator = helpers
     helpers_pkg.device_registry = device_registry
@@ -177,11 +185,18 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     # Minimal util.logging stub for pytest plugin compatibility
     util = types.ModuleType("homeassistant.util")
     util_logging = types.ModuleType("homeassistant.util.logging")
+    util_dt = types.ModuleType("homeassistant.util.dt")
 
     def log_exception(*args, **kwargs):  # pragma: no cover - simple no-op
         return None
 
+    def utcnow():  # pragma: no cover - simple stub
+        return datetime.utcnow()
+
     util_logging.log_exception = log_exception
+    util.dt = util_dt
+    util_dt.utcnow = utcnow
+    util_dt.now = utcnow
     util.logging = util_logging
     ha.util = util
 
@@ -196,6 +211,7 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["homeassistant.exceptions"] = exceptions
     sys.modules["homeassistant.const"] = const
     sys.modules["homeassistant.util"] = util
+    sys.modules["homeassistant.util.dt"] = util_dt
     sys.modules["homeassistant.util.logging"] = util_logging
     sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
     sys.modules["homeassistant.helpers.config_validation"] = cv
@@ -289,7 +305,7 @@ def mock_coordinator():
         },
         "capabilities": {
             "constant_flow": True,
-        "gwc_system": True,
+            "gwc_system": True,
             "bypass_system": True,
         },
     }
@@ -302,5 +318,3 @@ def mock_coordinator():
     coordinator.async_write_register = AsyncMock(return_value=True)
     coordinator.async_request_refresh = AsyncMock()
     return coordinator
-
-

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -117,8 +117,8 @@ class DummyClient:
     def __init__(self):
         self.writes = []
 
-    async def write_register(self, address, value, slave):
-        self.writes.append((address, value, slave))
+    async def write_register(self, address, value, unit=None, slave=None):
+        self.writes.append((address, value, unit or slave))
 
         class Response:
             def isError(self):
@@ -126,8 +126,10 @@ class DummyClient:
 
         return Response()
 
-    async def write_coil(self, address, value, slave):  # pragma: no cover - not used
-        self.writes.append((address, value, slave))
+    async def write_coil(
+        self, address, value, unit=None, slave=None
+    ):  # pragma: no cover - not used
+        self.writes.append((address, value, unit or slave))
 
         class Response:
             def isError(self):
@@ -141,9 +143,7 @@ async def test_set_temperature_scaling():
     """Ensure temperatures are scaled before writing to Modbus."""
 
     hass = SimpleNamespace()
-    coordinator = ThesslaGreenModbusCoordinator(
-        hass, "host", 502, 1, "dev", timedelta(seconds=1)
-    )
+    coordinator = ThesslaGreenModbusCoordinator(hass, "host", 502, 1, "dev", timedelta(seconds=1))
     coordinator.client = DummyClient()
     coordinator._ensure_connection = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
@@ -169,9 +169,7 @@ async def test_set_temperature_scaling():
 def test_target_temperature_none_when_unavailable():
     """Return None when no target temperature register is present."""
     hass = SimpleNamespace()
-    coordinator = ThesslaGreenModbusCoordinator(
-        hass, "host", 502, 1, "dev", timedelta(seconds=1)
-    )
+    coordinator = ThesslaGreenModbusCoordinator(hass, "host", 502, 1, "dev", timedelta(seconds=1))
     coordinator.capabilities.basic_control = True
     coordinator.data = {}
 


### PR DESCRIPTION
## Summary
- ensure `target_temperature` falls back through comfort, required and legacy values
- add `homeassistant.util.dt` stub in tests and accept `unit` in `DummyClient`

## Testing
- `black custom_components/thessla_green_modbus/climate.py`
- `black tests/conftest.py`
- `black tests/test_climate.py`
- `pytest tests/test_climate.py`


------
https://chatgpt.com/codex/tasks/task_e_689b01b016648326bd2d976a6def96a7