### PR TITLE
Handle missing port during config entry migration

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -30,6 +30,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Legacy default port used before version 2 when explicit port was optional
+LEGACY_DEFAULT_PORT = 8899
+
 # Supported platforms
 # Build platform list compatible with both real Home Assistant enums and test stubs
 PLATFORMS: list[Platform] = []
@@ -183,6 +186,13 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if "unit" in new_data and CONF_SLAVE_ID not in new_data:
         new_data[CONF_SLAVE_ID] = new_data["unit"]
         _LOGGER.info("Migrated 'unit' to '%s'", CONF_SLAVE_ID)
+
+    # Ensure port is present; older versions relied on legacy default
+    if CONF_PORT not in new_data:
+        new_data[CONF_PORT] = LEGACY_DEFAULT_PORT
+        _LOGGER.info(
+            "Added '%s' with legacy default %s", CONF_PORT, LEGACY_DEFAULT_PORT
+        )
 
     # Add new fields with defaults if missing
     if CONF_SCAN_INTERVAL not in new_options:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,46 @@
+"""Test config entry migrations."""
+import pytest
+from unittest.mock import MagicMock
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from custom_components.thessla_green_modbus import async_migrate_entry
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_adds_legacy_port():
+    """Test migration adds legacy default port when missing."""
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    config_entry = MagicMock(spec=ConfigEntry)
+    config_entry.version = 1
+    config_entry.data = {CONF_HOST: "192.168.0.10"}
+    config_entry.options = {}
+
+    result = await async_migrate_entry(hass, config_entry)
+
+    assert result is True
+    new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert new_data[CONF_PORT] == 8899
+    assert config_entry.version == 2
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_preserves_existing_port():
+    """Test migration keeps existing port value."""
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    config_entry = MagicMock(spec=ConfigEntry)
+    config_entry.version = 1
+    config_entry.data = {CONF_HOST: "192.168.0.10", CONF_PORT: 1234}
+    config_entry.options = {}
+
+    result = await async_migrate_entry(hass, config_entry)
+
+    assert result is True
+    new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert new_data[CONF_PORT] == 1234
+    assert config_entry.version == 2


### PR DESCRIPTION
## Summary
- ensure missing port is replaced with legacy default 8899 during migration
- add tests verifying port retention for legacy entries

## Testing
- `pytest tests/test_migration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b04dcf33083268d0c9ee2fdef4482