### PR TITLE
Clarify default Modbus port

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     host = entry.data[CONF_HOST]
     port = entry.data.get(
         CONF_PORT, DEFAULT_PORT
-    )  # Default to DEFAULT_PORT (8899 was used in legacy versions)
+    )  # Default to DEFAULT_PORT (502; legacy versions used 8899)
     
     # Try to get slave_id from multiple possible keys for compatibility
     slave_id = None

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -9,7 +9,7 @@ MODEL = "AirPack Home Serie 4"
 
 # Connection defaults
 DEFAULT_NAME = "ThesslaGreen"
-DEFAULT_PORT = 502
+DEFAULT_PORT = 502  # Standard Modbus TCP port; legacy versions used 8899
 DEFAULT_SLAVE_ID = 10
 DEFAULT_SCAN_INTERVAL = 30
 DEFAULT_TIMEOUT = 10


### PR DESCRIPTION
## Summary
- clarify that Modbus TCP port defaults to 502 and mention legacy 8899

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity'...)*

------
https://chatgpt.com/codex/tasks/task_e_689b04e2726c832688ff97b37bd250ff