### PR TITLE
Handle synchronous Modbus client close

### DIFF
--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -99,13 +99,19 @@ async def test_analyze_capabilities():
     assert capabilities["sensor_outside_temperature"] is True
 
 
-async def test_close_terminates_client():
-    """Ensure close() closes the underlying Modbus client."""
+@pytest.mark.parametrize("async_close", [True, False])
+async def test_close_terminates_client(async_close):
+    """Ensure close() handles both async and sync client close methods."""
     scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
-    mock_client = AsyncMock()
+    mock_client = AsyncMock() if async_close else MagicMock()
     scanner._client = mock_client
 
     await scanner.close()
 
-    mock_client.close.assert_awaited_once()
+    if async_close:
+        mock_client.close.assert_called_once()
+        mock_client.close.assert_awaited_once()
+    else:
+        mock_client.close.assert_called_once()
+
     assert scanner._client is None

--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -229,3 +229,31 @@ def test_disconnect_closes_client():
 
     import asyncio
     asyncio.run(run_test())
+
+
+def test_disconnect_closes_client_sync():
+    """Ensure _disconnect handles sync client.close."""
+
+    async def run_test():
+        hass = MagicMock()
+        coordinator = ThesslaGreenModbusCoordinator(
+            hass=hass,
+            host="localhost",
+            port=502,
+            slave_id=1,
+            name="Test",
+            scan_interval=30,
+            timeout=10,
+            retry=3,
+        )
+
+        client = MagicMock()
+        coordinator.client = client
+
+        await coordinator._disconnect()
+
+        client.close.assert_called_once()
+        assert coordinator.client is None
+
+    import asyncio
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- detect if Modbus client `close` returns a coroutine and await only when needed
- always reset and log disconnection for scanner and coordinator
- add tests covering async and sync close behaviors

## Testing
- `pytest tests/test_device_scanner.py::test_close_terminates_client -q`
- `pytest tests/test_scanner_close.py::test_disconnect_closes_client tests/test_scanner_close.py::test_disconnect_closes_client_sync -q`
- `pytest tests/test_scanner_close.py::test_async_setup_closes_scanner -q`
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator')*


------
https://chatgpt.com/codex/tasks/task_e_689b0879c6788326ae83855db031a190