### PR TITLE
Switch Modbus unit argument to slave

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -272,7 +272,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
-                response = await self.client.read_input_registers(0x0000, 1, unit=self.slave_id)
+                response = await self._call_modbus(
+                    self.client.read_input_registers, 0x0000, 1
+                )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
                 _LOGGER.debug("Connection test successful")
@@ -327,6 +329,13 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 self.statistics["connection_errors"] += 1
                 _LOGGER.exception("Unexpected error establishing connection: %s", exc)
                 raise
+
+    async def _call_modbus(self, func, *args, **kwargs):
+        """Invoke Modbus function handling slave/unit compatibility."""
+        try:  # pymodbus >=3.5 uses 'slave'
+            return await func(*args, slave=self.slave_id, **kwargs)
+        except TypeError:  # pragma: no cover - support older versions
+            return await func(*args, unit=self.slave_id, **kwargs)
 
     async def _async_update_data(self) -> Dict[str, Any]:
         """Fetch data from the device with optimized batch reading."""
@@ -409,8 +418,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["input_registers"]:
             try:
-                response = await self.client.read_input_registers(
-                    start_addr, count, unit=self.slave_id
+                response = await self._call_modbus(
+                    self.client.read_input_registers, start_addr, count
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -455,8 +464,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["holding_registers"]:
             try:
-                response = await self.client.read_holding_registers(
-                    start_addr, count, unit=self.slave_id
+                response = await self._call_modbus(
+                    self.client.read_holding_registers, start_addr, count
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -501,7 +510,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
-                response = await self.client.read_coils(start_addr, count, unit=self.slave_id)
+                response = await self._call_modbus(
+                    self.client.read_coils, start_addr, count
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read coil registers at 0x%04X: %s", start_addr, response
@@ -551,8 +562,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["discrete_inputs"]:
             try:
-                response = await self.client.read_discrete_inputs(
-                    start_addr, count, unit=self.slave_id
+                response = await self._call_modbus(
+                    self.client.read_discrete_inputs, start_addr, count
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -677,13 +688,13 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Determine register type and address
                 if register_name in HOLDING_REGISTERS:
                     address = HOLDING_REGISTERS[register_name]
-                    response = await self.client.write_register(
-                        address=address, value=value, unit=self.slave_id
+                    response = await self._call_modbus(
+                        self.client.write_register, address=address, value=value
                     )
                 elif register_name in COIL_REGISTERS:
                     address = COIL_REGISTERS[register_name]
-                    response = await self.client.write_coil(
-                        address=address, value=bool(value), unit=self.slave_id
+                    response = await self._call_modbus(
+                        self.client.write_coil, address=address, value=bool(value)
                     )
                 else:
                     _LOGGER.error("Unknown register for writing: %s", register_name)

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -91,12 +91,21 @@ class ThesslaGreenDeviceScanner:
         # Keep track of the Modbus client so it can be closed later
         self._client: Optional["AsyncModbusTcpClient"] = None
 
+    async def _call_modbus(self, func, *args, **kwargs):
+        """Call Modbus client method handling slave/unit keyword."""
+        try:  # pymodbus >=3.5 uses 'slave'
+            return await func(*args, slave=self.slave_id, **kwargs)
+        except TypeError:  # pragma: no cover - fallback for older versions
+            return await func(*args, unit=self.slave_id, **kwargs)
+
     async def _read_input(
         self, client: "AsyncModbusTcpClient", address: int, count: int
     ) -> Optional[List[int]]:
         """Read input registers."""
         try:
-            response = await client.read_input_registers(address, count, unit=self.slave_id)
+            response = await self._call_modbus(
+                client.read_input_registers, address, count
+            )
             if not response.isError():
                 return response.registers
         except (ModbusException, ConnectionException) as exc:
@@ -114,7 +123,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[int]]:
         """Read holding registers."""
         try:
-            response = await client.read_holding_registers(address, count, unit=self.slave_id)
+            response = await self._call_modbus(
+                client.read_holding_registers, address, count
+            )
             if not response.isError():
                 return response.registers
         except (ModbusException, ConnectionException) as exc:
@@ -132,7 +143,7 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read coil registers."""
         try:
-            response = await client.read_coils(address, count, unit=self.slave_id)
+            response = await self._call_modbus(client.read_coils, address, count)
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:
@@ -150,7 +161,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read discrete input registers."""
         try:
-            response = await client.read_discrete_inputs(address, count, unit=self.slave_id)
+            response = await self._call_modbus(
+                client.read_discrete_inputs, address, count
+            )
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -117,8 +117,8 @@ class DummyClient:
     def __init__(self):
         self.writes = []
 
-    async def write_register(self, address, value, unit=None, slave=None):
-        self.writes.append((address, value, unit or slave))
+    async def write_register(self, address, value, slave=None):
+        self.writes.append((address, value, slave))
 
         class Response:
             def isError(self):
@@ -126,10 +126,8 @@ class DummyClient:
 
         return Response()
 
-    async def write_coil(
-        self, address, value, unit=None, slave=None
-    ):  # pragma: no cover - not used
-        self.writes.append((address, value, unit or slave))
+    async def write_coil(self, address, value, slave=None):  # pragma: no cover - not used
+        self.writes.append((address, value, slave))
 
         class Response:
             def isError(self):


### PR DESCRIPTION
## Summary
- handle Modbus client changes by calling methods with `slave` and fallback to `unit`
- update Modbus coordinator and device scanner to use the compatibility helper
- adjust climate test stub to accept the new `slave` keyword

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator', IndentationError in climate.py, ModuleNotFoundError: No module named 'homeassistant.helpers.entity', ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689b0878ca988326ac068413abc567a1