### PR TITLE
Use _call_modbus for all read helpers

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -104,13 +104,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[int]]:
         """Read input registers."""
         try:
- codex/update-modbus-calls-for-slave_id
-            response = await client.read_input_registers(address, count, slave=self.slave_id)
-=======
             response = await self._call_modbus(
                 client.read_input_registers, address, count
             )
- main
             if not response.isError():
                 return response.registers
         except (ModbusException, ConnectionException) as exc:
@@ -124,13 +120,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[int]]:
         """Read holding registers."""
         try:
- codex/update-modbus-calls-for-slave_id
-            response = await client.read_holding_registers(address, count, slave=self.slave_id)
-=======
             response = await self._call_modbus(
                 client.read_holding_registers, address, count
             )
- main
             if not response.isError():
                 return response.registers
         except (ModbusException, ConnectionException) as exc:
@@ -146,11 +138,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read coil registers."""
         try:
- codex/update-modbus-calls-for-slave_id
-            response = await client.read_coils(address, count, slave=self.slave_id)
-=======
-            response = await self._call_modbus(client.read_coils, address, count)
- main
+            response = await self._call_modbus(
+                client.read_coils, address, count
+            )
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:
@@ -164,13 +154,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read discrete input registers."""
         try:
- codex/update-modbus-calls-for-slave_id
-            response = await client.read_discrete_inputs(address, count, slave=self.slave_id)
-=======
             response = await self._call_modbus(
                 client.read_discrete_inputs, address, count
             )
- main
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:


### PR DESCRIPTION
## Summary
- remove leftover merge markers from device scanner
- route all register read helpers through `_call_modbus`

## Testing
- `flake8 custom_components/thessla_green_modbus/device_scanner.py --select=E9,F63,F7,F82`
- `pytest` *(fails: IndentationError in custom_components/thessla_green_modbus/coordinator.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b0de3e6708326b3137b96eca7ec70