### PR TITLE
Refactor coordinator to use _call_modbus helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -273,13 +273,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
- codex/update-modbus-calls-for-slave_id
-                response = await self.client.read_input_registers(0x0000, 1, slave=self.slave_id)
-=======
-                response = await self._call_modbus(
-                    self.client.read_input_registers, 0x0000, 1
-                )
- main
+                response = await self._call_modbus(self.client.read_input_registers, 0x0000, 1)
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
                 _LOGGER.debug("Connection test successful")
@@ -423,13 +417,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["input_registers"]:
             try:
- codex/update-modbus-calls-for-slave_id
-                response = await self.client.read_input_registers(
-                    start_addr, count, slave=self.slave_id
-=======
                 response = await self._call_modbus(
                     self.client.read_input_registers, start_addr, count
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -472,13 +461,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["holding_registers"]:
             try:
- codex/update-modbus-calls-for-slave_id
-                response = await self.client.read_holding_registers(
-                    start_addr, count, slave=self.slave_id
-=======
                 response = await self._call_modbus(
                     self.client.read_holding_registers, start_addr, count
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -523,13 +507,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
- codex/update-modbus-calls-for-slave_id
-                response = await self.client.read_coils(start_addr, count, slave=self.slave_id)
-=======
-                response = await self._call_modbus(
-                    self.client.read_coils, start_addr, count
-                )
- main
+                response = await self._call_modbus(self.client.read_coils, start_addr, count)
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read coil registers at 0x%04X: %s", start_addr, response
@@ -577,13 +555,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["discrete_inputs"]:
             try:
- codex/update-modbus-calls-for-slave_id
-                response = await self.client.read_discrete_inputs(
-                    start_addr, count, slave=self.slave_id
-=======
                 response = await self._call_modbus(
                     self.client.read_discrete_inputs, start_addr, count
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -706,15 +679,6 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Determine register type and address
                 if register_name in HOLDING_REGISTERS:
                     address = HOLDING_REGISTERS[register_name]
- codex/update-modbus-calls-for-slave_id
-                    response = await self.client.write_register(
-                        address=address, value=value, slave=self.slave_id
-                    )
-                elif register_name in COIL_REGISTERS:
-                    address = COIL_REGISTERS[register_name]
-                    response = await self.client.write_coil(
-                        address=address, value=bool(value), slave=self.slave_id
-=======
                     response = await self._call_modbus(
                         self.client.write_register, address=address, value=value
                     )
@@ -722,7 +686,6 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                     address = COIL_REGISTERS[register_name]
                     response = await self._call_modbus(
                         self.client.write_coil, address=address, value=bool(value)
- main
                     )
                 else:
                     _LOGGER.error("Unknown register for writing: %s", register_name)


### PR DESCRIPTION
## Summary
- refactor connection tests and register reads/writes to call `_call_modbus`
- remove leftover merge conflict markers

## Testing
- `python -m isort custom_components/thessla_green_modbus/coordinator.py`
- `python -m black custom_components/thessla_green_modbus/coordinator.py`
- `python -m flake8 custom_components/thessla_green_modbus/coordinator.py`
- `pytest` *(fails: IndentationError in `custom_components/thessla_green_modbus/device_scanner.py`)*

------
https://chatgpt.com/codex/tasks/task_e_689b0de4f03c83269c094c9716afc357