### PR TITLE
Remove leftover conflict markers in Modbus integration

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -273,13 +273,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
- codex/remove-conflict-markers-and-clean-up-code
                 response = await self._call_modbus(
                     self.client.read_input_registers, 0x0000, 1
                 )
-=======
-                response = await self._call_modbus(self.client.read_input_registers, 0x0000, 1)
- main
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
                 _LOGGER.debug("Connection test successful")
@@ -513,13 +509,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
- codex/remove-conflict-markers-and-clean-up-code
                 response = await self._call_modbus(
                     self.client.read_coils, start_addr, count
                 )
-=======
-                response = await self._call_modbus(self.client.read_coils, start_addr, count)
- main
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read coil registers at 0x%04X: %s", start_addr, response

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -138,13 +138,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read coil registers."""
         try:
- codex/remove-conflict-markers-and-clean-up-code
-            response = await self._call_modbus(client.read_coils, address, count)
-=======
             response = await self._call_modbus(
                 client.read_coils, address, count
             )
- main
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:


### PR DESCRIPTION
## Summary
- Clean up merge artifacts in device scanner and coordinator
- Ensure Modbus operations consistently use `_call_modbus`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity'; ModuleNotFoundError: No module named 'homeassistant.helpers.entity', 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689b0fd2866c832693d78b5fa9ce722d