### PR TITLE
Clean up Modbus coordinator conflict markers and use wrapper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -273,13 +273,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
- codex/remove-conflict-markers-and-clean-up-code
-                response = await self._call_modbus(
-                    self.client.read_input_registers, 0x0000, 1
-                )
-=======
                 response = await self._call_modbus(self.client.read_input_registers, 0x0000, 1)
- main
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
                 _LOGGER.debug("Connection test successful")
@@ -513,13 +507,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
- codex/remove-conflict-markers-and-clean-up-code
-                response = await self._call_modbus(
-                    self.client.read_coils, start_addr, count
-                )
-=======
                 response = await self._call_modbus(self.client.read_coils, start_addr, count)
- main
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read coil registers at 0x%04X: %s", start_addr, response


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in Modbus coordinator
- ensure Modbus read/write calls use `_call_modbus`

## Testing
- `python -m isort custom_components/thessla_green_modbus/coordinator.py`
- `python -m black custom_components/thessla_green_modbus/coordinator.py`
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py`
- `python -c "import custom_components.thessla_green_modbus.coordinator"` *(fails: ModuleNotFoundError: No module named 'homeassistant')*
- `pytest` *(fails: IndentationError in device_scanner.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b0fc88800832685bb38e15a0f8c28