### PR TITLE
Clean up device_scanner modbus calls

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -133,13 +133,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read coil registers."""
         try:
- codex/create-modbus_helpers-module-and-refactor-code
-            response = await _call_modbus(client.read_coils, self.slave_id, address, count)
-=======
-            response = await self._call_modbus(
-                client.read_coils, address, count
+            response = await _call_modbus(
+                client.read_coils, self.slave_id, address, count
             )
- main
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:


### PR DESCRIPTION
## Summary
- remove leftover merge markers in device_scanner
- standardize `_call_modbus` usage across read helpers

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/device_scanner.py`
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_689b127f12f48326a1636817aa32fa6e