### PR TITLE
Clean write operations and remove merge remnants

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -274,14 +274,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
- codex/create-modbus_helpers-module-and-refactor-code
                 response = await _call_modbus(
-                    self.client.read_input_registers, self.slave_id, 0x0000, 1
-=======
-codex/resolve-merge-conflicts-in-modbus-files
-                response = await self._call_modbus(
-                    self.client.read_input_registers, 0x0000, 1
- main
+                    self.client.read_input_registers,
+                    self.slave_id,
+                    0x0000,
+                    1,
                 )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
@@ -509,14 +506,11 @@ codex/resolve-merge-conflicts-in-modbus-files
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
- codex/create-modbus_helpers-module-and-refactor-code
                 response = await _call_modbus(
-                    self.client.read_coils, self.slave_id, start_addr, count
-=======
- codex/resolve-merge-conflicts-in-modbus-files
-                response = await self._call_modbus(
-                    self.client.read_coils, start_addr, count
- main
+                    self.client.read_coils,
+                    self.slave_id,
+                    start_addr,
+                    count,
                 )
                 if response.isError():
                     _LOGGER.debug(

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -133,13 +133,12 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read coil registers."""
         try:
- codex/create-modbus_helpers-module-and-refactor-code
-            response = await _call_modbus(client.read_coils, self.slave_id, address, count)
-=======
-            response = await self._call_modbus(
-                client.read_coils, address, count
+            response = await _call_modbus(
+                client.read_coils,
+                self.slave_id,
+                address,
+                count,
             )
- main
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:


### PR DESCRIPTION
## Summary
- remove leftover merge markers and route connection test/coil reads through `_call_modbus`
- ensure `async_write_register` uses `_call_modbus` for holding and coil writes
- clean device scanner coil read to use `_call_modbus`

## Testing
- `python -m isort custom_components/thessla_green_modbus/coordinator.py`
- `python -m isort custom_components/thessla_green_modbus/device_scanner.py`
- `python -m black custom_components/thessla_green_modbus/coordinator.py`
- `python -m black custom_components/thessla_green_modbus/device_scanner.py`
- `pytest` *(fails: cannot import `CoordinatorEntity` and `homeassistant.helpers.entity`)*

------
https://chatgpt.com/codex/tasks/task_e_689b12791878832695883a1f2337de47