### PR TITLE
Refactor Modbus calls to use slave-aware helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -53,7 +53,7 @@ from .const import (
     REGISTER_MULTIPLIERS,
 )
 from .device_scanner import DeviceCapabilities, ThesslaGreenDeviceScanner
-from .modbus_helpers import _call_modbus
+from .modbus_helpers import _call_modbus as call_modbus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -131,6 +131,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             "average_response_time": 0.0,
             "total_registers_read": 0,
         }
+
+    async def _call_modbus(self, func, *args, **kwargs):
+        """Wrapper around Modbus calls injecting the slave ID."""
+        return await call_modbus(func, self.slave_id, *args, **kwargs)
 
     async def async_setup(self) -> bool:
         """Set up the coordinator by scanning the device."""
@@ -274,14 +278,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
- codex/create-modbus_helpers-module-and-refactor-code
-                response = await _call_modbus(
-                    self.client.read_input_registers, self.slave_id, 0x0000, 1
-=======
-codex/resolve-merge-conflicts-in-modbus-files
                 response = await self._call_modbus(
                     self.client.read_input_registers, 0x0000, 1
- main
                 )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
@@ -419,8 +417,8 @@ codex/resolve-merge-conflicts-in-modbus-files
 
         for start_addr, count in self._register_groups["input_registers"]:
             try:
-                response = await _call_modbus(
-                    self.client.read_input_registers, self.slave_id, start_addr, count
+                response = await self._call_modbus(
+                    self.client.read_input_registers, start_addr, count
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -463,8 +461,8 @@ codex/resolve-merge-conflicts-in-modbus-files
 
         for start_addr, count in self._register_groups["holding_registers"]:
             try:
-                response = await _call_modbus(
-                    self.client.read_holding_registers, self.slave_id, start_addr, count
+                response = await self._call_modbus(
+                    self.client.read_holding_registers, start_addr, count
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -509,14 +507,8 @@ codex/resolve-merge-conflicts-in-modbus-files
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
- codex/create-modbus_helpers-module-and-refactor-code
-                response = await _call_modbus(
-                    self.client.read_coils, self.slave_id, start_addr, count
-=======
- codex/resolve-merge-conflicts-in-modbus-files
                 response = await self._call_modbus(
                     self.client.read_coils, start_addr, count
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -565,8 +557,8 @@ codex/resolve-merge-conflicts-in-modbus-files
 
         for start_addr, count in self._register_groups["discrete_inputs"]:
             try:
-                response = await _call_modbus(
-                    self.client.read_discrete_inputs, self.slave_id, start_addr, count
+                response = await self._call_modbus(
+                    self.client.read_discrete_inputs, start_addr, count
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -689,17 +681,15 @@ codex/resolve-merge-conflicts-in-modbus-files
                 # Determine register type and address
                 if register_name in HOLDING_REGISTERS:
                     address = HOLDING_REGISTERS[register_name]
-                    response = await _call_modbus(
+                    response = await self._call_modbus(
                         self.client.write_register,
-                        self.slave_id,
                         address=address,
                         value=value,
                     )
                 elif register_name in COIL_REGISTERS:
                     address = COIL_REGISTERS[register_name]
-                    response = await _call_modbus(
+                    response = await self._call_modbus(
                         self.client.write_coil,
-                        self.slave_id,
                         address=address,
                         value=bool(value),
                     )


### PR DESCRIPTION
## Summary
- add internal `_call_modbus` wrapper that injects slave id
- use `_call_modbus` across connection test, optimized reads, and register writes
- remove leftover merge conflict markers

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_689b138b57e8832693c6ae503b8979f8