### PR TITLE
Clean Modbus calls and resolve leftover merge text

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -278,16 +278,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
- codex/refactor-coordinator.py-for-modbus-calls
                 response = await self._call_modbus(
                     self.client.read_input_registers, 0x0000, 1
-=======
-                response = await _call_modbus(
-                    self.client.read_input_registers,
-                    self.slave_id,
-                    0x0000,
-                    1,
- main
                 )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
@@ -515,16 +507,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
- codex/refactor-coordinator.py-for-modbus-calls
                 response = await self._call_modbus(
                     self.client.read_coils, start_addr, count
-=======
-                response = await _call_modbus(
-                    self.client.read_coils,
-                    self.slave_id,
-                    start_addr,
-                    count,
- main
                 )
                 if response.isError():
                     _LOGGER.debug(

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -134,14 +134,7 @@ class ThesslaGreenDeviceScanner:
         """Read coil registers."""
         try:
             response = await _call_modbus(
- codex/remove-conflicts-in-async_write_register
-                client.read_coils,
-                self.slave_id,
-                address,
-                count,
-=======
                 client.read_coils, self.slave_id, address, count
- main
             )
             if not response.isError():
                 return response.bits[:count]


### PR DESCRIPTION
## Summary
- remove stray codex/merge markers from coordinator and device scanner
- call `_call_modbus` uniformly for connection test and coil register reads

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/device_scanner.py`
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator')*


------
https://chatgpt.com/codex/tasks/task_e_689b16175b1c8326bce1e97fb285d76a