### PR TITLE
Simplify confirmation descriptions

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Confirm Configuration",
-        "description": "ThesslaGreen device detected:\n\n**Host:** {host}:{port}\n**Slave ID:** {slave_id}\n**Device Name:** {device_name}\n**Firmware Version:** {firmware_version}\n**Serial Number:** {serial_number}\n\n**Scan Statistics:**\n- Registers Found: {register_count}\n- Scan Success Rate: {scan_success_rate}\n- Capabilities Detected: {capabilities_count}\n- Main Features: {capabilities_list}\n\n{auto_detected_note}\n\nDo you want to continue with this configuration?"
+        "description": "ThesslaGreen device {device_name} detected at {host}:{port} with Slave ID {slave_id} and firmware {firmware_version}. {auto_detected_note} Do you want to continue with this configuration?"
       }
     },
     "error": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen:\n\n**Host:** {host}:{port}\n**Slave ID:** {slave_id}\n**Nazwa urządzenia:** {device_name}\n**Wersja firmware:** {firmware_version}\n**Numer seryjny:** {serial_number}\n\n**Statystyki skanowania:**\n- Znalezionych rejestrów: {register_count}\n- Skuteczność skanowania: {scan_success_rate}\n- Wykryte możliwości: {capabilities_count}\n- Główne funkcje: {capabilities_list}\n\n{auto_detected_note}\n\nCzy chcesz kontynuować tę konfigurację?"
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} pod adresem {host}:{port} (ID Slave {slave_id}, firmware {firmware_version}). {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
       }
     },
     "error": {


### PR DESCRIPTION
## Summary
- streamline confirmation descriptions in English and Polish translations

## Testing
- `pytest tests/test_translations.py`

------
https://chatgpt.com/codex/tasks/task_e_689b1610b40c8326ab6dbc12933c3a04