### PR TITLE
fix: rename model to Series 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 ## 📋 Kompatybilność
 
 ### Urządzenia
-- ✅ **ThesslaGreen AirPack Home Serie 4** - wszystkie modele
+- ✅ **ThesslaGreen AirPack Home Series 4** - wszystkie modele
 - ✅ **AirPack Home 300v-850h** (Energy+, Energy, Enthalpy)
 - ✅ **Protokół Modbus TCP/RTU** z auto-detekcją
 - ✅ **Firmware v3.x - v5.x** z automatyczną detekcją

--- a/README_en.md
+++ b/README_en.md
@@ -26,7 +26,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 ## 📋 Compatibility
 
 ### Devices
-- ✅ **ThesslaGreen AirPack Home Serie 4** – all models
+- ✅ **ThesslaGreen AirPack Home Series 4** – all models
 - ✅ **AirPack Home 300v‑850h** (Energy+, Energy, Enthalpy)
 - ✅ **Modbus TCP/RTU protocol** with auto detection
 - ✅ **Firmware v3.x – v5.x** with automatic detection

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 # Integration constants
 DOMAIN = "thessla_green_modbus"
 MANUFACTURER = "ThesslaGreen"
-MODEL = "AirPack Home Serie 4"
+MODEL = "AirPack Home Series 4"
 
 # Connection defaults
 DEFAULT_NAME = "ThesslaGreen"

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -296,7 +296,7 @@ class ThesslaGreenDeviceScanner:
                 _LOGGER.debug("Firmware version: %s", fw)
 
             # Determine model based on firmware features
-            model = "AirPack Home Serie 4"
+            model = "AirPack Home Series 4"
             if fw_data and fw_data[0] >= 4:
                 if fw_data[1] >= 85:
                     model = "AirPack⁴ Energy++"


### PR DESCRIPTION
## Summary
- fix model name "AirPack Home Serie 4" -> "AirPack Home Series 4" in constants and device scanner
- update documentation references

## Testing
- `pytest tests/test_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_689b160e159083268f94164c4865dfc5