### PR TITLE
Fix translation description line breaks

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "ThesslaGreen Modbus Configuration",
-        "description": "Configure connection to ThesslaGreen AirPack via Modbus TCP.\nThe integration will automatically detect available device functions and registers.",
+        "description": "Configure connection to ThesslaGreen AirPack via Modbus TCP. The integration will automatically detect available device functions and registers.",
         "data": {
           "host": "IP Address",
           "port": "Port",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfiguracja ThesslaGreen Modbus",
-        "description": "Skonfiguruj połączenie z ThesslaGreen AirPack przez Modbus TCP.\nIntegracja automatycznie wykryje dostępne funkcje i rejestry urządzenia.",
+        "description": "Skonfiguruj połączenie z ThesslaGreen AirPack przez Modbus TCP. Integracja automatycznie wykryje dostępne funkcje i rejestry urządzenia.",
         "data": {
           "host": "Adres IP",
           "port": "Port",


### PR DESCRIPTION
## Summary
- remove unintended line breaks from English and Polish config step descriptions to read smoothly

## Testing
- `pytest` (fails: SyntaxError in custom_components/thessla_green_modbus/device_scanner.py)


------
https://chatgpt.com/codex/tasks/task_e_689b184f4f4c8326a71f4d85aa91a822