### PR TITLE
chore: unify airflow translation

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -114,10 +114,10 @@
         "name": "Przepływ obejścia (bypassu)"
       },
       "supply_air_flow": {
-        "name": "Strumień nawiewu"
+        "name": "Przepływ nawiewu"
       },
       "exhaust_air_flow": {
-        "name": "Strumień wywiewu"
+        "name": "Przepływ wywiewu"
       },
       "co2_level": {
         "name": "Poziom CO2"


### PR DESCRIPTION
## Summary
- unify airflow translation in Polish

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/pl.json`
- `python -m script.translations develop` *(fails: ModuleNotFoundError: No module named 'script')*


------
https://chatgpt.com/codex/tasks/task_e_689b184678ec8326846942ad906199e1