### PR TITLE
Use consistent airflow wording in English translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -150,10 +150,10 @@
         "name": "Bypass Airflow"
       },
       "supply_air_flow": {
-        "name": "Supply Air Flow"
+        "name": "Supply Airflow"
       },
       "exhaust_air_flow": {
-        "name": "Exhaust Air Flow"
+        "name": "Exhaust Airflow"
       },
       "pm1_level": {
         "name": "PM1"


### PR DESCRIPTION
## Summary
- use consistent "Airflow" wording for supply and exhaust translation keys

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/en.json`
- `python -m script.translations develop` *(fails: No module named 'script')*

------
https://chatgpt.com/codex/tasks/task_e_689b1843772c8326b02a5dff58acecfb