### PR TITLE
Remove leftover merge markers in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -134,15 +134,6 @@ class ThesslaGreenDeviceScanner:
         """Read coil registers."""
         try:
             response = await _call_modbus(
- codex/refactor-device_scanner-and-coordinator-code
-=======
- codex/edit-emoji-strings-in-config_flow.py
-                client.read_coils,
-                self.slave_id,
-                address,
-                count,
-=======
-main
                 client.read_coils, self.slave_id, address, count
             )
             if not response.isError():


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in `_read_coil`
- ensure coil reads call `_call_modbus` correctly

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/device_scanner.py`


------
https://chatgpt.com/codex/tasks/task_e_689b1840f270832696c6bb40a231074c