### PR TITLE
chore: clean up coil read call

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -133,9 +133,7 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read coil registers."""
         try:
-            response = await _call_modbus(
-                client.read_coils, self.slave_id, address, count
-            )
+            response = await _call_modbus(client.read_coils, self.slave_id, address, count)
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:


### PR DESCRIPTION
## Summary
- remove stray merge artifact from `_read_coil`
- simplify Modbus coil read into a single-line call

## Testing
- `pytest tests/test_device_scanner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1a5d4d3083269adf4bfdad5c229a