### PR TITLE
Ensure scanner closes on failure

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -468,6 +468,8 @@ class ThesslaGreenDeviceScanner:
         except (OSError, asyncio.TimeoutError, ValueError) as exc:
             _LOGGER.exception("Device scan failed: %s", exc)
             raise
+        finally:
+            await self.close()
 
     async def close(self):
         """Close the scanner connection if any."""


### PR DESCRIPTION
## Summary
- Guarantee scanner connections are closed by adding a `finally` block in `scan_device`
- Test scanner close behavior on failure to ensure cleanup

## Testing
- `pytest tests/test_scanner_close.py`


------
https://chatgpt.com/codex/tasks/task_e_689b1d25e5f883268a66f2ef8d83d70c