### PR TITLE
Handle Modbus ModbusException as connection failure

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -68,7 +68,7 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
         raise CannotConnect from exc
     except ModbusException as exc:
         _LOGGER.exception("Modbus error: %s", exc)
-        raise InvalidAuth from exc
+        raise CannotConnect from exc
     except (OSError, asyncio.TimeoutError) as exc:
         _LOGGER.exception("Unexpected error during device validation: %s", exc)
         raise CannotConnect from exc


### PR DESCRIPTION
## Summary
- treat `ModbusException` as a connection error instead of auth failure
- test config flow reacts with `CannotConnect` on Modbus communication errors

## Testing
- `pytest tests/test_config_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_689b1d2737b4832699bf63d66736752c