### PR TITLE
Handle Modbus failures explicitly in switch and fan

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -10,6 +10,20 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+try:  # pragma: no cover - handle missing pymodbus during tests
+    from pymodbus.exceptions import ConnectionException, ModbusException
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
+
+    class ConnectionException(Exception):
+        """Fallback exception when pymodbus is unavailable."""
+
+        pass
+
+    class ModbusException(Exception):
+        """Fallback Modbus exception when pymodbus is unavailable."""
+
+        pass
+
 from .const import DOMAIN, HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
@@ -144,8 +158,9 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
 
             _LOGGER.info("Turned on fan")
 
-        except Exception as exc:
+        except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to turn on fan: %s", exc)
+            raise
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
@@ -168,8 +183,9 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
 
             _LOGGER.info("Turned off fan")
 
-        except Exception as exc:
+        except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to turn off fan: %s", exc)
+            raise
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
@@ -197,8 +213,9 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
 
             _LOGGER.info("Set fan speed to %d%%", actual_percentage)
 
-        except Exception as exc:
+        except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to set fan speed to %d%%: %s", percentage, exc)
+            raise
 
     def _get_current_mode(self) -> str | None:
         """Get current system mode."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3,6 +3,8 @@ import sys
 import types
 import asyncio
 import pytest
+from unittest.mock import AsyncMock
+from pymodbus.exceptions import ConnectionException
 
 # ---------------------------------------------------------------------------
 # Minimal Home Assistant stubs
@@ -29,6 +31,23 @@ class AddEntitiesCallback:  # pragma: no cover - simple stub
 
 entity_platform.AddEntitiesCallback = AddEntitiesCallback
 sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+helpers_uc = sys.modules.setdefault(
+    "homeassistant.helpers.update_coordinator",
+    types.ModuleType("homeassistant.helpers.update_coordinator"),
+)
+
+
+class CoordinatorEntity:  # pragma: no cover - simple stub
+    def __init__(self, coordinator=None):
+        self.coordinator = coordinator
+
+    @classmethod
+    def __class_getitem__(cls, item):  # pragma: no cover - allow subscripting
+        return cls
+
+
+helpers_uc.CoordinatorEntity = CoordinatorEntity
 
 # ---------------------------------------------------------------------------
 # Actual tests
@@ -70,3 +89,15 @@ def test_switch_turn_on_off(mock_coordinator):
         "on_off_panel_mode", 0, refresh=False
     )
     mock_coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_switch_turn_on_modbus_failure(mock_coordinator):
+    """Ensure Modbus errors are surfaced when turning on the switch."""
+    switch = ThesslaGreenSwitch(
+        mock_coordinator, "on_off_panel_mode", SWITCH_ENTITIES["on_off_panel_mode"]
+    )
+    mock_coordinator.async_write_register = AsyncMock(
+        side_effect=ConnectionException("fail")
+    )
+    with pytest.raises(ConnectionException):
+        asyncio.run(switch.async_turn_on())


### PR DESCRIPTION
## Summary
- Replace generic exception handlers with Modbus-specific exceptions and re-raise after logging
- Add tests ensuring Modbus write failures raise meaningful errors

## Testing
- `pytest tests/test_switch.py tests/test_fan.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1d34e6308326ac16853bf4c435a5