### PR TITLE
Use default timeout and retry

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -49,7 +49,11 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
 
     # Try to connect and scan device
     scanner = ThesslaGreenDeviceScanner(
-        host=host, port=port, slave_id=slave_id, timeout=10, retry=3
+        host=host,
+        port=port,
+        slave_id=slave_id,
+        timeout=DEFAULT_TIMEOUT,
+        retry=DEFAULT_RETRY,
     )
 
     try:


### PR DESCRIPTION
## Summary
- use DEFAULT_TIMEOUT and DEFAULT_RETRY for device scanner initialization

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689b1d3181788326b01d9d8102f68e69