### PR TITLE
Refine config flow error handling

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -117,9 +117,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except (ConnectionException, ModbusException):
                 _LOGGER.exception("Modbus communication error")
                 errors["base"] = "cannot_connect"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+            except ValueError as err:
+                _LOGGER.error("Invalid value provided: %s", err)
+                errors["base"] = "invalid_input"
+            except KeyError as err:
+                _LOGGER.error("Missing required data: %s", err)
+                errors["base"] = "invalid_input"
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception during configuration: %s", err)
+                raise
 
         # Show form
         data_schema = vol.Schema(

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -25,6 +25,7 @@
     "error": {
       "cannot_connect": "Cannot connect to device. Check IP address, port, and network connection.",
       "invalid_auth": "Authentication error. Check Slave ID settings.",
+      "invalid_input": "Invalid configuration provided. Check values and try again.",
       "unknown": "Unexpected error. Check logs for details."
     },
     "abort": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -25,6 +25,7 @@
     "error": {
       "cannot_connect": "Nie można połączyć się z urządzeniem. Sprawdź adres IP, port oraz połączenie sieciowe.",
       "invalid_auth": "Błąd autoryzacji. Sprawdź ustawienia Slave ID.",
+      "invalid_input": "Nieprawidłowa konfiguracja. Sprawdź wartości i spróbuj ponownie.",
       "unknown": "Nieoczekiwany błąd. Sprawdź logi dla szczegółów."
     },
     "abort": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -118,14 +118,14 @@ async def test_form_user_invalid_auth():
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_user_unexpected_exception():
-    """Test we handle unexpected exception."""
+async def test_form_user_invalid_value():
+    """Test we handle invalid value error."""
     flow = ConfigFlow()
     flow.hass = None
 
     with patch(
         "custom_components.thessla_green_modbus.config_flow.validate_input",
-        side_effect=Exception,
+        side_effect=ValueError,
     ):
         result = await flow.async_step_user(
             {
@@ -137,7 +137,49 @@ async def test_form_user_unexpected_exception():
         )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "unknown"}
+    assert result["errors"] == {"base": "invalid_input"}
+
+
+async def test_form_user_missing_key():
+    """Test we handle missing key error."""
+    flow = ConfigFlow()
+    flow.hass = None
+
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow.validate_input",
+        side_effect=KeyError("test"),
+    ):
+        result = await flow.async_step_user(
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 502,
+                "slave_id": 10,
+                CONF_NAME: "My Device",
+            }
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_input"}
+
+
+async def test_form_user_unexpected_exception():
+    """Test unexpected exceptions are raised."""
+    flow = ConfigFlow()
+    flow.hass = None
+
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow.validate_input",
+        side_effect=RuntimeError,
+    ):
+        with pytest.raises(RuntimeError):
+            await flow.async_step_user(
+                {
+                    CONF_HOST: "192.168.1.100",
+                    CONF_PORT: 502,
+                    "slave_id": 10,
+                    CONF_NAME: "My Device",
+                }
+            )
 
 
 async def test_validate_input_success():


### PR DESCRIPTION
## Summary
- handle invalid user input explicitly in config flow and rethrow unexpected errors
- add translation for new error and dedicated tests for invalid data cases

## Testing
- `pytest tests/test_config_flow.py -q`
- `pytest tests/test_translations.py::test_translation_structures_match -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1d4524a48326be8e56294acf7ed4