### PR TITLE
Lowercase mode names in special mode description

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -501,7 +501,7 @@
   "services": {
       "set_special_mode": {
         "name": "Set Special Mode",
-        "description": "Sets special operating mode of the heat recovery unit (BOOST, ECO, FIREPLACE, HOOD, etc.)",
+        "description": "Sets special operating mode of the heat recovery unit (boost, eco, fireplace, hood, etc.)",
         "fields": {
           "mode": {
             "name": "Special Mode",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -501,7 +501,7 @@
   "services": {
     "set_special_mode": {
       "name": "Ustaw tryb specjalny",
-      "description": "Ustawia specjalny tryb pracy rekuperatora (BOOST, ECO, KOMINEK, OKAP itd.)",
+      "description": "Ustawia specjalny tryb pracy rekuperatora (boost, eco, kominek, okap itd.)",
       "fields": {
         "mode": {
           "name": "Tryb specjalny",


### PR DESCRIPTION
## Summary
- lowercase special mode names in English and Polish translations
- verified no other description strings require case adjustment

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity', ModuleNotFoundError: No module named 'homeassistant.helpers.entity', ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689b2308cdbc8326bff1981af935ff19