### PR TITLE
Expose sleep special mode service

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 
 ### Sensory binarne (40+ automatycznie wykrywanych)
 - **Status systemu**: Zasilanie wentylatorów, bypass, GWC, pompy
-- **Tryby**: Letni/zimowy, auto/manual, tryby specjalne
+- **Tryby**: Letni/zimowy, auto/manual, tryby specjalne (boost, eco, away, sleep, fireplace, hood, party, bathroom, kitchen, summer, winter)
 - **Wejścia**: Expansion, alarm pożarowy, kontaktrony, czujniki
 - **Błędy i alarmy**: Wszystkie kody S1-S32 i E99-E105
 - **Zabezpieczenia**: Termiczne, przeciwmrozowe, przeciążenia

--- a/README_en.md
+++ b/README_en.md
@@ -97,7 +97,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 
 ### Binary sensors (40+ auto detected)
 - **System status**: fan power, bypass, GWC, pumps
-- **Modes**: summer/winter, auto/manual, special modes
+- **Modes**: summer/winter, auto/manual, special modes (boost, eco, away, sleep, fireplace, hood, party, bathroom, kitchen, summer, winter)
 - **Inputs**: expansion, fire alarm, contractors, sensors
 - **Errors and alarms**: all codes S1‑S32 and E99‑E105
 - **Protections**: thermal, anti freeze, overloads

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -38,8 +38,20 @@ def _scale_for_register(register_name: str, value: float) -> int:
 # Service schemas
 SET_SPECIAL_MODE_SCHEMA = vol.Schema({
     vol.Required("entity_id"): cv.entity_ids,
-    vol.Required("mode"): vol.In(["none", "boost", "eco", "away", "fireplace", "hood", 
-                                  "party", "bathroom", "kitchen", "summer", "winter"]),
+    vol.Required("mode"): vol.In([
+        "none",
+        "boost",
+        "eco",
+        "away",
+        "sleep",
+        "fireplace",
+        "hood",
+        "party",
+        "bathroom",
+        "kitchen",
+        "summer",
+        "winter",
+    ]),
     vol.Optional("duration", default=0): vol.All(vol.Coerce(int), vol.Range(min=0, max=480)),
 })
 

--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -21,6 +21,7 @@ set_special_mode:
             - "boost"
             - "eco"
             - "away"
+            - "sleep"
             - "fireplace"
             - "hood"
             - "party"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -513,6 +513,7 @@
                   "boost": "Boost",
                   "eco": "Eco",
                   "away": "Away",
+                  "sleep": "Sleep",
                   "fireplace": "Fireplace",
                   "hood": "Hood",
                   "party": "Party",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -513,6 +513,7 @@
                 "boost": "Boost",
                 "eco": "Eco",
                 "away": "Nieobecność",
+                "sleep": "Sen",
                 "fireplace": "Kominek",
                 "hood": "Okap",
                 "party": "Impreza",


### PR DESCRIPTION
## Summary
- expose `sleep` preset in `set_special_mode` service
- update translations for new mode
- document full list of available special modes

## Testing
- `pytest` *(fails: tests/test_binary_sensor.py, tests/test_fan.py, tests/test_number.py, tests/test_translations.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b231fd4c883269a8007dc38340c6d