### PR TITLE
feat: allow 1-minute special mode duration

### DIFF
--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -37,7 +37,7 @@ set_special_mode:
         number:
           min: 0
           max: 480
-          step: 5
+          step: 1
 
 set_airflow_schedule:
   name: Set Airflow Schedule

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -526,7 +526,7 @@
           },
           "duration": {
             "name": "Duration (minutes)",
-            "description": "Duration of special mode in minutes (0 = unlimited)"
+            "description": "Duration of special mode in minutes (1-minute steps, 0 = unlimited)"
           }
         }
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -526,7 +526,7 @@
         },
         "duration": {
           "name": "Czas trwania (minuty)",
-          "description": "Czas trwania trybu specjalnego w minutach (0 = bez limitu)"
+          "description": "Czas trwania trybu specjalnego w minutach (krok co 1 minutę, 0 = bez limitu)"
         }
       }
     },


### PR DESCRIPTION
## Summary
- allow configuring special mode duration in 1-minute steps
- clarify special mode duration translations

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ConnectionException' from 'pymodbus.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_689b230d31e48326bd24cd331c162ecb