### PR TITLE
Expand service translation fields

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -562,6 +562,22 @@
                 }
               }
             }
+          },
+          "start_time": {
+            "name": "Start Time",
+            "description": "Start time for the period (HH:MM)"
+          },
+          "end_time": {
+            "name": "End Time",
+            "description": "End time for the period (HH:MM)"
+          },
+          "airflow_rate": {
+            "name": "Airflow Rate",
+            "description": "Target airflow rate (%)"
+          },
+          "temperature": {
+            "name": "Temperature",
+            "description": "Target temperature (°C)"
           }
         }
       },
@@ -581,6 +597,14 @@
                 }
               }
             }
+          },
+          "temperature_threshold": {
+            "name": "Temperature Threshold",
+            "description": "Temperature threshold for automatic control"
+          },
+          "hysteresis": {
+            "name": "Hysteresis",
+            "description": "Temperature hysteresis value"
           }
         }
       },
@@ -600,17 +624,61 @@
                 }
               }
             }
+          },
+          "temperature_threshold": {
+            "name": "Temperature Threshold",
+            "description": "Temperature threshold for automatic control"
+          },
+          "hysteresis": {
+            "name": "Hysteresis",
+            "description": "Temperature hysteresis value"
           }
         }
       },
-    "set_air_quality_thresholds": {
-      "name": "Set Air Quality Thresholds",
-      "description": "Configures thresholds for air quality control system"
-    },
-    "set_temperature_curve": {
-      "name": "Set Heating Curve",
-      "description": "Configures heating curve for heating system"
-    },
+      "set_air_quality_thresholds": {
+        "name": "Set Air Quality Thresholds",
+        "description": "Configures thresholds for air quality control system",
+        "fields": {
+          "co2_low": {
+            "name": "CO2 Low Threshold",
+            "description": "CO2 low level threshold (ppm)"
+          },
+          "co2_medium": {
+            "name": "CO2 Medium Threshold",
+            "description": "CO2 medium level threshold (ppm)"
+          },
+          "co2_high": {
+            "name": "CO2 High Threshold",
+            "description": "CO2 high level threshold (ppm)"
+          },
+          "humidity_target": {
+            "name": "Humidity Target",
+            "description": "Target humidity level (%)"
+          }
+        }
+      },
+      "set_temperature_curve": {
+        "name": "Set Heating Curve",
+        "description": "Configures heating curve for heating system",
+        "fields": {
+          "slope": {
+            "name": "Slope",
+            "description": "Slope of the heating curve"
+          },
+          "offset": {
+            "name": "Offset",
+            "description": "Offset of the heating curve"
+          },
+          "max_supply_temp": {
+            "name": "Max Supply Temperature",
+            "description": "Maximum supply temperature"
+          },
+          "min_supply_temp": {
+            "name": "Min Supply Temperature",
+            "description": "Minimum supply temperature"
+          }
+        }
+      },
     "reset_filters": {
       "name": "Reset Filter Counter",
       "description": "Resets filter lifetime counter",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -562,6 +562,22 @@
               }
             }
           }
+        },
+        "start_time": {
+          "name": "Czas rozpoczęcia",
+          "description": "Czas rozpoczęcia okresu (HH:MM)"
+        },
+        "end_time": {
+          "name": "Czas zakończenia",
+          "description": "Czas zakończenia okresu (HH:MM)"
+        },
+        "airflow_rate": {
+          "name": "Przepływ powietrza",
+          "description": "Docelowy przepływ powietrza (%)"
+        },
+        "temperature": {
+          "name": "Temperatura",
+          "description": "Docelowa temperatura (°C)"
         }
       }
     },
@@ -581,6 +597,14 @@
               }
             }
           }
+        },
+        "temperature_threshold": {
+          "name": "Próg temperatury",
+          "description": "Próg temperatury dla automatycznej kontroli"
+        },
+        "hysteresis": {
+          "name": "Histereza",
+          "description": "Wartość histerezy temperatury"
         }
       }
     },
@@ -600,16 +624,60 @@
               }
             }
           }
+        },
+        "temperature_threshold": {
+          "name": "Próg temperatury",
+          "description": "Próg temperatury dla automatycznej kontroli"
+        },
+        "hysteresis": {
+          "name": "Histereza",
+          "description": "Wartość histerezy temperatury"
         }
       }
     },
     "set_air_quality_thresholds": {
       "name": "Ustaw progi jakości powietrza",
-      "description": "Konfiguruje progi dla systemu kontroli jakości powietrza"
+      "description": "Konfiguruje progi dla systemu kontroli jakości powietrza",
+      "fields": {
+        "co2_low": {
+          "name": "Próg CO2 niski",
+          "description": "Niski próg stężenia CO2 (ppm)"
+        },
+        "co2_medium": {
+          "name": "Próg CO2 średni",
+          "description": "Średni próg stężenia CO2 (ppm)"
+        },
+        "co2_high": {
+          "name": "Próg CO2 wysoki",
+          "description": "Wysoki próg stężenia CO2 (ppm)"
+        },
+        "humidity_target": {
+          "name": "Docelowa wilgotność",
+          "description": "Docelowy poziom wilgotności (%)"
+        }
+      }
     },
     "set_temperature_curve": {
       "name": "Ustaw krzywą grzewczą",
-      "description": "Konfiguruje krzywą grzewczą dla systemu ogrzewania"
+      "description": "Konfiguruje krzywą grzewczą dla systemu ogrzewania",
+      "fields": {
+        "slope": {
+          "name": "Nachylenie",
+          "description": "Nachylenie krzywej grzewczej"
+        },
+        "offset": {
+          "name": "Przesunięcie",
+          "description": "Przesunięcie krzywej grzewczej"
+        },
+        "max_supply_temp": {
+          "name": "Maks. temperatura nawiewu",
+          "description": "Maksymalna temperatura nawiewu"
+        },
+        "min_supply_temp": {
+          "name": "Min. temperatura nawiewu",
+          "description": "Minimalna temperatura nawiewu"
+        }
+      }
     },
     "reset_filters": {
       "name": "Resetuj licznik filtrów",


### PR DESCRIPTION
## Summary
- add schedule timing, airflow, and temperature fields
- translate bypass, GWC, air quality, and heating curve parameters

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator' and missing yaml)*

------
https://chatgpt.com/codex/tasks/task_e_689b23132c6483269fe1f5c7f38a1952