### PR TITLE
Increase fan entity speed steps to 10

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -82,7 +82,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         self._attr_supported_features = FanEntityFeature.SET_SPEED
 
         # Speed range (10-100% as per ThesslaGreen specs)
-        self._attr_speed_count = 9  # 10%, 20%, ..., 90%, 100%
+        self._attr_speed_count = 10  # 10%, 20%, ..., 100%
 
         _LOGGER.debug("Initialized fan entity")
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -4,7 +4,14 @@ import types
 import asyncio
 import pytest
 from unittest.mock import AsyncMock
-from pymodbus.exceptions import ConnectionException
+
+try:  # pragma: no cover - handle missing or incompatible pymodbus
+    from pymodbus.exceptions import ConnectionException
+except Exception:  # pragma: no cover
+    class ConnectionException(Exception):
+        """Fallback exception when pymodbus is unavailable."""
+
+        pass
 
 # ---------------------------------------------------------------------------
 # Minimal Home Assistant stubs
@@ -16,7 +23,9 @@ fan_mod = types.ModuleType("homeassistant.components.fan")
 
 
 class FanEntity:  # pragma: no cover - simple stub
-    pass
+    @property
+    def speed_count(self):
+        return getattr(self, "_attr_speed_count", None)
 
 
 class FanEntityFeature:  # pragma: no cover - simple stub
@@ -66,6 +75,7 @@ def test_fan_creation_and_state(mock_coordinator):
     mock_coordinator.data["supply_percentage"] = 50
     mock_coordinator.data["on_off_panel_mode"] = 1
     fan = ThesslaGreenFan(mock_coordinator)
+    assert fan.speed_count == 10
     assert fan.is_on is True
     assert fan.percentage == 50
 


### PR DESCRIPTION
## Summary
- set fan `_attr_speed_count` to 10 for 10% increments
- update fan tests to cover 10 discrete speed steps
- handle missing or incompatible `pymodbus` during tests

## Testing
- `pytest tests/test_fan.py -q`
- `pytest -q` *(fails: ImportError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689b230162548326b3cc448dc0061b93