### PR TITLE
Include port in ThesslaGreen entity unique IDs

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -21,7 +21,10 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     @property
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
-        return f"{DOMAIN}_{self.coordinator.host}_{self.coordinator.slave_id}_{self._key}"
+        return (
+            f"{DOMAIN}_{self.coordinator.host}_{self.coordinator.port}_"
+            f"{self.coordinator.slave_id}_{self._key}"
+        )
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
## Summary
- Incorporate the Modbus port into each entity's unique ID

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ConnectionException' from 'pymodbus.exceptions')*


------
https://chatgpt.com/codex/tasks/task_e_689b231c0720832695e3f59f649f100b