### PR TITLE
refactor device scanner slave id import

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -23,10 +23,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from pymodbus.client import AsyncModbusTcpClient
 
 from .modbus_helpers import _call_modbus
+from .const import DEFAULT_SLAVE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_SLAVE_ID = 10
 SOCKET_TIMEOUT = 6.0
 
 


### PR DESCRIPTION
## Summary
- remove local DEFAULT_SLAVE_ID constant in device scanner
- reuse shared DEFAULT_SLAVE_ID from const module

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ConnectionException' from 'pymodbus.exceptions')*


------
https://chatgpt.com/codex/tasks/task_e_689b23db5e8483269330607a09ee6169