### PR TITLE
refactor: polish firmware wording

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen {device_name} pod adresem {host}:{port} (ID Slave {slave_id}, firmware {firmware_version}). {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} pod adresem {host}:{port} (ID Slave {slave_id}, wersja oprogramowania {firmware_version}). {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
       }
     },
     "error": {


### PR DESCRIPTION
## Summary
- clarify Polish wording for firmware as "wersja oprogramowania"

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity')*


------
https://chatgpt.com/codex/tasks/task_e_689b25189e3883268aa194f4515258e4