### PR TITLE
Handle 0% fan speed by turning off fan

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -194,8 +194,13 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
             return
 
         try:
+            if percentage == 0:
+                await self.async_turn_off()
+                _LOGGER.info("Set fan speed to 0%")
+                return
+
             # Ensure minimum flow rate (ThesslaGreen typically requires 10% minimum)
-            actual_percentage = max(10, percentage) if percentage > 0 else 10
+            actual_percentage = max(10, percentage)
 
             # Determine which register to write based on current mode
             current_mode = self._get_current_mode()


### PR DESCRIPTION
## Summary
- turn fan off when set to 0% instead of enforcing minimum flow

## Testing
- `pytest` *(fails: AttributeError module homeassistant.util has no attribute '__path__')*

------
https://chatgpt.com/codex/tasks/task_e_689b251375bc8326b7af2a6cd839c3dd