### PR TITLE
Handle slave/unit compatibility in modbus helper

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -22,9 +22,24 @@ async def _call_modbus(
     ``slave`` or ``unit`` as the keyword for the target device.
     """
     params = inspect.signature(func).parameters
-    kwarg = "slave" if "slave" in params else "unit"
+    if "slave" in params:
+        kwarg = "slave"
+    elif "unit" in params:
+        kwarg = "unit"
+    else:
+        kwarg = None
+
     try:
-        return await func(*args, **{kwarg: slave_id}, **kwargs)
+        if kwarg is not None:
+            _LOGGER.debug(
+                "Calling %s with %s keyword", getattr(func, "__name__", repr(func)), kwarg
+            )
+            return await func(*args, **{kwarg: slave_id}, **kwargs)
+
+        _LOGGER.debug(
+            "Calling %s without address keyword", getattr(func, "__name__", repr(func))
+        )
+        return await func(*args, **kwargs)
     except Exception as err:  # pragma: no cover - log unexpected errors
         _LOGGER.error("Modbus call %s failed: %s", getattr(func, "__name__", repr(func)), err)
         raise

--- a/tests/test_modbus_helpers.py
+++ b/tests/test_modbus_helpers.py
@@ -1,0 +1,40 @@
+import logging
+import pytest
+
+from custom_components.thessla_green_modbus.modbus_helpers import _call_modbus
+
+pytestmark = pytest.mark.asyncio
+
+
+async def func_slave(*args, slave, **kwargs):
+    return slave
+
+
+async def func_unit(*args, unit, **kwargs):
+    return unit
+
+
+async def func_no_kw(*args, **kwargs):
+    assert "slave" not in kwargs and "unit" not in kwargs
+    return kwargs.get("value")
+
+
+async def test_call_modbus_slave(caplog):
+    caplog.set_level(logging.DEBUG)
+    result = await _call_modbus(func_slave, 7)
+    assert result == 7
+    assert "with slave keyword" in caplog.text
+
+
+async def test_call_modbus_unit(caplog):
+    caplog.set_level(logging.DEBUG)
+    result = await _call_modbus(func_unit, 9)
+    assert result == 9
+    assert "with unit keyword" in caplog.text
+
+
+async def test_call_modbus_no_keyword(caplog):
+    caplog.set_level(logging.DEBUG)
+    result = await _call_modbus(func_no_kw, 5, value=21)
+    assert result == 21
+    assert "without address keyword" in caplog.text


### PR DESCRIPTION
## Summary
- improve `_call_modbus` to support functions with `slave`, `unit`, or no address keyword
- add unit tests covering all keyword scenarios

## Testing
- `pytest tests/test_modbus_helpers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b280f2b7c8326af0fb5036975dac5