### PR TITLE
Use keyword count in Modbus read calls

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -278,7 +278,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
-                response = await self._call_modbus(self.client.read_input_registers, 0x0000, 1)
+                response = await self._call_modbus(
+                    self.client.read_input_registers, 0x0000, count=1
+                )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
                 _LOGGER.debug("Connection test successful")
@@ -415,7 +417,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["input_registers"]:
             try:
-                response = await self._call_modbus(self.client.read_input_registers, start_addr, count)
+                response = await self._call_modbus(
+                    self.client.read_input_registers, start_addr, count=count
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read input registers at 0x%04X: %s", start_addr, response
@@ -457,7 +461,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["holding_registers"]:
             try:
-                response = await self._call_modbus(self.client.read_holding_registers, start_addr, count)
+                response = await self._call_modbus(
+                    self.client.read_holding_registers, start_addr, count=count
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read holding registers at 0x%04X: %s", start_addr, response
@@ -501,7 +507,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
-                response = await self._call_modbus(self.client.read_coils, start_addr, count)
+                response = await self._call_modbus(
+                    self.client.read_coils, start_addr, count=count
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read coil registers at 0x%04X: %s", start_addr, response
@@ -549,7 +557,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["discrete_inputs"]:
             try:
-                response = await self._call_modbus(self.client.read_discrete_inputs, start_addr, count)
+                response = await self._call_modbus(
+                    self.client.read_discrete_inputs, start_addr, count=count
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read discrete inputs at 0x%04X: %s", start_addr, response

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -100,7 +100,7 @@ class ThesslaGreenDeviceScanner:
         """Read input registers."""
         try:
             response = await _call_modbus(
-                client.read_input_registers, self.slave_id, address, count
+                client.read_input_registers, self.slave_id, address, count=count
             )
             if not response.isError():
                 return response.registers
@@ -116,7 +116,7 @@ class ThesslaGreenDeviceScanner:
         """Read holding registers."""
         try:
             response = await _call_modbus(
-                client.read_holding_registers, self.slave_id, address, count
+                client.read_holding_registers, self.slave_id, address, count=count
             )
             if not response.isError():
                 return response.registers
@@ -133,7 +133,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[bool]]:
         """Read coil registers."""
         try:
-            response = await _call_modbus(client.read_coils, self.slave_id, address, count)
+            response = await _call_modbus(
+                client.read_coils, self.slave_id, address, count=count
+            )
             if not response.isError():
                 return response.bits[:count]
         except (ModbusException, ConnectionException) as exc:
@@ -148,7 +150,7 @@ class ThesslaGreenDeviceScanner:
         """Read discrete input registers."""
         try:
             response = await _call_modbus(
-                client.read_discrete_inputs, self.slave_id, address, count
+                client.read_discrete_inputs, self.slave_id, address, count=count
             )
             if not response.isError():
                 return response.bits[:count]


### PR DESCRIPTION
## Summary
- Pass register count as a keyword argument in device scanner Modbus reads
- Update coordinator Modbus reads to use keyword `count`

## Testing
- `pytest` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_689b28072b7c8326833ffa6d07bb10d2