### PR TITLE
Handle keyword-only args in modbus helper

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -23,8 +23,27 @@ async def _call_modbus(
     """
     params = inspect.signature(func).parameters
     kwarg = "slave" if "slave" in params else "unit"
+
+    # Map passed positional arguments to parameter names so that any values intended
+    # for keyword-only parameters (e.g. ``count``) are moved into ``kwargs``.
+    positional: list[Any] = []
+    param_iter = iter(params.values())
+    for arg in args:
+        try:
+            param = next(param_iter)
+        except StopIteration:
+            positional.append(arg)
+            continue
+
+        if param.kind is inspect.Parameter.KEYWORD_ONLY:
+            kwargs[param.name] = arg
+        else:
+            positional.append(arg)
+
     try:
-        return await func(*args, **{kwarg: slave_id}, **kwargs)
+        return await func(*positional, **{kwarg: slave_id}, **kwargs)
     except Exception as err:  # pragma: no cover - log unexpected errors
-        _LOGGER.error("Modbus call %s failed: %s", getattr(func, "__name__", repr(func)), err)
+        _LOGGER.error(
+            "Modbus call %s failed: %s", getattr(func, "__name__", repr(func)), err
+        )
         raise

--- a/tests/test_modbus_helpers.py
+++ b/tests/test_modbus_helpers.py
@@ -1,0 +1,21 @@
+import pytest
+
+from custom_components.thessla_green_modbus.modbus_helpers import _call_modbus
+
+
+@pytest.mark.asyncio
+async def test_call_modbus_keyword_only_count_unit():
+    async def func(address, *, count, unit=None):
+        return address, count, unit
+
+    result = await _call_modbus(func, 1, 10, 2)
+    assert result == (10, 2, 1)
+
+
+@pytest.mark.asyncio
+async def test_call_modbus_keyword_only_count_slave():
+    async def func(address, *, count, slave=None):
+        return address, count, slave
+
+    result = await _call_modbus(func, 1, 20, 3)
+    assert result == (20, 3, 1)


### PR DESCRIPTION
## Summary
- accommodate keyword-only parameters in Modbus helper by re-mapping positional arguments
- add unit tests for keyword-only count parameter

## Testing
- `pytest`
- `pytest tests/test_modbus_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_689b2808effc83269ecbd51b0184916c