### PR TITLE
Use keyword arg for Modbus read count

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -277,7 +277,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             try:
                 await self._ensure_connection()
                 # Try to read a basic register to verify communication
-                response = await self._call_modbus(self.client.read_input_registers, 0x0000, 1)
+                response = await self._call_modbus(
+                    self.client.read_input_registers,
+                    0x0000,
+                    count=1,
+                )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
                 _LOGGER.debug("Connection test successful")
@@ -414,7 +418,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["input_registers"]:
             try:
-                response = await self._call_modbus(self.client.read_input_registers, start_addr, count)
+                response = await self._call_modbus(
+                    self.client.read_input_registers,
+                    start_addr,
+                    count=count,
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read input registers at 0x%04X: %s", start_addr, response
@@ -456,7 +464,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["holding_registers"]:
             try:
-                response = await self._call_modbus(self.client.read_holding_registers, start_addr, count)
+                response = await self._call_modbus(
+                    self.client.read_holding_registers,
+                    start_addr,
+                    count=count,
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read holding registers at 0x%04X: %s", start_addr, response
@@ -500,7 +512,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["coil_registers"]:
             try:
-                response = await self._call_modbus(self.client.read_coils, start_addr, count)
+                response = await self._call_modbus(
+                    self.client.read_coils,
+                    start_addr,
+                    count=count,
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read coil registers at 0x%04X: %s", start_addr, response
@@ -548,7 +564,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
 
         for start_addr, count in self._register_groups["discrete_inputs"]:
             try:
-                response = await self._call_modbus(self.client.read_discrete_inputs, start_addr, count)
+                response = await self._call_modbus(
+                    self.client.read_discrete_inputs,
+                    start_addr,
+                    count=count,
+                )
                 if response.isError():
                     _LOGGER.debug(
                         "Failed to read discrete inputs at 0x%04X: %s", start_addr, response


### PR DESCRIPTION
## Summary
- pass `count` as keyword to `_call_modbus` for connection test and optimized batch reads

## Testing
- `pytest` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute dt)*
- `flake8 custom_components/thessla_green_modbus/coordinator.py` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_689b2817a9288326b3322411a85357f3