### PR TITLE
Clean up modbus coordinator

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -281,17 +281,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # issues with keyword-only parameters in pymodbus.
                 count = 1
                 response = await self._call_modbus(
- codex/update-modbus-calls-to-use-keyword-arguments
-                    self.client.read_input_registers, 0x0000, count=count
-=======
- codex/update-modbus-client-calls-to-use-keyword-arguments
                     self.client.read_input_registers,
                     0x0000,
-                    count=1,
-=======
-                    self.client.read_input_registers, 0x0000, count=1
- main
- main
+                    count=count,
                 )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
@@ -432,13 +424,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Pass "count" as a keyword argument to ensure compatibility with
                 # Modbus helpers that expect keyword-only parameters.
                 response = await self._call_modbus(
- codex/update-modbus-client-calls-to-use-keyword-arguments
                     self.client.read_input_registers,
                     start_addr,
                     count=count,
-=======
-                    self.client.read_input_registers, start_addr, count=count
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -484,13 +472,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Pass "count" as a keyword argument to ensure compatibility with
                 # Modbus helpers that expect keyword-only parameters.
                 response = await self._call_modbus(
- codex/update-modbus-client-calls-to-use-keyword-arguments
                     self.client.read_holding_registers,
                     start_addr,
                     count=count,
-=======
-                    self.client.read_holding_registers, start_addr, count=count
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -538,13 +522,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Pass "count" as a keyword argument to ensure compatibility with
                 # Modbus helpers that expect keyword-only parameters.
                 response = await self._call_modbus(
- codex/update-modbus-client-calls-to-use-keyword-arguments
                     self.client.read_coils,
                     start_addr,
                     count=count,
-=======
-                    self.client.read_coils, start_addr, count=count
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -596,13 +576,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Pass "count" as a keyword argument to ensure compatibility with
                 # Modbus helpers that expect keyword-only parameters.
                 response = await self._call_modbus(
- codex/update-modbus-client-calls-to-use-keyword-arguments
                     self.client.read_discrete_inputs,
                     start_addr,
                     count=count,
-=======
-                    self.client.read_discrete_inputs, start_addr, count=count
- main
                 )
                 if response.isError():
                     _LOGGER.debug(


### PR DESCRIPTION
## Summary
- remove stray conflict markers and `codex` references
- ensure `count` is passed as a keyword argument in all `_call_modbus` usages

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py`
- `pytest -q` *(fails: module 'homeassistant' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_689b2cebfecc83269fdcdd1f6071f547