### PR TITLE
Add voluptuous to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 # Testing
 pytest>=7.0.0
 pytest-asyncio>=0.21.0
+voluptuous>=0.13.1
 pytest-homeassistant-custom-component>=0.13.0
 
 # Code quality tools


### PR DESCRIPTION
## Summary
- add voluptuous to dev requirements to avoid import errors

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in coordinator)*

------
https://chatgpt.com/codex/tasks/task_e_689b2e9794608326ac90757cb4f922cd