### PR TITLE
docs: expand HACS info with full entity coverage

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,13 +1,18 @@
 # ThesslaGreen Modbus Integration
 
-Integracja Home Assistant dla rekuperatorów ThesslaGreen z komunikacją Modbus TCP.
+Pełna integracja Home Assistant dla rekuperatorów ThesslaGreen z komunikacją Modbus TCP/RTU. Pokrywa **wszystkie 200+ rejestry** z oficjalnej dokumentacji.
 
 ## Funkcje
-- Monitorowanie temperatury (4 czujniki)
-- Kontrola wentylacji i klimatu
-- Jakość powietrza (CO2, wilgotność)
-- Bypass letni
-- Alarmy i diagnostyka
+- 📊 **50+ czujników** – temperatury, przepływy, ciśnienia, jakość powietrza, energia i statusy systemu
+- 🔍 **40+ sensory binarne** – statusy, tryby, wejścia, alarmy i zabezpieczenia
+- 🎛️ **30+ kontrolki** – Climate, Switch, Number, Select i inne do pełnej kontroli urządzenia
+- 🌡️ **Zaawansowana encja Climate** z preset modes i funkcjami specjalnymi
+- 🛠️ **13 serwisów** API do automatyzacji, diagnostyki i konfiguracji
+- 🌿 Systemy **GWC** i **Bypass**, tryby specjalne (OKAP, KOMINEK, WIETRZENIE, PUSTY DOM, BOOST)
+- 🔧 **Diagnostyka i logowanie** – szczegółowe raporty błędów i wydajności
+- 📅 **Harmonogram tygodniowy** – pełna konfiguracja programów czasowych
+- 🔎 **Inteligentne skanowanie** – tylko aktywne encje
+- 🌍 **Wsparcie wielojęzyczne** – polski i angielski
 
 ## Instalacja
 1. Dodaj to repozytorium do HACS


### PR DESCRIPTION
## Summary
- detail HACS info with counts for sensors, controls, services and diagnostics

## Testing
- `pre-commit run --files info.md` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute)*
- `python -m script.hassfest` *(fails: No module named 'script')*

------
https://chatgpt.com/codex/tasks/task_e_689b2ea8ba58832693a5d45663cfb93c