### PR TITLE
refactor: drop optional import

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -322,7 +322,7 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
         )
 
     @property
-    def is_on(self) -> Optional[bool]:
+    def is_on(self) -> bool | None:
         """Return True if the binary sensor is on."""
         value = self.coordinator.data.get(self._register_name)
         


### PR DESCRIPTION
## Summary
- remove Optional typing import
- use `bool | None` for `is_on`

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest` *(fails: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator')*

------
https://chatgpt.com/codex/tasks/task_e_689b2ea2c75c8326adc9bdeceee507b5