### PR TITLE
Replace Slave ID terminology with Device ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **HVAC Mode Support**: Auto, Fan Only, Off modes
 
 #### Smart Device Detection & Configuration
-- **Auto-detection of Slave ID** - Automatically tries common slave IDs (1, 10, 247)
+- **Auto-detection of Device ID** - Automatically tries common device IDs (1, 10, 247)
 - **Enhanced Config Flow** - Better user experience with device info display
 - **Comprehensive Device Scanner** - Intelligent capability detection with 60+ capabilities
 - **Enhanced Error Handling** - Smart retry logic and graceful error recovery

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -51,7 +51,7 @@
    - Menu → Komunikacja → Modbus TCP
    - Włącz: TAK
    - Port: 502 (domyślny)
-   - Slave ID: 10 (domyślny)
+   - ID urządzenia: 10 (domyślny)
 
 2. **Skonfiguruj sieć:**
    - Ustaw statyczny IP dla rekuperatora
@@ -65,7 +65,7 @@
 4. **Wprowadź dane:**
    - **Host**: IP rekuperatora (np. 192.168.1.100)
    - **Port**: 502
-   - **Slave ID**: 10
+   - **ID urządzenia**: 10
    - **Nazwa**: ThesslaGreen AirPack
 
 5. **Kliknij DODAJ**
@@ -225,7 +225,7 @@ automation:
 2. **Sprawdź konfigurację Modbus:**
    - Czy Modbus TCP jest włączony?
    - Czy port 502 jest otwarty?
-   - Czy Slave ID jest poprawne?
+   - Czy ID urządzenia jest poprawne?
 
 3. **Sprawdź firewall:**
    - Czy HA ma dostęp do portu 502?

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -16,7 +16,7 @@ Before starting, make sure you have:
 
 1. **Access your AirPack panel**
 2. **Navigate to:** Menu → Communication → Modbus TCP
-3. **Set:** Enable = YES, Port = 502, Slave ID = 10
+3. **Set:** Enable = YES, Port = 502, Device ID = 10
 4. **Note your AirPack's IP address** (e.g., 192.168.1.100)
 
 ### Step 3: Install the Integration 📦
@@ -46,7 +46,7 @@ Before starting, make sure you have:
 4. **Enter:**
    - **IP Address:** 192.168.1.100 (your AirPack IP)
    - **Port:** 502
-   - **Slave ID:** 10 (will auto-detect if wrong)
+   - **Device ID:** 10 (will auto-detect if wrong)
 5. **Click:** SUBMIT
 
 🎉 **Done!** Your AirPack should now be connected.
@@ -158,7 +158,7 @@ title: Temperature Trends
 **Solutions:**
 1. **Check IP address** - Ping your AirPack: `ping 192.168.1.100`
 2. **Check Modbus settings** - Ensure TCP is enabled, port 502
-3. **Try different Slave ID** - Integration auto-detects 1, 10, 247
+3. **Try different Device IDs** - Integration auto-detects 1, 10, 247
 4. **Check firewall** - Ensure port 502 is open
 
 ### ❌ "No entities created"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - Menu → Komunikacja → Modbus TCP
 - Włącz: **TAK**
 - Port: **502** (domyślny)
-- Slave ID: **10** (domyślny)
+- ID urządzenia: **10** (domyślny)
 
 ### 2. Dodaj integrację w Home Assistant
 1. **Ustawienia** → **Integracje** → **+ DODAJ INTEGRACJĘ**
@@ -75,7 +75,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 3. Wprowadź dane:
    - **IP Address**: IP rekuperatora (np. 192.168.1.100)
    - **Port**: 502
-   - **Slave ID**: 10
+   - **ID urządzenia**: 10
 4. Integracja automatycznie przeskanuje urządzenie
 5. Kliknij **DODAJ**
 
@@ -270,7 +270,7 @@ Użyj serwisu `get_diagnostic_info` aby uzyskać:
 #### ❌ "Nie można połączyć"
 1. Sprawdź IP i ping do urządzenia: `ping 192.168.1.100`
 2. Upewnij się, że Modbus TCP jest włączony (port 502)
-3. Spróbuj różnych Slave ID (integracja auto-wykrywa 1, 10, 247)
+3. Spróbuj różnych ID urządzenia (integracja auto-wykrywa 1, 10, 247)
 4. Sprawdź zaporę sieciową
 
 #### ❌ "Brak encji"

--- a/README_en.md
+++ b/README_en.md
@@ -66,7 +66,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - Menu → Communication → Modbus TCP
 - Enable: **YES**
 - Port: **502** (default)
-- Slave ID: **10** (default)
+- Device ID: **10** (default)
 
 ### 2. Add the integration in Home Assistant
 1. **Settings** → **Devices & Services** → **+ ADD INTEGRATION**
@@ -74,7 +74,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 3. Enter the data:
    - **IP Address**: unit IP (e.g. 192.168.1.100)
    - **Port**: 502
-   - **Slave ID**: 10
+   - **Device ID**: 10
 4. The integration will automatically scan the device
 5. Click **ADD**
 
@@ -168,7 +168,7 @@ Use the `get_diagnostic_info` service to receive:
 #### ❌ "Cannot connect"
 1. Check IP and ping the device: `ping 192.168.1.100`
 2. Ensure Modbus TCP is enabled (port 502)
-3. Try different Slave IDs (integration auto detects 1, 10, 247)
+3. Try different Device IDs (integration auto detects 1, 10, 247)
 4. Check network firewall
 
 #### ❌ "No entities"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -7,29 +7,29 @@
         "data": {
           "host": "IP Address",
           "port": "Port",
-          "slave_id": "Device ID (Slave ID)",
+          "slave_id": "Device ID",
           "name": "Name"
         },
         "data_description": {
           "host": "IP address of the AirPack device on your local network",
           "port": "Modbus TCP port (default 502)",
-          "slave_id": "Modbus device ID (Slave ID, default 10)",
+          "slave_id": "Modbus device ID (default 10)",
           "name": "Device name in Home Assistant"
         }
       },
       "confirm": {
         "title": "Confirm Configuration",
-        "description": "ThesslaGreen device {device_name} detected at {host}:{port} with Slave ID {slave_id} and firmware {firmware_version}. {auto_detected_note} Do you want to continue with this configuration?"
+        "description": "ThesslaGreen device {device_name} detected at {host}:{port} with Device ID {slave_id} and firmware {firmware_version}. {auto_detected_note} Do you want to continue with this configuration?"
       }
     },
     "error": {
       "cannot_connect": "Cannot connect to device. Check IP address, port, and network connection.",
-      "invalid_auth": "Authentication error. Check Slave ID settings.",
+      "invalid_auth": "Authentication error. Check Device ID settings.",
       "invalid_input": "Invalid configuration provided. Check values and try again.",
       "unknown": "Unexpected error. Check logs for details."
     },
     "abort": {
-      "already_configured": "Device with this IP address and Slave ID is already configured."
+      "already_configured": "Device with this IP address and Device ID is already configured."
     }
   },
   "options": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -7,29 +7,29 @@
         "data": {
           "host": "Adres IP",
           "port": "Port",
-          "slave_id": "ID urządzenia (Slave ID)",
+          "slave_id": "ID urządzenia",
           "name": "Nazwa"
         },
         "data_description": {
           "host": "Adres IP urządzenia AirPack w sieci lokalnej",
           "port": "Port Modbus TCP (domyślnie 502)",
-          "slave_id": "ID urządzenia Modbus (Slave ID, domyślnie 10)",
+          "slave_id": "ID urządzenia Modbus (domyślnie 10)",
           "name": "Nazwa urządzenia w Home Assistant"
         }
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen {device_name} pod adresem {host}:{port} (ID Slave {slave_id}, wersja oprogramowania {firmware_version}). {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} pod adresem {host}:{port} (ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}). {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
       }
     },
     "error": {
       "cannot_connect": "Nie można połączyć się z urządzeniem. Sprawdź adres IP, port oraz połączenie sieciowe.",
-      "invalid_auth": "Błąd autoryzacji. Sprawdź ustawienia Slave ID.",
+      "invalid_auth": "Błąd autoryzacji. Sprawdź ustawienia ID urządzenia.",
       "invalid_input": "Nieprawidłowa konfiguracja. Sprawdź wartości i spróbuj ponownie.",
       "unknown": "Nieoczekiwany błąd. Sprawdź logi dla szczegółów."
     },
     "abort": {
-      "already_configured": "Urządzenie z tym adresem IP i Slave ID jest już skonfigurowane."
+      "already_configured": "Urządzenie z tym adresem IP i ID urządzenia jest już skonfigurowane."
     }
   },
   "options": {


### PR DESCRIPTION
## Summary
- rename references from "Slave ID" to "Device ID"/"ID urządzenia" across docs and translations
- adjust wording in user-facing strings and changelog

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CoordinatorEntity' from 'homeassistant.helpers.update_coordinator')*


------
https://chatgpt.com/codex/tasks/task_e_689b2ea3fc108326a1c89c4b35f9bf96