### PR TITLE
Handle entity registry errors explicitly

### DIFF
--- a/custom_components/thessla_green_modbus/cleanup_old_entities.py
+++ b/custom_components/thessla_green_modbus/cleanup_old_entities.py
@@ -112,9 +112,14 @@ def cleanup_entity_registry(config_dir: Path) -> bool:
             backup_path.unlink()
             return True
 
-    except Exception as exc:
-        _LOGGER.error("Error processing entity registry: %s", exc)
-        # Restore backup
+    except OSError as exc:
+        _LOGGER.error("Error processing entity registry file: %s", exc)
+        if backup_path.exists():
+            shutil.copy2(backup_path, registry_path)
+            _LOGGER.info("Restored backup from: %s", backup_path)
+        return False
+    except json.JSONDecodeError as exc:
+        _LOGGER.error("Error decoding entity registry JSON: %s", exc)
         if backup_path.exists():
             shutil.copy2(backup_path, registry_path)
             _LOGGER.info("Restored backup from: %s", backup_path)

--- a/tests/test_cleanup_old_entities.py
+++ b/tests/test_cleanup_old_entities.py
@@ -1,0 +1,55 @@
+import json
+import logging
+import shutil
+from pathlib import Path
+from unittest.mock import call, patch
+
+from custom_components.thessla_green_modbus.cleanup_old_entities import (
+    BACKUP_SUFFIX,
+    cleanup_entity_registry,
+)
+
+
+def _setup_registry(tmp_path: Path, content: str) -> Path:
+    storage_dir = tmp_path / ".storage"
+    storage_dir.mkdir()
+    registry_path = storage_dir / "core.entity_registry"
+    registry_path.write_text(content, encoding="utf-8")
+    return registry_path
+
+
+def test_cleanup_entity_registry_invalid_json_restores_backup(tmp_path, caplog):
+    registry_path = _setup_registry(tmp_path, "{invalid")
+    backup_path = registry_path.with_suffix(registry_path.suffix + BACKUP_SUFFIX)
+
+    with patch("shutil.copy2", wraps=shutil.copy2) as mock_copy:
+        with caplog.at_level(logging.ERROR):
+            assert not cleanup_entity_registry(tmp_path)
+
+    assert "Error decoding entity registry JSON" in caplog.text
+    assert mock_copy.call_args_list == [call(registry_path, backup_path), call(backup_path, registry_path)]
+    assert registry_path.read_text(encoding="utf-8") == "{invalid"
+
+
+def test_cleanup_entity_registry_oserror_restores_backup(tmp_path, caplog):
+    original = {
+        "data": {
+            "entities": [
+                {
+                    "entity_id": "number.rekuperator_predkosc",
+                    "platform": "thessla_green_modbus",
+                }
+            ]
+        }
+    }
+    registry_path = _setup_registry(tmp_path, json.dumps(original))
+    backup_path = registry_path.with_suffix(registry_path.suffix + BACKUP_SUFFIX)
+
+    with patch("json.dump", side_effect=OSError("disk error")):
+        with patch("shutil.copy2", wraps=shutil.copy2) as mock_copy:
+            with caplog.at_level(logging.ERROR):
+                assert not cleanup_entity_registry(tmp_path)
+
+    assert "Error processing entity registry file" in caplog.text
+    assert mock_copy.call_args_list == [call(registry_path, backup_path), call(backup_path, registry_path)]
+    assert json.loads(registry_path.read_text(encoding="utf-8")) == original


### PR DESCRIPTION
## Summary
- replace broad exception in entity registry cleanup with explicit `OSError` and `json.JSONDecodeError` handlers
- add tests ensuring failures log errors and restore backups

## Testing
- `python tests/run_tests.py` *(fails: 9 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_689b3067b8c48326a0afbbe207406e5c