### PR TITLE
Add standalone DeviceInfo fallback

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -34,10 +34,29 @@ try:  # pragma: no cover
     from homeassistant.helpers.device_registry import DeviceInfo
 except (ModuleNotFoundError, ImportError):  # pragma: no cover
 
-    class DeviceInfo(dict):
-        """Minimal fallback DeviceInfo for tests."""
+    class DeviceInfo:  # type: ignore[misc]
+        """Minimal fallback DeviceInfo for tests.
 
-        pass
+        Stores provided keyword arguments and exposes an ``as_dict`` method
+        similar to Home Assistant's ``DeviceInfo`` dataclass.
+        """
+
+        def __init__(self, **kwargs: Any) -> None:
+            self._data: Dict[str, Any] = dict(kwargs)
+
+        def as_dict(self) -> Dict[str, Any]:
+            """Return stored fields as a dictionary."""
+            return dict(self._data)
+
+        # Provide dictionary-style and attribute-style access for convenience in tests
+        def __getitem__(self, key: str) -> Any:  # pragma: no cover - simple mapping
+            return self._data[key]
+
+        def __getattr__(self, item: str) -> Any:
+            try:
+                return self._data[item]
+            except KeyError as exc:  # pragma: no cover - mirror dict behaviour
+                raise AttributeError(item) from exc
 
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -281,13 +300,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # issues with keyword-only parameters in pymodbus.
                 count = 1
                 response = await self._call_modbus(
- codex/remove-conflict-remnants-from-coordinator.py
-                    self.client.read_input_registers, 0x0000, count=count
-=======
                     self.client.read_input_registers,
                     0x0000,
                     count=count,
- main
                 )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")


### PR DESCRIPTION
## Summary
- implement minimal DeviceInfo class with `as_dict`
- ensure `get_device_info` and `device_info_dict` operate without Home Assistant's DeviceInfo

## Testing
- `pytest` *(fails: No module named 'yaml'; ModuleNotFoundError: No module named 'homeassistant.helpers.entity')*

------
https://chatgpt.com/codex/tasks/task_e_689b3052509483268eac78411309c7f1