### PR TITLE
Remove unused socket timeout constant

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -27,8 +27,6 @@ from .const import DEFAULT_SLAVE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
-SOCKET_TIMEOUT = 6.0
-
 
 @dataclass
 class DeviceInfo:


### PR DESCRIPTION
## Summary
- remove unused SOCKET_TIMEOUT constant from device scanner

## Testing
- `pytest` *(fails: SyntaxError in custom_components/thessla_green_modbus/coordinator.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b3052feb08326858588a61be10d75