### PR TITLE
Remove stray text from coordinator

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -281,13 +281,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # issues with keyword-only parameters in pymodbus.
                 count = 1
                 response = await self._call_modbus(
- codex/remove-conflict-remnants-from-coordinator.py
-                    self.client.read_input_registers, 0x0000, count=count
-=======
                     self.client.read_input_registers,
                     0x0000,
                     count=count,
- main
                 )
                 if response.isError():
                     raise ConnectionException("Cannot read basic register")
@@ -428,13 +424,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Pass "count" as a keyword argument to ensure compatibility with
                 # Modbus helpers that expect keyword-only parameters.
                 response = await self._call_modbus(
- codex/remove-conflict-remnants-from-coordinator.py
-                    self.client.read_input_registers, start_addr, count=count
-=======
                     self.client.read_input_registers,
                     start_addr,
                     count=count,
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -480,13 +472,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Pass "count" as a keyword argument to ensure compatibility with
                 # Modbus helpers that expect keyword-only parameters.
                 response = await self._call_modbus(
- codex/remove-conflict-remnants-from-coordinator.py
-                    self.client.read_holding_registers, start_addr, count=count
-=======
                     self.client.read_holding_registers,
                     start_addr,
                     count=count,
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -534,13 +522,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Pass "count" as a keyword argument to ensure compatibility with
                 # Modbus helpers that expect keyword-only parameters.
                 response = await self._call_modbus(
- codex/remove-conflict-remnants-from-coordinator.py
-                    self.client.read_coils, start_addr, count=count
-=======
                     self.client.read_coils,
                     start_addr,
                     count=count,
- main
                 )
                 if response.isError():
                     _LOGGER.debug(
@@ -592,13 +576,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 # Pass "count" as a keyword argument to ensure compatibility with
                 # Modbus helpers that expect keyword-only parameters.
                 response = await self._call_modbus(
- codex/remove-conflict-remnants-from-coordinator.py
-                    self.client.read_discrete_inputs, start_addr, count=count
-=======
                     self.client.read_discrete_inputs,
                     start_addr,
                     count=count,
- main
                 )
                 if response.isError():
                     _LOGGER.debug(


### PR DESCRIPTION
## Summary
- remove leftover conflict markers from Modbus coordinator
- keep `_call_modbus` invocations valid and pass `count` as keyword

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py`
- `python - <<'PY'
import sys, types, importlib.util
ha_util = types.ModuleType('homeassistant.util'); ha_util.dt = types.ModuleType('homeassistant.util.dt'); ha_util.dt.utcnow = lambda: None
sys.modules['homeassistant.util'] = ha_util; sys.modules['homeassistant.util.dt'] = ha_util.dt
ha_core = types.ModuleType('homeassistant.core'); ha_core.HomeAssistant = type('HomeAssistant', (), {})
sys.modules['homeassistant.core'] = ha_core
ha_helpers_update = types.ModuleType('homeassistant.helpers.update_coordinator'); ha_helpers_update.DataUpdateCoordinator = type('DataUpdateCoordinator', (), {}); ha_helpers_update.UpdateFailed = type('UpdateFailed', (Exception,), {})
sys.modules['homeassistant.helpers.update_coordinator'] = ha_helpers_update
ha_helpers_device = types.ModuleType('homeassistant.helpers.device_registry'); ha_helpers_device.DeviceInfo = dict
sys.modules['homeassistant.helpers.device_registry'] = ha_helpers_device
custom_components_pkg = types.ModuleType('custom_components'); custom_components_pkg.__path__ = ['custom_components']; sys.modules['custom_components'] = custom_components_pkg
thessla_pkg = types.ModuleType('custom_components.thessla_green_modbus'); thessla_pkg.__path__ = ['custom_components/thessla_green_modbus']; sys.modules['custom_components.thessla_green_modbus'] = thessla_pkg
spec = importlib.util.spec_from_file_location('custom_components.thessla_green_modbus.coordinator','custom_components/thessla_green_modbus/coordinator.py'); module = importlib.util.module_from_spec(spec); sys.modules[spec.name] = module; spec.loader.exec_module(module)
print('Coordinator class:', module.ThesslaGreenModbusCoordinator)
PY`
- `pytest -q --maxfail=1` (fails: AttributeError: module 'homeassistant' has no attribute 'util')

------
https://chatgpt.com/codex/tasks/task_e_689b30a6c758832691654111af7a2e8b