### PR TITLE
Remove duplicate DeviceInfo fallback

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -39,30 +39,6 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover
         def as_dict(self) -> Dict[str, Any]:
             """Return dictionary representation."""
             return dict(self)
-=======
-    class DeviceInfo:  # type: ignore[misc]
-        """Minimal fallback DeviceInfo for tests.
-
-        Stores provided keyword arguments and exposes an ``as_dict`` method
-        similar to Home Assistant's ``DeviceInfo`` dataclass.
-        """
-
-        def __init__(self, **kwargs: Any) -> None:
-            self._data: Dict[str, Any] = dict(kwargs)
-
-        def as_dict(self) -> Dict[str, Any]:
-            """Return stored fields as a dictionary."""
-            return dict(self._data)
-
-        # Provide dictionary-style and attribute-style access for convenience in tests
-        def __getitem__(self, key: str) -> Any:  # pragma: no cover - simple mapping
-            return self._data[key]
-
-        def __getattr__(self, item: str) -> Any:
-            try:
-                return self._data[item]
-            except KeyError as exc:  # pragma: no cover - mirror dict behaviour
-                raise AttributeError(item) from exc
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 


### PR DESCRIPTION
## Summary
- remove stray separator and duplicate DeviceInfo fallback

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py`
- `pytest` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689b342122e48326957df017b2f6b085