### PR TITLE
Remove duplicate DeviceInfo fallback

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -33,8 +33,6 @@ from homeassistant.core import HomeAssistant
 try:  # pragma: no cover
     from homeassistant.helpers.device_registry import DeviceInfo
 except (ModuleNotFoundError, ImportError):  # pragma: no cover
-
-
     class DeviceInfo:  # type: ignore[misc]
         """Minimal fallback DeviceInfo for tests.
 
@@ -58,12 +56,6 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover
                 return self._data[item]
             except KeyError as exc:  # pragma: no cover - mirror dict behaviour
                 raise AttributeError(item) from exc
-=======
-    class DeviceInfo(dict):
-        """Minimal fallback DeviceInfo for tests."""
-        def as_dict(self) -> Dict[str, Any]:
-            """Return dictionary representation."""
-            return dict(self)
 
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed


### PR DESCRIPTION
## Summary
- clean coordinator DeviceInfo fallback

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_689b3691701c83268ef6a140111e0d63