### PR TITLE
fix(pl): update Polish mode translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -417,7 +417,7 @@
         "name": "Tryb kominkowy"
       },
       "vacation_mode": {
-        "name": "Tryb wakacyjny"
+        "name": "Tryb urlopowy"
       },
       "hood_mode": {
         "name": "Tryb okapu"
@@ -431,7 +431,7 @@
         "name": "Tryb pracy",
         "state": {
           "auto": "Automatyczny",
-          "manual": "Manualny",
+          "manual": "Ręczny",
           "temporary": "Tymczasowy"
         }
       },


### PR DESCRIPTION
## Summary
- refine Polish translation for vacation mode
- rename manual mode state to Ręczny

## Testing
- `pytest` *(fails: SyntaxError in coordinator.py, ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689b36a7e75c8326b5e97a931e462378