### PR TITLE
Clarify usage docstring for cleanup script

### DIFF
--- a/custom_components/thessla_green_modbus/cleanup_old_entities.py
+++ b/custom_components/thessla_green_modbus/cleanup_old_entities.py
@@ -3,10 +3,10 @@
 Script to clean up old references in Home Assistant for the ThesslaGreen Modbus
 integration. Removes outdated entities and references that may cause errors.
 
-Usage: run this script before restarting Home Assistant after updating the
-integration:
-
+Usage:
     python3 cleanup_old_entities.py
+
+Run this script before restarting Home Assistant after updating the integration.
 """
 
 import logging


### PR DESCRIPTION
## Summary
- refine the cleanup script's module docstring and usage notes

## Testing
- `pytest tests/test_cleanup_old_entities.py`

------
https://chatgpt.com/codex/tasks/task_e_689b36a5d1388326908bcc7ef9d76721