### PR TITLE
Handle specific errors during number writes

### DIFF
--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -177,9 +177,9 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
                 "Failed to set %s to %.2f: %s", self.register_name, value, exc
             )
             raise
-        except Exception as exc:  # pragma: no cover - unexpected
+        except (ValueError, OSError) as exc:  # pragma: no cover - unexpected
             _LOGGER.exception(
-                "Unexpected error setting %s to %.2f: %s",
+                "Error setting %s to %.2f: %s",
                 self.register_name,
                 value,
                 exc,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -156,3 +156,16 @@ def test_number_set_value_write_failure(mock_coordinator):
     with pytest.raises(RuntimeError):
         asyncio.run(number.async_set_native_value(22))
     mock_coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.parametrize("exc_cls", [ValueError, OSError])
+def test_number_set_value_other_errors(mock_coordinator, exc_cls):
+    """Ensure ValueError and OSError propagate when setting the number."""
+    mock_coordinator.data["required_temperature"] = 20
+    entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
+    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
+
+    mock_coordinator.async_write_register = AsyncMock(side_effect=exc_cls("fail"))
+    with pytest.raises(exc_cls):
+        asyncio.run(number.async_set_native_value(22))
+    mock_coordinator.async_request_refresh.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Raise `ValueError` or `OSError` during number register writes instead of catching all exceptions
- Cover error propagation for register write failures

## Testing
- `pytest tests/test_number.py`


------
https://chatgpt.com/codex/tasks/task_e_689b39f6f4308326b1b33a5f0f1a932a