### PR TITLE
Handle specific import errors in Modbus exceptions

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_exceptions.py
+++ b/custom_components/thessla_green_modbus/modbus_exceptions.py
@@ -5,9 +5,13 @@ pymodbus is not installed. This allows tests to run without the dependency.
 """
 from __future__ import annotations
 
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
 try:  # pragma: no cover - handle missing or incompatible pymodbus
     from pymodbus.exceptions import ConnectionException, ModbusException
-except Exception:  # pragma: no cover
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
     class ConnectionException(Exception):
         """Fallback exception when pymodbus is unavailable."""
 
@@ -17,5 +21,8 @@ except Exception:  # pragma: no cover
         """Fallback Modbus exception when pymodbus is unavailable."""
 
         pass
+except Exception:  # pragma: no cover
+    _LOGGER.exception("Unexpected error importing pymodbus")
+    raise
 
 __all__ = ["ConnectionException", "ModbusException"]


### PR DESCRIPTION
## Summary
- Replace blanket `except Exception` with specific import error handling
- Log unexpected exceptions during `pymodbus` import

## Testing
- `flake8 custom_components/thessla_green_modbus/modbus_exceptions.py`


------
https://chatgpt.com/codex/tasks/task_e_689b39e9c64883268925ec650973a4f3