### PR TITLE
Refactor sensor unavailable constant

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -20,6 +20,9 @@ DEFAULT_SCAN_INTERVAL = 30
 DEFAULT_TIMEOUT = 10
 DEFAULT_RETRY = 3
 
+# Sensor constants
+SENSOR_UNAVAILABLE = 0x8000  # Indicates missing/invalid sensor reading
+
 # Configuration options
 CONF_SLAVE_ID = "slave_id"
 CONF_SCAN_INTERVAL = "scan_interval"

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -53,6 +53,7 @@ from .const import (
     DOMAIN,
     MANUFACTURER,
     MODEL,
+    SENSOR_UNAVAILABLE,
 )
 from .multipliers import REGISTER_MULTIPLIERS
 from .registers import HOLDING_REGISTERS, INPUT_REGISTERS
@@ -662,9 +663,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
     def _process_register_value(self, register_name: str, value: int) -> Any:
         """Process register value according to its type and multiplier."""
         # Check for sensor error values
-        if value == 0x8000 and "temperature" in register_name.lower():
+        if value == SENSOR_UNAVAILABLE and "temperature" in register_name.lower():
             return None  # No sensor
-        if value == 0x8000 and "flow" in register_name.lower():
+        if value == SENSOR_UNAVAILABLE and "flow" in register_name.lower():
             return None  # No sensor
 
         # Apply multiplier

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pymodbus.client import AsyncModbusTcpClient
 
 from .modbus_helpers import _call_modbus
-from .const import DEFAULT_SLAVE_ID
+from .const import DEFAULT_SLAVE_ID, SENSOR_UNAVAILABLE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,13 +153,13 @@ class ThesslaGreenDeviceScanner:
 
     def _is_valid_register_value(self, register_name: str, value: int) -> bool:
         """Check if register value is valid (not a sensor error/missing value)."""
-        # Temperature sensors use 0x8000 to indicate no sensor
+        # Temperature sensors use a sentinel value to indicate no sensor
         if "temperature" in register_name.lower():
-            return value != 0x8000 and value != 32768
+            return value != SENSOR_UNAVAILABLE
 
-        # Air flow sensors use 0x8000 to indicate no sensor
+        # Air flow sensors use the same sentinel for no sensor
         if any(x in register_name.lower() for x in ["flow", "air_flow", "flowrate"]):
-            return value != 0x8000 and value != 32768 and value != 65535
+            return value != SENSOR_UNAVAILABLE and value != 65535
 
         # Mode values should be in valid range
         if "mode" in register_name.lower():

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -3,6 +3,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.const import SENSOR_UNAVAILABLE
 
 
 pytestmark = pytest.mark.asyncio
@@ -72,7 +73,10 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("test_register", 0) is True
     
     # Invalid temperature sensor value
-    assert scanner._is_valid_register_value("outside_temperature", 32768) is False
+    assert (
+        scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
+        is False
+    )
     
     # Invalid air flow value
     assert scanner._is_valid_register_value("supply_air_flow", 65535) is False

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -3,6 +3,8 @@ import pytest
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
+from custom_components.thessla_green_modbus.const import SENSOR_UNAVAILABLE
+
 from conftest import CoordinatorMock
 
 from homeassistant.core import HomeAssistant
@@ -261,7 +263,9 @@ class TestThesslaGreenModbusCoordinator:
         assert result == 20.5
 
         # Invalid temperature (sensor disconnected)
-        result = coordinator_data._process_register_value("outside_temperature", 0x8000)
+        result = coordinator_data._process_register_value(
+            "outside_temperature", SENSOR_UNAVAILABLE
+        )
         assert result is None
 
         # Negative temperature (-5.0°C -> raw value 65486)
@@ -440,7 +444,10 @@ class TestThesslaGreenDeviceScanner:
         assert scanner._is_valid_register_value("mode", 1) is True
         
         # Invalid temperature sensor value
-        assert scanner._is_valid_register_value("outside_temperature", 32768) is False
+        assert (
+            scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
+            is False
+        )
         
         # Invalid air flow value
         assert scanner._is_valid_register_value("supply_air_flow", 65535) is False


### PR DESCRIPTION
## Summary
- centralize missing-sensor sentinel value in `SENSOR_UNAVAILABLE`
- simplify register validation to use `SENSOR_UNAVAILABLE`
- update tests to reference `SENSOR_UNAVAILABLE`

## Testing
- `pytest tests/test_device_scanner.py tests/test_optimized_integration.py` *(fails: ModuleNotFoundError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_689b39f1f5c483269eca04356da9f73b