### PR TITLE
Handle specific errors in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -128,9 +128,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except KeyError as err:
                 _LOGGER.error("Missing required data: %s", err)
                 errors["base"] = "invalid_input"
-            except Exception as err:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception during configuration: %s", err)
-                raise
 
         # Show form
         data_schema = vol.Schema(


### PR DESCRIPTION
## Summary
- remove broad `Exception` catch in config flow
- add connection error test coverage

## Testing
- `pytest tests/test_config_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_689b39f3e8e08326ad81d6f22087981f