### PR TITLE
Fix translation description formatting

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -20,8 +20,6 @@
       "confirm": {
         "title": "Confirm Configuration",
 
-        "description": "ThesslaGreen device {device_name} detected at {host}:{port} with Device ID {slave_id} and firmware {firmware_version}.\n{auto_detected_note} Do you want to continue with this configuration?"
-=======
         "description": "ThesslaGreen device {device_name} (serial {serial_number}) detected at {host}:{port} with Device ID {slave_id} and firmware {firmware_version}. Registers detected: {register_count} ({scan_success_rate} success). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Do you want to continue with this configuration?"
       }
     },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -19,8 +19,6 @@
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen {device_name} pod adresem {host}:{port} (ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}).\n{auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
-=======
         "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port} (ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}). Wykryto rejestrów: {register_count} (skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
       }
     },


### PR DESCRIPTION
## Summary
- remove leftover conflict marker and outdated text from English and Polish translations
- keep detailed confirmation description for device detection

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/en.json`
- `python -m json.tool custom_components/thessla_green_modbus/translations/pl.json`
- `pytest` *(fails: 60 failed, 27 passed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b39c999f083268e27195e650fb80e