### PR TITLE
Generate timestamped backup suffix and refine error handling

### DIFF
--- a/custom_components/thessla_green_modbus/cleanup_old_entities.py
+++ b/custom_components/thessla_green_modbus/cleanup_old_entities.py
@@ -31,8 +31,6 @@ OLD_ENTITY_PATTERNS = [
     "thessla.*rekuperator_predkosc",
 ]
 
-BACKUP_SUFFIX = f"_backup_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-
 
 def find_ha_config_dir() -> Path | None:
     """Find the Home Assistant configuration directory."""
@@ -44,7 +42,8 @@ def find_ha_config_dir() -> Path | None:
 
 def backup_file(file_path: Path) -> Path:
     """Create a backup of the file."""
-    backup_path = file_path.with_suffix(file_path.suffix + BACKUP_SUFFIX)
+    backup_suffix = datetime.now().strftime("_backup_%Y%m%d_%H%M%S")
+    backup_path = file_path.with_suffix(file_path.suffix + backup_suffix)
     shutil.copy2(file_path, backup_path)
     _LOGGER.info("Backup created: %s", backup_path)
     return backup_path
@@ -157,7 +156,7 @@ def cleanup_automations(config_dir: Path) -> bool:
             _LOGGER.info("Automations are clean")
             return True
 
-    except Exception as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         _LOGGER.error("Error checking automations: %s", exc)
         return False
 
@@ -197,7 +196,7 @@ def cleanup_configuration_yaml(config_dir: Path) -> bool:
             _LOGGER.info("Configuration is clean")
             return True
 
-    except Exception as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         _LOGGER.error("Error checking configuration: %s", exc)
         return False
 
@@ -221,7 +220,7 @@ def cleanup_custom_component_cache(config_dir: Path) -> bool:
                     cache_path.unlink()
                 _LOGGER.info("Removed cache: %s", cache_path)
                 cleaned = True
-            except Exception as exc:
+            except OSError as exc:
                 _LOGGER.warning("Unable to remove cache %s: %s", cache_path, exc)
 
     if not cleaned:
@@ -286,6 +285,6 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         _LOGGER.warning("\n\nInterrupted by user")
         raise SystemExit(1)
-    except Exception as exc:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         _LOGGER.error("\nUnexpected error: %s", exc)
         raise SystemExit(1)

--- a/custom_components/thessla_green_modbus/modbus_exceptions.py
+++ b/custom_components/thessla_green_modbus/modbus_exceptions.py
@@ -21,8 +21,5 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover
         """Fallback Modbus exception when pymodbus is unavailable."""
 
         pass
-except Exception:  # pragma: no cover
-    _LOGGER.exception("Unexpected error importing pymodbus")
-    raise
 
 __all__ = ["ConnectionException", "ModbusException"]

--- a/tests/test_cleanup_old_entities.py
+++ b/tests/test_cleanup_old_entities.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import call, patch
 
 from custom_components.thessla_green_modbus.cleanup_old_entities import (
-    BACKUP_SUFFIX,
     cleanup_entity_registry,
 )
 
@@ -20,12 +19,12 @@ def _setup_registry(tmp_path: Path, content: str) -> Path:
 
 def test_cleanup_entity_registry_invalid_json_restores_backup(tmp_path, caplog):
     registry_path = _setup_registry(tmp_path, "{invalid")
-    backup_path = registry_path.with_suffix(registry_path.suffix + BACKUP_SUFFIX)
 
     with patch("shutil.copy2", wraps=shutil.copy2) as mock_copy:
         with caplog.at_level(logging.ERROR):
             assert not cleanup_entity_registry(tmp_path)
 
+    backup_path = mock_copy.call_args_list[0].args[1]
     assert "Error decoding entity registry JSON" in caplog.text
     assert mock_copy.call_args_list == [call(registry_path, backup_path), call(backup_path, registry_path)]
     assert registry_path.read_text(encoding="utf-8") == "{invalid"
@@ -43,13 +42,13 @@ def test_cleanup_entity_registry_oserror_restores_backup(tmp_path, caplog):
         }
     }
     registry_path = _setup_registry(tmp_path, json.dumps(original))
-    backup_path = registry_path.with_suffix(registry_path.suffix + BACKUP_SUFFIX)
 
     with patch("json.dump", side_effect=OSError("disk error")):
         with patch("shutil.copy2", wraps=shutil.copy2) as mock_copy:
             with caplog.at_level(logging.ERROR):
                 assert not cleanup_entity_registry(tmp_path)
 
+    backup_path = mock_copy.call_args_list[0].args[1]
     assert "Error processing entity registry file" in caplog.text
     assert mock_copy.call_args_list == [call(registry_path, backup_path), call(backup_path, registry_path)]
     assert json.loads(registry_path.read_text(encoding="utf-8")) == original


### PR DESCRIPTION
## Summary
- generate a timestamped suffix within `backup_file` so backups reflect execution time
- replace broad `except Exception` handlers with specific error types for clearer diagnostics
- drop generic catch-all in `modbus_exceptions`

## Testing
- `pytest tests/test_cleanup_old_entities.py -q`
- `pytest -q` *(fails: missing async test plugin and coordinator/type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b3d2a0c548326a44a46c49960cb92