### PR TITLE
chore: translate asyncio pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,5 +118,5 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
-    "asyncio: markuje testy asynchroniczne",
+    "asyncio: marks asynchronous tests",
 ]


### PR DESCRIPTION
## Summary
- translate `asyncio` pytest marker description to English for consistency

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689b3dc818ec8326bd41d9df87178203