### PR TITLE
Clarify supply and exhaust airflow translation names

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -80,10 +80,10 @@
         "name": "Heating Temperature"
       },
       "supply_flowrate": {
-        "name": "Supply Airflow"
+        "name": "Target Supply Airflow"
       },
       "exhaust_flowrate": {
-        "name": "Exhaust Airflow"
+        "name": "Target Exhaust Airflow"
       },
       "heat_recovery_efficiency": {
         "name": "Heat Recovery Efficiency"
@@ -152,10 +152,10 @@
         "name": "Bypass Airflow"
       },
       "supply_air_flow": {
-        "name": "Supply Airflow"
+        "name": "Current Supply Airflow"
       },
       "exhaust_air_flow": {
-        "name": "Exhaust Airflow"
+        "name": "Current Exhaust Airflow"
       },
       "pm1_level": {
         "name": "PM1"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -76,10 +76,10 @@
         "name": "Temperatura otoczenia"
       },
       "supply_flowrate": {
-        "name": "Przepływ nawiewu"
+        "name": "Zadany przepływ nawiewu"
       },
       "exhaust_flowrate": {
-        "name": "Przepływ wywiewu"
+        "name": "Zadany przepływ wywiewu"
       },
       "heat_recovery_efficiency": {
         "name": "Sprawność rekuperacji"
@@ -115,10 +115,10 @@
         "name": "Przepływ obejścia (bypassu)"
       },
       "supply_air_flow": {
-        "name": "Przepływ nawiewu"
+        "name": "Aktualny przepływ nawiewu"
       },
       "exhaust_air_flow": {
-        "name": "Przepływ wywiewu"
+        "name": "Aktualny przepływ wywiewu"
       },
       "co2_level": {
         "name": "Poziom CO2"


### PR DESCRIPTION
## Summary
- give unique names to target and measured supply airflow readings
- do the same for exhaust airflow to keep translations consistent

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json`
- `pytest` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689b3d1ff3488326a8588f1677b37879