### PR TITLE
Lower minimum Home Assistant version

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.7.1",
+  "homeassistant": "2025.1.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",


### PR DESCRIPTION
## Summary
- downgrade Home Assistant core requirement to 2025.1.0

## Testing
- `pre_commit run --files custom_components/thessla_green_modbus/manifest.json`
- `pytest` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute 'hass')*

------
https://chatgpt.com/codex/tasks/task_e_689b3d18cc688326bdeadd3b1f58e295