### PR TITLE
Align module docstrings with future imports

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -1,6 +1,6 @@
-"""Config flow for ThesslaGreen Modbus integration."""
-
 from __future__ import annotations
+
+"""Config flow for ThesslaGreen Modbus integration."""
 
 import asyncio
 import logging
@@ -11,8 +11,6 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
-
-from .modbus_exceptions import ConnectionException, ModbusException
 
 from .const import (
     CONF_FORCE_FULL_REGISTER_LIST,
@@ -29,6 +27,7 @@ from .const import (
     DOMAIN,
 )
 from .device_scanner import ThesslaGreenDeviceScanner
+from .modbus_exceptions import ConnectionException, ModbusException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -190,9 +189,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "capabilities_count": str(len(capabilities_list)),
             "capabilities_list": ", ".join(capabilities_list) if capabilities_list else "None",
             "auto_detected_note": (
-                "Auto-detection successful!"
-                if register_count > 0
-                else "Limited auto-detection"
+                "Auto-detection successful!" if register_count > 0 else "Limited auto-detection"
             ),
         }
 

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -1,6 +1,6 @@
-"""Fan platform for the ThesslaGreen Modbus integration."""
-
 from __future__ import annotations
+
+"""Fan platform for the ThesslaGreen Modbus integration."""
 
 import logging
 from typing import Any, Dict
@@ -10,11 +10,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .modbus_exceptions import ConnectionException, ModbusException
 from .const import DOMAIN
-from .registers import HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
+from .modbus_exceptions import ConnectionException, ModbusException
+from .registers import HOLDING_REGISTERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -227,9 +227,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         if register_name not in HOLDING_REGISTERS:
             raise ValueError(f"Register {register_name} is not writable")
 
-        success = await self.coordinator.async_write_register(
-            register_name, value, refresh=False
-        )
+        success = await self.coordinator.async_write_register(register_name, value, refresh=False)
         if not success:
             raise RuntimeError(f"Failed to write register {register_name}")
 

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -1,6 +1,6 @@
-"""Number platform for the ThesslaGreen Modbus integration."""
-
 from __future__ import annotations
+
+"""Number platform for the ThesslaGreen Modbus integration."""
 
 import logging
 from typing import Any, Dict, Optional
@@ -12,12 +12,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .modbus_exceptions import ConnectionException, ModbusException
 from .const import DOMAIN
-from .entity_mappings import ENTITY_MAPPINGS
-from .registers import HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
+from .entity_mappings import ENTITY_MAPPINGS
+from .modbus_exceptions import ConnectionException, ModbusException
+from .registers import HOLDING_REGISTERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,9 +173,7 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
                 raise RuntimeError(f"Failed to write register {self.register_name}")
 
         except (ModbusException, ConnectionException, RuntimeError) as exc:
-            _LOGGER.error(
-                "Failed to set %s to %.2f: %s", self.register_name, value, exc
-            )
+            _LOGGER.error("Failed to set %s to %.2f: %s", self.register_name, value, exc)
             raise
         except (ValueError, OSError) as exc:  # pragma: no cover - unexpected
             _LOGGER.exception(

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -1,5 +1,6 @@
-"""Select platform for the ThesslaGreen Modbus integration."""
 from __future__ import annotations
+
+"""Select platform for the ThesslaGreen Modbus integration."""
 
 import logging
 from typing import Optional

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -1,6 +1,6 @@
-"""Service handlers for the ThesslaGreen Modbus integration."""
-
 from __future__ import annotations
+
+"""Service handlers for the ThesslaGreen Modbus integration."""
 
 import logging
 from typing import TYPE_CHECKING

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -1,6 +1,6 @@
-"""Switch platform for the ThesslaGreen Modbus integration."""
-
 from __future__ import annotations
+
+"""Switch platform for the ThesslaGreen Modbus integration."""
 
 import logging
 from typing import Any, Dict
@@ -10,11 +10,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .modbus_exceptions import ConnectionException, ModbusException
 from .const import COIL_REGISTERS, DOMAIN
-from .registers import HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
+from .modbus_exceptions import ConnectionException, ModbusException
+from .registers import HOLDING_REGISTERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -185,9 +185,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
 
     async def _write_register(self, register_name: str, value: int) -> None:
         """Write value to register."""
-        success = await self.coordinator.async_write_register(
-            register_name, value, refresh=False
-        )
+        success = await self.coordinator.async_write_register(register_name, value, refresh=False)
         if not success:
             raise RuntimeError(f"Failed to write register {register_name}")
 


### PR DESCRIPTION
## Summary
- position module docstrings after `from __future__ import annotations`
- describe the purpose of config flow, fan, number, select, services, and switch modules

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/fan.py custom_components/thessla_green_modbus/number.py custom_components/thessla_green_modbus/select.py custom_components/thessla_green_modbus/services.py custom_components/thessla_green_modbus/switch.py` *(fails: mypy errors in unrelated files)*
- `pytest` *(fails: 61 failed, 29 passed, 1 warning, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b3f2a1f888326b70fc98d707982f2