### PR TITLE
Use coordinator statistics for last update

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -10,11 +10,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .modbus_exceptions import ConnectionException, ModbusException
 from .const import DOMAIN
-from .registers import HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
+from .modbus_exceptions import ConnectionException, ModbusException
+from .registers import HOLDING_REGISTERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -227,9 +227,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         if register_name not in HOLDING_REGISTERS:
             raise ValueError(f"Register {register_name} is not writable")
 
-        success = await self.coordinator.async_write_register(
-            register_name, value, refresh=False
-        )
+        success = await self.coordinator.async_write_register(register_name, value, refresh=False)
         if not success:
             raise RuntimeError(f"Failed to write register {register_name}")
 
@@ -274,7 +272,11 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
             attributes["system_status"] = system_status
 
         # Add last update time
-        if self.coordinator.last_successful_update:
-            attributes["last_updated"] = self.coordinator.last_successful_update.isoformat()
+        last_update = (
+            self.coordinator.statistics.get("last_successful_update")
+            or self.coordinator.last_update
+        )
+        if last_update is not None:
+            attributes["last_updated"] = last_update.isoformat()
 
         return attributes

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -12,12 +12,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .modbus_exceptions import ConnectionException, ModbusException
 from .const import DOMAIN
-from .entity_mappings import ENTITY_MAPPINGS
-from .registers import HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
+from .entity_mappings import ENTITY_MAPPINGS
+from .modbus_exceptions import ConnectionException, ModbusException
+from .registers import HOLDING_REGISTERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,9 +173,7 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
                 raise RuntimeError(f"Failed to write register {self.register_name}")
 
         except (ModbusException, ConnectionException, RuntimeError) as exc:
-            _LOGGER.error(
-                "Failed to set %s to %.2f: %s", self.register_name, value, exc
-            )
+            _LOGGER.error("Failed to set %s to %.2f: %s", self.register_name, value, exc)
             raise
         except (ValueError, OSError) as exc:  # pragma: no cover - unexpected
             _LOGGER.exception(
@@ -213,8 +211,12 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
         }
 
         # Add last update time
-        if self.coordinator.last_successful_update:
-            attributes["last_updated"] = self.coordinator.last_successful_update.isoformat()
+        last_update = (
+            self.coordinator.statistics.get("last_successful_update")
+            or self.coordinator.last_update
+        )
+        if last_update is not None:
+            attributes["last_updated"] = last_update.isoformat()
 
         return attributes
 

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -10,11 +10,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .modbus_exceptions import ConnectionException, ModbusException
 from .const import COIL_REGISTERS, DOMAIN
-from .registers import HOLDING_REGISTERS
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
+from .modbus_exceptions import ConnectionException, ModbusException
+from .registers import HOLDING_REGISTERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -185,9 +185,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
 
     async def _write_register(self, register_name: str, value: int) -> None:
         """Write value to register."""
-        success = await self.coordinator.async_write_register(
-            register_name, value, refresh=False
-        )
+        success = await self.coordinator.async_write_register(register_name, value, refresh=False)
         if not success:
             raise RuntimeError(f"Failed to write register {register_name}")
 
@@ -217,8 +215,12 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
                 attributes["raw_value"] = raw_value
 
         # Add last update time
-        if self.coordinator.last_successful_update:
-            attributes["last_updated"] = self.coordinator.last_successful_update.isoformat()
+        last_update = (
+            self.coordinator.statistics.get("last_successful_update")
+            or self.coordinator.last_update
+        )
+        if last_update is not None:
+            attributes["last_updated"] = last_update.isoformat()
 
         # Add mode-specific information
         if "mode" in self.register_name:


### PR DESCRIPTION
## Summary
- Guard against missing update timestamps in fan, switch, and number entities
- Pull last successful update timestamp from coordinator statistics or fallback to last update

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/fan.py custom_components/thessla_green_modbus/switch.py custom_components/thessla_green_modbus/number.py` *(fails: mypy errors in unrelated files)*
- `pytest` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689b3f32edf48326aa020e930e53d38e