### PR TITLE
Clarify confirm dialog translation strings

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -20,7 +20,7 @@
       "confirm": {
         "title": "Confirm Configuration",
 
-        "description": "ThesslaGreen device {device_name} (serial {serial_number}) detected at {host}:{port} with Device ID {slave_id} and firmware {firmware_version}. Registers detected: {register_count} ({scan_success_rate} success). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Do you want to continue with this configuration?"
+        "description": "ThesslaGreen device {device_name} (serial {serial_number}) detected at {host}:{port} with Device ID {slave_id} and firmware {firmware_version}.\nRegisters detected: {register_count} ({scan_success_rate} success).\nCapabilities ({capabilities_count}): {capabilities_list}.\n{auto_detected_note}\nDo you want to continue with this configuration?"
       }
     },
     "error": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port} (ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}). Wykryto rejestrów: {register_count} (skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port} (ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}).\nWykryto rejestrów: {register_count} (skuteczność skanowania {scan_success_rate}).\nDostępne funkcje ({capabilities_count}): {capabilities_list}.\n{auto_detected_note}\nCzy chcesz kontynuować tę konfigurację?"
       }
     },
     "error": {


### PR DESCRIPTION
## Summary
- Add explicit line breaks to configuration confirmation messages in English and Polish translations for clarity

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json`


------
https://chatgpt.com/codex/tasks/task_e_689b3f4374f883268629195214e2d727