### PR TITLE
Add logging config for cleanup script

### DIFF
--- a/custom_components/thessla_green_modbus/cleanup_old_entities.py
+++ b/custom_components/thessla_green_modbus/cleanup_old_entities.py
@@ -16,6 +16,8 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 
+logging.basicConfig(level=logging.INFO)
+
 _LOGGER = logging.getLogger(__name__)
 
 # Configuration


### PR DESCRIPTION
## Summary
- ensure `cleanup_old_entities.py` outputs informational and error messages by default with a basic logging config

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/cleanup_old_entities.py` *(fails: invalid syntax in const.py, requires Python 3.12)*
- `python custom_components/thessla_green_modbus/cleanup_old_entities.py`


------
https://chatgpt.com/codex/tasks/task_e_689b47724ec08326af8452b873470444