### PR TITLE
Lower HA requirement and add voluptuous

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -5,12 +5,13 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.7.0",
+  "homeassistant": "2025.1.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",
   "requirements": [
-    "pymodbus>=3.5.0,<4.0.0"
+    "pymodbus>=3.5.0,<4.0.0",
+    "voluptuous>=0.13.1"
   ],
   "version": "2.1.1",
   "integration_type": "device",


### PR DESCRIPTION
## Summary
- broaden Home Assistant compatibility to 2025.1
- ensure voluptuous is installed alongside pymodbus

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json`
- `pytest` *(fails: SyntaxError in custom_components/thessla_green_modbus/const.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b4773edfc8326832ee014a21757a6