### PR TITLE
fix: translate presostat option

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -453,7 +453,7 @@
       "filter_change": {
         "name": "Filter Type",
         "state": {
-          "presostat": "Presostat",
+          "presostat": "Pressure switch",
           "flat_filters": "Flat Filters",
           "cleanpad": "CleanPad",
           "cleanpad_pure": "CleanPad Pure"
@@ -691,7 +691,7 @@
           "selector": {
             "select": {
               "options": {
-                "presostat": "Presostat",
+                "presostat": "Pressure switch",
                 "flat_filters": "Flat Filters",
                 "cleanpad": "CleanPad",
                 "cleanpad_pure": "CleanPad Pure"


### PR DESCRIPTION
## Summary
- translate `presostat` option to "Pressure switch" in `reset_filters` service
- ensure filter type state uses "Pressure switch" label

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/en.json`
- `pytest` *(fails: SyntaxError: invalid syntax in const.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b477ebe4c83269580f54be14d292c