### PR TITLE
chore: require Home Assistant 2025.7.1

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.7.0",
+  "homeassistant": "2025.7.1",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",


### PR DESCRIPTION
## Summary
- update integration manifest to require Home Assistant 2025.7.1

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/manifest.json`
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json`
- `pytest` *(fails: SyntaxError: invalid syntax in const.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b4781e45c8326812f2cb49ce0ce3a