### PR TITLE
Fix Polish time placeholders

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -36,7 +36,7 @@
     "step": {
       "init": {
         "title": "Opcje ThesslaGreen Modbus",
-        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Częstotliwość odczytu: {current_scan_interval}s\n- Limit czasu połączenia: {current_timeout}s\n- Liczba powtórzeń nieudanych odczytów: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
+        "description": "Skonfiguruj zaawansowane opcje integracji.\n\n**Aktualne ustawienia:**\n- Częstotliwość odczytu: {current_scan_interval} sek\n- Limit czasu połączenia: {current_timeout} sek\n- Liczba powtórzeń nieudanych odczytów: {current_retry}\n- Wymuś pełną listę rejestrów: {force_full_enabled}",
         "data": {
           "scan_interval": "Interwał skanowania (sekundy)",
           "timeout": "Limit czasu połączenia (sekundy)",


### PR DESCRIPTION
## Summary
- tweak Polish translations to show `sek` after current scan interval and timeout

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/translations/pl.json`
- `pytest` *(fails: Interrupted: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b477f8fc48326b1ae309fb8987c47