### PR TITLE
Align flow rate register names with snake_case

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -296,7 +296,7 @@ entities:
   - entity: climate.thessla_green_klimat
   - entity: sensor.thessla_outside_temperature
   - entity: sensor.thessla_supply_temperature
-  - entity: sensor.thessla_supply_flowrate
+  - entity: sensor.thessla_supply_flow_rate
   - entity: select.thessla_mode
   - entity: select.thessla_special_function
   - entity: binary_sensor.thessla_constant_flow_active

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -220,10 +220,10 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
             attrs["gwc_temperature"] = self.coordinator.data["gwc_temperature"]
 
         # Airflow
-        if "supply_flowrate" in self.coordinator.data:
-            attrs["supply_airflow"] = self.coordinator.data["supply_flowrate"]
-        if "exhaust_flowrate" in self.coordinator.data:
-            attrs["exhaust_airflow"] = self.coordinator.data["exhaust_flowrate"]
+        if "supply_flow_rate" in self.coordinator.data:
+            attrs["supply_airflow"] = self.coordinator.data["supply_flow_rate"]
+        if "exhaust_flow_rate" in self.coordinator.data:
+            attrs["exhaust_airflow"] = self.coordinator.data["exhaust_flow_rate"]
 
         # System status
         if "heat_recovery_efficiency" in self.coordinator.data:

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -120,7 +120,6 @@ SPECIAL_FUNCTION_MAP = {
     "winter": 1024,
 }
 
-=======
 # Unit mappings
 REGISTER_UNITS = {
     # Temperature registers - 0.1°C resolution
@@ -134,8 +133,8 @@ REGISTER_UNITS = {
     # Flow registers - m³/h
     "supply_air_flow": "m³/h",
     "exhaust_air_flow": "m³/h",
-    "supply_flowrate": "m³/h",
-    "exhaust_flowrate": "m³/h",
+    "supply_flow_rate": "m³/h",
+    "exhaust_flow_rate": "m³/h",
     # Percentages
     "air_flow_rate_manual": "%",
     # Temperature set-point
@@ -199,8 +198,8 @@ STATE_CLASSES = {
     "gwc_temperature": "measurement",
     "ambient_temperature": "measurement",
     "heating_temperature": "measurement",
-    "supply_flowrate": "measurement",
-    "exhaust_flowrate": "measurement",
+    "supply_flow_rate": "measurement",
+    "exhaust_flow_rate": "measurement",
     "supply_air_flow": "measurement",
     "exhaust_air_flow": "measurement",
     "co2_level": "measurement",

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -692,8 +692,8 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("Could not calculate efficiency: %s", exc)
 
         # Calculate flow balance
-        if "supply_flowrate" in data and "exhaust_flowrate" in data:
-            data["flow_balance"] = data["supply_flowrate"] - data["exhaust_flowrate"]
+        if "supply_flow_rate" in data and "exhaust_flow_rate" in data:
+            data["flow_balance"] = data["supply_flow_rate"] - data["exhaust_flow_rate"]
             data["flow_balance_status"] = (
                 "balanced"
                 if abs(data["flow_balance"]) < 10

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -158,7 +158,7 @@ class ThesslaGreenDeviceScanner:
             return value != SENSOR_UNAVAILABLE
 
         # Air flow sensors use the same sentinel for no sensor
-        if any(x in register_name.lower() for x in ["flow", "air_flow", "flowrate"]):
+        if any(x in register_name.lower() for x in ["flow", "air_flow", "flow_rate"]):
             return value != SENSOR_UNAVAILABLE and value != 65535
 
         # Mode values should be in valid range
@@ -311,13 +311,13 @@ class ThesslaGreenDeviceScanner:
 
             # Scan flow sensors (0x0018-0x001E)
             flow_sensors = [
-                (0x0018, "supply_flowrate"),
-                (0x0019, "exhaust_flowrate"),
-                (0x001A, "outdoor_flowrate"),
-                (0x001B, "inside_flowrate"),
-                (0x001C, "gwc_flowrate"),
-                (0x001D, "heat_recovery_flowrate"),
-                (0x001E, "bypass_flowrate"),
+                (0x0018, "supply_flow_rate"),
+                (0x0019, "exhaust_flow_rate"),
+                (0x001A, "outdoor_flow_rate"),
+                (0x001B, "inside_flow_rate"),
+                (0x001C, "gwc_flow_rate"),
+                (0x001D, "heat_recovery_flow_rate"),
+                (0x001E, "bypass_flow_rate"),
             ]
 
             for addr, reg_name in flow_sensors:

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -239,11 +239,11 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         attributes = {}
 
         # Add flow information
-        if "supply_flowrate" in self.coordinator.data:
-            attributes["supply_flow"] = self.coordinator.data["supply_flowrate"]
+        if "supply_flow_rate" in self.coordinator.data:
+            attributes["supply_flow"] = self.coordinator.data["supply_flow_rate"]
 
-        if "exhaust_flowrate" in self.coordinator.data:
-            attributes["exhaust_flow"] = self.coordinator.data["exhaust_flowrate"]
+        if "exhaust_flow_rate" in self.coordinator.data:
+            attributes["exhaust_flow"] = self.coordinator.data["exhaust_flow_rate"]
 
         if "supply_percentage" in self.coordinator.data:
             attributes["supply_percentage"] = self.coordinator.data["supply_percentage"]

--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -32,8 +32,8 @@ INPUT_REGISTERS: Dict[str, int] = {
     "exhaust_air_flow": 0x0101,
     "constant_flow_active": 0x010F,
     # Flow set-points
-    "supply_flowrate": 0x0112,
-    "exhaust_flowrate": 0x0113,
+    "supply_flow_rate": 0x0112,
+    "exhaust_flow_rate": 0x0113,
 }
 
 # HOLDING REGISTERS (03 - READ/WRITE HOLDING REGISTER)

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -141,50 +141,50 @@ SENSOR_DEFINITIONS = {
     },
     
     # Flow sensors
-    "supply_flowrate": {
-        "translation_key": "supply_flowrate",
+    "supply_flow_rate": {
+        "translation_key": "supply_flow_rate",
         "icon": "mdi:fan",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
-    "exhaust_flowrate": {
-        "translation_key": "exhaust_flowrate",
+    "exhaust_flow_rate": {
+        "translation_key": "exhaust_flow_rate",
         "icon": "mdi:fan-clock",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
-    "outdoor_flowrate": {
-        "translation_key": "outdoor_flowrate",
+    "outdoor_flow_rate": {
+        "translation_key": "outdoor_flow_rate",
         "icon": "mdi:weather-windy",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
-    "inside_flowrate": {
-        "translation_key": "inside_flowrate",
+    "inside_flow_rate": {
+        "translation_key": "inside_flow_rate",
         "icon": "mdi:home-circle",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
-    "gwc_flowrate": {
-        "translation_key": "gwc_flowrate",
+    "gwc_flow_rate": {
+        "translation_key": "gwc_flow_rate",
         "icon": "mdi:pipe",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
-    "heat_recovery_flowrate": {
-        "translation_key": "heat_recovery_flowrate",
+    "heat_recovery_flow_rate": {
+        "translation_key": "heat_recovery_flow_rate",
         "icon": "mdi:heat-pump",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
-    "bypass_flowrate": {
-        "translation_key": "bypass_flowrate",
+    "bypass_flow_rate": {
+        "translation_key": "bypass_flow_rate",
         "icon": "mdi:pipe-leak",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -1,8 +1,7 @@
 
 """Service handlers for the ThesslaGreen Modbus integration."""
-import annotations
 
-"""Service handlers for the ThesslaGreen Modbus integration."""
+from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -79,10 +79,10 @@
       "heating_temperature": {
         "name": "Heating Temperature"
       },
-      "supply_flowrate": {
+      "supply_flow_rate": {
         "name": "Target Supply Airflow"
       },
-      "exhaust_flowrate": {
+      "exhaust_flow_rate": {
         "name": "Target Exhaust Airflow"
       },
       "heat_recovery_efficiency": {
@@ -136,19 +136,19 @@
       "heat_exchanger_temperature_4": {
         "name": "Heat Exchanger Temperature 4"
       },
-      "outdoor_flowrate": {
+      "outdoor_flow_rate": {
         "name": "Outdoor Airflow"
       },
-      "inside_flowrate": {
+      "inside_flow_rate": {
         "name": "Indoor Airflow"
       },
-      "gwc_flowrate": {
+      "gwc_flow_rate": {
         "name": "GWC Airflow"
       },
-      "heat_recovery_flowrate": {
+      "heat_recovery_flow_rate": {
         "name": "Heat Recovery Airflow"
       },
-      "bypass_flowrate": {
+      "bypass_flow_rate": {
         "name": "Bypass Airflow"
       },
       "supply_air_flow": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -75,10 +75,10 @@
       "ambient_temperature": {
         "name": "Temperatura otoczenia"
       },
-      "supply_flowrate": {
+      "supply_flow_rate": {
         "name": "Zadany przepływ nawiewu"
       },
-      "exhaust_flowrate": {
+      "exhaust_flow_rate": {
         "name": "Zadany przepływ wywiewu"
       },
       "heat_recovery_efficiency": {
@@ -99,19 +99,19 @@
       "heat_exchanger_temperature_4": {
         "name": "Temperatura wymiennika 4"
       },
-      "outdoor_flowrate": {
+      "outdoor_flow_rate": {
         "name": "Przepływ zewnętrzny"
       },
-      "inside_flowrate": {
+      "inside_flow_rate": {
         "name": "Przepływ wewnętrzny"
       },
-      "gwc_flowrate": {
+      "gwc_flow_rate": {
         "name": "Przepływ GWC"
       },
-      "heat_recovery_flowrate": {
+      "heat_recovery_flow_rate": {
         "name": "Przepływ rekuperatora"
       },
-      "bypass_flowrate": {
+      "bypass_flow_rate": {
         "name": "Przepływ obejścia (bypassu)"
       },
       "supply_air_flow": {

--- a/example_configuration.yaml
+++ b/example_configuration.yaml
@@ -14,8 +14,8 @@ template:
       - name: "ThesslaGreen Efficiency"
         unit_of_measurement: "%"
         state: >
-          {% set supply_flow = states('sensor.thessla_supply_flowrate') | float(0) %}
-          {% set exhaust_flow = states('sensor.thessla_exhaust_flowrate') | float(0) %}
+          {% set supply_flow = states('sensor.thessla_supply_flow_rate') | float(0) %}
+          {% set exhaust_flow = states('sensor.thessla_exhaust_flow_rate') | float(0) %}
           {% if supply_flow > 0 and exhaust_flow > 0 %}
             {{ ((min(supply_flow, exhaust_flow) / max(supply_flow, exhaust_flow)) * 100) | round(1) }}
           {% else %}
@@ -252,7 +252,7 @@ group:
 #   - entity: climate.thessla_green_climate
 #   - entity: sensor.thessla_outside_temperature
 #   - entity: sensor.thessla_supply_temperature
-#   - entity: sensor.thessla_supply_flowrate
+#   - entity: sensor.thessla_supply_flow_rate
 #   - entity: select.thessla_mode
 # title: ThesslaGreen Control
 # show_header_toggle: false

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -317,8 +317,8 @@ def test_post_process_data(coordinator):
         "outside_temperature": 100,  # 10.0°C
         "supply_temperature": 200,   # 20.0°C  
         "exhaust_temperature": 250,  # 25.0°C
-        "supply_flowrate": 150,
-        "exhaust_flowrate": 140,
+        "supply_flow_rate": 150,
+        "exhaust_flow_rate": 140,
     }
     
     processed_data = coordinator._post_process_data(raw_data)


### PR DESCRIPTION
## Summary
- rename CSV-derived flowrate registers to snake_case (e.g. `supply_flow_rate`)
- update all modules, translations, and docs to reference new names
- fix services import for Python 3.11

## Testing
- `pytest` *(fails: AttributeError: module 'voluptuous' has no attribute 'Match')*


------
https://chatgpt.com/codex/tasks/task_e_689b4d66b2bc8326b1b30f2595b024b7