### PR TITLE
Refactor service schemas to use shared option lists

### DIFF
--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -1,4 +1,3 @@
-
 """Service handlers for the ThesslaGreen Modbus integration."""
 
 from __future__ import annotations
@@ -60,27 +59,7 @@ def _scale_for_register(register_name: str, value: float) -> int:
 SET_SPECIAL_MODE_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_ids,
-
-
         vol.Required("mode"): vol.In(SPECIAL_MODE_OPTIONS),
-
-        vol.Required("mode"): vol.In(
-            [
-                "none",
-                "boost",
-                "eco",
-                "away",
-                "sleep",
-                "fireplace",
-                "hood",
-                "party",
-                "bathroom",
-                "kitchen",
-                "summer",
-                "winter",
-            ]
-        ),
-
         vol.Optional("duration", default=0): vol.All(vol.Coerce(int), vol.Range(min=0, max=480)),
     }
 )
@@ -90,10 +69,6 @@ SET_AIRFLOW_SCHEDULE_SCHEMA = vol.Schema(
         vol.Required("entity_id"): cv.entity_ids,
         vol.Required("day"): vol.In(DAYS_OF_WEEK),
         vol.Required("period"): vol.In(PERIODS),
-        vol.Required("day"): vol.In(
-            ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
-        ),
-        vol.Required("period"): vol.In(["1", "2"]),
         vol.Required("start_time"): cv.time,
         vol.Required("end_time"): cv.time,
         vol.Required("airflow_rate"): vol.All(vol.Coerce(int), vol.Range(min=10, max=100)),
@@ -104,9 +79,7 @@ SET_AIRFLOW_SCHEDULE_SCHEMA = vol.Schema(
 SET_BYPASS_PARAMETERS_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_ids,
-        vol.Required("mode"): vol.In(["auto", "open", "closed"]),
         vol.Required("mode"): vol.In(BYPASS_MODES),
-        vol.Required("mode"): vol.In(["auto", "open", "closed"]),
         vol.Optional("temperature_threshold"): vol.All(
             vol.Coerce(float), vol.Range(min=18.0, max=30.0)
         ),
@@ -117,9 +90,7 @@ SET_BYPASS_PARAMETERS_SCHEMA = vol.Schema(
 SET_GWC_PARAMETERS_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_ids,
-        vol.Required("mode"): vol.In(["off", "auto", "forced"]),
         vol.Required("mode"): vol.In(GWC_MODES),
-        vol.Required("mode"): vol.In(["off", "auto", "forced"]),
         vol.Optional("temperature_threshold"): vol.All(
             vol.Coerce(float), vol.Range(min=-5.0, max=15.0)
         ),
@@ -150,22 +121,14 @@ SET_TEMPERATURE_CURVE_SCHEMA = vol.Schema(
 RESET_FILTERS_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_ids,
-        vol.Required("filter_type"): vol.In(
-            ["presostat", "flat_filters", "cleanpad", "cleanpad_pure"]
-        ),
         vol.Required("filter_type"): vol.In(FILTER_TYPES),
-        vol.Required("filter_type"): vol.In(
-            ["presostat", "flat_filters", "cleanpad", "cleanpad_pure"]
-        ),
     }
 )
 
 RESET_SETTINGS_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_ids,
-        vol.Required("reset_type"): vol.In(["user_settings", "schedule_settings", "all_settings"]),
         vol.Required("reset_type"): vol.In(RESET_TYPES),
-        vol.Required("reset_type"): vol.In(["user_settings", "schedule_settings", "all_settings"]),
     }
 )
 
@@ -182,19 +145,12 @@ SET_MODBUS_PARAMETERS_SCHEMA = vol.Schema(
         vol.Optional("baud_rate"): vol.In(MODBUS_BAUD_RATES),
         vol.Optional("parity"): vol.In(MODBUS_PARITY),
         vol.Optional("stop_bits"): vol.In(MODBUS_STOP_BITS),
-        vol.Required("port"): vol.In(["air_b", "air_plus"]),
-        vol.Optional("baud_rate"): vol.In(
-            ["4800", "9600", "14400", "19200", "28800", "38400", "57600", "76800", "115200"]
-        ),
-        vol.Optional("parity"): vol.In(["none", "even", "odd"]),
-        vol.Optional("stop_bits"): vol.In(["1", "2"]),
     }
 )
 
 SET_DEVICE_NAME_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_ids,
-        vol.Required("device_name"): vol.All(cv.string, vol.Match(r"^[ -~]{1,16}$")),
         vol.Required("device_name"): vol.All(cv.string, vol.Length(min=1, max=16)),
     }
 )


### PR DESCRIPTION
## Summary
- simplify service schemas by removing duplicate field definitions
- reference shared option lists for validation
- streamline device name validation

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/services.py` *(fails: mypy found 55 errors in other files)*
- `pytest tests/test_services.py`
- `pytest tests/test_services_scaling.py` *(fails: KeyError: 'heating_curve_slope')*


------
https://chatgpt.com/codex/tasks/task_e_689b65c40bac8326b9689b983ea7ffd7