### PR TITLE
Clarify Modbus translation descriptions

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "ThesslaGreen Modbus Configuration",
-        "description": "Configure connection to a ThesslaGreen AirPack over Modbus TCP. The integration automatically detects available device functions and registers.",
+        "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP. The integration automatically detects device functions and registers.",
         "data": {
           "host": "IP Address",
           "port": "Port",
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Confirm Configuration",
-        "description": "ThesslaGreen device {device_name} (serial {serial_number}) detected at {host}:{port} with Device ID {slave_id} and firmware {firmware_version}. Registers detected: {register_count} ({scan_success_rate} success). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Do you want to continue with this configuration?"
+        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID {slave_id} runs firmware {firmware_version}. Registers: {register_count} ({scan_success_rate} success). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Continue with this configuration?"
       }
     },
     "error": {
@@ -36,7 +36,7 @@
     "step": {
       "init": {
         "title": "ThesslaGreen Modbus Options",
-        "description": "Configure advanced integration options. Current settings: Scan Interval {current_scan_interval}s, Timeout {current_timeout}s, Retry Count {current_retry}, Force Full Register List {force_full_enabled}.",
+        "description": "Configure advanced integration options. Current settings. Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}.",
         "data": {
           "scan_interval": "Scan Interval (seconds)",
           "timeout": "Connection Timeout (seconds)",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfiguracja ThesslaGreen Modbus",
-        "description": "Skonfiguruj połączenie z ThesslaGreen AirPack przez Modbus TCP. Integracja automatycznie wykrywa dostępne funkcje i rejestry urządzenia.",
+        "description": "Skonfiguruj połączenie z ThesslaGreen AirPack przez Modbus TCP. Integracja automatycznie wykrywa funkcje i rejestry urządzenia.",
         "data": {
           "host": "Adres IP",
           "port": "Port",
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port} (ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}). Wykryto {register_count} rejestrów (skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}. Wykryto {register_count} rejestrów (skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
       }
     },
     "error": {
@@ -36,7 +36,7 @@
     "step": {
       "init": {
         "title": "Opcje ThesslaGreen Modbus",
-        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu {current_scan_interval} sek, Limit czasu połączenia {current_timeout} sek, Liczba powtórzeń nieudanych odczytów {current_retry}, Wymuś pełną listę rejestrów {force_full_enabled}.",
+        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia. Częstotliwość odczytu: {current_scan_interval} sek. Limit czasu połączenia: {current_timeout} sek. Liczba powtórzeń nieudanych odczytów: {current_retry}. Wymuś pełną listę rejestrów: {force_full_enabled}.",
         "data": {
           "scan_interval": "Interwał skanowania (sekundy)",
           "timeout": "Limit czasu połączenia (sekundy)",


### PR DESCRIPTION
## Summary
- shorten English configuration and option descriptions
- improve Polish descriptions with shorter sentences and clearer phrasing

## Testing
- `pytest tests/test_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_689b69b3635c83269652c9805797f92c