### PR TITLE
feat: make cleanup script configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,43 @@ logger:
 - **Diagnostyka**: Szczegółowe metryki wydajności i błędów
 - **Stabilność**: Retry logic, fallback reads, graceful degradation
 
+## 🧹 Czyszczenie starych encji
+
+Po aktualizacji integracji możesz usunąć nieużywane encje przy pomocy
+skryptu `cleanup_old_entities.py`.
+
+```bash
+python3 custom_components/thessla_green_modbus/cleanup_old_entities.py
+```
+
+Skrypt domyślnie obsługuje polskie i angielskie nazwy encji
+(`rekuperator_predkosc`, `rekuperator_speed`).
+
+### Dodatkowe wzorce
+
+Możesz dodać własne wzorce poprzez opcję CLI lub plik konfiguracyjny:
+
+```bash
+python3 custom_components/thessla_green_modbus/cleanup_old_entities.py \
+    --pattern "thessla.*ventilation_speed" \
+    --pattern "number.extra_sensor"
+```
+
+Plik JSON z dodatkowymi wzorcami (domyślnie `cleanup_config.json` obok skryptu):
+
+```json
+{
+  "old_entity_patterns": ["thessla.*ventilation_speed"]
+}
+```
+
+Uruchomienie z własnym plikiem:
+
+```bash
+python3 custom_components/thessla_green_modbus/cleanup_old_entities.py \
+    --config my_cleanup_config.json
+```
+
 ## 🤝 Wsparcie i rozwój
 
 ### Dokumentacja


### PR DESCRIPTION
## Summary
- extend cleanup tool with English entity patterns
- allow loading extra patterns from a JSON config and CLI arguments
- document multilingual cleanup usage in README

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/cleanup_old_entities.py README.md` *(failed: mypy: Name "ConnectionException" already defined, and more)*
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/cleanup_old_entities.py README.md`
- `pytest` *(failed: ThesslaGreenModbusCoordinator() takes no arguments, and more)*

------
https://chatgpt.com/codex/tasks/task_e_689b69b089748326b8b6ad9c8a158550