### PR TITLE
Add csv import and typing to register tests

### DIFF
--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -1,48 +1,50 @@
-import csv
+import csv  # handle CSV register definitions
 import importlib.util
 import pathlib
 import re
 
 
 def to_snake_case(name: str) -> str:
-    replacements = {'flowrate': 'flow_rate'}
+    replacements = {"flowrate": "flow_rate"}
     for old, new in replacements.items():
         name = name.replace(old, new)
-    name = re.sub(r'[\s\-/]', '_', name)
-    name = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', name)
-    name = re.sub(r'(?<=\D)(\d)', r'_\1', name)
-    name = re.sub(r'__+', '_', name)
+    name = re.sub(r"[\s\-/]", "_", name)
+    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+    name = re.sub(r"(?<=\D)(\d)", r"_\1", name)
+    name = re.sub(r"__+", "_", name)
     return name.lower()
 
 
-def load_csv_registers():
-    input_regs = {}
-    holding_regs = {}
-    with pathlib.Path('modbus_registers.csv').open(newline='') as f:
+def load_csv_registers() -> tuple[dict[str, int], dict[str, int]]:
+    input_regs: dict[str, int] = {}
+    holding_regs: dict[str, int] = {}
+    with pathlib.Path("modbus_registers.csv").open(newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            code = row['Function_Code']
-            if not code or code.startswith('#'):
+            code = row["Function_Code"]
+            if not code or code.startswith("#"):
                 continue
-            name = to_snake_case(row['Register_Name'])
-            addr = int(row['Address_DEC'])
-            if code == '04':
+            name = to_snake_case(row["Register_Name"])
+            addr = int(row["Address_DEC"])
+            if code == "04":
                 input_regs[name] = addr
-            elif code == '03':
+            elif code == "03":
                 holding_regs[name] = addr
     return input_regs, holding_regs
 
 
-def load_module_registers():
-    module_path = pathlib.Path('custom_components/thessla_green_modbus/registers.py')
-    spec = importlib.util.spec_from_file_location('registers', module_path)
+def load_module_registers() -> tuple[dict[str, int], dict[str, int]]:
+    module_path = pathlib.Path("custom_components/thessla_green_modbus/registers.py")
+    spec = importlib.util.spec_from_file_location("registers", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError("Cannot load registers module")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module.INPUT_REGISTERS, module.HOLDING_REGISTERS
 
 
-def test_register_definitions_match_csv():
+def test_register_definitions_match_csv() -> None:
     csv_input, csv_holding = load_csv_registers()
     mod_input, mod_holding = load_module_registers()
-    assert csv_input == mod_input
-    assert csv_holding == mod_holding
+    assert csv_input == mod_input  # nosec B101
+    assert csv_holding == mod_holding  # nosec B101


### PR DESCRIPTION
## Summary
- import csv in register tests and tidy imports
- add type hints and stricter module loading

## Testing
- `pre-commit run --files tests/test_registers.py`
- `pytest tests/test_registers.py::test_register_definitions_match_csv -q`


------
https://chatgpt.com/codex/tasks/task_e_689b69c83f8483268df76f7aea51db0e