### PR TITLE
Fix GWC delta temperature register naming

### DIFF
--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -208,7 +208,7 @@ HOLDING_REGISTERS: Dict[str, int] = {
     'gwc_regen': 4262,
     'gwc_mode': 4263,
     'gwc_regen_period': 4264,
-    'delta_tgwc': 4266,
+    'delta_t_gwc': 4266,
     'start_gwc_regen_winter_time': 4267,
     'stop_gwc_regen_winter_time': 4268,
     'start_gwc_regen_summer_time': 4269,

--- a/tools/generate_registers.py
+++ b/tools/generate_registers.py
@@ -17,6 +17,7 @@ def to_snake_case(name: str) -> str:
     for old, new in replacements.items():
         name = name.replace(old, new)
     name = re.sub(r'[\s\-/]', '_', name)
+    name = re.sub(r'(.)([A-Z][a-z]+)', r'\1_\2', name)
     name = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', name)
     name = re.sub(r'(?<=\D)(\d)', r'_\1', name)
     name = re.sub(r'__+', '_', name)


### PR DESCRIPTION
## Summary
- handle consecutive capitals when converting register names to snake_case
- regenerate registers so GWC temperature-difference register exports as `delta_t_gwc`

## Testing
- `pytest` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b69f8cba083268e7340e2f86c85ec