### PR TITLE
Clarify HVAC mode mappings and add tests

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -26,12 +26,12 @@ _LOGGER = logging.getLogger(__name__)
 HVAC_MODE_MAP = {
     0: HVACMode.AUTO,  # Automatic mode
     1: HVACMode.FAN_ONLY,  # Manual mode
-    2: HVACMode.FAN_ONLY,  # Temporary mode
+    2: HVACMode.FAN_ONLY,  # Temporary boost mode
 }
 
 HVAC_MODE_REVERSE_MAP = {
     HVACMode.AUTO: 0,
-    HVACMode.FAN_ONLY: 1,
+    HVACMode.FAN_ONLY: 1,  # Manual and temporary modes use fan-only
     HVACMode.OFF: 0,  # Will be handled by on_off_panel_mode
 }
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -100,7 +100,11 @@ sys.modules["homeassistant.helpers.device_registry"] = device_registry
 # Actual imports after stubbing
 # ---------------------------------------------------------------------------
 
-from custom_components.thessla_green_modbus.climate import ThesslaGreenClimate
+from custom_components.thessla_green_modbus.climate import (
+    HVAC_MODE_MAP,
+    HVAC_MODE_REVERSE_MAP,
+    ThesslaGreenClimate,
+)
 from custom_components.thessla_green_modbus.const import DOMAIN
 from custom_components.thessla_green_modbus.multipliers import REGISTER_MULTIPLIERS
 from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS
@@ -175,3 +179,14 @@ def test_target_temperature_none_when_unavailable():
 
     coordinator.data["comfort_temperature"] = 20.0
     assert climate.target_temperature == 20.0
+
+
+def test_hvac_mode_mappings():
+    """Verify device modes map to and from Home Assistant HVAC modes."""
+    assert HVAC_MODE_MAP[0] == HVACMode.AUTO
+    assert HVAC_MODE_MAP[1] == HVACMode.FAN_ONLY
+    assert HVAC_MODE_MAP[2] == HVACMode.FAN_ONLY
+
+    assert HVAC_MODE_REVERSE_MAP[HVACMode.AUTO] == 0
+    assert HVAC_MODE_REVERSE_MAP[HVACMode.FAN_ONLY] == 1
+    assert HVAC_MODE_REVERSE_MAP[HVACMode.OFF] == 0


### PR DESCRIPTION
## Summary
- document temporary boost as device mode 2 and clarify HVAC mode mappings
- add tests verifying device and Home Assistant HVAC mode mapping

## Testing
- `pytest tests/test_climate.py` *(fails: KeyError: 'comfort_temperature')*
- `pytest tests/test_climate.py::test_hvac_mode_mappings`

------
https://chatgpt.com/codex/tasks/task_e_689b69ad9024832686c3ddcafce993ed