### PR TITLE
Remove unused discrete input sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 ### Sensory binarne (40+ automatycznie wykrywanych)
 - **Status systemu**: Zasilanie wentylatorów, bypass, GWC, pompy
 - **Tryby**: Letni/zimowy, auto/manual, tryby specjalne (boost, eco, away, sleep, fireplace, hood, party, bathroom, kitchen, summer, winter)
-- **Wejścia**: Expansion, alarm pożarowy, kontaktrony, czujniki
+- **Wejścia**: Expansion, alarm pożarowy, czujnik zanieczyszczenia
 - **Błędy i alarmy**: Wszystkie kody S1-S32 i E99-E105
 - **Zabezpieczenia**: Termiczne, przeciwmrozowe, przeciążenia
 

--- a/README_en.md
+++ b/README_en.md
@@ -98,7 +98,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 ### Binary sensors (40+ auto detected)
 - **System status**: fan power, bypass, GWC, pumps
 - **Modes**: summer/winter, auto/manual, special modes (boost, eco, away, sleep, fireplace, hood, party, bathroom, kitchen, summer, winter)
-- **Inputs**: expansion, fire alarm, contractors, sensors
+- **Inputs**: expansion, fire alarm, air quality sensor
 - **Errors and alarms**: all codes S1‑S32 and E99‑E105
 - **Protections**: thermal, anti freeze, overloads
 

--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -1,13 +1,11 @@
 """Binary sensors for the ThesslaGreen Modbus integration."""
+
 from __future__ import annotations
 
 import logging
 from typing import Any, Dict
 
-from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
-    BinarySensorEntity,
-)
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -69,7 +67,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "coil_registers",
     },
-    
     # System status (from discrete inputs)
     "expansion": {
         "translation_key": "expansion",
@@ -83,105 +80,12 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
-    "external_contact_1": {
-        "translation_key": "external_contact_1",
-        "icon": "mdi:electric-switch",
-        "device_class": BinarySensorDeviceClass.OPENING,
-        "register_type": "discrete_inputs",
-    },
-    "external_contact_2": {
-        "translation_key": "external_contact_2",
-        "icon": "mdi:electric-switch",
-        "device_class": BinarySensorDeviceClass.OPENING,
-        "register_type": "discrete_inputs",
-    },
-    "external_contact_3": {
-        "translation_key": "external_contact_3",
-        "icon": "mdi:electric-switch",
-        "device_class": BinarySensorDeviceClass.OPENING,
-        "register_type": "discrete_inputs",
-    },
-    "external_contact_4": {
-        "translation_key": "external_contact_4",
-        "icon": "mdi:electric-switch",
-        "device_class": BinarySensorDeviceClass.OPENING,
-        "register_type": "discrete_inputs",
-    },
-    
-    # Alarms and errors (from discrete inputs)
-    "fire_alarm": {
+    "ppoz": {
         "translation_key": "fire_alarm",
         "icon": "mdi:fire",
         "device_class": BinarySensorDeviceClass.SAFETY,
         "register_type": "discrete_inputs",
     },
-    "frost_alarm": {
-        "translation_key": "frost_alarm",
-        "icon": "mdi:snowflake-alert",
-        "device_class": BinarySensorDeviceClass.COLD,
-        "register_type": "discrete_inputs",
-    },
-    "filter_alarm": {
-        "translation_key": "filter_alarm",
-        "icon": "mdi:filter-variant-remove",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "discrete_inputs",
-    },
-    "maintenance_alarm": {
-        "translation_key": "maintenance_alarm",
-        "icon": "mdi:wrench-clock",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "discrete_inputs",
-    },
-    "sensor_error": {
-        "translation_key": "sensor_error",
-        "icon": "mdi:sensor-off",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "discrete_inputs",
-    },
-    "communication_error": {
-        "translation_key": "communication_error",
-        "icon": "mdi:wifi-off",
-        "device_class": BinarySensorDeviceClass.CONNECTIVITY,
-        "register_type": "discrete_inputs",
-    },
-    "fan_error": {
-        "translation_key": "fan_error",
-        "icon": "mdi:fan-off",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "discrete_inputs",
-    },
-    "heater_error": {
-        "translation_key": "heater_error",
-        "icon": "mdi:heating-coil",
-        "device_class": BinarySensorDeviceClass.HEAT,
-        "register_type": "discrete_inputs",
-    },
-    "cooler_error": {
-        "translation_key": "cooler_error",
-        "icon": "mdi:snowflake-off",
-        "device_class": BinarySensorDeviceClass.COLD,
-        "register_type": "discrete_inputs",
-    },
-    "bypass_error": {
-        "translation_key": "bypass_error",
-        "icon": "mdi:pipe-disconnected",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "discrete_inputs",
-    },
-    "gwc_error": {
-        "translation_key": "gwc_error",
-        "icon": "mdi:pipe-wrench",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "discrete_inputs",
-    },
-    "expansion_error": {
-        "translation_key": "expansion_error",
-        "icon": "mdi:expansion-card-variant",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "discrete_inputs",
-    },
-    
     # Active protection systems (from input registers)
     "frost_protection_active": {
         "translation_key": "frost_protection_active",
@@ -255,7 +159,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
     },
-    
     # Device main status (from holding registers)
     "on_off_panel_mode": {
         "translation_key": "on_off_panel_mode",
@@ -273,21 +176,23 @@ async def async_setup_entry(
 ) -> None:
     """Set up ThesslaGreen binary sensor entities based on available registers."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
+
     entities = []
-    
+
     # Create binary sensors only for available registers (autoscan result)
     for register_name, sensor_def in BINARY_SENSOR_DEFINITIONS.items():
         register_type = sensor_def["register_type"]
-        
+
         # Check if this register is available on the device
         if register_name in coordinator.available_registers.get(register_type, set()):
             entities.append(ThesslaGreenBinarySensor(coordinator, register_name, sensor_def))
             _LOGGER.debug("Created binary sensor: %s", sensor_def["translation_key"])
-    
+
     if entities:
         async_add_entities(entities, True)
-        _LOGGER.info("Created %d binary sensor entities for %s", len(entities), coordinator.device_name)
+        _LOGGER.info(
+            "Created %d binary sensor entities for %s", len(entities), coordinator.device_name
+        )
     else:
         _LOGGER.warning("No binary sensor entities created - no compatible registers found")
 
@@ -325,56 +230,56 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return True if the binary sensor is on."""
         value = self.coordinator.data.get(self._register_name)
-        
+
         if value is None:
             return None
-        
+
         # Handle different register types
         register_type = self._sensor_def["register_type"]
-        
+
         if register_type in ["coil_registers", "discrete_inputs"]:
             # Coils and discrete inputs are already boolean
             return bool(value)
-        
+
         elif register_type == "input_registers":
             # Input registers: 1 = active/on, 0 = inactive/off
             return bool(value)
-        
+
         elif register_type == "holding_registers":
             # Holding registers: depends on register
             if self._register_name == "on_off_panel_mode":
                 return bool(value)
             else:
                 return bool(value)
-        
+
         return False
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         """Return additional state attributes."""
         attrs = {}
-        
+
         # Add register information for debugging
-        if hasattr(self.coordinator, 'device_scan_result') and self.coordinator.device_scan_result:
+        if hasattr(self.coordinator, "device_scan_result") and self.coordinator.device_scan_result:
             attrs["register_name"] = self._register_name
             attrs["register_type"] = self._sensor_def["register_type"]
-        
+
         # Add raw value for diagnostic purposes
         raw_value = self.coordinator.data.get(self._register_name)
         if raw_value is not None:
             attrs["raw_value"] = raw_value
-        
+
         # Add specific information for alarm/error sensors
         if "alarm" in self._register_name or "error" in self._register_name:
             attrs["severity"] = "warning" if self.is_on else "normal"
-        
+
         return attrs
 
     @property
     def icon(self) -> str:
         """Return the icon for the binary sensor."""
         base_icon = self._attr_icon
-        
+
         # Dynamic icon changes for certain sensors
         if self._register_name in ["bypass", "gwc", "power_supply_fans", "heating_cable"]:
             if self.is_on:
@@ -387,12 +292,12 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
                     return "mdi:heating-coil-off"
                 elif "pipe" in base_icon:
                     return "mdi:pipe-disconnected"
-        
+
         # Dynamic icon for alarms and errors
         if "alarm" in self._register_name or "error" in self._register_name:
             if self.is_on:
                 return "mdi:alert-circle"
             else:
                 return "mdi:check-circle"
-        
+
         return base_icon

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -278,18 +278,6 @@
       "winter_heating_active": {
         "name": "Winter Heating"
       },
-      "filter_alarm": {
-        "name": "Filter Alarm"
-      },
-      "maintenance_alarm": {
-        "name": "Maintenance Alarm"
-      },
-      "sensor_error": {
-        "name": "Sensor Error"
-      },
-      "communication_error": {
-        "name": "Communication Error"
-      },
       "duct_water_heater_pump": {
         "name": "Water Heater Pump"
       },
@@ -308,41 +296,8 @@
       "contamination_sensor": {
         "name": "Contamination Sensor"
       },
-      "external_contact_1": {
-        "name": "External Contact 1"
-      },
-      "external_contact_2": {
-        "name": "External Contact 2"
-      },
-      "external_contact_3": {
-        "name": "External Contact 3"
-      },
-      "external_contact_4": {
-        "name": "External Contact 4"
-      },
-      "fire_alarm": {
+      "ppoz": {
         "name": "Fire Alarm"
-      },
-      "frost_alarm": {
-        "name": "Frost Alarm"
-      },
-      "fan_error": {
-        "name": "Fan Error"
-      },
-      "heater_error": {
-        "name": "Heater Error"
-      },
-      "cooler_error": {
-        "name": "Cooler Error"
-      },
-      "bypass_error": {
-        "name": "Bypass Error"
-      },
-      "gwc_error": {
-        "name": "GWC Error"
-      },
-      "expansion_error": {
-        "name": "Expansion Module Error"
       },
       "night_cooling_active": {
         "name": "Night Cooling Active"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -263,7 +263,7 @@
       "heating_cable": {
         "name": "Kabel grzejny"
       },
-      "fire_alarm": {
+      "ppoz": {
         "name": "Alarm pożarowy"
       },
       "expansion": {
@@ -283,51 +283,6 @@
       },
       "contamination_sensor": {
         "name": "Czujnik zanieczyszczenia"
-      },
-      "external_contact_1": {
-        "name": "Kontakt zewnętrzny 1"
-      },
-      "external_contact_2": {
-        "name": "Kontakt zewnętrzny 2"
-      },
-      "external_contact_3": {
-        "name": "Kontakt zewnętrzny 3"
-      },
-      "external_contact_4": {
-        "name": "Kontakt zewnętrzny 4"
-      },
-      "frost_alarm": {
-        "name": "Alarm przeciwmrozowy"
-      },
-      "filter_alarm": {
-        "name": "Alarm filtra"
-      },
-      "maintenance_alarm": {
-        "name": "Alarm konserwacji"
-      },
-      "sensor_error": {
-        "name": "Błąd czujnika"
-      },
-      "communication_error": {
-        "name": "Błąd komunikacji"
-      },
-      "fan_error": {
-        "name": "Błąd wentylatora"
-      },
-      "heater_error": {
-        "name": "Błąd grzałki"
-      },
-      "cooler_error": {
-        "name": "Błąd chłodnicy"
-      },
-      "bypass_error": {
-        "name": "Błąd obejścia (bypassu)"
-      },
-      "gwc_error": {
-        "name": "Błąd GWC"
-      },
-      "expansion_error": {
-        "name": "Błąd modułu Expansion"
       },
       "frost_protection_active": {
         "name": "Ochrona przeciwmrozowa"


### PR DESCRIPTION
## Summary
- drop unmapped discrete input sensors from `binary_sensor.py`
- clean up translations to match new sensor set
- update docs to reflect available inputs

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json README_en.md README.md` *(fails: mypy: Name "ConnectionException" already defined; Returning Any from function declared to return "list[int] | None"; Name "DeviceInfo" already defined, etc.)*
- `pytest` *(fails: ThesslaGreenModbusCoordinator() takes no arguments; DeviceInfo() takes no arguments; async def functions are not natively supported, etc.)*
- `pytest tests/test_translations.py::test_translation_keys_present`

------
https://chatgpt.com/codex/tasks/task_e_689b69ba10648326b1e29517bf6c6f12