### PR TITLE
refactor scanner to dynamically discover registers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ try:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
     from homeassistant.exceptions import ConfigEntryNotReady
+    import homeassistant.util  # ensure util submodule is loaded for plugins
 except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     ha = types.ModuleType("homeassistant")
     core = types.ModuleType("homeassistant.core")

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -3,20 +3,18 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
-from custom_components.thessla_green_modbus.const import SENSOR_UNAVAILABLE
+from custom_components.thessla_green_modbus.const import (
+    SENSOR_UNAVAILABLE,
+    COIL_REGISTERS,
+    DISCRETE_INPUT_REGISTERS,
+)
+from custom_components.thessla_green_modbus.registers import (
+    HOLDING_REGISTERS,
+    INPUT_REGISTERS,
+)
 
 
 pytestmark = pytest.mark.asyncio
-
-
-@pytest.fixture
-def mock_modbus_response():
-    """Mock Modbus response."""
-    response = MagicMock()
-    response.isError.return_value = False
-    response.registers = [4, 85, 0]  # Version 4.85.0
-    response.bits = [True, False, True]
-    return response
 
 
 async def test_device_scanner_initialization():
@@ -28,26 +26,54 @@ async def test_device_scanner_initialization():
     assert scanner.slave_id == 10
 
 
-async def test_scan_device_success(mock_modbus_response):
-    """Test successful device scan."""
+async def test_scan_device_success():
+    """Test successful device scan with dynamic register scanning."""
     scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
-    
+
+    async def fake_read_input(client, address, count):
+        data = [1] * count
+        if address == 0:
+            data[0:3] = [4, 85, 0]
+        return data
+
+    async def fake_read_holding(client, address, count):
+        return [1] * count
+
+    async def fake_read_coil(client, address, count):
+        return [False] * count
+
+    async def fake_read_discrete(client, address, count):
+        return [False] * count
+
     with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
         mock_client = AsyncMock()
         mock_client.connect.return_value = True
-        mock_client.read_input_registers.return_value = mock_modbus_response
-        mock_client.read_holding_registers.return_value = mock_modbus_response
-        mock_client.read_coils.return_value = mock_modbus_response
-        mock_client.read_discrete_inputs.return_value = mock_modbus_response
         mock_client_class.return_value = mock_client
 
-        result = await scanner.scan_device()
-        await scanner.close()
+        with patch.object(
+            scanner, "_read_input", AsyncMock(side_effect=fake_read_input)
+        ), patch.object(
+            scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)
+        ), patch.object(
+            scanner, "_read_coil", AsyncMock(side_effect=fake_read_coil)
+        ), patch.object(
+            scanner, "_read_discrete", AsyncMock(side_effect=fake_read_discrete)
+        ):
+            result = await scanner.scan_device()
 
-        assert "available_registers" in result
-        assert "device_info" in result
-        assert "capabilities" in result
-        assert result["device_info"]["firmware"] == "4.85.0"
+    assert set(result["available_registers"]["input_registers"]) == set(
+        INPUT_REGISTERS.keys()
+    )
+    assert set(result["available_registers"]["holding_registers"]) == set(
+        HOLDING_REGISTERS.keys()
+    )
+    assert set(result["available_registers"]["coil_registers"]) == set(
+        COIL_REGISTERS.keys()
+    )
+    assert set(result["available_registers"]["discrete_inputs"]) == set(
+        DISCRETE_INPUT_REGISTERS.keys()
+    )
+    assert result["device_info"]["firmware"] == "4.85.0"
 
 
 async def test_scan_device_connection_failure():
@@ -95,12 +121,12 @@ async def test_analyze_capabilities():
     }
     
     capabilities = scanner._analyze_capabilities()
-    
-    assert capabilities["constant_flow"] is True
-    assert capabilities["gwc_system"] is True
-    assert capabilities["bypass_system"] is True
-    assert capabilities["expansion_module"] is True
-    assert capabilities["sensor_outside_temperature"] is True
+
+    assert capabilities.constant_flow is True
+    assert capabilities.gwc_system is True
+    assert capabilities.bypass_system is True
+    assert capabilities.expansion_module is True
+    assert capabilities.sensor_outside_temperature is True
 
 
 @pytest.mark.parametrize("async_close", [True, False])

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -1,4 +1,5 @@
 import csv
+import csv
 import importlib.util
 import pathlib
 import re


### PR DESCRIPTION
## Summary
- refactor device scanner to iterate over register maps instead of hard-coded lists
- derive device capabilities from discovered registers
- cover dynamic scan with tests

## Testing
- `pytest tests/test_device_scanner.py tests/test_registers.py`
- `pytest` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b6a80ac4483269bbc3c8fa277dd1b