### PR TITLE
Add fire alarm binary sensor translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -299,6 +299,9 @@
       "ppoz": {
         "name": "Fire Alarm"
       },
+      "fire_alarm": {
+        "name": "Fire Alarm"
+      },
       "night_cooling_active": {
         "name": "Night Cooling Active"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -266,6 +266,9 @@
       "ppoz": {
         "name": "Alarm pożarowy"
       },
+      "fire_alarm": {
+        "name": "Alarm pożarowy"
+      },
       "expansion": {
         "name": "Moduł rozszerzający"
       },


### PR DESCRIPTION
## Summary
- add `fire_alarm` translations for binary sensor in English and Polish

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json`
- `pytest` *(fails: `AttributeError: module 'homeassistant' has no attribute 'util'`)*

------
https://chatgpt.com/codex/tasks/task_e_689b706791308326a67984d82cd3975c