### PR TITLE
Return scanned register blocks

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -404,7 +404,8 @@ class ThesslaGreenDeviceScanner:
             for key, value in caps_dict.items():
                 setattr(caps, key, value)
 
-            register_blocks = {}
+            # Copy the discovered register address blocks so they can be returned
+            register_blocks = present_blocks.copy()
             _LOGGER.info(
                 "Device scan completed: %d registers detected, %d capabilities detected",
                 sum(len(v) for v in self.available_registers.values()),


### PR DESCRIPTION
## Summary
- return the discovered register address blocks from `scan`
- ensure `scan_device` exposes the returned blocks via `scan_blocks`
- add regression test for register block propagation

## Testing
- `pytest tests/test_services.py::test_air_quality_register_map -vv` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_689b706c24308326893f8038504f0c3e