### PR TITLE
Prune unsupported ThesslaGreen sensors

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -86,76 +86,10 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.SAFETY,
         "register_type": "discrete_inputs",
     },
-    # Active protection systems (from input registers)
-    "frost_protection_active": {
-        "translation_key": "frost_protection_active",
-        "icon": "mdi:snowflake-check",
-        "device_class": BinarySensorDeviceClass.COLD,
-        "register_type": "input_registers",
-    },
-    "defrost_cycle_active": {
-        "translation_key": "defrost_cycle_active",
-        "icon": "mdi:snowflake-thermometer",
-        "device_class": BinarySensorDeviceClass.RUNNING,
-        "register_type": "input_registers",
-    },
-    "summer_bypass_active": {
-        "translation_key": "summer_bypass_active",
-        "icon": "mdi:weather-sunny",
-        "device_class": BinarySensorDeviceClass.RUNNING,
-        "register_type": "input_registers",
-    },
-    "winter_heating_active": {
-        "translation_key": "winter_heating_active",
-        "icon": "mdi:weather-snowy",
-        "device_class": BinarySensorDeviceClass.HEAT,
-        "register_type": "input_registers",
-    },
-    "night_cooling_active": {
-        "translation_key": "night_cooling_active",
-        "icon": "mdi:weather-night",
-        "device_class": BinarySensorDeviceClass.COLD,
-        "register_type": "input_registers",
-    },
+    # Active modes (from input registers)
     "constant_flow_active": {
         "translation_key": "constant_flow_active",
         "icon": "mdi:waves",
-        "device_class": BinarySensorDeviceClass.RUNNING,
-        "register_type": "input_registers",
-    },
-    "air_quality_control_active": {
-        "translation_key": "air_quality_control_active",
-        "icon": "mdi:air-filter",
-        "device_class": BinarySensorDeviceClass.RUNNING,
-        "register_type": "input_registers",
-    },
-    "humidity_control_active": {
-        "translation_key": "humidity_control_active",
-        "icon": "mdi:water-percent",
-        "device_class": BinarySensorDeviceClass.MOISTURE,
-        "register_type": "input_registers",
-    },
-    "temperature_control_active": {
-        "translation_key": "temperature_control_active",
-        "icon": "mdi:thermometer-auto",
-        "device_class": BinarySensorDeviceClass.HEAT,
-        "register_type": "input_registers",
-    },
-    "demand_control_active": {
-        "translation_key": "demand_control_active",
-        "icon": "mdi:hand-extended",
-        "device_class": BinarySensorDeviceClass.RUNNING,
-        "register_type": "input_registers",
-    },
-    "schedule_control_active": {
-        "translation_key": "schedule_control_active",
-        "icon": "mdi:calendar-clock",
-        "device_class": BinarySensorDeviceClass.RUNNING,
-        "register_type": "input_registers",
-    },
-    "manual_control_active": {
-        "translation_key": "manual_control_active",
-        "icon": "mdi:hand-pointing-up",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "input_registers",
     },

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -1,6 +1,5 @@
 """Constants and register definitions for the ThesslaGreen Modbus integration."""
 
-
 import json
 from pathlib import Path
 
@@ -146,39 +145,11 @@ DEVICE_CLASSES = {
     "duct_supply_temperature": "temperature",
     "gwc_temperature": "temperature",
     "ambient_temperature": "temperature",
-    "heating_temperature": "temperature",
-    "heat_exchanger_temperature_1": "temperature",
-    "heat_exchanger_temperature_2": "temperature",
-    "heat_exchanger_temperature_3": "temperature",
-    "heat_exchanger_temperature_4": "temperature",
-    # Humidity
-    "humidity_indoor": "humidity",
-    "humidity_outdoor": "humidity",
-    # Power/Energy
-    "preheater_power": "power",
-    "main_heater_power": "power",
-    "cooler_power": "power",
-    "supply_fan_power": "power",
-    "exhaust_fan_power": "power",
-    "total_power_consumption": "power",
-    "daily_energy_consumption": "energy",
-    "annual_energy_consumption": "energy",
-    "annual_energy_savings": "energy",
-    # Mass
-    "co2_reduction": "weight",
-    # Pressure
-    "supply_pressure": "pressure",
-    "exhaust_pressure": "pressure",
-    "differential_pressure": "pressure",
-    # Voltage/Current
+    # Voltage
     "dac_supply": "voltage",
     "dac_exhaust": "voltage",
     "dac_heater": "voltage",
     "dac_cooler": "voltage",
-    "motor_supply_current": "current",
-    "motor_exhaust_current": "current",
-    "motor_supply_voltage": "voltage",
-    "motor_exhaust_voltage": "voltage",
 }
 
 # State classes for statistics
@@ -191,42 +162,12 @@ STATE_CLASSES = {
     "duct_supply_temperature": "measurement",
     "gwc_temperature": "measurement",
     "ambient_temperature": "measurement",
-    "heating_temperature": "measurement",
     "supply_flow_rate": "measurement",
     "exhaust_flow_rate": "measurement",
     "supply_air_flow": "measurement",
     "exhaust_air_flow": "measurement",
-    "co2_level": "measurement",
-    "humidity_indoor": "measurement",
-    "humidity_outdoor": "measurement",
-    "pm1_level": "measurement",
-    "pm25_level": "measurement",
-    "pm10_level": "measurement",
-    "voc_level": "measurement",
-    "air_quality_index": "measurement",
-    "heat_recovery_efficiency": "measurement",
-    "supply_pressure": "measurement",
-    "exhaust_pressure": "measurement",
-    "differential_pressure": "measurement",
-    "preheater_power": "measurement",
-    "main_heater_power": "measurement",
-    "cooler_power": "measurement",
-    "supply_fan_power": "measurement",
-    "exhaust_fan_power": "measurement",
-    "total_power_consumption": "measurement",
-    "motor_supply_rpm": "measurement",
-    "motor_exhaust_rpm": "measurement",
-    "motor_supply_current": "measurement",
-    "motor_exhaust_current": "measurement",
-    "motor_supply_voltage": "measurement",
-    "motor_exhaust_voltage": "measurement",
-    # Total increasing values
-    "daily_energy_consumption": "total_increasing",
-    "annual_energy_consumption": "total_increasing",
-    "annual_energy_savings": "total_increasing",
-    "system_uptime": "total_increasing",
-    "fault_counter": "total_increasing",
-    "maintenance_counter": "total_increasing",
-    "filter_replacement_counter": "total_increasing",
-    "co2_reduction": "total_increasing",
+    "dac_supply": "measurement",
+    "dac_exhaust": "measurement",
+    "dac_heater": "measurement",
+    "dac_cooler": "measurement",
 }

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -1,38 +1,17 @@
 """Sensors for the ThesslaGreen Modbus integration."""
+
 from __future__ import annotations
 
 import logging
 from typing import Any, Dict, Optional
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    PERCENTAGE,
-    UnitOfEnergy,
-    UnitOfMass,
-    UnitOfPower,
-    UnitOfPressure,
-    UnitOfTemperature,
-    UnitOfTime,
-    UnitOfVolumeFlowRate,
-    CONCENTRATION_PARTS_PER_MILLION,
-    CONCENTRATION_PARTS_PER_BILLION,
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    ELECTRIC_CURRENT_MILLIAMPERE,
-    ELECTRIC_POTENTIAL_VOLT,
-    ELECTRIC_POTENTIAL_MILLIVOLT,
-    REVOLUTIONS_PER_MINUTE,
-)
+from homeassistant.const import ELECTRIC_POTENTIAL_VOLT, UnitOfTemperature, UnitOfVolumeFlowRate
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    DOMAIN,
-)
+from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 
@@ -97,49 +76,6 @@ SENSOR_DEFINITIONS = {
         "unit": UnitOfTemperature.CELSIUS,
         "register_type": "input_registers",
     },
-    "heating_temperature": {
-        "translation_key": "heating_temperature",
-        "icon": "mdi:thermometer-high",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    
-    # Heat exchanger temperatures
-    "heat_exchanger_temperature_1": {
-        "translation_key": "heat_exchanger_temperature_1",
-        "icon": "mdi:heat-pump",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "heat_exchanger_temperature_2": {
-        "translation_key": "heat_exchanger_temperature_2",
-        "icon": "mdi:heat-pump",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "heat_exchanger_temperature_3": {
-        "translation_key": "heat_exchanger_temperature_3",
-        "icon": "mdi:heat-pump",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "heat_exchanger_temperature_4": {
-        "translation_key": "heat_exchanger_temperature_4",
-        "icon": "mdi:heat-pump",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    
     # Flow sensors
     "supply_flow_rate": {
         "translation_key": "supply_flow_rate",
@@ -151,41 +87,6 @@ SENSOR_DEFINITIONS = {
     "exhaust_flow_rate": {
         "translation_key": "exhaust_flow_rate",
         "icon": "mdi:fan-clock",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "input_registers",
-    },
-    "outdoor_flow_rate": {
-        "translation_key": "outdoor_flow_rate",
-        "icon": "mdi:weather-windy",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "input_registers",
-    },
-    "inside_flow_rate": {
-        "translation_key": "inside_flow_rate",
-        "icon": "mdi:home-circle",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "input_registers",
-    },
-    "gwc_flow_rate": {
-        "translation_key": "gwc_flow_rate",
-        "icon": "mdi:pipe",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "input_registers",
-    },
-    "heat_recovery_flow_rate": {
-        "translation_key": "heat_recovery_flow_rate",
-        "icon": "mdi:heat-pump",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "input_registers",
-    },
-    "bypass_flow_rate": {
-        "translation_key": "bypass_flow_rate",
-        "icon": "mdi:pipe-leak",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
@@ -204,275 +105,6 @@ SENSOR_DEFINITIONS = {
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "holding_registers",
     },
-    
-    # Air quality sensors
-    "co2_level": {
-        "translation_key": "co2_level",
-        "icon": "mdi:molecule-co2",
-        "device_class": SensorDeviceClass.CO2,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": CONCENTRATION_PARTS_PER_MILLION,
-        "register_type": "input_registers",
-    },
-    "humidity_indoor": {
-        "translation_key": "humidity_indoor",
-        "icon": "mdi:water-percent",
-        "device_class": SensorDeviceClass.HUMIDITY,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": PERCENTAGE,
-        "register_type": "input_registers",
-    },
-    "humidity_outdoor": {
-        "translation_key": "humidity_outdoor",
-        "icon": "mdi:water-percent",
-        "device_class": SensorDeviceClass.HUMIDITY,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": PERCENTAGE,
-        "register_type": "input_registers",
-    },
-    "pm1_level": {
-        "translation_key": "pm1_level",
-        "icon": "mdi:air-filter",
-        "device_class": SensorDeviceClass.PM1,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        "register_type": "input_registers",
-    },
-    "pm25_level": {
-        "translation_key": "pm25_level",
-        "icon": "mdi:air-filter",
-        "device_class": SensorDeviceClass.PM25,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        "register_type": "input_registers",
-    },
-    "pm10_level": {
-        "translation_key": "pm10_level",
-        "icon": "mdi:air-filter",
-        "device_class": SensorDeviceClass.PM10,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        "register_type": "input_registers",
-    },
-    "voc_level": {
-        "translation_key": "voc_level",
-        "icon": "mdi:air-filter",
-        "device_class": SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": CONCENTRATION_PARTS_PER_BILLION,
-        "register_type": "input_registers",
-    },
-    "air_quality_index": {
-        "translation_key": "air_quality_index",
-        "icon": "mdi:air-filter",
-        "device_class": SensorDeviceClass.AQI,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": None,
-        "register_type": "input_registers",
-    },
-    
-    # System efficiency and status
-    "heat_recovery_efficiency": {
-        "translation_key": "heat_recovery_efficiency",
-        "icon": "mdi:percent",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": PERCENTAGE,
-        "register_type": "input_registers",
-    },
-    "filter_lifetime_remaining": {
-        "translation_key": "filter_lifetime_remaining",
-        "icon": "mdi:filter-variant",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTime.DAYS,
-        "register_type": "input_registers",
-    },
-    
-    # Power and energy sensors
-    "preheater_power": {
-        "translation_key": "preheater_power",
-        "icon": "mdi:heating-coil",
-        "device_class": SensorDeviceClass.POWER,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPower.WATT,
-        "register_type": "input_registers",
-    },
-    "main_heater_power": {
-        "translation_key": "main_heater_power",
-        "icon": "mdi:heating-coil",
-        "device_class": SensorDeviceClass.POWER,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPower.WATT,
-        "register_type": "input_registers",
-    },
-    "cooler_power": {
-        "translation_key": "cooler_power",
-        "icon": "mdi:snowflake",
-        "device_class": SensorDeviceClass.POWER,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPower.WATT,
-        "register_type": "input_registers",
-    },
-    "supply_fan_power": {
-        "translation_key": "supply_fan_power",
-        "icon": "mdi:fan",
-        "device_class": SensorDeviceClass.POWER,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPower.WATT,
-        "register_type": "input_registers",
-    },
-    "exhaust_fan_power": {
-        "translation_key": "exhaust_fan_power",
-        "icon": "mdi:fan-clock",
-        "device_class": SensorDeviceClass.POWER,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPower.WATT,
-        "register_type": "input_registers",
-    },
-    "total_power_consumption": {
-        "translation_key": "total_power_consumption",
-        "icon": "mdi:lightning-bolt",
-        "device_class": SensorDeviceClass.POWER,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPower.WATT,
-        "register_type": "input_registers",
-    },
-    "daily_energy_consumption": {
-        "translation_key": "daily_energy_consumption",
-        "icon": "mdi:counter",
-        "device_class": SensorDeviceClass.ENERGY,
-        "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": UnitOfEnergy.WATT_HOUR,
-        "register_type": "input_registers",
-    },
-    "annual_energy_consumption": {
-        "translation_key": "annual_energy_consumption",
-        "icon": "mdi:counter",
-        "device_class": SensorDeviceClass.ENERGY,
-        "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": UnitOfEnergy.KILO_WATT_HOUR,
-        "register_type": "input_registers",
-    },
-    "annual_energy_savings": {
-        "translation_key": "annual_energy_savings",
-        "icon": "mdi:leaf",
-        "device_class": SensorDeviceClass.ENERGY,
-        "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": UnitOfEnergy.KILO_WATT_HOUR,
-        "register_type": "input_registers",
-    },
-    "co2_reduction": {
-        "translation_key": "co2_reduction",
-        "icon": "mdi:tree",
-        "device_class": SensorDeviceClass.WEIGHT,
-        "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": UnitOfMass.KILOGRAMS,
-        "register_type": "input_registers",
-    },
-    
-    # System diagnostics
-    "system_uptime": {
-        "translation_key": "system_uptime",
-        "icon": "mdi:clock-outline",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": UnitOfTime.HOURS,
-        "register_type": "input_registers",
-    },
-    "fault_counter": {
-        "translation_key": "fault_counter",
-        "icon": "mdi:alert-circle",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": None,
-        "register_type": "input_registers",
-    },
-    "maintenance_counter": {
-        "translation_key": "maintenance_counter",
-        "icon": "mdi:wrench",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": None,
-        "register_type": "input_registers",
-    },
-    "filter_replacement_counter": {
-        "translation_key": "filter_replacement_counter",
-        "icon": "mdi:filter-variant",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
-        "unit": None,
-        "register_type": "input_registers",
-    },
-    
-    # Pressure sensors
-    "supply_pressure": {
-        "translation_key": "supply_pressure",
-        "icon": "mdi:gauge",
-        "device_class": SensorDeviceClass.PRESSURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPressure.PA,
-        "register_type": "input_registers",
-    },
-    "exhaust_pressure": {
-        "translation_key": "exhaust_pressure",
-        "icon": "mdi:gauge",
-        "device_class": SensorDeviceClass.PRESSURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPressure.PA,
-        "register_type": "input_registers",
-    },
-    "differential_pressure": {
-        "translation_key": "differential_pressure",
-        "icon": "mdi:gauge",
-        "device_class": SensorDeviceClass.PRESSURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfPressure.PA,
-        "register_type": "input_registers",
-    },
-    
-    # Motor diagnostics
-    "motor_supply_rpm": {
-        "translation_key": "motor_supply_rpm",
-        "icon": "mdi:fan",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": REVOLUTIONS_PER_MINUTE,
-        "register_type": "input_registers",
-    },
-    "motor_exhaust_rpm": {
-        "translation_key": "motor_exhaust_rpm",
-        "icon": "mdi:fan-clock",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": REVOLUTIONS_PER_MINUTE,
-        "register_type": "input_registers",
-    },
-    "motor_supply_current": {
-        "translation_key": "motor_supply_current",
-        "icon": "mdi:current-ac",
-        "device_class": SensorDeviceClass.CURRENT,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": ELECTRIC_CURRENT_MILLIAMPERE,
-        "register_type": "input_registers",
-    },
-    "motor_exhaust_current": {
-        "translation_key": "motor_exhaust_current",
-        "icon": "mdi:current-ac",
-        "device_class": SensorDeviceClass.CURRENT,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": ELECTRIC_CURRENT_MILLIAMPERE,
-        "register_type": "input_registers",
-    },
-    "motor_supply_voltage": {
-        "translation_key": "motor_supply_voltage",
-        "icon": "mdi:lightning-bolt",
-        "device_class": SensorDeviceClass.VOLTAGE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": ELECTRIC_POTENTIAL_MILLIVOLT,
-        "register_type": "input_registers",
-    },
-    "motor_exhaust_voltage": {
-        "translation_key": "motor_exhaust_voltage",
-        "icon": "mdi:lightning-bolt",
-        "device_class": SensorDeviceClass.VOLTAGE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": ELECTRIC_POTENTIAL_MILLIVOLT,
-        "register_type": "input_registers",
-    },
-    
     # PWM control values
     "dac_supply": {
         "translation_key": "dac_supply",
@@ -506,54 +138,30 @@ SENSOR_DEFINITIONS = {
         "unit": ELECTRIC_POTENTIAL_VOLT,
         "register_type": "input_registers",
     },
-    
-    # Damper positions
-    "damper_position_bypass": {
-        "translation_key": "damper_position_bypass",
-        "icon": "mdi:valve",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": PERCENTAGE,
-        "register_type": "input_registers",
-    },
-    "damper_position_gwc": {
-        "translation_key": "damper_position_gwc",
-        "icon": "mdi:valve",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": PERCENTAGE,
-        "register_type": "input_registers",
-    },
-    "damper_position_mix": {
-        "translation_key": "damper_position_mix",
-        "icon": "mdi:valve",
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": PERCENTAGE,
-        "register_type": "input_registers",
-    },
-    
     # Firmware and version info
-    "firmware_major": {
+    "version_major": {
         "translation_key": "firmware_major",
         "icon": "mdi:chip",
         "unit": None,
         "register_type": "input_registers",
     },
-    "firmware_minor": {
+    "version_minor": {
         "translation_key": "firmware_minor",
         "icon": "mdi:chip",
         "unit": None,
         "register_type": "input_registers",
     },
-    "firmware_patch": {
+    "version_patch": {
         "translation_key": "firmware_patch",
         "icon": "mdi:chip",
         "unit": None,
         "register_type": "input_registers",
     },
-    "expansion_version": {
+    "exp_version": {
         "translation_key": "expansion_version",
         "icon": "mdi:expansion-card",
         "unit": None,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
 }
 
@@ -565,18 +173,18 @@ async def async_setup_entry(
 ) -> None:
     """Set up ThesslaGreen sensor entities based on available registers."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
+
     entities = []
-    
+
     # Create sensors only for available registers (autoscan result)
     for register_name, sensor_def in SENSOR_DEFINITIONS.items():
         register_type = sensor_def["register_type"]
-        
+
         # Check if this register is available on the device
         if register_name in coordinator.available_registers.get(register_type, set()):
             entities.append(ThesslaGreenSensor(coordinator, register_name, sensor_def))
             _LOGGER.debug("Created sensor: %s", sensor_def["translation_key"])
-    
+
     if entities:
         async_add_entities(entities, True)
         _LOGGER.info("Created %d sensor entities for %s", len(entities), coordinator.device_name)
@@ -619,35 +227,35 @@ class ThesslaGreenSensor(ThesslaGreenEntity, SensorEntity):
     def native_value(self) -> Optional[float | int | str]:
         """Return the state of the sensor."""
         value = self.coordinator.data.get(self._register_name)
-        
+
         if value is None:
             return None
-        
+
         # Special handling for firmware version display
-        if self._register_name in ["firmware_major", "firmware_minor", "firmware_patch"]:
+        if self._register_name in ["version_major", "version_minor", "version_patch"]:
             return value
-        
+
         # Special handling for expansion version (convert hex to decimal.decimal format)
-        if self._register_name == "expansion_version" and isinstance(value, int):
+        if self._register_name == "exp_version" and isinstance(value, int):
             major = (value >> 8) & 0xFF
             minor = value & 0xFF
             return f"{major}.{minor:02d}"
-        
+
         return value
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         """Return additional state attributes."""
         attrs = {}
-        
+
         # Add register address for debugging
-        if hasattr(self.coordinator, 'device_scan_result') and self.coordinator.device_scan_result:
+        if hasattr(self.coordinator, "device_scan_result") and self.coordinator.device_scan_result:
             attrs["register_name"] = self._register_name
             attrs["register_type"] = self._sensor_def["register_type"]
-        
+
         # Add raw value for diagnostic purposes
         raw_value = self.coordinator.data.get(self._register_name)
         if raw_value is not None and isinstance(raw_value, (int, float)):
             attrs["raw_value"] = raw_value
-        
+
         return attrs

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -75,146 +75,17 @@
       "ambient_temperature": {
         "name": "Ambient Temperature"
       },
-      "heating_temperature": {
-        "name": "Heating Temperature"
-      },
       "supply_flow_rate": {
         "name": "Target Supply Airflow"
       },
       "exhaust_flow_rate": {
         "name": "Target Exhaust Airflow"
       },
-      "heat_recovery_efficiency": {
-        "name": "Heat Recovery Efficiency"
-      },
-      "co2_level": {
-        "name": "CO2 Level"
-      },
-      "humidity_indoor": {
-        "name": "Indoor Humidity"
-      },
-      "humidity_outdoor": {
-        "name": "Outdoor Humidity"
-      },
-      "pm25_level": {
-        "name": "PM2.5"
-      },
-      "pm10_level": {
-        "name": "PM10"
-      },
-      "voc_level": {
-        "name": "VOC"
-      },
-      "air_quality_index": {
-        "name": "Air Quality Index"
-      },
-      "filter_lifetime_remaining": {
-        "name": "Filter Life Remaining"
-      },
-      "total_power_consumption": {
-        "name": "Total Power Consumption"
-      },
-      "daily_energy_consumption": {
-        "name": "Daily Energy Consumption"
-      },
-      "annual_energy_consumption": {
-        "name": "Annual Energy Consumption"
-      },
-      "system_uptime": {
-        "name": "System Uptime"
-      },
-      "heat_exchanger_temperature_1": {
-        "name": "Heat Exchanger Temperature 1"
-      },
-      "heat_exchanger_temperature_2": {
-        "name": "Heat Exchanger Temperature 2"
-      },
-      "heat_exchanger_temperature_3": {
-        "name": "Heat Exchanger Temperature 3"
-      },
-      "heat_exchanger_temperature_4": {
-        "name": "Heat Exchanger Temperature 4"
-      },
-      "outdoor_flow_rate": {
-        "name": "Outdoor Airflow"
-      },
-      "inside_flow_rate": {
-        "name": "Indoor Airflow"
-      },
-      "gwc_flow_rate": {
-        "name": "GWC Airflow"
-      },
-      "heat_recovery_flow_rate": {
-        "name": "Heat Recovery Airflow"
-      },
-      "bypass_flow_rate": {
-        "name": "Bypass Airflow"
-      },
       "supply_air_flow": {
         "name": "Current Supply Airflow"
       },
       "exhaust_air_flow": {
         "name": "Current Exhaust Airflow"
-      },
-      "pm1_level": {
-        "name": "PM1"
-      },
-      "preheater_power": {
-        "name": "Preheater Power"
-      },
-      "main_heater_power": {
-        "name": "Main Heater Power"
-      },
-      "cooler_power": {
-        "name": "Cooler Power"
-      },
-      "supply_fan_power": {
-        "name": "Supply Fan Power"
-      },
-      "exhaust_fan_power": {
-        "name": "Exhaust Fan Power"
-      },
-      "annual_energy_savings": {
-        "name": "Annual Energy Savings"
-      },
-      "co2_reduction": {
-        "name": "Annual CO2 Reduction"
-      },
-      "fault_counter": {
-        "name": "Fault Counter"
-      },
-      "maintenance_counter": {
-        "name": "Maintenance Counter"
-      },
-      "filter_replacement_counter": {
-        "name": "Filter Replacement Counter"
-      },
-      "supply_pressure": {
-        "name": "Supply Pressure"
-      },
-      "exhaust_pressure": {
-        "name": "Exhaust Pressure"
-      },
-      "differential_pressure": {
-        "name": "Differential Pressure"
-      },
-      "motor_supply_rpm": {
-        "name": "Supply Fan RPM"
-      },
-      "motor_exhaust_rpm": {
-        "name": "Exhaust Fan RPM"
-      },
-      "motor_supply_current": {
-        "name": "Supply Fan Current"
-      },
-      "motor_exhaust_current": {
-        "name": "Exhaust Fan Current"
-      },
-      "motor_supply_voltage": {
-        "name": "Supply Fan Voltage"
-      },
-      "motor_exhaust_voltage": {
-        "name": "Exhaust Fan Voltage"
       },
       "dac_supply": {
         "name": "Supply DAC"
@@ -227,15 +98,6 @@
       },
       "dac_cooler": {
         "name": "Cooler DAC"
-      },
-      "damper_position_bypass": {
-        "name": "Bypass Damper Position"
-      },
-      "damper_position_gwc": {
-        "name": "GWC Damper Position"
-      },
-      "damper_position_mix": {
-        "name": "Mix Damper Position"
       },
       "firmware_major": {
         "name": "Firmware Major"
@@ -266,18 +128,6 @@
       "constant_flow_active": {
         "name": "Constant Flow"
       },
-      "frost_protection_active": {
-        "name": "Frost Protection"
-      },
-      "defrost_cycle_active": {
-        "name": "Defrost Cycle"
-      },
-      "summer_bypass_active": {
-        "name": "Summer Bypass"
-      },
-      "winter_heating_active": {
-        "name": "Winter Heating"
-      },
       "duct_water_heater_pump": {
         "name": "Water Heater Pump"
       },
@@ -296,32 +146,8 @@
       "contamination_sensor": {
         "name": "Contamination Sensor"
       },
-      "ppoz": {
-        "name": "Fire Alarm"
-      },
       "fire_alarm": {
         "name": "Fire Alarm"
-      },
-      "night_cooling_active": {
-        "name": "Night Cooling Active"
-      },
-      "air_quality_control_active": {
-        "name": "Air Quality Control Active"
-      },
-      "humidity_control_active": {
-        "name": "Humidity Control Active"
-      },
-      "temperature_control_active": {
-        "name": "Temperature Control Active"
-      },
-      "demand_control_active": {
-        "name": "Demand Control Active"
-      },
-      "schedule_control_active": {
-        "name": "Schedule Control Active"
-      },
-      "manual_control_active": {
-        "name": "Manual Control Active"
       },
       "on_off_panel_mode": {
         "name": "Panel Power"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -81,140 +81,11 @@
       "exhaust_flow_rate": {
         "name": "Zadany przepływ wywiewu"
       },
-      "heat_recovery_efficiency": {
-        "name": "Sprawność rekuperacji"
-      },
-      "heating_temperature": {
-        "name": "Temperatura grzania"
-      },
-      "heat_exchanger_temperature_1": {
-        "name": "Temperatura wymiennika 1"
-      },
-      "heat_exchanger_temperature_2": {
-        "name": "Temperatura wymiennika 2"
-      },
-      "heat_exchanger_temperature_3": {
-        "name": "Temperatura wymiennika 3"
-      },
-      "heat_exchanger_temperature_4": {
-        "name": "Temperatura wymiennika 4"
-      },
-      "outdoor_flow_rate": {
-        "name": "Przepływ zewnętrzny"
-      },
-      "inside_flow_rate": {
-        "name": "Przepływ wewnętrzny"
-      },
-      "gwc_flow_rate": {
-        "name": "Przepływ GWC"
-      },
-      "heat_recovery_flow_rate": {
-        "name": "Przepływ rekuperatora"
-      },
-      "bypass_flow_rate": {
-        "name": "Przepływ obejścia (bypassu)"
-      },
       "supply_air_flow": {
         "name": "Aktualny przepływ nawiewu"
       },
       "exhaust_air_flow": {
         "name": "Aktualny przepływ wywiewu"
-      },
-      "co2_level": {
-        "name": "Poziom CO2"
-      },
-      "humidity_indoor": {
-        "name": "Wilgotność wewnętrzna"
-      },
-      "humidity_outdoor": {
-        "name": "Wilgotność zewnętrzna"
-      },
-      "pm1_level": {
-        "name": "PM1.0"
-      },
-      "pm25_level": {
-        "name": "PM2.5"
-      },
-      "pm10_level": {
-        "name": "PM10"
-      },
-      "voc_level": {
-        "name": "VOC"
-      },
-      "air_quality_index": {
-        "name": "Indeks jakości powietrza"
-      },
-      "filter_lifetime_remaining": {
-        "name": "Pozostały czas pracy filtra"
-      },
-      "preheater_power": {
-        "name": "Moc wstępnego grzania"
-      },
-      "main_heater_power": {
-        "name": "Moc głównego grzania"
-      },
-      "cooler_power": {
-        "name": "Moc chłodzenia"
-      },
-      "supply_fan_power": {
-        "name": "Moc wentylatora nawiewnego"
-      },
-      "exhaust_fan_power": {
-        "name": "Moc wentylatora wywiewnego"
-      },
-      "total_power_consumption": {
-        "name": "Całkowite zużycie energii"
-      },
-      "daily_energy_consumption": {
-        "name": "Dzienne zużycie energii"
-      },
-      "annual_energy_consumption": {
-        "name": "Roczne zużycie energii"
-      },
-      "annual_energy_savings": {
-        "name": "Roczne oszczędności energii"
-      },
-      "co2_reduction": {
-        "name": "Roczna redukcja CO2"
-      },
-      "system_uptime": {
-        "name": "Czas pracy systemu"
-      },
-      "fault_counter": {
-        "name": "Licznik błędów"
-      },
-      "maintenance_counter": {
-        "name": "Licznik konserwacji"
-      },
-      "filter_replacement_counter": {
-        "name": "Licznik wymian filtra"
-      },
-      "supply_pressure": {
-        "name": "Ciśnienie nawiewu"
-      },
-      "exhaust_pressure": {
-        "name": "Ciśnienie wywiewu"
-      },
-      "differential_pressure": {
-        "name": "Ciśnienie różnicowe"
-      },
-      "motor_supply_rpm": {
-        "name": "Obroty silnika nawiewnego"
-      },
-      "motor_exhaust_rpm": {
-        "name": "Obroty silnika wywiewnego"
-      },
-      "motor_supply_current": {
-        "name": "Prąd silnika nawiewnego"
-      },
-      "motor_exhaust_current": {
-        "name": "Prąd silnika wywiewnego"
-      },
-      "motor_supply_voltage": {
-        "name": "Napięcie silnika nawiewnego"
-      },
-      "motor_exhaust_voltage": {
-        "name": "Napięcie silnika wywiewnego"
       },
       "dac_supply": {
         "name": "Sterowanie wentylatorem nawiewnym"
@@ -227,15 +98,6 @@
       },
       "dac_cooler": {
         "name": "Sterowanie chłodnicą"
-      },
-      "damper_position_bypass": {
-        "name": "Pozycja przepustnicy obejścia (bypassu)"
-      },
-      "damper_position_gwc": {
-        "name": "Pozycja przepustnicy GWC"
-      },
-      "damper_position_mix": {
-        "name": "Pozycja przepustnicy mieszającej"
       },
       "firmware_major": {
         "name": "Wersja firmware (główna)"
@@ -263,9 +125,6 @@
       "heating_cable": {
         "name": "Kabel grzejny"
       },
-      "ppoz": {
-        "name": "Alarm pożarowy"
-      },
       "fire_alarm": {
         "name": "Alarm pożarowy"
       },
@@ -287,41 +146,8 @@
       "contamination_sensor": {
         "name": "Czujnik zanieczyszczenia"
       },
-      "frost_protection_active": {
-        "name": "Ochrona przeciwmrozowa"
-      },
-      "defrost_cycle_active": {
-        "name": "Cykl odszraniania"
-      },
-      "summer_bypass_active": {
-        "name": "Letnie obejście (bypass)"
-      },
-      "winter_heating_active": {
-        "name": "Zimowe grzanie"
-      },
-      "night_cooling_active": {
-        "name": "Nocne chłodzenie"
-      },
       "constant_flow_active": {
         "name": "Stały przepływ"
-      },
-      "air_quality_control_active": {
-        "name": "Kontrola jakości powietrza"
-      },
-      "humidity_control_active": {
-        "name": "Kontrola wilgotności"
-      },
-      "temperature_control_active": {
-        "name": "Kontrola temperatury"
-      },
-      "demand_control_active": {
-        "name": "Kontrola na żądanie"
-      },
-      "schedule_control_active": {
-        "name": "Kontrola harmonogramu"
-      },
-      "manual_control_active": {
-        "name": "Kontrola manualna"
       },
       "on_off_panel_mode": {
         "name": "Zasilanie główne"


### PR DESCRIPTION
## Summary
- remove entity definitions without known modbus registers
- map firmware and expansion version sensors to existing register names
- trim device class mappings and translations to only supported entities

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/sensor.py custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/const.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json` *(fails: mypy errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689b735363688326be72b1c131b4fa07