### PR TITLE
test: verify register coverage

### DIFF
--- a/tests/test_register_coverage.py
+++ b/tests/test_register_coverage.py
@@ -1,5 +1,7 @@
+"""Validate coverage of register definitions against CSV specification."""
+
 import csv
-import pathlib
+from pathlib import Path
 
 from custom_components.thessla_green_modbus.const import COIL_REGISTERS, DISCRETE_INPUT_REGISTERS
 from custom_components.thessla_green_modbus.device_scanner import _to_snake_case
@@ -12,11 +14,17 @@ FUNCTION_MAP = {
     "04": INPUT_REGISTERS,
 }
 
+CSV_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "thessla_green_modbus"
+    / "modbus_registers.csv"
+)
+
 
 def load_csv_mappings() -> dict[str, dict[str, int]]:
-    path = pathlib.Path("modbus_registers.csv")
     result: dict[str, dict[str, int]] = {code: {} for code in FUNCTION_MAP}
-    with path.open(newline="") as csvfile:
+    with CSV_PATH.open(newline="") as csvfile:
         reader = csv.DictReader(
             row for row in csvfile if row.strip() and not row.lstrip().startswith("#")
         )
@@ -28,7 +36,7 @@ def load_csv_mappings() -> dict[str, dict[str, int]]:
     return result
 
 
-def test_all_registers_covered():
+def test_all_registers_covered() -> None:
     csv_maps = load_csv_mappings()
     missing = []
     mismatched = []


### PR DESCRIPTION
## Summary
- ensure register definitions cover every entry from `modbus_registers.csv`

## Testing
- `pre-commit run --files tests/test_register_coverage.py` (fails: mypy)
- `pytest tests/test_register_coverage.py`


------
https://chatgpt.com/codex/tasks/task_e_689b73669e308326b1bf7095948854ae