### PR TITLE
refactor: tidy translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Confirm Configuration",
-        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID {slave_id} runs firmware {firmware_version}. Registers: {register_count} ({scan_success_rate} success). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Continue with this configuration?"
+        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID {slave_id} runs firmware {firmware_version}. Registers: {register_count} ( {scan_success_rate} success). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Continue with this configuration?"
       }
     },
     "error": {
@@ -36,7 +36,7 @@
     "step": {
       "init": {
         "title": "ThesslaGreen Modbus Options",
-        "description": "Configure advanced integration options. Current settings. Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}.",
+        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}.",
         "data": {
           "scan_interval": "Scan Interval (seconds)",
           "timeout": "Connection Timeout (seconds)",
@@ -248,51 +248,6 @@
         "name": "Required Temperature"
       }
     }
-  },
-  "errors": {
-    "s_2": "I2C communication error",
-    "s_6": "FPX heater thermal protection triggered maximum times",
-    "s_7": "Calibration impossible due to low outside temperature",
-    "s_8": "Product key required",
-    "s_9": "Unit stopped from AirS panel",
-    "s_10": "Fire sensor triggered",
-    "s_13": "Unit stopped from Air+ or Air++ panel",
-    "s_14": "Water heater antifreeze protection triggered maximum times",
-    "s_15": "Water heater antifreeze protection failed",
-    "s_16": "Electric heater thermal protection activated with FPX system",
-    "s_17": "Filters not replaced (pressure switch)",
-    "s_19": "Filters not replaced (no pressure switch)",
-    "s_20": "Channel filter not replaced",
-    "s_22": "Heat exchanger antifreeze protection failed (FPX)",
-    "s_23": "Damaged temperature sensor at exchanger inlet in FPX conditions",
-    "s_24": "Damaged supply duct sensor after water heater",
-    "s_25": "Damaged outdoor temperature sensor",
-    "s_26": "Damaged outdoor and GWC glycol temperature sensors",
-    "s_29": "Temperature before exchanger too high",
-    "s_30": "Supply fan failure",
-    "s_31": "Exhaust fan failure",
-    "s_32": "No communication with TG-02 module",
-    "e_99": "AirPack product key required",
-    "e_100": "No reading from outdoor air temperature sensor (TZ1)",
-    "e_101": "No reading from supply air temperature sensor (TN1)",
-    "e_102": "No reading from exhaust air temperature sensor (TP)",
-    "e_103": "No reading from heat exchanger inlet sensor (TZ2)",
-    "e_104": "No reading from room temperature sensor (TO)",
-    "e_105": "No reading from supply air sensor after duct exchanger (TN2)",
-    "e_106": "No reading from outdoor temperature sensor for glycol GWC (TZ3)",
-    "e_138": "Supply fan CF sensor failure",
-    "e_139": "Exhaust fan CF sensor failure",
-    "e_152": "Exhaust air temperature above maximum",
-    "e_196": "Installation calibration not performed",
-    "e_197": "Installation calibration aborted",
-    "e_198": "No communication with CF2 module",
-    "e_199": "No communication with CF module",
-    "e_200": "Electric heater thermal protection triggered in unit",
-    "e_201": "Electric heater thermal protection triggered in duct",
-    "e_249": "No communication with Expansion module",
-    "e_250": "Filter replacement required (no pressure switch)",
-    "e_251": "Channel filter replacement required",
-    "e_252": "Filter replacement required (pressure switch)"
   },
   "services": {
     "set_special_mode": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}. Wykryto {register_count} rejestrów (skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}. Wykryto {register_count} rejestrów ( skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
       }
     },
     "error": {
@@ -36,7 +36,7 @@
     "step": {
       "init": {
         "title": "Opcje ThesslaGreen Modbus",
-        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu {current_scan_interval} s, Limit czasu połączenia {current_timeout} s, Liczba powtórzeń nieudanych odczytów {current_retry}, Wymuś pełną listę rejestrów {force_full_enabled}.",
+        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}.",
         "data": {
           "scan_interval": "Interwał skanowania (s)",
           "timeout": "Limit czasu połączenia (s)",
@@ -248,51 +248,6 @@
         "name": "Wymagana temperatura"
       }
     }
-  },
-  "errors": {
-    "s_2": "Błąd komunikacji I2C",
-    "s_6": "Zabezpieczenie termiczne nagrzewnicy FPX zadziałało maksymalną ilość razy w określonym czasie",
-    "s_7": "Brak możliwości kalibracji urządzenia z powodu zbyt niskiej temperatury zewnętrznej",
-    "s_8": "Sygnalizacja konieczności wprowadzenia klucza produktu",
-    "s_9": "Centrala zatrzymana z panelu AirS",
-    "s_10": "Zadziałał czujnik PPOŻ",
-    "s_13": "Centrala zatrzymana z panelu Air+ lub AirL+, Air++ lub AirMobile",
-    "s_14": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej zadziałało maksymalną ilość razy",
-    "s_15": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej nie przyniosło oczekiwanych rezultatów",
-    "s_16": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej przy aktywnym systemie FPX",
-    "s_17": "Nie wymieniono filtrów w centrali (presostat)",
-    "s_19": "Nie wymieniono filtrów w centrali (bez presostatu)",
-    "s_20": "Nie wymieniono filtra kanałowego",
-    "s_22": "Nie zadziałało zabezpieczenie przeciwzamrożeniowe wymiennika (FPX)",
-    "s_23": "Uszkodzony czujnik temperatury na wlocie do wymiennika przy warunkach wymagających systemu FPX",
-    "s_24": "Uszkodzony czujnik temperatury w kanale nawiewnym za nagrzewnicą wodną",
-    "s_25": "Uszkodzony czujnik temperatury powietrza zewnętrznego",
-    "s_26": "Uszkodzony czujnik temperatury powietrza zewnętrznego oraz czujnik GWC glikolowego",
-    "s_29": "Zbyt wysoka temperatura przed rekuperatorem",
-    "s_30": "Nie działa wentylator nawiewny",
-    "s_31": "Nie działa wentylator wywiewny",
-    "s_32": "Brak komunikacji z modułem TG-02",
-    "e_99": "Sygnalizacja konieczności wprowadzenia klucza produktu AirPack",
-    "e_100": "Brak odczytu z czujnika temperatury powietrza zewnętrznego (TZ1)",
-    "e_101": "Brak odczytu z czujnika temperatury powietrza nawiewanego (TN1)",
-    "e_102": "Brak odczytu z czujnika temperatury powietrza usuwanego (TP)",
-    "e_103": "Brak odczytu z czujnika temperatury na wlocie do wymiennika (TZ2)",
-    "e_104": "Brak odczytu z czujnika temperatury pomieszczenia (TO)",
-    "e_105": "Brak odczytu z czujnika temperatury nawiewu za wymiennikiem kanałowym (TN2)",
-    "e_106": "Brak odczytu z czujnika temperatury zewnętrznej GWC (TZ3)",
-    "e_138": "Awaria czujnika CF wentylatora nawiewnego",
-    "e_139": "Awaria czujnika CF wentylatora wywiewnego",
-    "e_152": "Temperatura powietrza usuwanego wyższa od maksymalnej",
-    "e_196": "Regulacja instalacji nie została wykonana",
-    "e_197": "Regulacja instalacji została przerwana",
-    "e_198": "Brak komunikacji z modułem CF2",
-    "e_199": "Brak komunikacji z modułem CF",
-    "e_200": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali",
-    "e_201": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w kanale",
-    "e_249": "Brak komunikacji z modułem Expansion",
-    "e_250": "Konieczność wymiany filtrów (bez presostatu)",
-    "e_251": "Konieczność wymiany filtra kanałowego",
-    "e_252": "Konieczność wymiany filtrów (z presostatem)"
   },
   "services": {
     "set_special_mode": {


### PR DESCRIPTION
## Summary
- clean up translation placeholders and grammar
- drop leftover error translations after register cleanup

## Testing
- `hass --script check_config --config tmp_config` *(fails: Component error: thessla_green_modbus - Exception importing custom_components.thessla_green_modbus)*
- `pytest tests/test_translations.py` *(fails: IndentationError in registers.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b89a17cc88326a92e765e5a3d6cf7