### PR TITLE
chore: validate register coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,11 @@ repos:
     rev: v4.5.0
     hooks:
       - id: check-merge-conflict
+  - repo: local
+    hooks:
+      - id: validate-registers
+        name: Validate Modbus register coverage
+        entry: python tools/validate_registers.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,9 @@ python -m pytest tests/ --cov=custom_components.thessla_green_modbus
 # Validate register mappings against CSV definitions
 python -m pytest tests/test_register_coverage.py -v
 
+# Verify CSV and registers.py are in sync
+python tools/validate_registers.py
+
 # Run optimization validation
 python run_optimization_tests.py
 ```

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate register addresses against CSV definition."""
+
+from __future__ import annotations
+
+import ast
+import csv
+from pathlib import Path
+from typing import Dict, Set
+
+ROOT = Path(__file__).resolve().parents[1]
+CSV_PATH = ROOT / "custom_components" / "thessla_green_modbus" / "data" / "modbus_registers.csv"
+REGISTERS_PATH = ROOT / "custom_components" / "thessla_green_modbus" / "registers.py"
+
+FUNCTION_MAP = {
+    "COIL_REGISTERS": "01",
+    "DISCRETE_INPUT_REGISTERS": "02",
+    "INPUT_REGISTERS": "04",
+    "HOLDING_REGISTERS": "03",
+}
+
+
+def parse_csv(path: Path) -> tuple[Dict[str, Dict[str, Set[int]]], Dict[str, Set[int]]]:
+    """Return grouped and total addresses from the CSV."""
+
+    groups: Dict[str, Dict[str, Set[int]]] = {}
+    totals: Dict[str, Set[int]] = {}
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            code = row["Function_Code"].strip()
+            if not code or code.startswith("#"):
+                continue
+            name = row["Register_Name"].strip()
+            addr = int(row["Address_DEC"].strip())
+            groups.setdefault(code, {}).setdefault(name, set()).add(addr)
+            totals.setdefault(code, set()).add(addr)
+    return groups, totals
+
+
+def parse_registers(path: Path) -> Dict[str, Set[int]]:
+    """Return a mapping of dictionary name to addresses from registers.py."""
+
+    tree = ast.parse(path.read_text())
+    result: Dict[str, Set[int]] = {}
+    for node in tree.body:
+        target = None
+        value = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            target = node.target
+            value = node.value
+        if isinstance(target, ast.Name) and target.id in FUNCTION_MAP:
+            name = target.id
+            values = set()
+            dict_node = value
+            if isinstance(dict_node, ast.Dict):
+                for val in dict_node.values:
+                    if isinstance(val, ast.Constant) and isinstance(val.value, int):
+                        values.add(val.value)
+            result[name] = values
+    return result
+
+
+def main() -> None:
+    csv_groups, csv_totals = parse_csv(CSV_PATH)
+    py_addrs = parse_registers(REGISTERS_PATH)
+    ok = True
+    for dict_name, func_code in FUNCTION_MAP.items():
+        py_set = py_addrs.get(dict_name, set())
+        missing: list[int] = []
+        for addr_set in csv_groups.get(func_code, {}).values():
+            if addr_set.isdisjoint(py_set):
+                missing.extend(sorted(addr_set))
+        extra = py_set - csv_totals.get(func_code, set())
+        if missing or extra:
+            ok = False
+            if missing:
+                print(f"{dict_name} missing addresses: {missing}")
+            if extra:
+                print(f"{dict_name} extra addresses: {sorted(extra)}")
+    if not ok:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to ensure register addresses match CSV definitions
- check register coverage during pre-commit
- document register validation script usage

## Testing
- `pre-commit run --files tools/validate_registers.py .pre-commit-config.yaml CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_689b904c69408326bb41ee42b5d88630