### PR TITLE
Add temperature limit and airflow coefficient registers

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -9,7 +9,114 @@ NUMBER_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "max": 26,
         "step": 0.5,
         "scale": 0.5,
-    }
+    },
+    # Temperature limit registers
+    "min_gwc_air_temperature": {
+        "unit": "°C",
+        "min": -20,
+        "max": 50,
+        "step": 0.5,
+        "scale": 0.5,
+    },
+    "max_gwc_air_temperature": {
+        "unit": "°C",
+        "min": -20,
+        "max": 50,
+        "step": 0.5,
+        "scale": 0.5,
+    },
+    "min_bypass_temperature": {
+        "unit": "°C",
+        "min": 0,
+        "max": 40,
+        "step": 0.5,
+        "scale": 0.5,
+    },
+    # Airflow coefficient registers
+    "fan_speed_1_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "fan_speed_2_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "fan_speed_3_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "hood_supply_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "hood_exhaust_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "fireplace_supply_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "airing_bathroom_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "airing_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "contamination_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "empty_house_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "airing_switch_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "open_window_coef": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "bypass_coef_1": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
+    "bypass_coef_2": {
+        "unit": "%",
+        "min": 0,
+        "max": 200,
+        "step": 1,
+    },
 }
 
 ENTITY_MAPPINGS: Dict[str, Dict[str, Dict[str, Any]]] = {

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -120,8 +120,11 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
         # Step size
         self._attr_native_step = self.entity_config.get("step", 1)
 
-        # Mode - slider for temperatures and durations, box for others
-        if "temperature" in self.register_name or "duration" in self.register_name:
+        # Mode - slider for temperatures, durations and coefficients
+        if any(
+            keyword in self.register_name
+            for keyword in ["temperature", "duration", "coef", "percentage"]
+        ):
             self._attr_mode = NumberMode.SLIDER
         else:
             self._attr_mode = NumberMode.BOX
@@ -129,19 +132,25 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
         # Icon
         if "temperature" in self.register_name:
             self._attr_icon = "mdi:thermometer"
-        elif "flow" in self.register_name or "rate" in self.register_name:
+        elif (
+            "flow" in self.register_name
+            or "rate" in self.register_name
+            or "fan_speed" in self.register_name
+        ):
             self._attr_icon = "mdi:fan"
         elif "duration" in self.register_name:
             self._attr_icon = "mdi:timer"
         elif "intensity" in self.register_name:
             self._attr_icon = "mdi:gauge"
+        elif "coef" in self.register_name or "percentage" in self.register_name:
+            self._attr_icon = "mdi:percent"
         else:
             self._attr_icon = "mdi:numeric"
 
         # Entity category for configuration parameters
         if any(
             keyword in self.register_name
-            for keyword in ["hysteresis", "correction", "max", "min", "balance"]
+            for keyword in ["hysteresis", "correction", "max", "min", "balance", "coef"]
         ):
             self._attr_entity_category = EntityCategory.CONFIG
 


### PR DESCRIPTION
## Summary
- define writable number mappings for temperature limits and airflow coefficients
- allow number entities to handle coefficient registers with sliders and icons

## Testing
- `flake8 custom_components/thessla_green_modbus/entity_mappings.py custom_components/thessla_green_modbus/number.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component'; IndentationError in tests/test_registers.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b9037f01883268c1fd1668f352811