### PR TITLE
Remove enhanced capability analysis helper

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -474,10 +474,6 @@ class ThesslaGreenDeviceScanner:
         self._client = None
         _LOGGER.debug("Disconnected from ThesslaGreen device")
 
-    def _analyze_capabilities_enhanced(self) -> DeviceCapabilities:
-        """Enhanced capability analysis for optimization tests."""
-        return self._analyze_capabilities()
-
     def _group_registers_for_batch_read(
         self, addresses: List[int], max_gap: int = 10
     ) -> List[Tuple[int, int]]:


### PR DESCRIPTION
## Summary
- drop `_analyze_capabilities_enhanced` and use `_analyze_capabilities` directly
- adjust tests to call `_analyze_capabilities`

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_optimized_integration.py tests/run_optimization_tests.py`
- `pytest` *(fails: IndentationError in tests/test_registers.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b93c92c408326b1e6e19c938accc1