### PR TITLE
refactor: use built-in dict type hints

### DIFF
--- a/custom_components/thessla_green_modbus/multipliers.py
+++ b/custom_components/thessla_green_modbus/multipliers.py
@@ -1,8 +1,6 @@
 """Value conversion factors for ThesslaGreen Modbus registers."""
 
-from typing import Dict
-
-REGISTER_MULTIPLIERS: Dict[str, float] = {
+REGISTER_MULTIPLIERS: dict[str, float] = {
     # Temperature sensors with 0.1°C resolution
     "outside_temperature": 0.1,
     "supply_temperature": 0.1,

--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -1,9 +1,7 @@
 """Register definitions for the ThesslaGreen Modbus integration."""
 
-from typing import Dict
-
 # Generated from modbus_registers.csv
-COIL_REGISTERS: Dict[str, int] = {
+COIL_REGISTERS: dict[str, int] = {
     "duct_water_heater_pump": 5,
     "bypass": 9,
     "info": 10,
@@ -14,7 +12,7 @@ COIL_REGISTERS: Dict[str, int] = {
     "hood": 15,
 }
 
-DISCRETE_INPUT_REGISTERS: Dict[str, int] = {
+DISCRETE_INPUT_REGISTERS: dict[str, int] = {
     "duct_heater_protection": 0,
     "expansion": 1,
     "dp_duct_filter_overflow": 3,
@@ -33,7 +31,7 @@ DISCRETE_INPUT_REGISTERS: Dict[str, int] = {
     "empty_house": 21,
 }
 
-INPUT_REGISTERS: Dict[str, int] = {
+INPUT_REGISTERS: dict[str, int] = {
     "version_major": 0,
     "version_minor": 1,
     "day_of_week": 2,
@@ -64,7 +62,7 @@ INPUT_REGISTERS: Dict[str, int] = {
     "water_removal_active": 298,
 }
 
-HOLDING_REGISTERS: Dict[str, int] = {
+HOLDING_REGISTERS: dict[str, int] = {
     'date_time_1': 0,
     'date_time_2': 1,
     'date_time_3': 2,


### PR DESCRIPTION
## Summary
- replace `Dict` annotations with builtin `dict` in register and multiplier definitions
- drop now-unused `typing` imports

## Testing
- `SKIP=black pre-commit run --files custom_components/thessla_green_modbus/registers.py custom_components/thessla_green_modbus/multipliers.py`
- `pytest` *(fails: IndentationError: expected an indented block after 'with' statement on line 47)*

------
https://chatgpt.com/codex/tasks/task_e_689b93ca1bf8832682dfb474829977af