### PR TITLE
Fix placeholder spacing in translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Confirm Configuration",
-        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID {slave_id} runs firmware {firmware_version}. Registers: {register_count} ( {scan_success_rate} success). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Continue with this configuration?"
+        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID {slave_id} runs firmware {firmware_version}. Registers: {register_count} ({scan_success_rate} success rate). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Continue with this configuration?"
       }
     },
     "error": {
@@ -329,7 +329,7 @@
         },
         "temperature": {
           "name": "Temperature",
-          "description": "Target temperature (°C)"
+          "description": "Target temperature (\u00b0C)"
         }
       }
     },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia {slave_id}, wersja oprogramowania {firmware_version}. Wykryto {register_count} rejestrów (skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia {slave_id} działa na oprogramowaniu w wersji {firmware_version}. Wykryto {register_count} rejestrów (skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
       }
     },
     "error": {


### PR DESCRIPTION
## Summary
- remove stray spaces in placeholder expressions
- polish long configuration description strings in English and Polish

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json`
- `pytest` *(fails: IndentationError in tests/test_registers.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b93ce8c1083268c14a4c93f7c5977