### PR TITLE
Add number entity translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -249,6 +249,57 @@
     "number": {
       "required_temperature": {
         "name": "Required Temperature"
+      },
+      "min_gwc_air_temperature": {
+        "name": "Min GWC Air Temperature"
+      },
+      "max_gwc_air_temperature": {
+        "name": "Max GWC Air Temperature"
+      },
+      "min_bypass_temperature": {
+        "name": "Min Bypass Temperature"
+      },
+      "fan_speed_1_coef": {
+        "name": "Fan Speed 1 Coefficient"
+      },
+      "fan_speed_2_coef": {
+        "name": "Fan Speed 2 Coefficient"
+      },
+      "fan_speed_3_coef": {
+        "name": "Fan Speed 3 Coefficient"
+      },
+      "hood_supply_coef": {
+        "name": "Hood Supply Coefficient"
+      },
+      "hood_exhaust_coef": {
+        "name": "Hood Exhaust Coefficient"
+      },
+      "fireplace_supply_coef": {
+        "name": "Fireplace Supply Coefficient"
+      },
+      "airing_bathroom_coef": {
+        "name": "Bathroom Airing Coefficient"
+      },
+      "airing_coef": {
+        "name": "Airing Coefficient"
+      },
+      "contamination_coef": {
+        "name": "Contamination Coefficient"
+      },
+      "empty_house_coef": {
+        "name": "Empty House Coefficient"
+      },
+      "airing_switch_coef": {
+        "name": "Airing Switch Coefficient"
+      },
+      "open_window_coef": {
+        "name": "Open Window Coefficient"
+      },
+      "bypass_coef_1": {
+        "name": "Bypass Coefficient 1"
+      },
+      "bypass_coef_2": {
+        "name": "Bypass Coefficient 2"
       }
     }
   },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -249,6 +249,57 @@
     "number": {
       "required_temperature": {
         "name": "Wymagana temperatura"
+      },
+      "min_gwc_air_temperature": {
+        "name": "Min. temperatura GWC"
+      },
+      "max_gwc_air_temperature": {
+        "name": "Maks. temperatura GWC"
+      },
+      "min_bypass_temperature": {
+        "name": "Min. temperatura bypassu"
+      },
+      "fan_speed_1_coef": {
+        "name": "Współczynnik prędkości wentylatora 1"
+      },
+      "fan_speed_2_coef": {
+        "name": "Współczynnik prędkości wentylatora 2"
+      },
+      "fan_speed_3_coef": {
+        "name": "Współczynnik prędkości wentylatora 3"
+      },
+      "hood_supply_coef": {
+        "name": "Współczynnik nawiewu okapu"
+      },
+      "hood_exhaust_coef": {
+        "name": "Współczynnik wywiewu okapu"
+      },
+      "fireplace_supply_coef": {
+        "name": "Współczynnik nawiewu kominka"
+      },
+      "airing_bathroom_coef": {
+        "name": "Współczynnik przewietrzania łazienki"
+      },
+      "airing_coef": {
+        "name": "Współczynnik przewietrzania"
+      },
+      "contamination_coef": {
+        "name": "Współczynnik zanieczyszczenia"
+      },
+      "empty_house_coef": {
+        "name": "Współczynnik trybu nieobecności"
+      },
+      "airing_switch_coef": {
+        "name": "Współczynnik przełącznika przewietrzania"
+      },
+      "open_window_coef": {
+        "name": "Współczynnik otwartego okna"
+      },
+      "bypass_coef_1": {
+        "name": "Współczynnik bypassu 1"
+      },
+      "bypass_coef_2": {
+        "name": "Współczynnik bypassu 2"
       }
     }
   },


### PR DESCRIPTION
## Summary
- add English and Polish names for all number entity mappings

## Testing
- `SKIP=validate-registers pre-commit run --files custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json`
- `pytest tests/test_translations.py` *(fails: SyntaxError in registers.py)*

------
https://chatgpt.com/codex/tasks/task_e_689ba164f2b08326ba0815e16a2c9d0d