### PR TITLE
Move future import to top of registers module

### DIFF
--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -1,9 +1,8 @@
 """Register definitions for the ThesslaGreen Modbus integration."""
 
-from typing import Dict
-
-
 from __future__ import annotations
+
+from typing import Dict
 
 
 # Generated from modbus_registers.csv


### PR DESCRIPTION
## Summary
- place `from __future__ import annotations` directly under the module docstring in `registers.py`

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/registers.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba4fed2388326a7501a4b587efcb8