### PR TITLE
chore: move docstrings above future import

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Fan platform for the ThesslaGreen Modbus integration."""
+from __future__ import annotations
 
 import logging
 from typing import Any, Dict

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Number platform for the ThesslaGreen Modbus integration."""
+from __future__ import annotations
 
 import logging
 from typing import Any, Dict, Optional

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Select platform for the ThesslaGreen Modbus integration."""
+from __future__ import annotations
 
 import logging
 from typing import Optional

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Switch platform for the ThesslaGreen Modbus integration."""
+from __future__ import annotations
 
 import logging
 from typing import Any, Dict


### PR DESCRIPTION
## Summary
- move module docstrings to top of fan, number, select, and switch platforms
- place `from __future__ import annotations` directly after module docstrings

## Testing
- `ruff check custom_components/thessla_green_modbus/fan.py custom_components/thessla_green_modbus/number.py custom_components/thessla_green_modbus/select.py custom_components/thessla_green_modbus/switch.py`
- `flake8 --ignore=E501,W503 --count custom_components/thessla_green_modbus/fan.py custom_components/thessla_green_modbus/number.py custom_components/thessla_green_modbus/select.py custom_components/thessla_green_modbus/switch.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba7a883c08326a7f2bd18f0856e51