### PR TITLE
Shorten confirm step translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Confirm Configuration",
-        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID {slave_id} runs firmware {firmware_version}. Registers: {register_count} ({scan_success_rate} success rate). Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note} Continue with this configuration?"
+        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID: {slave_id}. Firmware version: {firmware_version}. Registers found: {register_count}. Scan success rate: {scan_success_rate}. Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Continue with this configuration?"
       }
     },
     "error": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -19,7 +19,7 @@
       },
       "confirm": {
         "title": "Potwierdź konfigurację",
-        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia {slave_id} działa na oprogramowaniu w wersji {firmware_version}. Wykryto {register_count} rejestrów (skuteczność skanowania {scan_success_rate}). Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note} Czy chcesz kontynuować tę konfigurację?"
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia: {slave_id}. Wersja oprogramowania: {firmware_version}. Wykryto {register_count} rejestrów. Skuteczność skanowania: {scan_success_rate}. Dostępne funkcje ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Czy chcesz kontynuować tę konfigurację?"
       }
     },
     "error": {


### PR DESCRIPTION
## Summary
- split confirm step description into concise sentences for English and Polish translations

## Testing
- `python - <<'PY'
import json,sys
from pathlib import Path

def get_keys(obj, prefix=''):
    keys=set()
    if isinstance(obj, dict):
        for k,v in obj.items():
            new_prefix = f"{prefix}.{k}" if prefix else k
            keys.update(get_keys(v,new_prefix))
    else:
        keys.add(prefix)
    return keys

paths=['custom_components/thessla_green_modbus/translations/en.json','custom_components/thessla_green_modbus/translations/pl.json']
objs=[json.load(open(p,encoding='utf-8')) for p in paths]
keys=[get_keys(o) for o in objs]
missing_en = sorted(keys[0]-keys[1])
missing_pl = sorted(keys[1]-keys[0])
print('EN missing vs PL:', missing_en)
print('PL missing vs EN:', missing_pl)
PY`
- `pytest` *(fails: AttributeError in homeassistant.util)*

------
https://chatgpt.com/codex/tasks/task_e_689ba704a3548326a4b7648a2638d824