### PR TITLE
Add register generation script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,15 @@ python3 custom_components/thessla_green_modbus/cleanup_old_entities.py \
 - 💡 [Propozycje funkcji](https://github.com/thesslagreen/thessla-green-modbus-ha/discussions)
 - 🤝 [Contributing](CONTRIBUTING.md)
 
+### Regenerating registers.py
+If you modify `custom_components/thessla_green_modbus/data/modbus_registers.csv`, rebuild the generated module:
+
+```bash
+python tools/generate_registers.py
+```
+
+Commit the updated `custom_components/thessla_green_modbus/registers.py` along with the CSV changes.
+
 ### Changelog
 Zobacz [CHANGELOG.md](CHANGELOG.md) dla pełnej historii zmian.
 


### PR DESCRIPTION
## Summary
- add script to build registers.py from CSV
- document how to regenerate registers.py when CSV changes

## Testing
- `python tools/generate_registers.py`
- `pytest` *(fails: AttributeError in homeassistant.util)*

------
https://chatgpt.com/codex/tasks/task_e_689ba6fa22c88326bec53407101ef0b3