### PR TITLE
docs: document register generation

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -229,6 +229,15 @@ logger:
 - 💡 [Feature requests](https://github.com/thesslagreen/thessla-green-modbus-ha/discussions)
 - 🤝 [Contributing](CONTRIBUTING.md)
 
+### Regenerating registers.py
+If you modify `custom_components/thessla_green_modbus/data/modbus_registers.csv`, rebuild the generated module:
+
+```bash
+python tools/generate_registers.py
+```
+
+Commit the updated `custom_components/thessla_green_modbus/registers.py` along with the CSV changes.
+
 ### Changelog
 See [CHANGELOG.md](CHANGELOG.md) for full history.
 


### PR DESCRIPTION
## Summary
- document how to regenerate registers from CSV in the English README

## Testing
- `python tools/validate_registers.py`
- `python - <<'PY' ...` (address count check)
- `pytest -ra` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_689ba977243c832680a1d138fda984a8