### PR TITLE
Sanitize host in unique IDs and migrate existing entries

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -203,34 +203,51 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     """Migrate old entry."""
     _LOGGER.debug("Migrating ThesslaGreen Modbus from version %s", config_entry.version)
 
-    if config_entry.version != 1:
-        return True
-
     new_data = {**config_entry.data}
     new_options = {**config_entry.options}
 
-    # Migrate "unit" to CONF_SLAVE_ID if needed
-    if "unit" in new_data and CONF_SLAVE_ID not in new_data:
-        new_data[CONF_SLAVE_ID] = new_data["unit"]
-        _LOGGER.info("Migrated 'unit' to '%s'", CONF_SLAVE_ID)
+    if config_entry.version == 1:
+        # Migrate "unit" to CONF_SLAVE_ID if needed
+        if "unit" in new_data and CONF_SLAVE_ID not in new_data:
+            new_data[CONF_SLAVE_ID] = new_data["unit"]
+            _LOGGER.info("Migrated 'unit' to '%s'", CONF_SLAVE_ID)
 
-    # Ensure port is present; older versions relied on legacy default
-    if CONF_PORT not in new_data:
-        new_data[CONF_PORT] = LEGACY_DEFAULT_PORT
-        _LOGGER.info("Added '%s' with legacy default %s", CONF_PORT, LEGACY_DEFAULT_PORT)
+        # Ensure port is present; older versions relied on legacy default
+        if CONF_PORT not in new_data:
+            new_data[CONF_PORT] = LEGACY_DEFAULT_PORT
+            _LOGGER.info("Added '%s' with legacy default %s", CONF_PORT, LEGACY_DEFAULT_PORT)
 
-    # Add new fields with defaults if missing
-    if CONF_SCAN_INTERVAL not in new_options:
-        new_options[CONF_SCAN_INTERVAL] = DEFAULT_SCAN_INTERVAL
-    if CONF_TIMEOUT not in new_options:
-        new_options[CONF_TIMEOUT] = DEFAULT_TIMEOUT
-    if CONF_RETRY not in new_options:
-        new_options[CONF_RETRY] = DEFAULT_RETRY
-    if CONF_FORCE_FULL_REGISTER_LIST not in new_options:
-        new_options[CONF_FORCE_FULL_REGISTER_LIST] = False
+        # Add new fields with defaults if missing
+        if CONF_SCAN_INTERVAL not in new_options:
+            new_options[CONF_SCAN_INTERVAL] = DEFAULT_SCAN_INTERVAL
+        if CONF_TIMEOUT not in new_options:
+            new_options[CONF_TIMEOUT] = DEFAULT_TIMEOUT
+        if CONF_RETRY not in new_options:
+            new_options[CONF_RETRY] = DEFAULT_RETRY
+        if CONF_FORCE_FULL_REGISTER_LIST not in new_options:
+            new_options[CONF_FORCE_FULL_REGISTER_LIST] = False
 
-    config_entry.version = 2
-    hass.config_entries.async_update_entry(config_entry, data=new_data, options=new_options)
+        config_entry.version = 2
+
+    # Build new unique ID replacing ':' in host with '-' to avoid separator conflicts
+    host = new_data.get(CONF_HOST)
+    port = new_data.get(CONF_PORT, LEGACY_DEFAULT_PORT)
+    # Determine slave ID using same logic as setup
+    if CONF_SLAVE_ID in new_data:
+        slave_id = new_data[CONF_SLAVE_ID]
+    elif "slave_id" in new_data:
+        slave_id = new_data["slave_id"]
+    elif "unit" in new_data:
+        slave_id = new_data["unit"]
+    else:
+        slave_id = DEFAULT_SLAVE_ID
+
+    unique_host = host.replace(":", "-") if host else host
+    new_unique_id = f"{unique_host}:{port}:{slave_id}"
+
+    hass.config_entries.async_update_entry(
+        config_entry, data=new_data, options=new_options, unique_id=new_unique_id
+    )
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -106,8 +106,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._scan_result = info.get("scan_result", {})
 
                 # Set unique ID based on host, port and slave_id
+                # Replace colons in host (IPv6) with hyphens to avoid separator conflicts
+                unique_host = user_input[CONF_HOST].replace(":", "-")
                 await self.async_set_unique_id(
-                    f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}:{user_input[CONF_SLAVE_ID]}"
+                    f"{unique_host}:{user_input[CONF_PORT]}:{user_input[CONF_SLAVE_ID]}"
                 )
                 self._abort_if_unique_id_configured()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -79,6 +79,36 @@ async def test_form_user_success():
     }
 
 
+async def test_unique_id_sanitized():
+    """Ensure unique ID replaces colons in host with hyphens."""
+    flow = ConfigFlow()
+    flow.hass = None
+
+    validation_result = {
+        "title": "ThesslaGreen fe80::1",
+        "device_info": {},
+        "scan_result": {},
+    }
+
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow.validate_input",
+        return_value=validation_result,
+    ), patch(
+        "custom_components.thessla_green_modbus.config_flow.ConfigFlow._abort_if_unique_id_configured",
+    ), patch(
+        "custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"
+    ) as mock_set_unique_id:
+        await flow.async_step_user(
+            {
+                CONF_HOST: "fe80::1",
+                CONF_PORT: 502,
+                "slave_id": 10,
+                CONF_NAME: "My Device",
+            }
+        )
+
+    mock_set_unique_id.assert_called_once_with("fe80--1:502:10")
+
 async def test_form_user_cannot_connect():
     """Test we handle cannot connect error."""
     flow = ConfigFlow()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 
 from custom_components.thessla_green_modbus import async_migrate_entry
+from custom_components.thessla_green_modbus.const import CONF_SLAVE_ID
 
 
 @pytest.mark.asyncio
@@ -44,3 +45,28 @@ async def test_migrate_entry_preserves_existing_port():
     new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
     assert new_data[CONF_PORT] == 1234
     assert config_entry.version == 2
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_updates_unique_id():
+    """Test migration replaces colons in host for unique_id."""
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    config_entry = MagicMock(spec=ConfigEntry)
+    config_entry.version = 2
+    config_entry.data = {
+        CONF_HOST: "fe80::1",
+        CONF_PORT: 1234,
+        CONF_SLAVE_ID: 5,
+    }
+    config_entry.options = {}
+    config_entry.unique_id = "fe80::1:1234:5"
+
+    result = await async_migrate_entry(hass, config_entry)
+
+    assert result is True
+    assert (
+        hass.config_entries.async_update_entry.call_args.kwargs["unique_id"]
+        == "fe80--1:1234:5"
+    )


### PR DESCRIPTION
## Summary
- Sanitize host part of unique IDs in config flow by replacing colons with hyphens
- Migrate existing config entries to new unique ID format and keep options/data
- Add regression tests for unique ID sanitization and migration

## Testing
- `pytest`
- `pytest tests/test_config_flow.py tests/test_migration.py`


------
https://chatgpt.com/codex/tasks/task_e_689bac416670832681861cc0e1daa3c8