### PR TITLE
Remove unused path in register coverage test

### DIFF
--- a/tests/test_register_coverage.py
+++ b/tests/test_register_coverage.py
@@ -24,7 +24,6 @@ CSV_PATH = (
 
 
 def load_csv_mappings() -> dict[str, dict[str, int]]:
-    path = pathlib.Path("custom_components/thessla_green_modbus/data/modbus_registers.csv")
     result: dict[str, dict[str, int]] = {code: {} for code in FUNCTION_MAP}
     with CSV_PATH.open(newline="") as csvfile:
         reader = csv.DictReader(


### PR DESCRIPTION
## Summary
- remove unused `path` variable from `load_csv_mappings`
- ensure coverage test relies on `CSV_PATH`

## Testing
- `pytest tests/test_register_coverage.py -q` *(fails: Missing registers: ['03:date_time', '03:lock_date', '03:air_flow_rate_temporary', '03:supply_air_temperature_temporary', '03:pres_check_day', '03:pres_check_time', '03:device_name']; mismatched addresses: [])*

------
https://chatgpt.com/codex/tasks/task_e_689bac64846c8326be2ad59a56623a6e