### PR TITLE
Remove unused heat recovery attribute

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -221,10 +221,6 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
         if "exhaust_flow_rate" in self.coordinator.data:
             attrs["exhaust_airflow"] = self.coordinator.data["exhaust_flow_rate"]
 
-        # System status
-        if "heat_recovery_efficiency" in self.coordinator.data:
-            attrs["heat_recovery_efficiency"] = self.coordinator.data["heat_recovery_efficiency"]
-
         # Special systems
         attrs["bypass_active"] = self.coordinator.data.get("bypass", False)
         attrs["gwc_active"] = self.coordinator.data.get("gwc", False)


### PR DESCRIPTION
## Summary
- remove unused heat recovery efficiency attribute from climate entity

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/climate.py` *(fails: Found 56 errors in 5 files)*
- `pytest` *(fails: module 'homeassistant' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_689bac469518832686cfd7eb44a2666d