### PR TITLE
Warn on duplicate register addresses

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -122,6 +122,11 @@ class ThesslaGreenDeviceScanner:
                     except (TypeError, ValueError):
                         continue
                     if code in register_map:
+                        if addr in register_map[code]:
+                            _LOGGER.warning(
+                                "Duplicate register address %s for function code %s: %s", addr, code, name
+                            )
+                            continue
                         register_map[code][addr] = name
         except FileNotFoundError:
             _LOGGER.error("Register definition file not found: %s", csv_path)


### PR DESCRIPTION
## Summary
- warn when register CSV contains duplicate addresses
- test duplicate detection during register load

## Testing
- `pytest -q` *(fails: AttributeError: module 'homeassistant' has no attribute 'util')*
- `pytest tests/test_device_scanner.py::test_load_registers_duplicate_warning -q`


------
https://chatgpt.com/codex/tasks/task_e_689bac58801483268d7ac9ebc9c01b3a