### PR TITLE
Remove unused SPECIAL_MODES constant

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -80,14 +80,6 @@ SPECIAL_FUNCTION_MAP = {
     "winter": 1024,
 }
 
-# Complete mapping including additional internal modes
-SPECIAL_MODES = {
-    "normal": 0,
-    **SPECIAL_FUNCTION_MAP,
-    "defrost": 2048,
-    "frost_protection": 4096,
-}
-
 # Unit mappings
 REGISTER_UNITS = {
     # Temperature registers - 0.1°C resolution


### PR DESCRIPTION
## Summary
- drop unused SPECIAL_MODES constant from modbus integration constants

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/const.py` *(fails: mypy errors in unrelated files)*
- `pytest` *(fails: AttributeError in homeassistant.util)*

------
https://chatgpt.com/codex/tasks/task_e_689bac515d208326ab7115656cff9628