### PR TITLE
refactor: remove unused Dict import from registers

### DIFF
--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Dict
-
-
 # Generated from modbus_registers.csv
 
 COIL_REGISTERS: dict[str, int] = {

--- a/tools/generate_registers.py
+++ b/tools/generate_registers.py
@@ -11,8 +11,6 @@ CSV_PATH = ROOT / "custom_components" / "thessla_green_modbus" / "data" / "modbu
 OUTPUT_PATH = ROOT / "custom_components" / "thessla_green_modbus" / "registers.py"
 
 
-
-
 def to_snake_case(name: str) -> str:
     """Convert a register name from the CSV to ``snake_case``."""
     replacements = {"flowrate": "flow_rate"}
@@ -90,7 +88,6 @@ def write_file(
     with OUTPUT_PATH.open("w", newline="\n") as f:
         f.write('"""Register definitions for the ThesslaGreen Modbus integration."""\n\n')
         f.write("from __future__ import annotations\n\n")
-        f.write("from typing import Dict\n\n\n")
         f.write("# Generated from modbus_registers.csv\n\n")
         sections = [
             ("COIL_REGISTERS", coils),


### PR DESCRIPTION
## Summary
- remove unused Dict import from generated registers file
- update register generator to avoid reintroducing unused import

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers.py tools/generate_registers.py` (fails: mypy errors in unrelated files)
- `python -m pytest tests/ -q` (fails: AttributeError: module 'homeassistant' has no attribute 'util')
- `python run_optimization_tests.py` (fails: file not found)


------
https://chatgpt.com/codex/tasks/task_e_689bac3ba57c83268a08b897039e25e3