### PR TITLE
Rename fire alarm key and use translation keys in tests

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -80,7 +80,7 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
-    "ppoz": {
+    "fire_alarm": {
         "translation_key": "fire_alarm",
         "icon": "mdi:fire",
         "device_class": BinarySensorDeviceClass.SAFETY,

--- a/custom_components/thessla_green_modbus/data/modbus_registers.csv
+++ b/custom_components/thessla_green_modbus/data/modbus_registers.csv
@@ -23,7 +23,7 @@ Function_Code,Address_HEX,Address_DEC,Access,Register_Name,Description,Min,Max,D
 02,0x000C,12,R/-,fan_speed_2,Stan wejścia przełącznika AirS w pozycji "2 bieg",0,1,,,"0 - OFF; 1 - ON",,
 02,0x000D,13,R/-,fan_speed_1,Stan wejścia przełącznika AirS w pozycji "1 bieg",0,1,,,"0 - OFF; 1 - ON",,
 02,0x000E,14,R/-,fireplace,Stan wejścia włącznika funkcji KOMINEK,0,1,,,"0 - OFF; 1 - ON",,
-02,0x000F,15,R/-,ppoz,Stan wejścia sygnału alarmu pożarowego (P.POZ.),0,1,,,"0 - OFF; 1 - ON",,
+02,0x000F,15,R/-,fire_alarm,Stan wejścia sygnału alarmu pożarowego (P.POZ.),0,1,,,"0 - OFF; 1 - ON",,
 02,0x0012,18,R/-,dp_ahu_filter_overflow,Stan wejścia presostatu filtrów w rekuperatorze (DP1),0,1,,,"0 - OFF; 1 - ON",,
 02,0x0013,19,R/-,ahu_filter_protection,Stan wejścia zabezpieczenia termicznego nagrzewnicy systemu przeciwzamrożeniowego FPX,0,1,,,"0 - OFF; 1 - ON",,
 02,0x0015,21,R/-,empty_house,Stan wejścia sygnału załączenia funkcji PUSTY DOM,0,1,,,"0 - OFF; 1 - ON",,

--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Dict
-
-
 # Generated from modbus_registers.csv
 
 COIL_REGISTERS: dict[str, int] = {
@@ -31,7 +28,7 @@ DISCRETE_INPUT_REGISTERS: dict[str, int] = {
     "fan_speed_2": 12,
     "fan_speed_1": 13,
     "fireplace": 14,
-    "ppoz": 15,
+    "fire_alarm": 15,
     "dp_ahu_filter_overflow": 18,
     "ahu_filter_protection": 19,
     "empty_house": 21,


### PR DESCRIPTION
## Summary
- rename fire alarm register/key from `ppoz` to `fire_alarm`
- ensure translations for fire alarm are referenced
- test utilities load translation keys rather than dictionary keys

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/registers.py custom_components/thessla_green_modbus/data/modbus_registers.csv tests/test_translations.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json` *(fails: Item "float" of "float | int | None" has no attribute "isoformat"... )*
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/registers.py custom_components/thessla_green_modbus/data/modbus_registers.csv tests/test_translations.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json`
- `pytest tests/test_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_689bac2be0cc83269750ee08d1e3ef54