### PR TITLE
Prune unsupported multipliers

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, SPECIAL_FUNCTION_MAP
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
+from .registers import HOLDING_REGISTERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -283,12 +284,12 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
 
         _LOGGER.debug("Setting target temperature to %s°C", temperature)
 
-        # Set comfort temperature
-        success = await self.coordinator.async_write_register(
-            "comfort_temperature", temperature, refresh=False
-        )
+        success = True
+        if "comfort_temperature" in HOLDING_REGISTERS:
+            success = await self.coordinator.async_write_register(
+                "comfort_temperature", temperature, refresh=False
+            )
 
-        # Also set required temperature for KOMFORT mode
         if success:
             success = await self.coordinator.async_write_register(
                 "required_temperature", temperature, refresh=False

--- a/custom_components/thessla_green_modbus/multipliers.py
+++ b/custom_components/thessla_green_modbus/multipliers.py
@@ -10,43 +10,14 @@ REGISTER_MULTIPLIERS: dict[str, float] = {
     "gwc_temperature": 0.1,
     "ambient_temperature": 0.1,
     "heating_temperature": 0.1,
-    "heat_exchanger_temperature_1": 0.1,
-    "heat_exchanger_temperature_2": 0.1,
-    "heat_exchanger_temperature_3": 0.1,
-    "heat_exchanger_temperature_4": 0.1,
     # Temperature settings with 0.5°C resolution
     "required_temperature": 0.5,
-    "comfort_temperature": 0.5,
-    "economy_temperature": 0.5,
-    "night_temperature": 0.5,
-    "away_temperature": 0.5,
-    "frost_protection_temperature": 0.5,
-    "max_supply_temperature": 0.5,
-    "min_supply_temperature": 0.5,
-    "heating_curve_offset": 0.5,
-    "bypass_temperature_threshold": 0.5,
-    "bypass_hysteresis": 0.5,
-    "gwc_temperature_threshold": 0.5,
-    "gwc_hysteresis": 0.5,
-    "preheating_temperature": 0.5,
-    "defrost_temperature": 0.5,
-    "night_cooling_temperature": 0.5,
     "supply_air_temperature_manual": 0.5,
+    "supply_air_temperature_temporary_1": 0.5,
     "supply_air_temperature_temporary_2": 0.5,
-    # Legacy register shares the same scaling as required_temperature
-    "required_temperature_legacy": 0.5,
-    "supply_air_temperature_temporary": 0.5,
-    # Legacy alias
-    "required_temp": 0.5,
     # Voltage/Current conversions
     "dac_supply": 0.00244,  # 0-4095 -> 0-10V
     "dac_exhaust": 0.00244,
     "dac_heater": 0.00244,
     "dac_cooler": 0.00244,
-    "motor_supply_current": 0.001,  # mA to A
-    "motor_exhaust_current": 0.001,
-    "motor_supply_voltage": 0.001,  # mV to V
-    "motor_exhaust_voltage": 0.001,
-    # Other multipliers
-    "heating_curve_slope": 0.1,
 }

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -145,23 +145,17 @@ async def test_set_temperature_scaling():
     coordinator.client = DummyClient()
     coordinator._ensure_connection = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
-    coordinator.available_registers["holding_registers"].update(
-        {"comfort_temperature", "required_temperature"}
-    )
+    coordinator.available_registers["holding_registers"].add("required_temperature")
     coordinator.capabilities.basic_control = True
 
     climate = ThesslaGreenClimate(coordinator)
 
     await climate.async_set_temperature(**{const.ATTR_TEMPERATURE: 21.5})
 
-    addr_comfort = HOLDING_REGISTERS["comfort_temperature"]
     addr_required = HOLDING_REGISTERS["required_temperature"]
-    expected = int(round(21.5 / REGISTER_MULTIPLIERS["comfort_temperature"]))
+    expected = int(round(21.5 / REGISTER_MULTIPLIERS["required_temperature"]))
 
-    assert coordinator.client.writes == [
-        (addr_comfort, expected, coordinator.slave_id),
-        (addr_required, expected, coordinator.slave_id),
-    ]
+    assert coordinator.client.writes == [(addr_required, expected, coordinator.slave_id)]
 
 
 def test_target_temperature_none_when_unavailable():
@@ -175,7 +169,7 @@ def test_target_temperature_none_when_unavailable():
 
     assert climate.target_temperature is None
 
-    coordinator.data["comfort_temperature"] = 20.0
+    coordinator.data["required_temperature"] = 20.0
     assert climate.target_temperature == 20.0
 
 

--- a/tests/test_services_scaling.py
+++ b/tests/test_services_scaling.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS
 import custom_components.thessla_green_modbus.services as services
+from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS
 from custom_components.thessla_green_modbus.services import _scale_for_register
 
 
@@ -37,134 +37,6 @@ class Services:
 
 
 @pytest.mark.asyncio
-async def test_temperature_curve_service_scaling(monkeypatch):
-    """Ensure set_temperature_curve writes scaled values to Modbus."""
-
-    hass = SimpleNamespace()
-    hass.services = Services()
-    coordinator = DummyCoordinator()
-
-    monkeypatch.setattr(
-        services, "_get_coordinator_from_entity_id", lambda h, e: coordinator
-    )
-    monkeypatch.setattr(
-        services, "async_extract_entity_ids", lambda h, call: call.data["entity_id"]
-    )
-
-    await services.async_setup_services(hass)
-    handler = hass.services.handlers["set_temperature_curve"]
-
-    call = SimpleNamespace(
-        data={
-            "entity_id": ["climate.device"],
-            "slope": 2.5,
-            "offset": 1.0,
-            "max_supply_temp": 45.0,
-            "min_supply_temp": 20.0,
-        }
-    )
-
-    await handler(call)
-
-    writes = coordinator.writes
-    expected_slope = _scale_for_register("heating_curve_slope", 2.5)
-    expected_offset = _scale_for_register("heating_curve_offset", 1.0)
-    expected_max = _scale_for_register("max_supply_temperature", 45.0)
-    expected_min = _scale_for_register("min_supply_temperature", 20.0)
-
-    assert writes[0] == (HOLDING_REGISTERS["heating_curve_slope"], expected_slope, 1)
-    assert writes[1] == (HOLDING_REGISTERS["heating_curve_offset"], expected_offset, 1)
-    assert writes[2] == (HOLDING_REGISTERS["max_supply_temperature"], expected_max, 1)
-    assert writes[3] == (HOLDING_REGISTERS["min_supply_temperature"], expected_min, 1)
-
-
-@pytest.mark.asyncio
-async def test_bypass_parameters_service_scaling(monkeypatch):
-    """Ensure set_bypass_parameters writes scaled values."""
-
-    hass = SimpleNamespace()
-    hass.services = Services()
-    coordinator = DummyCoordinator()
-
-    monkeypatch.setattr(
-        services, "_get_coordinator_from_entity_id", lambda h, e: coordinator
-    )
-    monkeypatch.setattr(
-        services, "async_extract_entity_ids", lambda h, call: call.data["entity_id"]
-    )
-
-    await services.async_setup_services(hass)
-    handler = hass.services.handlers["set_bypass_parameters"]
-
-    call = SimpleNamespace(
-        data={
-            "entity_id": ["climate.device"],
-            "mode": "auto",
-            "temperature_threshold": 20.5,
-            "hysteresis": 2.5,
-        }
-    )
-
-    await handler(call)
-
-    writes = coordinator.writes
-    expected_mode = _scale_for_register("bypass_mode", 0)
-    expected_temp = _scale_for_register("bypass_temperature_threshold", 20.5)
-    expected_hyst = _scale_for_register("bypass_hysteresis", 2.5)
-
-    assert writes[0] == (HOLDING_REGISTERS["bypass_mode"], expected_mode, 1)
-    assert writes[1] == (
-        HOLDING_REGISTERS["bypass_temperature_threshold"],
-        expected_temp,
-        1,
-    )
-    assert writes[2] == (HOLDING_REGISTERS["bypass_hysteresis"], expected_hyst, 1)
-
-
-@pytest.mark.asyncio
-async def test_gwc_parameters_service_scaling(monkeypatch):
-    """Ensure set_gwc_parameters writes scaled values."""
-
-    hass = SimpleNamespace()
-    hass.services = Services()
-    coordinator = DummyCoordinator()
-
-    monkeypatch.setattr(
-        services, "_get_coordinator_from_entity_id", lambda h, e: coordinator
-    )
-    monkeypatch.setattr(
-        services, "async_extract_entity_ids", lambda h, call: call.data["entity_id"]
-    )
-
-    await services.async_setup_services(hass)
-    handler = hass.services.handlers["set_gwc_parameters"]
-
-    call = SimpleNamespace(
-        data={
-            "entity_id": ["climate.device"],
-            "mode": "auto",
-            "temperature_threshold": 5.0,
-            "hysteresis": 1.5,
-        }
-    )
-
-    await handler(call)
-
-    writes = coordinator.writes
-    expected_mode = _scale_for_register("gwc_mode", 1)
-    expected_temp = _scale_for_register("gwc_temperature_threshold", 5.0)
-    expected_hyst = _scale_for_register("gwc_hysteresis", 1.5)
-
-    assert writes[0] == (HOLDING_REGISTERS["gwc_mode"], expected_mode, 1)
-    assert writes[1] == (
-        HOLDING_REGISTERS["gwc_temperature_threshold"],
-        expected_temp,
-        1,
-    )
-    assert writes[2] == (HOLDING_REGISTERS["gwc_hysteresis"], expected_hyst, 1)
-
-
-@pytest.mark.asyncio
 async def test_airflow_schedule_service_scaling(monkeypatch):
     """Ensure set_airflow_schedule scales values before writing."""
 
@@ -172,9 +44,7 @@ async def test_airflow_schedule_service_scaling(monkeypatch):
     hass.services = Services()
     coordinator = DummyCoordinator()
 
-    monkeypatch.setattr(
-        services, "_get_coordinator_from_entity_id", lambda h, e: coordinator
-    )
+    monkeypatch.setattr(services, "_get_coordinator_from_entity_id", lambda h, e: coordinator)
     monkeypatch.setattr(
         services, "async_extract_entity_ids", lambda h, call: call.data["entity_id"]
     )
@@ -222,4 +92,3 @@ async def test_airflow_schedule_service_scaling(monkeypatch):
         expected_temp,
         1,
     )
-


### PR DESCRIPTION
## Summary
- remove multipliers for registers that have no Modbus definitions
- guard comfort temperature writes to only run when register exists
- update tests to align with supported register set

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/multipliers.py custom_components/thessla_green_modbus/climate.py tests/test_climate.py tests/test_services_scaling.py`
- `pytest -q` *(fails: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689bace389108326b477e0584b13c742