### PR TITLE
Replace comfort preset with eco preset in example configuration

### DIFF
--- a/example_configuration.yaml
+++ b/example_configuration.yaml
@@ -124,7 +124,7 @@ automation:
         target:
           entity_id: climate.thessla_green_climate
         data:
-          preset_mode: "comfort"
+          preset_mode: "eco"
 
   # Away mode activation
   - alias: "ThesslaGreen: Away mode"
@@ -187,7 +187,7 @@ script:
         target:
           entity_id: climate.thessla_green_climate
         data:
-          preset_mode: "comfort"
+          preset_mode: "eco"
       - service: number.set_value
         target:
           entity_id: number.thessla_air_flow_rate_manual


### PR DESCRIPTION
## Summary
- use eco preset instead of comfort in example configuration

## Testing
- `pre-commit run --files example_configuration.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689bb155da888326a2232b360b98e840