### PR TITLE
refactor: extract snake case utility

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -6,7 +6,6 @@ import asyncio
 import csv
 import inspect
 import logging
-import re
 from dataclasses import asdict, dataclass, field
 from importlib.resources import files
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
@@ -19,23 +18,9 @@ if TYPE_CHECKING:  # pragma: no cover
 from .const import COIL_REGISTERS, DEFAULT_SLAVE_ID, DISCRETE_INPUT_REGISTERS, SENSOR_UNAVAILABLE
 from .modbus_helpers import _call_modbus
 from .registers import HOLDING_REGISTERS, INPUT_REGISTERS
+from .utils import _to_snake_case
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _to_snake_case(name: str) -> str:
-    """Convert register names to snake_case."""
-    replacements = {"flowrate": "flow_rate"}
-    for old, new in replacements.items():
-        name = name.replace(old, new)
-    name = re.sub(r"[\s\-/]", "_", name)
-    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
-    name = re.sub(r"(?<=\D)(\d)", r"_\1", name)
-    name = re.sub(r"__+", "_", name)
-    name = name.lower()
-    token_map = {"temp": "temperature"}
-    tokens = [token_map.get(token, token) for token in name.split("_")]
-    return "_".join(tokens)
 
 
 @dataclass
@@ -124,7 +109,10 @@ class ThesslaGreenDeviceScanner:
                     if code in register_map:
                         if addr in register_map[code]:
                             _LOGGER.warning(
-                                "Duplicate register address %s for function code %s: %s", addr, code, name
+                                "Duplicate register address %s for function code %s: %s",
+                                addr,
+                                code,
+                                name,
                             )
                             continue
                         register_map[code][addr] = name

--- a/custom_components/thessla_green_modbus/utils.py
+++ b/custom_components/thessla_green_modbus/utils.py
@@ -1,0 +1,22 @@
+"""Utility helpers for ThesslaGreen Modbus integration."""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["_to_snake_case"]
+
+
+def _to_snake_case(name: str) -> str:
+    """Convert register names to snake_case."""
+    replacements = {"flowrate": "flow_rate"}
+    for old, new in replacements.items():
+        name = name.replace(old, new)
+    name = re.sub(r"[\s\-/]", "_", name)
+    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+    name = re.sub(r"(?<=\D)(\d)", r"_\1", name)
+    name = re.sub(r"__+", "_", name)
+    name = name.lower()
+    token_map = {"temp": "temperature"}
+    tokens = [token_map.get(token, token) for token in name.split("_")]
+    return "_".join(tokens)

--- a/tests/test_register_coverage.py
+++ b/tests/test_register_coverage.py
@@ -4,8 +4,8 @@ import csv
 from pathlib import Path
 
 from custom_components.thessla_green_modbus.const import COIL_REGISTERS, DISCRETE_INPUT_REGISTERS
-from custom_components.thessla_green_modbus.device_scanner import _to_snake_case
 from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS, INPUT_REGISTERS
+from custom_components.thessla_green_modbus.utils import _to_snake_case
 
 FUNCTION_MAP = {
     "01": COIL_REGISTERS,

--- a/tests/test_register_csv_presence.py
+++ b/tests/test_register_csv_presence.py
@@ -4,8 +4,8 @@ import csv
 from pathlib import Path
 
 from custom_components.thessla_green_modbus.const import COIL_REGISTERS, DISCRETE_INPUT_REGISTERS
-from custom_components.thessla_green_modbus.device_scanner import _to_snake_case
 from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS, INPUT_REGISTERS
+from custom_components.thessla_green_modbus.utils import _to_snake_case
 
 CSV_PATH = (
     Path(__file__).resolve().parent.parent

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -1,21 +1,8 @@
 import csv
 import importlib.util
 import pathlib
-import re
 
-
-def to_snake_case(name: str) -> str:
-    replacements = {"flowrate": "flow_rate"}
-    for old, new in replacements.items():
-        name = name.replace(old, new)
-    name = re.sub(r"[\s\-/]", "_", name)
-    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
-    name = re.sub(r"(?<=\D)(\d)", r"_\1", name)
-    name = re.sub(r"__+", "_", name)
-    name = name.lower()
-    token_map = {"temp": "temperature"}
-    tokens = [token_map.get(token, token) for token in name.split("_")]
-    return "_".join(tokens)
+from custom_components.thessla_green_modbus.utils import _to_snake_case
 
 
 def _build_register_map(rows: list[tuple[str, int]]) -> dict[str, int]:
@@ -45,7 +32,7 @@ def load_csv_registers() -> tuple[dict[str, int], dict[str, int], dict[str, int]
             code = row["Function_Code"]
             if not code or code.startswith("#"):
                 continue
-            name = to_snake_case(row["Register_Name"])
+            name = _to_snake_case(row["Register_Name"])
             addr = int(row["Address_DEC"])
             if code == "01":
                 coil_rows.append((name, addr))


### PR DESCRIPTION
## Summary
- move `_to_snake_case` into new `utils` module and export via `__all__`
- update device scanner and tests to use shared helper

## Testing
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/utils.py custom_components/thessla_green_modbus/device_scanner.py tests/test_registers.py tests/test_register_coverage.py tests/test_register_csv_presence.py pyproject.toml`
- `pytest tests/test_registers.py tests/test_register_coverage.py tests/test_register_csv_presence.py tests/test_device_scanner.py` *(fails: Missing registers: ['03:date_time', '03:lock_date', '03:air_flow_rate_temporary', '03:supply_air_temperature_temporary', '03:pres_check_day', '03:pres_check_time', '03:device_name']; Missing registers: ['date_time', 'date_time', ...])*

------
https://chatgpt.com/codex/tasks/task_e_689bb52a6344832681fa3510626d4568