### PR TITLE
Remove duplicate exp_version translation

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -128,9 +128,6 @@
       "version_patch": {
         "name": "Firmware Patch"
       },
-      "exp_version": {
-        "name": "Expansion Version"
-      },
       "day_of_week": {
         "name": "Day of Week"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -128,9 +128,6 @@
       "version_patch": {
         "name": "Wersja firmware (poprawka)"
       },
-      "exp_version": {
-        "name": "Wersja modułu Expansion"
-      },
       "day_of_week": {
         "name": "Dzień tygodnia"
       },


### PR DESCRIPTION
## Summary
- remove duplicate `exp_version` entries in English and Polish translations

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/en.json`
- `python -m json.tool custom_components/thessla_green_modbus/translations/pl.json`


------
https://chatgpt.com/codex/tasks/task_e_689bba11da5483269479573a7aeebda1