### PR TITLE
Add IPv6 redaction for diagnostics

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,23 @@
+from custom_components.thessla_green_modbus.diagnostics import _redact_sensitive_data
+
+
+def test_redact_ipv4_and_ipv6():
+    data = {
+        "connection": {"host": "192.168.0.17"},
+        "recent_errors": [{"message": "Error contacting 192.168.0.17 and 2001:db8::1"}],
+    }
+
+    redacted = _redact_sensitive_data(data)
+
+    assert redacted["connection"]["host"] == "192.xxx.xxx.17"
+    message = redacted["recent_errors"][0]["message"]
+    assert "192.xxx.xxx.17" in message
+    assert "2001:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:0001" in message
+
+
+def test_redact_ipv6_connection():
+    data = {"connection": {"host": "2001:db8::7334"}}
+
+    redacted = _redact_sensitive_data(data)
+
+    assert redacted["connection"]["host"] == ("2001:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:7334")


### PR DESCRIPTION
## Summary
- anonymize IPv6 addresses in diagnostics alongside IPv4
- add tests covering IPv4 and IPv6 address redaction

## Testing
- `python -m black custom_components/thessla_green_modbus/diagnostics.py tests/test_diagnostics.py`
- `flake8 custom_components/thessla_green_modbus/diagnostics.py tests/test_diagnostics.py`
- `pytest tests/test_diagnostics.py`
- `pytest` *(fails: AttributeError: 'module' object at homeassistant.util has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_689bba1c9728832682d7479058b83a3f