### PR TITLE
Remove duplicate ppoz translation

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -250,9 +250,6 @@
       "water_removal_active": {
         "name": "Aktywne odprowadzanie wody"
       },
-      "ppoz": {
-        "name": "Alarm pożarowy"
-      },
       "constant_flow_active": {
         "name": "Stały przepływ"
       },


### PR DESCRIPTION
## Summary
- remove duplicate `ppoz` translation entry from Polish locale

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/pl.json`
- `pre-commit run --files custom_components/thessla_green_modbus/translations/pl.json`
- `pytest` *(fails: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689bba0fb17483268515b5241fb1dd41