### PR TITLE
Add airflow limit and bypass register entities

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -117,6 +117,39 @@ NUMBER_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "max": 200,
         "step": 1,
     },
+    # Airflow limit registers
+    "max_supply_air_flow_rate": {
+        "unit": "m³/h",
+        "min": 0,
+        "max": 500,
+        "step": 5,
+    },
+    "max_exhaust_air_flow_rate": {
+        "unit": "m³/h",
+        "min": 0,
+        "max": 500,
+        "step": 5,
+    },
+    "nominal_supply_air_flow": {
+        "unit": "m³/h",
+        "min": 0,
+        "max": 500,
+        "step": 5,
+    },
+    "nominal_exhaust_air_flow": {
+        "unit": "m³/h",
+        "min": 0,
+        "max": 500,
+        "step": 5,
+    },
+    # Bypass settings
+    "bypass_off": {
+        "unit": "°C",
+        "min": 0,
+        "max": 40,
+        "step": 0.5,
+        "scale": 0.5,
+    },
 }
 
 ENTITY_MAPPINGS: Dict[str, Dict[str, Dict[str, Any]]] = {

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -6,7 +6,12 @@ from typing import Any, Dict, Optional
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfTime
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfTemperature,
+    UnitOfTime,
+    UnitOfVolumeFlowRate,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -26,6 +31,7 @@ UNIT_MAPPINGS = {
     "%": PERCENTAGE,
     "min": UnitOfTime.MINUTES,
     "h": UnitOfTime.HOURS,
+    "m³/h": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
 }
 
 

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -169,6 +169,42 @@ SENSOR_DEFINITIONS = {
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "holding_registers",
     },
+    "max_supply_air_flow_rate": {
+        "translation_key": "max_supply_air_flow_rate",
+        "icon": "mdi:fan",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+        "register_type": "holding_registers",
+    },
+    "max_exhaust_air_flow_rate": {
+        "translation_key": "max_exhaust_air_flow_rate",
+        "icon": "mdi:fan-clock",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+        "register_type": "holding_registers",
+    },
+    "nominal_supply_air_flow": {
+        "translation_key": "nominal_supply_air_flow",
+        "icon": "mdi:fan",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+        "register_type": "holding_registers",
+    },
+    "nominal_exhaust_air_flow": {
+        "translation_key": "nominal_exhaust_air_flow",
+        "icon": "mdi:fan-clock",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+        "register_type": "holding_registers",
+    },
+    "bypass_off": {
+        "translation_key": "bypass_off",
+        "icon": "mdi:thermometer-off",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "holding_registers",
+    },
     # PWM control values
     "dac_supply": {
         "translation_key": "dac_supply",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -92,6 +92,21 @@
       "exhaust_air_flow": {
         "name": "Current Exhaust Airflow"
       },
+      "max_supply_air_flow_rate": {
+        "name": "Max Supply Airflow"
+      },
+      "max_exhaust_air_flow_rate": {
+        "name": "Max Exhaust Airflow"
+      },
+      "nominal_supply_air_flow": {
+        "name": "Nominal Supply Airflow"
+      },
+      "nominal_exhaust_air_flow": {
+        "name": "Nominal Exhaust Airflow"
+      },
+      "bypass_off": {
+        "name": "Bypass Off Temperature"
+      },
       "dac_supply": {
         "name": "Supply DAC"
       },
@@ -407,6 +422,21 @@
       },
       "bypass_coef_2": {
         "name": "Bypass Coefficient 2"
+      },
+      "max_supply_air_flow_rate": {
+        "name": "Max Supply Airflow"
+      },
+      "max_exhaust_air_flow_rate": {
+        "name": "Max Exhaust Airflow"
+      },
+      "nominal_supply_air_flow": {
+        "name": "Nominal Supply Airflow"
+      },
+      "nominal_exhaust_air_flow": {
+        "name": "Nominal Exhaust Airflow"
+      },
+      "bypass_off": {
+        "name": "Bypass Off Temperature"
       }
     }
   },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -92,6 +92,21 @@
       "exhaust_air_flow": {
         "name": "Aktualny przepływ wywiewu"
       },
+      "max_supply_air_flow_rate": {
+        "name": "Maksymalny przepływ nawiewu"
+      },
+      "max_exhaust_air_flow_rate": {
+        "name": "Maksymalny przepływ wywiewu"
+      },
+      "nominal_supply_air_flow": {
+        "name": "Nominalny przepływ nawiewu"
+      },
+      "nominal_exhaust_air_flow": {
+        "name": "Nominalny przepływ wywiewu"
+      },
+      "bypass_off": {
+        "name": "Temperatura wyłączenia bypassu"
+      },
       "dac_supply": {
         "name": "Sterowanie wentylatorem nawiewnym"
       },
@@ -407,6 +422,21 @@
       },
       "bypass_coef_2": {
         "name": "Współczynnik bypassu 2"
+      },
+      "max_supply_air_flow_rate": {
+        "name": "Maksymalny przepływ nawiewu"
+      },
+      "max_exhaust_air_flow_rate": {
+        "name": "Maksymalny przepływ wywiewu"
+      },
+      "nominal_supply_air_flow": {
+        "name": "Nominalny przepływ nawiewu"
+      },
+      "nominal_exhaust_air_flow": {
+        "name": "Nominalny przepływ wywiewu"
+      },
+      "bypass_off": {
+        "name": "Temperatura wyłączenia bypassu"
       }
     }
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,8 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     device_registry = types.ModuleType("homeassistant.helpers.device_registry")
     service_helper = types.ModuleType("homeassistant.helpers.service")
     entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    script_helper = types.ModuleType("homeassistant.helpers.script")
+    script_helper._schedule_stop_scripts_after_shutdown = lambda *args, **kwargs: None
     exceptions = types.ModuleType("homeassistant.exceptions")
     const = types.ModuleType("homeassistant.const")
     data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
@@ -158,6 +160,7 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     helpers_pkg.selector = selector
     helpers_pkg.service = service_helper
     helpers_pkg.entity_registry = entity_registry
+    helpers_pkg.script = script_helper
 
     # Minimal pymodbus stubs
     class ModbusTcpClient:  # type: ignore[override]
@@ -221,6 +224,7 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["homeassistant.helpers.device_registry"] = device_registry
     sys.modules["homeassistant.helpers.service"] = service_helper
     sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
+    sys.modules["homeassistant.helpers.script"] = script_helper
     sys.modules["homeassistant.exceptions"] = exceptions
     sys.modules["homeassistant.const"] = const
     sys.modules["homeassistant.util"] = util

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -128,3 +128,18 @@ def test_translation_structures_match():
                 compare_dict(en[key], pl[key], f"{path}{key}.")
 
     compare_dict(EN, PL)
+
+
+def test_new_translation_keys_present():
+    """Ensure translations exist for newly added registers."""
+    new_keys = [
+        "max_supply_air_flow_rate",
+        "max_exhaust_air_flow_rate",
+        "nominal_supply_air_flow",
+        "nominal_exhaust_air_flow",
+        "bypass_off",
+    ]
+    for trans in (EN, PL):
+        for key in new_keys:
+            assert key in trans["entity"]["sensor"]
+            assert key in trans["entity"]["number"]


### PR DESCRIPTION
## Summary
- support airflow limit and bypass registers via new number mappings
- expose airflow limit and bypass registers as sensors
- translate new registers and add unit tests

## Testing
- `pytest tests/test_number.py tests/test_sensor_platform.py tests/test_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_689bbe0c5fa483269f757490769bdd70