### PR TITLE
Remove unused number scaling

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -8,7 +8,6 @@ NUMBER_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "min": 16,
         "max": 26,
         "step": 0.5,
-        "scale": 0.5,
     },
     # Temperature limit registers
     "min_gwc_air_temperature": {
@@ -16,21 +15,18 @@ NUMBER_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "min": -20,
         "max": 50,
         "step": 0.5,
-        "scale": 0.5,
     },
     "max_gwc_air_temperature": {
         "unit": "°C",
         "min": -20,
         "max": 50,
         "step": 0.5,
-        "scale": 0.5,
     },
     "min_bypass_temperature": {
         "unit": "°C",
         "min": 0,
         "max": 40,
         "step": 0.5,
-        "scale": 0.5,
     },
     # Airflow coefficient registers
     "fan_speed_1_coef": {

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -207,10 +207,6 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
             if raw_value is not None:
                 attributes["raw_value"] = raw_value
 
-        # Add scale information if applicable
-        if "scale" in self.entity_config:
-            attributes["scale_factor"] = self.entity_config["scale"]
-
         # Add valid range
         attributes["valid_range"] = {
             "min": self._attr_native_min_value,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -132,6 +132,7 @@ def test_number_creation_and_state(mock_coordinator):
     entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
     number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
     assert number.native_value == 20
+    assert "scale_factor" not in number.extra_state_attributes
 
     mock_coordinator.data["required_temperature"] = 21.5
     assert number.native_value == 21.5


### PR DESCRIPTION
## Summary
- drop unused `scale` settings for number entities
- remove scale attribute logic and add test ensuring absence

## Testing
- `pytest tests/test_number.py -q` *(fails: module 'homeassistant.helpers' has no attribute 'script')*
- `pytest -q` *(fails: module 'homeassistant' has no attribute 'util')*

------
https://chatgpt.com/codex/tasks/task_e_689bc03080988326b1156f5cbbdfffd6