### PR TITLE
Clean up unused translation keys

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -119,9 +119,6 @@
       "dac_cooler": {
         "name": "Cooler DAC"
       },
-      "exp_version": {
-        "name": "Expansion Version"
-      },
       "firmware_major": {
         "name": "Firmware Major"
       },
@@ -133,15 +130,6 @@
       },
       "expansion_version": {
         "name": "Expansion Version"
-      },
-      "version_major": {
-        "name": "Firmware Major"
-      },
-      "version_minor": {
-        "name": "Firmware Minor"
-      },
-      "version_patch": {
-        "name": "Firmware Patch"
       },
       "day_of_week": {
         "name": "Day of Week"
@@ -258,9 +246,6 @@
       },
       "water_removal_active": {
         "name": "Water Removal Active"
-      },
-      "ppoz": {
-        "name": "Fire Alarm"
       },
       "fire_alarm": {
         "name": "Fire Alarm"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -119,9 +119,6 @@
       "dac_cooler": {
         "name": "Sterowanie chłodnicą"
       },
-      "exp_version": {
-        "name": "Wersja modułu Expansion"
-      },
       "firmware_major": {
         "name": "Wersja firmware (główna)"
       },
@@ -133,15 +130,6 @@
       },
       "expansion_version": {
         "name": "Wersja modułu Expansion"
-      },
-      "version_major": {
-        "name": "Wersja firmware (główna)"
-      },
-      "version_minor": {
-        "name": "Wersja firmware (podrzędna)"
-      },
-      "version_patch": {
-        "name": "Wersja firmware (poprawka)"
       },
       "day_of_week": {
         "name": "Dzień tygodnia"
@@ -198,9 +186,6 @@
       },
       "heating_cable": {
         "name": "Kabel grzejny"
-      },
-      "ppoz": {
-        "name": "Alarm pożarowy"
       },
       "fire_alarm": {
         "name": "Alarm pożarowy"


### PR DESCRIPTION
## Summary
- remove obsolete translation entries no longer used
- enforce test to catch extra translation keys

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json tests/test_translations.py` *(mypy, bandit skipped)*
- `pytest tests/test_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_689c34bbaa508326a6117fceea8a0921