### PR TITLE
docs: correct ThesslaGreen services branding

### DIFF
--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -1,6 +1,6 @@
 # Complete services for ThesslaGreen Modbus Integration
 # Compatibility: Home Assistant 2025.* + pymodbus 3.5.*+
-# All models: thessla green AirPack Home series 4
+# All models: ThesslaGreen AirPack Home series 4
 
 set_special_mode:
   name: Set Special Mode


### PR DESCRIPTION
## Summary
- fix ThesslaGreen naming in services file comments

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/services.yaml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689c34a998588326bd144bc50994d22b