### PR TITLE
Expand Min/Maks abbreviations in Polish translations

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -358,13 +358,13 @@
         "name": "Wymagana temperatura"
       },
       "min_gwc_air_temperature": {
-        "name": "Min. temperatura GWC"
+        "name": "Minimalna temperatura GWC"
       },
       "max_gwc_air_temperature": {
-        "name": "Maks. temperatura GWC"
+        "name": "Maksymalna temperatura GWC"
       },
       "min_bypass_temperature": {
-        "name": "Min. temperatura bypassu"
+        "name": "Minimalna temperatura bypassu"
       },
       "fan_speed_1_coef": {
         "name": "Współczynnik prędkości wentylatora 1"
@@ -598,11 +598,11 @@
           "description": "Przesunięcie krzywej grzewczej"
         },
         "max_supply_temp": {
-          "name": "Maks. temperatura nawiewu",
+          "name": "Maksymalna temperatura nawiewu",
           "description": "Maksymalna temperatura nawiewu"
         },
         "min_supply_temp": {
-          "name": "Min. temperatura nawiewu",
+          "name": "Minimalna temperatura nawiewu",
           "description": "Minimalna temperatura nawiewu"
         }
       }


### PR DESCRIPTION
## Summary
- use full "Minimalna" and "Maksymalna" wording instead of abbreviations in Polish locale

## Testing
- `pytest tests/test_translations.py`

------
https://chatgpt.com/codex/tasks/task_e_689c38028f108326be8313a62dfa5824