### PR TITLE
Handle blank register names in scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -102,7 +102,10 @@ class ThesslaGreenDeviceScanner:
                     code = row.get("Function_Code")
                     if not code or code.startswith("#"):
                         continue
-                    name = _to_snake_case(row.get("Register_Name", ""))
+                    name_raw = row.get("Register_Name")
+                    if not isinstance(name_raw, str) or not name_raw.strip():
+                        continue
+                    name = _to_snake_case(name_raw)
                     try:
                         addr = int(row.get("Address_DEC", 0))
                     except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- skip CSV register rows with empty names before converting to snake case

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` (fails: mypy reported existing type errors)
- `pytest` (fails: 33 failed, 71 passed, 9 errors)


------
https://chatgpt.com/codex/tasks/task_e_689c3828f1d88326841c13891b5d788a