### PR TITLE
Add pre-commit check for register generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,14 @@ repos:
       - id: check-merge-conflict
   - repo: local
     hooks:
+      - id: generate-registers
+        name: Ensure registers.py is up to date
+        entry: >
+          bash -c 'python tools/generate_registers.py &&
+                   git diff --exit-code custom_components/thessla_green_modbus/registers.py'
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: validate-registers
         name: Validate Modbus register coverage
         entry: python tools/validate_registers.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,16 @@ custom_components/thessla_green_modbus/
     └── pl.json
 ```
 
+### Regenerating register definitions
+
+Whenever `custom_components/thessla_green_modbus/data/modbus_registers.csv` is modified, regenerate `custom_components/thessla_green_modbus/registers.py`:
+
+```bash
+python tools/generate_registers.py
+```
+
+Commit the updated CSV and Python files together.
+
 ## Testing
 
 ### Running Tests


### PR DESCRIPTION
## Summary
- ensure registers.py is regenerated from the CSV during pre-commit
- document how to regenerate registers.py after editing the CSV

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_689c3e95ddf883268e4d5848ae6fcca1