### PR TITLE
Avoid redundant scanner close in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -76,8 +76,6 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
     except (OSError, asyncio.TimeoutError) as exc:
         _LOGGER.exception("Unexpected error during device validation: %s", exc)
         raise CannotConnect from exc
-    finally:
-        await scanner.close()
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -103,14 +103,19 @@ async def test_unique_id_sanitized():
         "scan_result": {},
     }
 
-    with patch(
-        "custom_components.thessla_green_modbus.config_flow.validate_input",
-        return_value=validation_result,
-    ), patch(
-        "custom_components.thessla_green_modbus.config_flow.ConfigFlow._abort_if_unique_id_configured",
-    ), patch(
-        "custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"
-    ) as mock_set_unique_id:
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            return_value=validation_result,
+        ),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
+            "_abort_if_unique_id_configured",
+        ),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"
+        ) as mock_set_unique_id,
+    ):
         await flow.async_step_user(
             {
                 CONF_HOST: "fe80::1",
@@ -121,6 +126,7 @@ async def test_unique_id_sanitized():
         )
 
     mock_set_unique_id.assert_called_once_with("fe80--1:502:10")
+
 
 async def test_form_user_cannot_connect():
     """Test we handle cannot connect error."""
@@ -301,7 +307,6 @@ async def test_validate_input_success():
         }
         mock_scanner_cls.return_value = scanner_instance
         result = await validate_input(hass, data)
-        scanner_instance.close.assert_awaited_once()
 
     assert result["title"] == "Test"
     assert "device_info" in result


### PR DESCRIPTION
## Summary
- Remove explicit `scanner.close()` in config flow `validate_input`
- Update config flow test to match scanner's self-closing behavior

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py`
- `pre-commit run --files tests/test_config_flow.py` (skipping `mypy` and `bandit`)
- `pytest tests/test_config_flow.py::test_validate_input_success`


------
https://chatgpt.com/codex/tasks/task_e_689c3eae7c5883269773fc63ecb105bc