### PR TITLE
Align service register names with register definitions

### DIFF
--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -89,23 +89,14 @@ set_bypass_parameters:
       selector:
         select:
           options: !include options/bypass_modes.json
-    temperature_threshold:
-      name: Temperature Threshold
-      description: Activation temperature °C.
+    min_outdoor_temperature:
+      name: Minimum Outdoor Temperature
+      description: Minimum outdoor temperature for bypass activation °C.
       required: false
       selector:
         number:
-          min: 18.0
-          max: 30.0
-          step: 0.5
-    hysteresis:
-      name: Hysteresis
-      description: Temperature hysteresis °C.
-      required: false
-      selector: &hysteresis_selector
-        number:
-          min: 1.0
-          max: 5.0
+          min: 10.0
+          max: 40.0
           step: 0.5
 
 set_gwc_parameters:
@@ -120,20 +111,24 @@ set_gwc_parameters:
       selector:
         select:
           options: !include options/gwc_modes.json
-    temperature_threshold:
-      name: Temperature Threshold
-      description: Activation temperature °C.
+    min_air_temperature:
+      name: Minimum Air Temperature
+      description: Lower outdoor temperature threshold °C.
       required: false
       selector:
         number:
-          min: -5.0
-          max: 15.0
+          min: 0.0
+          max: 20.0
           step: 0.5
-    hysteresis:
-      name: Hysteresis
-      description: Temperature hysteresis °C.
+    max_air_temperature:
+      name: Maximum Air Temperature
+      description: Upper outdoor temperature threshold °C.
       required: false
-      selector: *hysteresis_selector
+      selector:
+        number:
+          min: 30.0
+          max: 80.0
+          step: 0.5
 
 set_air_quality_thresholds:
   name: Set Air Quality Thresholds

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -514,13 +514,9 @@
             }
           }
         },
-        "temperature_threshold": {
-          "name": "Temperature Threshold",
-          "description": "Temperature threshold for automatic control"
-        },
-        "hysteresis": {
-          "name": "Hysteresis",
-          "description": "Temperature hysteresis value"
+        "min_outdoor_temperature": {
+          "name": "Minimum Outdoor Temperature",
+          "description": "Minimum outdoor temperature to enable bypass"
         }
       }
     },
@@ -541,13 +537,13 @@
             }
           }
         },
-        "temperature_threshold": {
-          "name": "Temperature Threshold",
-          "description": "Temperature threshold for automatic control"
+        "min_air_temperature": {
+          "name": "Minimum Air Temperature",
+          "description": "Lower outdoor temperature threshold"
         },
-        "hysteresis": {
-          "name": "Hysteresis",
-          "description": "Temperature hysteresis value"
+        "max_air_temperature": {
+          "name": "Maximum Air Temperature",
+          "description": "Upper outdoor temperature threshold"
         }
       }
     },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -514,13 +514,9 @@
             }
           }
         },
-        "temperature_threshold": {
-          "name": "Próg temperatury",
-          "description": "Próg temperatury dla automatycznej kontroli"
-        },
-        "hysteresis": {
-          "name": "Histereza",
-          "description": "Wartość histerezy temperatury"
+        "min_outdoor_temperature": {
+          "name": "Minimalna temperatura zewnętrzna",
+          "description": "Minimalna temperatura zewnętrzna włączająca bypass"
         }
       }
     },
@@ -541,13 +537,13 @@
             }
           }
         },
-        "temperature_threshold": {
-          "name": "Próg temperatury",
-          "description": "Próg temperatury dla automatycznej kontroli"
+        "min_air_temperature": {
+          "name": "Minimalna temperatura powietrza",
+          "description": "Dolny próg temperatury powietrza zewnętrznego"
         },
-        "hysteresis": {
-          "name": "Histereza",
-          "description": "Wartość histerezy temperatury"
+        "max_air_temperature": {
+          "name": "Maksymalna temperatura powietrza",
+          "description": "Górny próg temperatury powietrza zewnętrznego"
         }
       }
     },


### PR DESCRIPTION
## Summary
- fix bypass and GWC services to use correct register names
- document new service parameters and translations

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/services.py custom_components/thessla_green_modbus/services.yaml custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json` (failed: mypy type errors in unrelated files)
- `pytest` (failed: missing registers and other errors)


------
https://chatgpt.com/codex/tasks/task_e_689c3e7d6e3883269142a9ffe1541933