### PR TITLE
Namespace hood registers

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -61,8 +61,8 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "coil_registers",
     },
-    "hood": {
-        "translation_key": "hood",
+    "hood_output": {
+        "translation_key": "hood_output",
         "icon": "mdi:stove",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "coil_registers",

--- a/custom_components/thessla_green_modbus/data/modbus_registers.csv
+++ b/custom_components/thessla_green_modbus/data/modbus_registers.csv
@@ -8,13 +8,13 @@ Function_Code,Address_HEX,Address_DEC,Access,Register_Name,Description,Min,Max,D
 01,0x000C,12,R/-,heating_cable,Stan wyjścia przekaźnika zasilania kabla grzejnego,0,1,,,"0 - OFF; 1 - ON",,
 01,0x000D,13,R/-,work_permit,Stan wyjścia przekaźnika potwierdzenia pracy (Expansion),0,1,,,"0 - OFF; 1 - ON",,
 01,0x000E,14,R/-,gwc,Stan wyjścia przekaźnika GWC,0,1,,,"0 - OFF; 1 - ON",,
-01,0x000F,15,R/-,hood,Stan wyjścia zasilającego przepustnicę okapu,0,1,,,"0 - OFF; 1 - ON",,
+01,0x000F,15,R/-,hood_output,Stan wyjścia zasilającego przepustnicę okapu,0,1,,,"0 - OFF; 1 - ON",,
 
 # 02 - READ DISCRETE INPUTS
 02,0x0000,0,R/-,duct_heater_protection,Stan wejścia zabezpieczenia termicznego elektrycznej nagrzewnicy kanałowej,0,1,,,"0 - OFF; 1 - ON",,
 02,0x0001,1,R/-,expansion,Komunikacja z modułem Expansion,0,1,,,"0 - brak; 1 - jest",,
 02,0x0003,3,R/-,dp_duct_filter_overflow,Stan wejścia presostatu filtra kanałowego,0,1,,,"0 - OFF; 1 - ON",,
-02,0x0004,4,R/-,hood,Stan wejścia włącznika funkcji OKAP,0,1,,,"0 - OFF; 1 - ON",,
+02,0x0004,4,R/-,hood_switch,Stan wejścia włącznika funkcji OKAP,0,1,,,"0 - OFF; 1 - ON",,
 02,0x0005,5,R/-,contamination_sensor,Stan wejścia dwustanowego czujnika jakości powietrza,0,1,,,"0 - OFF; 1 - ON",,
 02,0x0006,6,R/-,airing_sensor,Stan wejścia dwustanowego czujnika wilgotności,0,1,,,"0 - OFF; 1 - ON",,
 02,0x0007,7,R/-,airing_switch,Stan wejścia włącznika funkcji WIETRZENIE,0,1,,,"0 - OFF; 1 - ON",,

--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -12,14 +12,14 @@ COIL_REGISTERS: dict[str, int] = {
     "heating_cable": 12,
     "work_permit": 13,
     "gwc": 14,
-    "hood": 15,
+    "hood_output": 15,
 }
 
 DISCRETE_INPUT_REGISTERS: dict[str, int] = {
     "duct_heater_protection": 0,
     "expansion": 1,
     "dp_duct_filter_overflow": 3,
-    "hood": 4,
+    "hood_switch": 4,
     "contamination_sensor": 5,
     "airing_sensor": 6,
     "airing_switch": 7,

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -187,8 +187,8 @@
       "work_permit": {
         "name": "Work Permit"
       },
-      "hood": {
-        "name": "Hood"
+      "hood_output": {
+        "name": "Hood Output"
       },
       "expansion": {
         "name": "Expansion Module"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -190,8 +190,8 @@
       "work_permit": {
         "name": "Potwierdzenie pracy (Expansion)"
       },
-      "hood": {
-        "name": "Okap"
+      "hood_output": {
+        "name": "Wyjście okapu"
       },
       "contamination_sensor": {
         "name": "Czujnik zanieczyszczenia"


### PR DESCRIPTION
## Summary
- rename hood coils and discrete inputs to hood_output and hood_switch
- point binary sensor at hood_output and update translations
- sync Modbus register CSV with new names

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers.py custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/data/modbus_registers.csv custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json` *(failed: mypy errors in unrelated modules)*
- `pytest` *(failed: multiple missing attribute and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c40a643448326832f625edbbbb154