### PR TITLE
chore: tidy test imports and fix scanner test name

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 try:
     import homeassistant.util  # ensure util submodule is loaded for plugins
     import homeassistant.util.dt  # noqa: F401
-    import homeassistant.util.logging  # noqa: F401
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.exceptions import ConfigEntryNotReady
@@ -252,10 +249,9 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["pymodbus.exceptions"] = pymodbus_exceptions
     sys.modules["pymodbus.pdu"] = pymodbus_pdu
 
-DOMAIN = "thessla_green_modbus"
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-# Ensure util.logging is importable for pytest plugin
-import homeassistant.util.logging  # type: ignore
+DOMAIN = "thessla_green_modbus"
 
 
 class CoordinatorMock(MagicMock):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,8 +1,10 @@
 """Tests for ThesslaGreenBinarySensor entity."""
+
 import sys
 import types
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Minimal Home Assistant stubs
@@ -47,12 +49,12 @@ sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 # Actual tests
 # ---------------------------------------------------------------------------
 
-from custom_components.thessla_green_modbus.binary_sensor import (
+from custom_components.thessla_green_modbus.binary_sensor import (  # noqa: E402
     BINARY_SENSOR_DEFINITIONS,
     ThesslaGreenBinarySensor,
     async_setup_entry,
 )
-from custom_components.thessla_green_modbus.const import DOMAIN
+from custom_components.thessla_green_modbus.const import DOMAIN  # noqa: E402
 
 
 def test_binary_sensor_creation_and_state(mock_coordinator):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -100,15 +100,16 @@ sys.modules["homeassistant.helpers.device_registry"] = device_registry
 # Actual imports after stubbing
 # ---------------------------------------------------------------------------
 
-from custom_components.thessla_green_modbus.climate import (
+from custom_components.thessla_green_modbus.climate import (  # noqa: E402
     HVAC_MODE_MAP,
     HVAC_MODE_REVERSE_MAP,
     ThesslaGreenClimate,
 )
-from custom_components.thessla_green_modbus.const import DOMAIN
-from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
-from custom_components.thessla_green_modbus.multipliers import REGISTER_MULTIPLIERS
-from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS
+from custom_components.thessla_green_modbus.coordinator import (  # noqa: E402
+    ThesslaGreenModbusCoordinator,
+)
+from custom_components.thessla_green_modbus.multipliers import REGISTER_MULTIPLIERS  # noqa: E402
+from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS  # noqa: E402
 
 
 class DummyClient:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -134,7 +134,9 @@ for name, module in modules.items():
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # ✅ FIXED: Import correct coordinator class name
-from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+from custom_components.thessla_green_modbus.coordinator import (  # noqa: E402
+    ThesslaGreenModbusCoordinator,
+)
 
 
 @pytest.fixture

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -1,20 +1,17 @@
 """Test device scanner for ThesslaGreen Modbus integration."""
 
 import logging
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+import pytest
+
 from custom_components.thessla_green_modbus.const import (
-    SENSOR_UNAVAILABLE,
     COIL_REGISTERS,
     DISCRETE_INPUT_REGISTERS,
+    SENSOR_UNAVAILABLE,
 )
-from custom_components.thessla_green_modbus.registers import (
-    HOLDING_REGISTERS,
-    INPUT_REGISTERS,
-)
-
+from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS, INPUT_REGISTERS
 
 pytestmark = pytest.mark.asyncio
 
@@ -28,7 +25,7 @@ async def test_device_scanner_initialization():
     assert scanner.slave_id == 10
 
 
-async def test_scan_device_success():
+async def test_scan_device_success_dynamic():
     """Test successful device scan with dynamic register scanning."""
     scanner = ThesslaGreenDeviceScanner("192.168.1.1", 502, 10)
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,9 +1,11 @@
 """Tests for ThesslaGreenFan entity."""
+
+import asyncio
 import sys
 import types
-import asyncio
-import pytest
 from unittest.mock import AsyncMock
+
+import pytest
 
 from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 
@@ -61,7 +63,7 @@ helpers_uc.CoordinatorEntity = CoordinatorEntity
 # Actual tests
 # ---------------------------------------------------------------------------
 
-from custom_components.thessla_green_modbus.fan import ThesslaGreenFan
+from custom_components.thessla_green_modbus.fan import ThesslaGreenFan  # noqa: E402
 
 
 def test_fan_creation_and_state(mock_coordinator):
@@ -81,9 +83,7 @@ def test_fan_creation_and_state(mock_coordinator):
 def test_fan_turn_on_modbus_failure(mock_coordinator):
     """Ensure connection errors during turn on are raised."""
     fan = ThesslaGreenFan(mock_coordinator)
-    mock_coordinator.async_write_register = AsyncMock(
-        side_effect=ConnectionException("fail")
-    )
+    mock_coordinator.async_write_register = AsyncMock(side_effect=ConnectionException("fail"))
     with pytest.raises(ConnectionException):
         asyncio.run(fan.async_turn_on(percentage=40))
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -64,9 +64,7 @@ class AddEntitiesCallback:  # pragma: no cover - simple stub
 entity_platform.AddEntitiesCallback = AddEntitiesCallback
 sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 
-helpers = sys.modules.setdefault(
-    "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
-)
+helpers = sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
 if not hasattr(helpers, "__path__"):
     helpers.__path__ = []  # mark as package
 entity_helper = types.ModuleType("homeassistant.helpers.entity")
@@ -136,12 +134,12 @@ helpers_uc.CoordinatorEntity = CoordinatorEntity
 # Actual tests
 # ---------------------------------------------------------------------------
 
-from custom_components.thessla_green_modbus.number import (
+from custom_components.thessla_green_modbus.const import DOMAIN  # noqa: E402
+from custom_components.thessla_green_modbus.number import (  # noqa: E402
     ENTITY_MAPPINGS,
     ThesslaGreenNumber,
     async_setup_entry,
 )
-from custom_components.thessla_green_modbus.const import DOMAIN
 
 
 def test_number_creation_and_state(mock_coordinator):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,8 +1,8 @@
 """Tests for ThesslaGreenSelect entity."""
+
+import asyncio
 import sys
 import types
-import asyncio
-import pytest
 
 # ---------------------------------------------------------------------------
 # Minimal Home Assistant stubs
@@ -34,7 +34,7 @@ sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 # Actual tests
 # ---------------------------------------------------------------------------
 
-from custom_components.thessla_green_modbus.select import (
+from custom_components.thessla_green_modbus.select import (  # noqa: E402
     SELECT_DEFINITIONS,
     ThesslaGreenSelect,
 )

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -1,8 +1,10 @@
 """Tests for ThesslaGreen sensor platform setup."""
+
 import sys
 import types
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Minimal Home Assistant stubs
@@ -59,11 +61,11 @@ sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 # Actual tests
 # ---------------------------------------------------------------------------
 
-from custom_components.thessla_green_modbus.sensor import (
+from custom_components.thessla_green_modbus.const import DOMAIN  # noqa: E402
+from custom_components.thessla_green_modbus.sensor import (  # noqa: E402
     SENSOR_DEFINITIONS,
     async_setup_entry,
 )
-from custom_components.thessla_green_modbus.const import DOMAIN
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- tidy test imports and add E402 noqa tags where needed
- drop unused imports
- rename duplicate device scanner test

## Testing
- `pre-commit run --files tests/conftest.py tests/test_binary_sensor.py tests/test_climate.py tests/test_coordinator.py tests/test_fan.py tests/test_number.py tests/test_select.py tests/test_sensor_platform.py tests/test_device_scanner.py`
- `pytest tests/test_binary_sensor.py tests/test_climate.py tests/test_coordinator.py tests/test_fan.py tests/test_number.py tests/test_select.py tests/test_sensor_platform.py tests/test_device_scanner.py` *(fails: DeviceInfo takes no arguments; AttributeError AsyncModbusTcpClient; expected await not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c47cd9d2083268cb6e32a3ad862b0