### PR TITLE
Ensure config flow docstring precedes future import

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Config flow for ThesslaGreen Modbus integration."""
+from __future__ import annotations
 
 import asyncio
 import logging


### PR DESCRIPTION
## Summary
- place module docstring at top of `config_flow.py`
- move `from __future__ import annotations` directly under the docstring

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py` *(fails: mypy errors in unrelated files)*
- `pytest tests/test_config_flow.py` *(fails: async def functions not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689c47c83a6883269aa38ce00027a9f2