### PR TITLE
Fix duplicate device scanner test and clean up util logging stub

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,18 +231,6 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
     sys.modules["homeassistant.helpers.config_validation"] = cv
     sys.modules["homeassistant.helpers.selector"] = selector
-    # Minimal util logging stub required by pytest_homeassistant_custom_component
-    util = types.ModuleType("homeassistant.util")
-    util_logging = types.ModuleType("homeassistant.util.logging")
-
-    def log_exception(format_err, *args):  # pragma: no cover - simple stub
-        return None
-
-    util_logging.log_exception = log_exception
-    util.logging = util_logging
-    ha.util = util
-    sys.modules["homeassistant.util"] = util
-    sys.modules["homeassistant.util.logging"] = util_logging
     sys.modules["pymodbus"] = pymodbus
     sys.modules["pymodbus.client"] = pymodbus_client
     sys.modules["pymodbus.client.tcp"] = pymodbus_client_tcp

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -75,8 +75,8 @@ def mock_modbus_response():
     return response
 
 
-async def test_scan_device_success(mock_modbus_response):
-    """Test successful device scan."""
+async def test_scan_device_success_static(mock_modbus_response):
+    """Test successful device scan with predefined registers."""
     regs = {
         "04": {16: "outside_temperature"},
         "03": {0: "mode"},


### PR DESCRIPTION
## Summary
- rename static device scan test to avoid duplicate name
- drop redundant `homeassistant.util.logging` stub from test fixture

## Testing
- `pytest tests/test_device_scanner.py` *(fails: AssertionError)*
- `pytest tests/test_select.py tests/test_climate.py tests/test_binary_sensor.py tests/test_coordinator.py tests/test_fan.py tests/test_number.py tests/test_sensor_platform.py` *(fails: IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_689c4df33d0c8326a91bfc083a4fca5f