### PR TITLE
Use helpers.translation module

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for ThesslaGreen Modbus integration."""
+
 from __future__ import annotations
 
 import asyncio
@@ -10,6 +11,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import translation
 
 from .const import (
     CONF_FORCE_FULL_REGISTER_LIST,
@@ -177,19 +179,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         scan_success_rate = "100%" if register_count > 0 else "0%"
 
         if register_count > 0:
-            auto_detected_note = await self.hass.helpers.translation.async_translate(
-                f"{DOMAIN}.auto_detected_note_success"
+            auto_detected_note = await translation.async_translate(
+                self.hass, f"{DOMAIN}.auto_detected_note_success"
             )
             if auto_detected_note is None:
                 auto_detected_note = "Auto-detection successful!"
         else:
-            auto_detected_note = await self.hass.helpers.translation.async_translate(
-                f"{DOMAIN}.auto_detected_note_limited"
+            auto_detected_note = await translation.async_translate(
+                self.hass, f"{DOMAIN}.auto_detected_note_limited"
             )
             if auto_detected_note is None:
-                auto_detected_note = (
-                    "Limited auto-detection - some registers may be missing."
-                )
+                auto_detected_note = "Limited auto-detection - some registers may be missing."
 
         description_placeholders = {
             "host": self._data[CONF_HOST],

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import re
 from typing import Any, Dict
-import ipaddress
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import translation
 
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
@@ -26,8 +27,8 @@ async def async_get_config_entry_diagnostics(
     diagnostics = coordinator.get_diagnostic_data()
 
     # Add human-readable descriptions for active error/status registers
-    translations = await hass.helpers.translation.async_get_translations(
-        hass.config.language, f"component.{DOMAIN}"
+    translations = await translation.async_get_translations(
+        hass, hass.config.language, f"component.{DOMAIN}"
     )
     active_errors: Dict[str, str] = {}
     if coordinator.data:


### PR DESCRIPTION
## Summary
- use new helpers.translation API for config flow auto-detected message
- switch diagnostics translation call to helpers.translation

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/diagnostics.py` *(fails: mypy IndentationError in coordinator.py)*
- `pytest` *(fails: IndentationError in coordinator.py and missing imports)*

------
https://chatgpt.com/codex/tasks/task_e_689c527cba2083268c205d20181969ee