### PR TITLE
Validate length for multi-register writes

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -776,6 +776,12 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                         )
                         return False
                     if len(value) != MULTI_REGISTER_SIZES[start_register]:
+                        _LOGGER.error(
+                            "Register %s expects %d values", 
+                            start_register,
+                            MULTI_REGISTER_SIZES[start_register],
+                        )
+                        return False
 
                 if register_name in MULTI_REGISTER_SIZES:
                     if (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -235,6 +235,22 @@ async def test_async_write_multi_register_non_start(coordinator):
     coordinator.async_request_refresh.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_async_write_multi_register_wrong_length(coordinator):
+    """Reject writes with incorrect number of values."""
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator._ensure_connection = AsyncMock()
+    client = MagicMock()
+    client.write_registers = AsyncMock()
+    coordinator.client = client
+
+    result = await coordinator.async_write_register("date_time_1", [1, 2, 3])
+
+    assert result is False
+    client.write_registers.assert_not_awaited()
+    coordinator.async_request_refresh.assert_not_called()
+
+
 def test_performance_stats(coordinator):
     """Test performance statistics."""
     stats = coordinator.performance_stats


### PR DESCRIPTION
## Summary
- validate multi-register writes by checking expected value count
- test coordinator rejects writes with the wrong number of values

## Testing
- `pytest tests/test_coordinator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689c5a92340c832680f3ac5191651c51