### PR TITLE
Log invalid register values when rejected

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -246,22 +246,33 @@ class ThesslaGreenDeviceScanner:
 
         # Temperature sensors use a sentinel value to indicate no sensor
         if "temperature" in name:
-            return value != SENSOR_UNAVAILABLE
+            if value == SENSOR_UNAVAILABLE:
+                _LOGGER.debug("Invalid value for %s: %s", register_name, value)
+                return False
+            return True
 
         # Air flow sensors use the same sentinel for no sensor
         if any(x in name for x in ["flow", "air_flow", "flow_rate"]):
-            return value not in (SENSOR_UNAVAILABLE, 65535)
+            if value in (SENSOR_UNAVAILABLE, 65535):
+                _LOGGER.debug("Invalid value for %s: %s", register_name, value)
+                return False
+            return True
 
         # Discrete allowed values for specific registers
         if name in REGISTER_ALLOWED_VALUES:
-            return value in REGISTER_ALLOWED_VALUES[name]
+            if value not in REGISTER_ALLOWED_VALUES[name]:
+                _LOGGER.debug("Invalid value for %s: %s", register_name, value)
+                return False
+            return True
 
         # Use range from CSV if available
         if name in self._register_ranges:
             min_val, max_val = self._register_ranges[name]
             if min_val is not None and value < min_val:
+                _LOGGER.debug("Invalid value for %s: %s", register_name, value)
                 return False
             if max_val is not None and value > max_val:
+                _LOGGER.debug("Invalid value for %s: %s", register_name, value)
                 return False
 
         # Default: consider valid


### PR DESCRIPTION
## Summary
- log register name and raw value when rejecting invalid Modbus register values

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: custom_components/thessla_green_modbus/coordinator.py:780: error: expected an indented block after 'if' statement on line 778)*
- `pytest` *(errors: IndentationError in coordinator.py; missing dependencies for Home Assistant tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c5a78101c8326b8d0ee577d04188a