### PR TITLE
fix: remove duplicate lock_date entry

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -69,7 +69,6 @@ MULTI_REGISTER_SIZES = {
     "date_time_2": 4,
     "date_time_3": 4,
     "date_time_4": 4,
-    "lock_date_1": 3,
     "lock_date_2": 3,
     "lock_date_3": 3,
 }
@@ -776,6 +775,12 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                         )
                         return False
                     if len(value) != MULTI_REGISTER_SIZES[start_register]:
+                        _LOGGER.error(
+                            "Register %s expects %d values",
+                            register_name,
+                            MULTI_REGISTER_SIZES[start_register],
+                        )
+                        return False
 
                 if register_name in MULTI_REGISTER_SIZES:
                     if (


### PR DESCRIPTION
## Summary
- remove duplicate `lock_date_1` entry in multi-register map
- validate multi-register write lengths

## Testing
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/coordinator.py`
- `pytest` *(fails: KeyError, AttributeError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_689c5a80a77083269810927e917bb356