### PR TITLE
Use async_get_translations in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -177,19 +177,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         capabilities_list = [k.replace("_", " ").title() for k, v in capabilities.items() if v]
 
         scan_success_rate = "100%" if register_count > 0 else "0%"
+        translations = await translation.async_get_translations(
+            self.hass, self.hass.config.language, DOMAIN
+        )
 
         if register_count > 0:
-            auto_detected_note = await translation.async_translate(
-                self.hass, f"{DOMAIN}.auto_detected_note_success"
+            auto_detected_note = translations.get(
+                "auto_detected_note_success", "Auto-detection successful!"
             )
-            if auto_detected_note is None:
-                auto_detected_note = "Auto-detection successful!"
         else:
-            auto_detected_note = await translation.async_translate(
-                self.hass, f"{DOMAIN}.auto_detected_note_limited"
+            auto_detected_note = translations.get(
+                "auto_detected_note_limited",
+                "Limited auto-detection - some registers may be missing.",
             )
-            if auto_detected_note is None:
-                auto_detected_note = "Limited auto-detection - some registers may be missing."
 
         description_placeholders = {
             "host": self._data[CONF_HOST],


### PR DESCRIPTION
## Summary
- use async_get_translations in config flow confirm step

## Testing
- `pytest` *(fails: AttributeError: 'int' object has no attribute 'total_seconds', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689c8dd19dc48326a04d812102570ee6