### PR TITLE
Handle BCD time registers in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -30,6 +30,18 @@ REGISTER_ALLOWED_VALUES: Dict[str, Set[int]] = {
     "antifreez_mode": {0, 1},
 }
 
+# Registers storing times as BCD HHMM values
+BCD_TIME_PREFIXES: Tuple[str, ...] = ("schedule_", "setting_", "airing_")
+
+
+def _decode_bcd_time(value: int) -> Optional[int]:
+    """Decode a BCD encoded HHMM value to an integer."""
+    hours = ((value >> 12) & 0xF) * 10 + ((value >> 8) & 0xF)
+    minutes = ((value >> 4) & 0xF) * 10 + (value & 0xF)
+    if hours > 23 or minutes > 59:
+        return None
+    return hours * 100 + minutes
+
 
 @dataclass
 class DeviceInfo:
@@ -244,6 +256,14 @@ class ThesslaGreenDeviceScanner:
         """Check if register value is valid (not a sensor error/missing value)."""
         name = register_name.lower()
 
+        # Decode BCD time values before validation
+        if name.startswith(BCD_TIME_PREFIXES):
+            decoded = _decode_bcd_time(value)
+            if decoded is None:
+                _LOGGER.debug("Invalid BCD time for %s: %s", register_name, value)
+                return False
+            value = decoded
+
         # Temperature sensors use a sentinel value to indicate no sensor
         if "temperature" in name:
             if value == SENSOR_UNAVAILABLE:
@@ -369,9 +389,10 @@ class ThesslaGreenDeviceScanner:
             or "contamination_sensor" in self.available_registers["discrete_inputs"]
         )
 
-        # Weekly schedule features
+        # Weekly schedule features - look for any scheduling related registers
+        schedule_keywords = {"schedule", "weekly", "airing", "setting"}
         caps.weekly_schedule = any(
-            "schedule" in reg.lower() or "weekly" in reg.lower()
+            any(keyword in reg.lower() for keyword in schedule_keywords)
             for registers in self.available_registers.values()
             for reg in registers
         )

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -197,6 +197,19 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("supply_percentage", 100) is True
     assert scanner._is_valid_register_value("supply_percentage", 200) is False
 
+    # BCD time registers
+    scanner._register_ranges["schedule_start_time"] = (0, 2359)
+    assert scanner._is_valid_register_value("schedule_start_time", 0x1234) is True
+    assert scanner._is_valid_register_value("schedule_start_time", 0x2460) is False
+
+
+async def test_capabilities_detect_schedule_keywords():
+    """Ensure capability detection considers scheduling related registers."""
+    scanner = ThesslaGreenDeviceScanner("host", 502, 10)
+    scanner.available_registers["holding_registers"].add("airing_start_time")
+    caps = scanner._analyze_capabilities()
+    assert caps.weekly_schedule is True
+
 
 async def test_load_registers_duplicate_warning(tmp_path, caplog):
     """Warn when duplicate register addresses are encountered."""


### PR DESCRIPTION
## Summary
- decode schedule/setting/airing registers stored as BCD HHMM before validation
- detect weekly schedule capability using broader schedule keywords
- test handling of BCD time registers

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py`
- `pytest tests/test_device_scanner.py::test_is_valid_register_value tests/test_device_scanner.py::test_capabilities_detect_schedule_keywords`
- `pytest` *(fails: KeyError: 'schedule_monday_period1_...' and other related errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d8f47a08326a51a71d705ceb14a