### PR TITLE
Handle dynamic ventilation percentage bounds

### DIFF
--- a/custom_components/thessla_green_modbus/data/modbus_registers.csv
+++ b/custom_components/thessla_green_modbus/data/modbus_registers.csv
@@ -52,8 +52,8 @@ Function_Code,Address_HEX,Address_DEC,Access,Register_Name,Description,Min,Max,D
 04,0x0111,273,R/-,exhaust_percentage,Zadana intensywność wentylacji (nawiew),0,150,,1,%,"Zakres wartości podczas pracy ograniczony wartościami (0x04) 0x0114 oraz 0x0115",,
 04,0x0112,274,R/-,supply_flow_rate,Zadany strumień przepływu (nawiew),0,4095,,1,m3/h,"Strumień powietrza nawiewanego mierzony przez system CF",,
 04,0x0113,275,R/-,exhaust_flow_rate,Zadany strumień przepływu (wywiew),0,4095,,1,m3/h,"Strumień powietrza nawiewanego mierzony przez system CF",,
-04,0x0114,276,R/-,min_percentage,Minimalna możliwa do ustawienia intensywność wentylacji,10,10,,1,%,"Zakres dynamiczny - wartość jest zależna od instalacji i wartości nominalnych wydatków z kalibracji, nie mniejsza niż 10%",,
-04,0x0115,277,R/-,max_percentage,Maksymalna możliwa do ustawienia intensywność wentylacji,150,150,,1,%,"Zakres dynamiczny - wartość jest zależna od instalacji i wartości nominalnych wydatków z kalibracji, nie większa niż 150%",,
+04,0x0114,276,R/-,min_percentage,Minimalna możliwa do ustawienia intensywność wentylacji,0,150,,1,%,"Zakres dynamiczny ustalany przez urządzenie; granice 0-150 służą jedynie do walidacji i nie powinny generować logów o nieprawidłowych wartościach",,
+04,0x0115,277,R/-,max_percentage,Maksymalna możliwa do ustawienia intensywność wentylacji,0,150,,1,%,"Zakres dynamiczny ustalany przez urządzenie; granice 0-150 służą jedynie do walidacji i nie powinny generować logów o nieprawidłowych wartościach",,
 04,0x012A,298,R/-,water_removal_active,Status działania procedury HEWR,0,1,1,1,"0 - brak (procedura nieaktywna); 1 - jest (trwa procedura)",4.80,
 
 # 03 - READ HOLDING REGISTER

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -197,6 +197,12 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("supply_percentage", 100) is True
     assert scanner._is_valid_register_value("supply_percentage", 200) is False
 
+    # Dynamic percentage limits should accept device-provided values
+    assert scanner._is_valid_register_value("min_percentage", 20) is True
+    assert scanner._is_valid_register_value("max_percentage", 120) is True
+    assert scanner._is_valid_register_value("min_percentage", -1) is False
+    assert scanner._is_valid_register_value("max_percentage", 200) is False
+
 
 async def test_load_registers_duplicate_warning(tmp_path, caplog):
     """Warn when duplicate register addresses are encountered."""


### PR DESCRIPTION
## Summary
- allow dynamic min/max ventilation percentage values without invalid logs
- test device scanner range handling for min and max percentage registers

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/data/modbus_registers.csv tests/test_device_scanner.py`
- `pytest tests/test_device_scanner.py::test_is_valid_register_value`
- `pytest` *(fails: KeyError, AttributeError and others)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d9233f48326ba4d7382b833d143