### PR TITLE
Handle unsupported platforms

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -44,7 +44,10 @@ for domain in PLATFORM_DOMAINS:
     if hasattr(Platform, domain.upper()):
         PLATFORMS.append(getattr(Platform, domain.upper()))
     else:
-        PLATFORMS.append(Platform(domain))
+        try:
+            PLATFORMS.append(Platform(domain))
+        except ValueError:
+            _LOGGER.warning("Skipping unsupported platform: %s", domain)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:


### PR DESCRIPTION
## Summary
- Skip unknown platform domains when building PLATFORMS

## Testing
- `python -m pytest` *(fails: 36 failed, 73 passed, 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c8da286548326b47af5ab4e9b1d23