### PR TITLE
Specify DeviceCapabilities as_dict return type

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -78,7 +78,7 @@ class DeviceCapabilities:
     sensor_heating_temperature: bool = False
     temperature_sensors_count: int = 0
 
-    def as_dict(self) -> Dict:
+    def as_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 


### PR DESCRIPTION
## Summary
- type: narrow as_dict return type for DeviceCapabilities

## Testing
- `mypy custom_components/thessla_green_modbus/device_scanner.py --follow-imports=skip`


------
https://chatgpt.com/codex/tasks/task_e_689c9052cbbc8326a14833697d7d37fa