### PR TITLE
Fix limited auto-detection translation call

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -197,12 +197,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         else:
             auto_detected_note = translations.get(
                 "auto_detected_note_limited",
-                f"component.{DOMAIN}.auto_detected_note_success",
-                "Auto-detection successful!",
-            )
-        else:
-            auto_detected_note = translations.get(
-                f"component.{DOMAIN}.auto_detected_note_limited",
                 "Limited auto-detection - some registers may be missing.",
             )
 


### PR DESCRIPTION
## Summary
- replace limited auto-detection translation lookup with key and default fallback

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py` (fails: mypy errors in unrelated files)
- `pytest` (fails: missing homeassistant dependencies)


------
https://chatgpt.com/codex/tasks/task_e_689c941cf5cc8326b13c19911cffa7c9