### PR TITLE
Preload platform modules to avoid blocking import

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import timedelta
+from importlib import import_module
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, Platform
@@ -30,9 +31,14 @@ from .const import (
 from .const import PLATFORMS as PLATFORM_DOMAINS
 from .modbus_exceptions import ConnectionException, ModbusException
 
-# Import heavy modules lazily in setup functions to ease testing
-
 _LOGGER = logging.getLogger(__name__)
+
+# Preload platform modules to avoid runtime import warnings
+for _platform in PLATFORM_DOMAINS:
+    try:
+        import_module(f".{_platform}", __name__)
+    except Exception:  # pragma: no cover - environment-dependent
+        _LOGGER.debug("Could not preload platform %s", _platform, exc_info=True)
 
 # Legacy default port used before version 2 when explicit port was optional
 LEGACY_DEFAULT_PORT = 8899

--- a/tests/test_no_blocking_import.py
+++ b/tests/test_no_blocking_import.py
@@ -1,0 +1,48 @@
+"""Test that platform imports do not trigger blocking warnings."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from custom_components.thessla_green_modbus import async_setup_entry
+
+
+@pytest.mark.asyncio
+async def test_no_blocking_import_log(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure setup does not log blocking import warnings."""
+    hass = MagicMock()
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+
+    entry = MagicMock()
+    entry.entry_id = "test"
+    entry.data = {CONF_HOST: "192.168.1.100", CONF_PORT: 502, "slave_id": 10}
+    entry.options = {}
+    entry.title = "Test"
+    entry.add_update_listener = MagicMock()
+    entry.async_on_unload = MagicMock()
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator"
+        ) as mock_coord,
+        patch("custom_components.thessla_green_modbus.er.async_get"),
+        patch(
+            "custom_components.thessla_green_modbus.er.async_entries_for_config_entry",
+            return_value=[],
+            create=True,
+        ),
+    ):
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_setup = AsyncMock(return_value=True)
+        mock_coord.return_value = mock_coordinator
+
+        with caplog.at_level(logging.WARNING):
+            await async_setup_entry(hass, entry)
+
+    assert "blocking call to import_module" not in caplog.text


### PR DESCRIPTION
## Summary
- import platform modules during initialization to avoid runtime blocking imports
- add test ensuring setup emits no 'blocking call to import_module' warning

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/__init__.py` *(mypy skipped: source file found twice error)*
- `SKIP=bandit,mypy pre-commit run --files tests/test_no_blocking_import.py`
- `pytest tests/test_no_blocking_import.py::test_no_blocking_import_log -vv --asyncio-mode=auto --log-cli-level=WARNING`


------
https://chatgpt.com/codex/tasks/task_e_689c9b8ceeb0832680581e5abc2116d4