### PR TITLE
Async register loading for device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -49,7 +49,7 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
     name = data.get(CONF_NAME, DEFAULT_NAME)
 
     # Try to connect and scan device
-    scanner = ThesslaGreenDeviceScanner(
+    scanner = await ThesslaGreenDeviceScanner.create(
         host=host,
         port=port,
         slave_id=slave_id,

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -171,7 +171,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         # Scan device to discover available registers and capabilities
         if not self.force_full_register_list:
             _LOGGER.info("Scanning device for available registers...")
-            scanner = ThesslaGreenDeviceScanner(
+            scanner = await ThesslaGreenDeviceScanner.create(
                 host=self.host,
                 port=self.port,
                 slave_id=self.slave_id,

--- a/tests/run_optimization_tests.py
+++ b/tests/run_optimization_tests.py
@@ -69,7 +69,7 @@ async def validate_optimization_metrics():
         print("🔍 Testing device scanner optimization...")
         from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
 
-        scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
+        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 
         # Check if scanner has optimization methods
         if hasattr(scanner, "_group_registers_for_batch_read") and hasattr(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -348,20 +348,20 @@ async def test_validate_input_success():
         CONF_NAME: "Test",
     }
 
+    scanner_instance = AsyncMock()
+    scanner_instance.scan_device.return_value = {
+        "available_registers": {},
+        "device_info": {
+            "device_name": "ThesslaGreen AirPack",
+            "firmware": "1.0",
+            "serial_number": "123",
+        },
+        "capabilities": {},
+    }
     with patch(
-        "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner"
-    ) as mock_scanner_cls:
-        scanner_instance = AsyncMock()
-        scanner_instance.scan_device.return_value = {
-            "available_registers": {},
-            "device_info": {
-                "device_name": "ThesslaGreen AirPack",
-                "firmware": "1.0",
-                "serial_number": "123",
-            },
-            "capabilities": {},
-        }
-        mock_scanner_cls.return_value = scanner_instance
+        "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",
+        AsyncMock(return_value=scanner_instance),
+    ):
         result = await validate_input(hass, data)
 
     assert result["title"] == "Test"

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -1,6 +1,7 @@
 """Comprehensive test suite for ThesslaGreen Modbus integration - OPTIMIZED VERSION."""
 
 import logging
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -420,7 +421,7 @@ class TestThesslaGreenDeviceScanner:
         """Test successful device scanning."""
         from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
 
-        scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
+        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 
         with patch("pymodbus.client.ModbusTcpClient", return_value=mock_modbus_client):
             result = await scanner.scan_device()
@@ -435,7 +436,7 @@ class TestThesslaGreenDeviceScanner:
         """Test scanner behavior on connection failure."""
         from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
 
-        scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
+        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 
         mock_client = MagicMock()
         mock_client.connect.return_value = False
@@ -448,7 +449,7 @@ class TestThesslaGreenDeviceScanner:
         """Test register value validation logic."""
         from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
 
-        scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
+        scanner = asyncio.run(ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10))
 
         # Valid values
         assert scanner._is_valid_register_value("test_register", 100) is True
@@ -467,7 +468,7 @@ class TestThesslaGreenDeviceScanner:
         """Test capability analysis logic."""
         from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
 
-        scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
+        scanner = asyncio.run(ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10))
         scanner.available_registers = {
             "input_registers": {
                 "constant_flow_active",
@@ -645,7 +646,7 @@ class TestPerformanceOptimizations:
         """Test that device scanner provides optimization statistics."""
         from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
 
-        scanner = ThesslaGreenDeviceScanner("192.168.1.100", 502, 10)
+        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 
         # Mock successful scan
         with patch("pymodbus.client.ModbusTcpClient") as mock_client_class:

--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -266,7 +266,7 @@ def test_scan_device_closes_client_on_failure():
     """Ensure scan_device closes the client even when scan fails."""
 
     async def run_test():
-        scanner = ThesslaGreenDeviceScanner("localhost", 502)
+        scanner = await ThesslaGreenDeviceScanner.create("localhost", 502)
         scanner.scan = AsyncMock(side_effect=ConnectionException("fail"))
         scanner.close = AsyncMock()
 


### PR DESCRIPTION
## Summary
- load device register map using `asyncio.to_thread` to avoid blocking
- create async factory for `ThesslaGreenDeviceScanner` and await it in config flow and coordinator
- adjust tests for new async initialization

## Testing
- `pytest tests/test_config_flow.py::test_validate_input_no_data -q`
- `pytest` *(fails: AttributeError: 'ThesslaGreenModbusCoordinator' object ...)*

------
https://chatgpt.com/codex/tasks/task_e_689c9b8926988326847e247f737cc2bd