### PR TITLE
Use UnitOfElectricPotential for voltage sensors

### DIFF
--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, Optional
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ELECTRIC_POTENTIAL_VOLT,
     PERCENTAGE,
+    UnitOfElectricPotential,
     UnitOfTemperature,
     UnitOfVolumeFlowRate,
 )
@@ -211,7 +211,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:sine-wave",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "register_type": "input_registers",
     },
     "dac_exhaust": {
@@ -219,7 +219,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:sine-wave",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "register_type": "input_registers",
     },
     "dac_heater": {
@@ -227,7 +227,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:sine-wave",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "register_type": "input_registers",
     },
     "dac_cooler": {
@@ -235,7 +235,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:sine-wave",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "register_type": "input_registers",
     },
     # Percentage sensors


### PR DESCRIPTION
## Summary
- adopt `UnitOfElectricPotential` constant in sensor definitions
- update voltage sensor units to `UnitOfElectricPotential.VOLT`

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/sensor.py` *(fails: mypy errors in unrelated files)*
- `pytest` *(fails: ImportError: cannot import name 'UnitOfElectricPotential' from 'homeassistant.const')*
- `python - <<'PY'
import importlib
import custom_components.thessla_green_modbus.sensor as sensor
print(sensor.UnitOfElectricPotential.VOLT)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689c9b879c4c8326bd5de19a0e66cf13