### PR TITLE
feat: add legacy entity aliases

### DIFF
--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -27,6 +27,7 @@ from .const import (
     SPECIAL_FUNCTION_MAP,
     SPECIAL_MODE_OPTIONS,
 )
+from .entity_mappings import map_legacy_entity_id
 
 if TYPE_CHECKING:
     from .coordinator import ThesslaGreenModbusCoordinator
@@ -601,9 +602,16 @@ async def async_unload_services(hass: HomeAssistant) -> None:
 def _get_coordinator_from_entity_id(
     hass: HomeAssistant, entity_id: str
 ) -> ThesslaGreenModbusCoordinator | None:
-    """Get coordinator from entity ID using entity registry."""
+    """Get coordinator from entity ID using entity registry.
+
+    Legacy entity IDs are transparently mapped to their new counterparts to
+    maintain backward compatibility with older automations.
+    """
+
+    mapped_entity_id = map_legacy_entity_id(entity_id)
+
     entity_registry = er.async_get(hass)
-    entry = entity_registry.async_get(entity_id) if entity_registry else None
+    entry = entity_registry.async_get(mapped_entity_id) if entity_registry else None
     if not entry:
         return None
     return hass.data.get(DOMAIN, {}).get(entry.config_entry_id)


### PR DESCRIPTION
## Summary
- map legacy entity ids to new ids and warn users
- look up coordinators using the new ids
- test cleanup tool against alias entries

## Testing
- `pytest` *(fails: tests/test_optimized_integration.py::TestThesslaGreenModbusCoordinator::test_coordinator_write_invalid_register - KeyError: 'air_flow_rate_manual', tests/test_optimized_integration.py::TestThesslaGreenModbusCoordinator::test_temperature_value_processing - AttributeError: 'ThesslaGreenModbusCoordinator' object has no attribute 'statistics', tests/test_optimized_integration.py::TestThesslaGreenModbusCoordinator::test_register_grouping - AttributeError: 'ThesslaGreenModbusCoordinator' object has no attribute 'statistics', tests/test_optimized_integration.py::TestThesslaGreenConfigFlow::test_config_flow_user_input_success - AssertionError: assert False, tests/test_optimized_integration.py::TestThesslaGreenDeviceScanner::test_device_scanner_success - AttributeError: <module 'custom_components.thessla_green_modbus.device_scanner' has no attribute 'DeviceCapabilities'>, tests/test_optimized_integration.py::TestThesslaGreenDeviceScanner::test_device_scanner_connection_failure - AttributeError: <module 'custom_components.thessla_green_modbus.device_scanner' has no attribute 'DeviceCapabilities'>, tests/test_optimized_integration.py::TestThesslaGreenClimate::test_climate_entity_creation - AttributeError: 'NoneType' object has no attribute 'data', tests/test_optimized_integration.py::TestThesslaGreenClimate::test_climate_set_preset_mode - ImportError: cannot import name 'HVACMode', tests/test_optimized_integration.py::TestThesslaGreenClimate::test_climate_fan_mode_calculation - AssertionError: assert None is not None, tests/test_optimized_integration.py::TestPerformanceOptimizations::test_register_grouping_performance - AttributeError: 'ThesslaGreenModbusCoordinator' object has no attribute 'statistics', tests/test_optimized_integration.py::TestPerformanceOptimizations::test_scan_optimization_stats - AttributeError: <module 'custom_components.thessla_green_modbus.device_scanner' has no attribute 'DeviceCapabilities'>, tests/test_register_coverage.py::test_all_registers_covered - AssertionError: Missing registers: ['03:date_time', '03:lock_date', '03:lock_time'], tests/test_register_csv_presence.py::test_all_csv_registers_defined - AssertionError: Missing registers: ['date_time', 'lock_date', 'lock_time'], tests/test_registers.py::test_register_definitions_match_csv - AssertionError: assert 26 == 29, tests/test_scanner_close.py::test_async_setup_closes_scanner - AttributeError: <module 'custom_components.thessla_green_modbus.device_scanner' has no attribute 'DeviceCapabilities'>, tests/test_scanner_close.py::test_disconnect_closes_client - AttributeError: 'ThesslaGreenModbusCoordinator' object has no attribute 'statistics', tests/test_scanner_close.py::test_disconnect_closes_client_sync - AttributeError: 'ThesslaGreenModbusCoordinator' object has no attribute 'statistics', tests/test_select.py::test_select_option_change - AssertionError: expected await not found., tests/test_services_scaling.py::test_airflow_schedule_service_passes_user_values - KeyError: 'schedule_monday_period1_airflow_rate')`

------
https://chatgpt.com/codex/tasks/task_e_689cc0e5f13883269753b5333d7b88de