### PR TITLE
Handle HHMM ranges for time registers

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -177,6 +177,12 @@ class ThesslaGreenDeviceScanner:
                             max_val = int(float(max_raw)) if max_raw not in (None, "") else None
                         except ValueError:
                             max_val = None
+
+                        # Adjust ranges for registers storing BCD times
+                        if name.startswith(BCD_TIME_PREFIXES):
+                            min_val = (min_val * 100) if min_val is not None else 0
+                            max_val = (max_val * 100) if max_val is not None else 2359
+
                         if code in rows:
                             rows[code].append((name, addr, min_val, max_val))
 

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -210,10 +210,10 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("max_percentage", 120) is True
     assert scanner._is_valid_register_value("min_percentage", -1) is False
     assert scanner._is_valid_register_value("max_percentage", 200) is False
-    # BCD time registers
-    scanner._register_ranges["schedule_start_time"] = (0, 2359)
-    assert scanner._is_valid_register_value("schedule_start_time", 0x1234) is True
-    assert scanner._is_valid_register_value("schedule_start_time", 0x2460) is False
+    # BCD time registers loaded from CSV should handle HHMM values
+    assert scanner._register_ranges["schedule_summer_mon_1"] == (0, 2300)
+    assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x0400) is True
+    assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x2200) is True
 
 
 async def test_capabilities_detect_schedule_keywords():

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -454,6 +454,8 @@ class TestThesslaGreenDeviceScanner:
         # Valid values
         assert scanner._is_valid_register_value("test_register", 100) is True
         assert scanner._is_valid_register_value("mode", 1) is True
+        assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x0400) is True
+        assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x2200) is True
 
         # Invalid temperature sensor value
         assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False


### PR DESCRIPTION
## Summary
- interpret scheduling-related registers as HHMM times
- validate schedule times like 04:00 and 22:00

## Testing
- `pytest tests/test_device_scanner.py::test_is_valid_register_value -q`
- `pytest` *(fails: KeyError, AttributeError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689cc0e2238c83269e3bb8b76f397c3a