### PR TITLE
Handle edge cases for BCD time decoding

### DIFF
--- a/tests/test_decode_bcd_time.py
+++ b/tests/test_decode_bcd_time.py
@@ -1,0 +1,21 @@
+"""Tests for BCD time decoding."""
+
+import pytest
+
+from custom_components.thessla_green_modbus.device_scanner import _decode_bcd_time
+
+
+def test_decode_bcd_time_valid():
+    """Decode a valid BCD time."""
+    assert _decode_bcd_time(0x1234) == 1234  # nosec B101
+
+
+def test_decode_bcd_time_2400():
+    """Decode 24:00 to 00:00."""
+    assert _decode_bcd_time(0x2400) == 0  # nosec B101
+
+
+@pytest.mark.parametrize("value", [0x1A00, 0x2360, 0x9999])
+def test_decode_bcd_time_malformed(value):
+    """Return None for malformed BCD values."""
+    assert _decode_bcd_time(value) is None  # nosec B101


### PR DESCRIPTION
## Summary
- validate each BCD nibble before converting times
- interpret 0x2400 as midnight
- add tests for valid, 24:00 and malformed BCD times

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_decode_bcd_time.py` *(fails: mypy missing package mapping)*
- `pytest tests/test_decode_bcd_time.py`
- `pytest tests/test_device_scanner.py` *(fails: expected register 'mode' not found)*


------
https://chatgpt.com/codex/tasks/task_e_689cc0e477b8832686bba38ef7674692