### PR TITLE
Count boolean capabilities in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -563,7 +563,13 @@ class ThesslaGreenDeviceScanner:
                 "Device scan completed: %d registers detected, %d capabilities detected",
                 sum(len(v) for v in self.available_registers.values()),
                 sum(
-                    1 for v in caps.as_dict().values() if bool(v) and not isinstance(v, (set, int))
+                    1
+                    for v in caps.as_dict().values()
+                    if (isinstance(v, bool) and v)
+                    or (
+                        bool(v)
+                        and not isinstance(v, (set, int, bool))
+                    )
                 ),
             )
 
@@ -603,7 +609,13 @@ class ThesslaGreenDeviceScanner:
                 info.firmware,
                 register_count,
                 sum(
-                    1 for v in caps.as_dict().values() if bool(v) and not isinstance(v, (set, int))
+                    1
+                    for v in caps.as_dict().values()
+                    if (isinstance(v, bool) and v)
+                    or (
+                        bool(v)
+                        and not isinstance(v, (set, int, bool))
+                    )
                 ),
             )
 


### PR DESCRIPTION
## Summary
- include boolean values when tallying capabilities during and after device scan
- cover capability counting with new test and ensure deterministic register scanning tests

## Testing
- `pytest tests/test_device_scanner.py`

------
https://chatgpt.com/codex/tasks/task_e_689cc50209f08326b8cf7eba5de8e058