### PR TITLE
Use holding registers for DAC voltage sensors

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -426,7 +426,7 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_exhaust": {
         "translation_key": "dac_exhaust",
@@ -434,7 +434,7 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_heater": {
         "translation_key": "dac_heater",
@@ -442,7 +442,7 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_cooler": {
         "translation_key": "dac_cooler",
@@ -450,7 +450,7 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     # Percentage sensors
     "supply_percentage": {


### PR DESCRIPTION
## Summary
- fix DAC voltage sensors to read from holding registers

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity_mappings.py` *(fails: mypy errors in unrelated files)*
- `pytest` *(fails: multiple attribute and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc44166483268410dc15bc6ebb49