### PR TITLE
Fix DAC sensor register types

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -426,7 +426,7 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_exhaust": {
         "translation_key": "dac_exhaust",
@@ -434,7 +434,7 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_heater": {
         "translation_key": "dac_heater",
@@ -442,7 +442,7 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_cooler": {
         "translation_key": "dac_cooler",
@@ -450,7 +450,7 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     # Percentage sensors
     "supply_percentage": {


### PR DESCRIPTION
## Summary
- update DAC sensor register types to `holding_registers`

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: AttributeError: 'ThesslaGreenModbusCoordinator' object has no attribute 'modbus_params', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689cdc361bec8326a66867743da228ad