### PR TITLE
Allow discovery of unavailable temperature sensors

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -394,11 +394,11 @@ class ThesslaGreenDeviceScanner:
                 return False
             value = decoded
 
-        # Temperature sensors use a sentinel value to indicate no sensor
+        # Temperature sensors may report a sentinel value when the sensor is unavailable.
+        # Log the condition but still treat the register as valid so it is discovered.
         if "temperature" in name:
             if value == SENSOR_UNAVAILABLE:
-                _LOGGER.debug("Invalid value for %s: %s", register_name, value)
-                return False
+                _LOGGER.debug("Sensor unavailable for %s: %s", register_name, value)
             return True
 
         # Air flow sensors use the same sentinel for no sensor

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -196,8 +196,11 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("test_register", 100) is True
     assert scanner._is_valid_register_value("test_register", 0) is True
 
-    # Invalid temperature sensor value
-    assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
+    # Temperature sensor marked unavailable should still be considered valid
+    assert (
+        scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
+        is True
+    )
 
     # Invalid air flow value
     assert scanner._is_valid_register_value("supply_air_flow", 65535) is False

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -457,8 +457,11 @@ class TestThesslaGreenDeviceScanner:
         assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x0400) is True
         assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x2200) is True
 
-        # Invalid temperature sensor value
-        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
+        # Temperature sensor marked unavailable should still be considered valid
+        assert (
+            scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
+            is True
+        )
 
         # Invalid air flow value
         assert scanner._is_valid_register_value("supply_air_flow", 65535) is False


### PR DESCRIPTION
## Summary
- keep temperature registers available even when the initial value is SENSOR_UNAVAILABLE
- update tests for new temperature register behavior

## Testing
- `pytest` *(fails: 37 failed, 83 passed, 14 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc473410832692c1d2ecf5cf0b0d