### PR TITLE
Include manual airing time registers in BCD decoding

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -31,7 +31,12 @@ REGISTER_ALLOWED_VALUES: Dict[str, Set[int]] = {
 }
 
 # Registers storing times as BCD HHMM values
-BCD_TIME_PREFIXES: Tuple[str, ...] = ("schedule_", "setting_", "airing_")
+BCD_TIME_PREFIXES: Tuple[str, ...] = (
+    "schedule_",
+    "setting_",
+    "airing_",
+    "manual_airing_",
+)
 
 
 def _decode_bcd_time(value: int) -> Optional[int]:
@@ -648,10 +653,7 @@ class ThesslaGreenDeviceScanner:
                     1
                     for v in caps.as_dict().values()
                     if (isinstance(v, bool) and v)
-                    or (
-                        bool(v)
-                        and not isinstance(v, (set, int, bool))
-                    )
+                    or (bool(v) and not isinstance(v, (set, int, bool)))
                 ),
             )
 
@@ -694,10 +696,7 @@ class ThesslaGreenDeviceScanner:
                     1
                     for v in caps.as_dict().values()
                     if (isinstance(v, bool) and v)
-                    or (
-                        bool(v)
-                        and not isinstance(v, (set, int, bool))
-                    )
+                    or (bool(v) and not isinstance(v, (set, int, bool)))
                 ),
             )
 


### PR DESCRIPTION
## Summary
- add `manual_airing_` prefix so manual airing time registers are decoded as BCD times
- format device scanner with Black

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: mypy - existing repository errors)*
- `pytest` *(fails: multiple import and attribute errors in tests)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_689cdc489f388326befe55c88eb0ad3e