### PR TITLE
Handle missing temperature sensors and partial input reads

### DIFF
--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -1,7 +1,7 @@
 """Comprehensive test suite for ThesslaGreen Modbus integration - OPTIMIZED VERSION."""
 
-import logging
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -457,8 +457,8 @@ class TestThesslaGreenDeviceScanner:
         assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x0400) is True
         assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x2200) is True
 
-        # Invalid temperature sensor value
-        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
+        # Missing temperature sensor value should still mark register present
+        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is True
 
         # Invalid air flow value
         assert scanner._is_valid_register_value("supply_air_flow", 65535) is False


### PR DESCRIPTION
## Summary
- log failed input-register reads and attempt single-register fallbacks
- treat SENSOR_UNAVAILABLE temperature registers as present
- test scanner behaviour with partial input reads and missing sensors

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py tests/test_optimized_integration.py`
- `pytest tests/test_device_scanner.py::test_scan_handles_partial_input_and_missing_temperature tests/test_device_scanner.py::test_is_valid_register_value`
- `pytest tests/test_optimized_integration.py -k test_register_value_validation`


------
https://chatgpt.com/codex/tasks/task_e_689cdc38988c8326afd01b55a4df294f