### PR TITLE
feat: skip unsupported holding registers

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -215,7 +215,8 @@ logger:
 - **Optimized reads**: register grouping, 60% fewer Modbus calls
 - **Auto scanning**: only available registers, no errors
 - **Diagnostics**: detailed performance and error metrics
-- **Stability**: retry logic, fallback reads, graceful degradation
+- **Stability**: retry logic, fallback reads, graceful degradation, and automatic
+  skipping of unsupported registers
 
 ## 🤝 Support and development
 


### PR DESCRIPTION
## Summary
- skip unresponsive holding registers after repeated failures
- document skipped registers in README
- test to ensure failing registers are retried only once

## Testing
- `pytest tests/test_device_scanner.py::test_read_holding_skips_unresponsive_register -q`
- `pytest -q` *(fails: ImportError: cannot import name 'translation' from 'homeassistant.helpers')*

------
https://chatgpt.com/codex/tasks/task_e_689ce23a51fc832691bb8a15a42dcb85