### PR TITLE
Handle register read failures individually

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -592,6 +592,20 @@ class ThesslaGreenDeviceScanner:
                 for start, count in self._group_registers_for_batch_read(addresses):
                     values = await read_fn(client, start, count)
                     if values is None:
+                        if count > 1:
+                            for addr in range(start, start + count):
+                                single = await read_fn(client, addr, 1)
+                                if single is None:
+                                    continue
+                                name = addr_to_name.get(addr)
+                                if not name:
+                                    continue
+                                value = single[0]
+                                if reg_type in ("input_registers", "holding_registers"):
+                                    if self._is_valid_register_value(name, value):
+                                        self.available_registers[reg_type].add(name)
+                                else:
+                                    self.available_registers[reg_type].add(name)
                         continue
                     for offset, value in enumerate(values):
                         addr = start + offset
@@ -623,6 +637,20 @@ class ThesslaGreenDeviceScanner:
                 for start, count in self._group_registers_for_batch_read(addresses):
                     values = await read_fn(client, start, count)
                     if values is None:
+                        if count > 1:
+                            for addr in range(start, start + count):
+                                single = await read_fn(client, addr, 1)
+                                if single is None:
+                                    continue
+                                reg_name = addr_to_name.get(addr)
+                                if not reg_name:
+                                    continue
+                                value = single[0]
+                                if reg_type in ("input_registers", "holding_registers"):
+                                    if self._is_valid_register_value(reg_name, value):
+                                        self.available_registers[reg_type].add(reg_name)
+                                else:
+                                    self.available_registers[reg_type].add(reg_name)
                         continue
                     for offset, value in enumerate(values):
                         addr = start + offset


### PR DESCRIPTION
## Summary
- handle per-register reads when batch register scans return no data

## Testing
- `pytest` *(fails: 34 failed, 82 passed, 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ce46f5a0483268818f3cc05633109