### PR TITLE
Handle SENSOR_UNAVAILABLE temperature registers

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -395,8 +395,11 @@ class ThesslaGreenDeviceScanner:
         # Temperature sensors use a sentinel value to indicate no sensor
         if "temperature" in name:
             if value == SENSOR_UNAVAILABLE:
-                self._log_invalid_value(register_name, value)
-                return False
+                _LOGGER.debug(
+                    "Temperature register %s unavailable: %s",
+                    register_name,
+                    value,
+                )
             return True
 
         # Air flow sensors use the same sentinel for no sensor

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -455,8 +455,11 @@ class TestThesslaGreenDeviceScanner:
         assert scanner._is_valid_register_value("test_register", 100) is True
         assert scanner._is_valid_register_value("mode", 1) is True
 
-        # Invalid temperature sensor value
-        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
+        # Temperature sensor unavailable value should be considered valid
+        assert (
+            scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
+            is True
+        )
 
         # Invalid air flow value
         assert scanner._is_valid_register_value("supply_air_flow", 65535) is False


### PR DESCRIPTION
## Summary
- accept SENSOR_UNAVAILABLE for temperature registers during device scan
- update tests to treat SENSOR_UNAVAILABLE as valid and ensure such registers stay available

## Testing
- `pytest tests/test_device_scanner.py::test_is_valid_register_value tests/test_device_scanner.py::test_temperature_register_unavailable_kept -q`
- `pytest tests/test_optimized_integration.py::TestThesslaGreenDeviceScanner::test_register_value_validation -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce46c10b88326acddc6aa62fcaa6f