### PR TITLE
Handle unavailable temperature registers in scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -201,9 +201,8 @@ class ThesslaGreenDeviceScanner:
                         except ValueError:
                             max_val = None
                         # Warn if a range is expected but Min/Max is missing
-                        if (
-                            (min_raw not in (None, "") or max_raw not in (None, ""))
-                            and (min_val is None or max_val is None)
+                        if (min_raw not in (None, "") or max_raw not in (None, "")) and (
+                            min_val is None or max_val is None
                         ):
                             _LOGGER.warning(
                                 "Incomplete range for %s: Min=%s Max=%s",
@@ -395,8 +394,7 @@ class ThesslaGreenDeviceScanner:
         # Temperature sensors use a sentinel value to indicate no sensor
         if "temperature" in name:
             if value == SENSOR_UNAVAILABLE:
-                self._log_invalid_value(register_name, value)
-                return False
+                _LOGGER.debug("Temperature sensor %s unavailable: %s", register_name, value)
             return True
 
         # Air flow sensors use the same sentinel for no sensor

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -1,7 +1,7 @@
 """Comprehensive test suite for ThesslaGreen Modbus integration - OPTIMIZED VERSION."""
 
-import logging
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -455,8 +455,8 @@ class TestThesslaGreenDeviceScanner:
         assert scanner._is_valid_register_value("test_register", 100) is True
         assert scanner._is_valid_register_value("mode", 1) is True
 
-        # Invalid temperature sensor value
-        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
+        # SENSOR_UNAVAILABLE should still be treated as valid for temperature sensors
+        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is True
 
         # Invalid air flow value
         assert scanner._is_valid_register_value("supply_air_flow", 65535) is False


### PR DESCRIPTION
## Summary
- treat SENSOR_UNAVAILABLE temperature readings as valid and log at debug level
- adjust tests for new temperature handling
- ensure unavailable temperature register remains in available list after scan

## Testing
- `pytest tests/test_device_scanner.py::test_is_valid_register_value tests/test_device_scanner.py::test_scan_includes_unavailable_temperature tests/test_optimized_integration.py::TestThesslaGreenDeviceScanner::test_register_value_validation`
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py tests/test_optimized_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_689ce45ccb108326945e90aef5a92fa2