### PR TITLE
Handle missing firmware registers gracefully

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -571,7 +571,13 @@ class ThesslaGreenDeviceScanner:
             present_blocks = {}
             # Read firmware version
             fw_data = await self._read_input(client, 0x0000, 5)
-            if fw_data and len(fw_data) >= 3:
+            if not fw_data or len(fw_data) < 3:
+                _LOGGER.info(
+                    "Firmware registers unavailable; firmware version could not be determined"
+                )
+                fw_data = None
+                info.firmware = "Unknown"
+            else:
                 fw = f"{fw_data[0]}.{fw_data[1]}.{fw_data[2]}"
                 info.firmware = fw
                 _LOGGER.debug("Firmware version: %s", fw)


### PR DESCRIPTION
## Summary
- Handle missing firmware registers without repeated warnings and mark firmware as unknown
- Add test verifying fallback when firmware registers are absent

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py`
- `pytest` *(fails: tests/test_optimized_integration.py::TestThesslaGreenModbusCoordinator::test_coordinator_write_invalid_register - KeyError ...)*
- `pytest tests/test_device_scanner.py::test_scan_device_firmware_unavailable -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce9a4ec108326b306b5fc1d8a4d56