### PR TITLE
Cache timed-out input registers in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -127,6 +127,10 @@ class ThesslaGreenDeviceScanner:
         # can avoid retrying them repeatedly during scanning
         self._failed_holding: Set[int] = set()
 
+        # Track input registers that consistently fail to respond so we can
+        # avoid retrying them repeatedly during scanning
+        self._failed_input: Set[int] = set()
+
         # Placeholder for register map and value ranges loaded asynchronously
         self._registers: Dict[str, Dict[int, str]] = {}
         self._register_ranges: Dict[str, Tuple[Optional[int], Optional[int]]] = {}
@@ -270,6 +274,14 @@ class ThesslaGreenDeviceScanner:
         start = address
         end = address + count - 1
 
+        if any(reg in self._failed_input for reg in range(start, end + 1)):
+            _LOGGER.debug(
+                "Skipping cached failed input registers 0x%04X-0x%04X",
+                start,
+                end,
+            )
+            return None
+
         for attempt in range(1, self.retry + 1):
             try:
                 response = await _call_modbus(
@@ -302,6 +314,10 @@ class ThesslaGreenDeviceScanner:
             end,
             self.retry,
         )
+        self._failed_input.update(range(start, end + 1))
+        _LOGGER.debug(
+            "Caching failed input registers 0x%04X-0x%04X", start, end
+        )
         return None
 
     async def _read_holding(
@@ -309,7 +325,9 @@ class ThesslaGreenDeviceScanner:
     ) -> Optional[List[int]]:
         """Read holding registers with retry and failure tracking."""
         if address in self._failed_holding:
-            # We've already determined this register does not respond
+            _LOGGER.debug(
+                "Skipping cached failed holding register 0x%04X", address
+            )
             return None
 
         for attempt in range(1, self.retry + 1):
@@ -340,7 +358,7 @@ class ThesslaGreenDeviceScanner:
 
         # After retry attempts mark register as unsupported to avoid future retries
         self._failed_holding.add(address)
-        _LOGGER.warning("Skipping unsupported holding register 0x%04X", address)
+        _LOGGER.debug("Caching failed holding register 0x%04X", address)
         return None
 
     async def _read_coil(


### PR DESCRIPTION
## Summary
- cache unresponsive input registers and skip future reads
- downgrade cached failure logging to debug level

## Testing
- `pytest` *(fails: AttributeError: 'int' object has no attribute 'total_seconds', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ce9a1576083268b9b2716f8c68a31