### PR TITLE
Handle unavailable temperature sensor values

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -400,12 +400,8 @@ class ThesslaGreenDeviceScanner:
         # Temperature sensors use a sentinel value to indicate no sensor
         if "temperature" in name:
             if value == SENSOR_UNAVAILABLE:
-                _LOGGER.debug("Temperature sensor %s unavailable: %s", register_name, value)
-                _LOGGER.debug(
-                    "Temperature register %s unavailable: %s",
-                    register_name,
-                    value,
-                )
+                # Treat the register as unavailable without logging
+                return False
             return True
 
         # Air flow sensors use the same sentinel for no sensor

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -456,14 +456,8 @@ class TestThesslaGreenDeviceScanner:
         assert scanner._is_valid_register_value("mode", 1) is True
 
 
-        # SENSOR_UNAVAILABLE should still be treated as valid for temperature sensors
-        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is True
-
-        # Temperature sensor unavailable value should be considered valid
-        assert (
-            scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
-            is True
-        )
+        # SENSOR_UNAVAILABLE should be treated as unavailable for temperature sensors
+        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
 
 
         # Invalid air flow value


### PR DESCRIPTION
## Summary
- Skip logging for temperature registers that return sentinel value 32768 and mark them unavailable
- Add regression tests ensuring sensors with sentinel value are excluded and produce no warnings

## Testing
- `python -m pytest tests/test_device_scanner.py -q`
- `python -m pytest tests/test_optimized_integration.py::TestThesslaGreenDeviceScanner::test_register_value_validation -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce9412ec0832691ceca3671cc7839