### PR TITLE
Add retry backoff and failure tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Interwał skanowania**: 10-300s (domyślnie 30s)
 - **Timeout**: 5-60s (domyślnie 10s)
 - **Retry**: 1-5 prób (domyślnie 3)
+- **Backoff**: 0-5s opóźnienia między próbami (domyślnie 0, wykładniczy)
 - **Pełna lista rejestrów**: Pomiń skanowanie (może powodować błędy)
+
+Adresy rejestrów, które wielokrotnie nie odpowiadają, są automatycznie pomijane w kolejnych skanach.
 
 ## 📊 Dostępne encje
 

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -105,6 +105,7 @@ class ThesslaGreenDeviceScanner:
         slave_id: int = DEFAULT_SLAVE_ID,
         timeout: int = 10,
         retry: int = 3,
+        backoff: float = 0,
         verbose_invalid_values: bool = False,
     ) -> None:
         """Initialize device scanner with consistent parameter names."""
@@ -113,6 +114,7 @@ class ThesslaGreenDeviceScanner:
         self.slave_id = slave_id
         self.timeout = timeout
         self.retry = retry
+        self.backoff = backoff
         self.verbose_invalid_values = verbose_invalid_values
 
         # Available registers storage
@@ -124,8 +126,9 @@ class ThesslaGreenDeviceScanner:
         }
 
         # Track holding registers that consistently fail to respond so we
-        # can avoid retrying them repeatedly during scanning
-        self._failed_holding: Set[int] = set()
+        # can avoid retrying them repeatedly during scanning. The value is
+        # a failure counter per register address.
+        self._holding_failures: Dict[int, int] = {}
 
         # Placeholder for register map and value ranges loaded asynchronously
         self._registers: Dict[str, Dict[int, str]] = {}
@@ -149,10 +152,11 @@ class ThesslaGreenDeviceScanner:
         slave_id: int = DEFAULT_SLAVE_ID,
         timeout: int = 10,
         retry: int = 3,
+        backoff: float = 0,
         verbose_invalid_values: bool = False,
     ) -> "ThesslaGreenDeviceScanner":
         """Factory to create an initialized scanner instance."""
-        self = cls(host, port, slave_id, timeout, retry, verbose_invalid_values)
+        self = cls(host, port, slave_id, timeout, retry, backoff, verbose_invalid_values)
         await self._async_setup()
         return self
 
@@ -296,6 +300,9 @@ class ThesslaGreenDeviceScanner:
                     exc_info=True,
                 )
 
+            if self.backoff and attempt < self.retry:
+                await asyncio.sleep(self.backoff * (2 ** (attempt - 1)))
+
         _LOGGER.warning(
             "Failed to read input registers 0x%04X-0x%04X after %d retries",
             start,
@@ -307,9 +314,10 @@ class ThesslaGreenDeviceScanner:
     async def _read_holding(
         self, client: "AsyncModbusTcpClient", address: int, count: int
     ) -> Optional[List[int]]:
-        """Read holding registers with retry and failure tracking."""
-        if address in self._failed_holding:
-            # We've already determined this register does not respond
+        """Read holding registers with retry and per-register failure tracking."""
+        failures = self._holding_failures.get(address, 0)
+        if failures >= self.retry:
+            _LOGGER.warning("Skipping unsupported holding register 0x%04X", address)
             return None
 
         for attempt in range(1, self.retry + 1):
@@ -319,6 +327,8 @@ class ThesslaGreenDeviceScanner:
                 )
                 if response is None or response.isError():
                     raise ModbusException("No response")
+                if address in self._holding_failures:
+                    del self._holding_failures[address]
                 return response.registers
             except (ModbusException, ConnectionException) as exc:
                 _LOGGER.debug(
@@ -338,9 +348,12 @@ class ThesslaGreenDeviceScanner:
                 )
                 break
 
-        # After retry attempts mark register as unsupported to avoid future retries
-        self._failed_holding.add(address)
-        _LOGGER.warning("Skipping unsupported holding register 0x%04X", address)
+            if self.backoff and attempt < self.retry:
+                await asyncio.sleep(self.backoff * (2 ** (attempt - 1)))
+
+        self._holding_failures[address] = failures + 1
+        if self._holding_failures[address] >= self.retry:
+            _LOGGER.warning("Skipping unsupported holding register 0x%04X", address)
         return None
 
     async def _read_coil(


### PR DESCRIPTION
## Summary
- add configurable retry backoff and per-register failure tracking to device scanner
- document retry/backoff behavior and skipping of failing addresses
- test new retry logic and backoff

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py README.md`
- `pytest tests/test_device_scanner.py`


------
https://chatgpt.com/codex/tasks/task_e_689ce9445740832691dc826746eaed1c