### PR TITLE
Handle decimal HHMM schedule values

### DIFF
--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -455,22 +455,24 @@ class TestThesslaGreenDeviceScanner:
         assert scanner._is_valid_register_value("test_register", 100) is True
         assert scanner._is_valid_register_value("mode", 1) is True
 
-
         # SENSOR_UNAVAILABLE should still be treated as valid for temperature sensors
         assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is True
 
         # Temperature sensor unavailable value should be considered valid
-        assert (
-            scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
-            is True
-        )
-
+        assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is True
 
         # Invalid air flow value
         assert scanner._is_valid_register_value("supply_air_flow", 65535) is False
 
         # Invalid mode value
         assert scanner._is_valid_register_value("mode", 5) is False
+
+        # Schedule registers accept both BCD and decimal times
+        scanner._register_ranges["schedule_start_time"] = (0, 2359)
+        assert scanner._is_valid_register_value("schedule_start_time", 0x1234) is True
+        assert scanner._is_valid_register_value("schedule_start_time", 800) is True
+        assert scanner._is_valid_register_value("schedule_start_time", 0x2460) is False
+        assert scanner._is_valid_register_value("schedule_start_time", 2400) is False
 
     def test_capability_analysis(self):
         """Test capability analysis logic."""


### PR DESCRIPTION
## Summary
- parse schedule register times encoded as plain decimal HHMM as well as BCD
- test BCD and decimal schedule decoding in device scanner
- ensure integration tests verify decimal time handling

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py tests/test_optimized_integration.py`
- `pytest tests/test_device_scanner.py::test_is_valid_register_value tests/test_device_scanner.py::test_decode_bcd_time tests/test_optimized_integration.py::TestThesslaGreenDeviceScanner::test_register_value_validation -q`
- ⚠️ `pytest` *(fails: 40 failed, 81 passed, 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ce94940a883269981f4cee41caab5