### PR TITLE
Log invalid registers at debug by default

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -378,9 +378,16 @@ class ThesslaGreenDeviceScanner:
         return None
 
     def _log_invalid_value(self, register_name: str, value: int) -> None:
-        """Log invalid register value once per scan session."""
+        """Log invalid register value once per scan session.
+
+        When ``verbose_invalid_values`` is ``False`` the first invalid value is
+        logged at ``DEBUG`` level and subsequent ones are suppressed. If the
+        flag is ``True`` the first occurrence is logged at ``INFO`` level and
+        further occurrences are logged at ``DEBUG`` level.
+        """
         if register_name not in self._reported_invalid:
-            _LOGGER.info("Invalid value for %s: %s", register_name, value)
+            level = logging.INFO if self.verbose_invalid_values else logging.DEBUG
+            _LOGGER.log(level, "Invalid value for %s: %s", register_name, value)
             self._reported_invalid.add(register_name)
         elif self.verbose_invalid_values:
             _LOGGER.debug("Invalid value for %s: %s", register_name, value)

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -583,3 +583,34 @@ async def test_close_terminates_client(async_close):
         mock_client.close.assert_called_once()
 
     assert scanner._client is None
+
+
+async def test_log_invalid_value_debug_when_not_verbose(caplog):
+    """Invalid values log at DEBUG level when not verbose."""
+    scanner = ThesslaGreenDeviceScanner("host", 502)
+
+    caplog.set_level(logging.DEBUG)
+    scanner._log_invalid_value("test_register", 1)
+
+    assert caplog.records[0].levelno == logging.DEBUG
+    assert "Invalid value for test_register: 1" in caplog.text
+
+    caplog.clear()
+    scanner._log_invalid_value("test_register", 1)
+
+    assert not caplog.records
+
+
+async def test_log_invalid_value_info_then_debug_when_verbose(caplog):
+    """First invalid value logs INFO when verbose, then DEBUG."""
+    scanner = ThesslaGreenDeviceScanner("host", 502, verbose_invalid_values=True)
+
+    caplog.set_level(logging.DEBUG)
+    scanner._log_invalid_value("test_register", 1)
+
+    assert caplog.records[0].levelno == logging.INFO
+
+    caplog.clear()
+    scanner._log_invalid_value("test_register", 1)
+
+    assert caplog.records[0].levelno == logging.DEBUG


### PR DESCRIPTION
## Summary
- log invalid register values at DEBUG when verbose logging disabled
- keep first invalid value at INFO only when verbose logging enabled
- add tests validating invalid value log levels

## Testing
- `pytest` *(fails: KeyError, AttributeError, AssertionError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_689ce94a934483269546f14edb4db0ff