### PR TITLE
Cache failed input registers and test behavior

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -138,6 +138,8 @@ class ThesslaGreenDeviceScanner:
         # can avoid retrying them repeatedly during scanning. The value is
         # a failure counter per register address.
         self._holding_failures: Dict[int, int] = {}
+        # Cache holding registers that have exceeded retry attempts
+        self._failed_holding: Set[int] = set()
 
         # Track input registers that consistently fail to respond so we can
         # avoid retrying them repeatedly during scanning


### PR DESCRIPTION
## Summary
- cache holding registers that exceed retry attempts
- track and skip failed input register reads
- add tests covering new caching behavior

## Testing
- `pytest tests/test_device_scanner.py::test_read_holding_skips_after_failure tests/test_device_scanner.py::test_read_input_skips_cached_failures -q`


------
https://chatgpt.com/codex/tasks/task_e_689ced6bfd448326982ec2b75b1c4634