### PR TITLE
Add optional UART register scan flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Retry**: 1-5 prób (domyślnie 3)
 - **Backoff**: 0-5s opóźnienia między próbami (domyślnie 0, wykładniczy)
 - **Pełna lista rejestrów**: Pomiń skanowanie (może powodować błędy)
+- **Ustawienia UART**: Skanuj opcjonalne rejestry konfiguracji portu (0x1168-0x116B)
 
 Adresy rejestrów, które wielokrotnie nie odpowiadają, są automatycznie pomijane w kolejnych skanach.
 

--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -18,12 +18,14 @@ from .const import (
     CONF_FORCE_FULL_REGISTER_LIST,
     CONF_RETRY,
     CONF_SCAN_INTERVAL,
+    CONF_SCAN_UART_SETTINGS,
     CONF_SLAVE_ID,
     CONF_TIMEOUT,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_RETRY,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SCAN_UART_SETTINGS,
     DEFAULT_SLAVE_ID,
     DEFAULT_TIMEOUT,
     DOMAIN,
@@ -85,6 +87,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     timeout = entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
     retry = entry.options.get(CONF_RETRY, DEFAULT_RETRY)
     force_full_register_list = entry.options.get(CONF_FORCE_FULL_REGISTER_LIST, False)
+    scan_uart_settings = entry.options.get(
+        CONF_SCAN_UART_SETTINGS, DEFAULT_SCAN_UART_SETTINGS
+    )
 
     _LOGGER.info(
         "Initializing ThesslaGreen device: %s at %s:%s (slave_id=%s, scan_interval=%ds)",
@@ -108,6 +113,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         timeout=timeout,
         retry=retry,
         force_full_register_list=force_full_register_list,
+        scan_uart_settings=scan_uart_settings,
         entry=entry,
     )
 

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -17,12 +17,14 @@ from .const import (
     CONF_FORCE_FULL_REGISTER_LIST,
     CONF_RETRY,
     CONF_SCAN_INTERVAL,
+    CONF_SCAN_UART_SETTINGS,
     CONF_SLAVE_ID,
     CONF_TIMEOUT,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_RETRY,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SCAN_UART_SETTINGS,
     DEFAULT_SLAVE_ID,
     DEFAULT_TIMEOUT,
     DOMAIN,
@@ -242,6 +244,9 @@ class OptionsFlow(config_entries.OptionsFlow):
         current_timeout = self.config_entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
         current_retry = self.config_entry.options.get(CONF_RETRY, DEFAULT_RETRY)
         force_full = self.config_entry.options.get(CONF_FORCE_FULL_REGISTER_LIST, False)
+        current_scan_uart = self.config_entry.options.get(
+            CONF_SCAN_UART_SETTINGS, DEFAULT_SCAN_UART_SETTINGS
+        )
 
         data_schema = vol.Schema(
             {
@@ -261,6 +266,10 @@ class OptionsFlow(config_entries.OptionsFlow):
                     CONF_FORCE_FULL_REGISTER_LIST,
                     default=force_full,
                 ): bool,
+                vol.Optional(
+                    CONF_SCAN_UART_SETTINGS,
+                    default=current_scan_uart,
+                ): bool,
             }
         )
 
@@ -272,5 +281,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                 "current_timeout": str(current_timeout),
                 "current_retry": str(current_retry),
                 "force_full_enabled": "Yes" if force_full else "No",
+                "scan_uart_enabled": "Yes" if current_scan_uart else "No",
             },
         )

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -38,6 +38,9 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_TIMEOUT = "timeout"
 CONF_RETRY = "retry"
 CONF_FORCE_FULL_REGISTER_LIST = "force_full_register_list"
+CONF_SCAN_UART_SETTINGS = "scan_uart_settings"
+
+DEFAULT_SCAN_UART_SETTINGS = False
 
 # Platforms supported by the integration
 # Diagnostics is handled separately and therefore not listed here

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -100,6 +100,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         timeout: int = 10,
         retry: int = 3,
         force_full_register_list: bool = False,
+        scan_uart_settings: bool = False,
         entry: Optional[Any] = None,
     ) -> None:
         """Initialize the coordinator."""
@@ -117,6 +118,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         self.timeout = timeout
         self.retry = retry
         self.force_full_register_list = force_full_register_list
+        self.scan_uart_settings = scan_uart_settings
         self.entry = entry
 
         # Connection management
@@ -177,6 +179,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                 slave_id=self.slave_id,
                 timeout=self.timeout,
                 retry=self.retry,
+                scan_uart_settings=self.scan_uart_settings,
             )
 
             try:

--- a/custom_components/thessla_green_modbus/data/modbus_registers.csv
+++ b/custom_components/thessla_green_modbus/data/modbus_registers.csv
@@ -314,10 +314,11 @@ Function_Code,Address_HEX,Address_DEC,Access,Register_Name,Description,Min,Max,D
 03,0x1165,4453,R/W,uart0Baud,Nastawy komunikacji Modbus - port Air-B Szybkość transmisji,0,8,1,3,"0 - 4800; 1 - 9600; 2 - 14400; 3 - 19200; 4 - 28800; 5 - 38400; 6 - 57600; 7 - 76800; 8 - 115200",4.76,
 03,0x1166,4454,R/W,uart0Parity,Nastawy komunikacji Modbus - port Air-B Parzystość,0,2,0,1,"0 - brak; 1 - parzysty; 2 - nieparzysty",4.76,
 03,0x1167,4455,R/W,uart0Stop,Nastawy komunikacji Modbus - port Air-B Bity stopu,0,1,0,1,"0 - jeden; 1 - dwa",4.76,
-03,0x1168,4456,R/W,uart1Id,Nastawy komunikacji Modbus - port Air++ ID urządzenia,10,19,10,1,,4.76,
-03,0x1169,4457,R/W,uart1Baud,Nastawy komunikacji Modbus - port Air++ Szybkość transmisji,0,8,1,3,"0 - 4800; 1 - 9600; 2 - 14400; 3 - 19200; 4 - 28800; 5 - 38400; 6 - 57600; 7 - 76800; 8 - 115200",4.76,
-03,0x116A,4458,R/W,uart1Parity,Nastawy komunikacji Modbus - port Air++ Parzystość,0,2,0,1,"0 - brak; 1 - parzysty; 2 - nieparzysty",4.76,
-03,0x116B,4459,R/W,uart1Stop,Nastawy komunikacji Modbus - port Air++ Bity stopu,0,1,0,1,"0 - jeden; 1 - dwa",4.76,
+# OPCJONALNE USTAWIENIA UART
+03,0x1168,4456,R/W,uart1Id,Nastawy komunikacji Modbus - port Air++ ID urządzenia,10,19,10,1,,4.76,opcjonalny
+03,0x1169,4457,R/W,uart1Baud,Nastawy komunikacji Modbus - port Air++ Szybkość transmisji,0,8,1,3,"0 - 4800; 1 - 9600; 2 - 14400; 3 - 19200; 4 - 28800; 5 - 38400; 6 - 57600; 7 - 76800; 8 - 115200",4.76,opcjonalny
+03,0x116A,4458,R/W,uart1Parity,Nastawy komunikacji Modbus - port Air++ Parzystość,0,2,0,1,"0 - brak; 1 - parzysty; 2 - nieparzysty",4.76,opcjonalny
+03,0x116B,4459,R/W,uart1Stop,Nastawy komunikacji Modbus - port Air++ Bity stopu,0,1,0,1,"0 - jeden; 1 - dwa",4.76,opcjonalny
 
 # NAZWA URZĄDZENIA
 03,0x1FD0,8144,R/W,deviceName,Nazwa urządzenia,0,65535,0,1,"Znaki zapisane w systemie ASCII",,

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -68,6 +68,9 @@ def _decode_bcd_time(value: int) -> Optional[int]:
 # Maximum registers per batch read (Modbus limit)
 MAX_BATCH_REGISTERS = 16
 
+# Optional UART configuration registers (Air++ port)
+UART_OPTIONAL_REGS = range(0x1168, 0x116C)
+
 
 @dataclass
 class DeviceInfo:
@@ -116,6 +119,7 @@ class ThesslaGreenDeviceScanner:
         retry: int = 3,
         backoff: float = 0,
         verbose_invalid_values: bool = False,
+        scan_uart_settings: bool = False,
     ) -> None:
         """Initialize device scanner with consistent parameter names."""
         self.host = host
@@ -125,6 +129,7 @@ class ThesslaGreenDeviceScanner:
         self.retry = retry
         self.backoff = backoff
         self.verbose_invalid_values = verbose_invalid_values
+        self.scan_uart_settings = scan_uart_settings
 
         # Available registers storage
         self.available_registers: Dict[str, Set[str]] = {
@@ -167,9 +172,12 @@ class ThesslaGreenDeviceScanner:
         retry: int = 3,
         backoff: float = 0,
         verbose_invalid_values: bool = False,
+        scan_uart_settings: bool = False,
     ) -> "ThesslaGreenDeviceScanner":
         """Factory to create an initialized scanner instance."""
-        self = cls(host, port, slave_id, timeout, retry, backoff, verbose_invalid_values)
+        self = cls(
+            host, port, slave_id, timeout, retry, backoff, verbose_invalid_values, scan_uart_settings
+        )
         await self._async_setup()
         return self
 
@@ -715,6 +723,8 @@ class ThesslaGreenDeviceScanner:
             for reg_type, (reg_map, read_fn) in register_maps.items():
                 addr_to_name = {addr: name for name, addr in reg_map.items()}
                 addresses = sorted(addr_to_name)
+                if reg_type == "holding_registers" and not self.scan_uart_settings:
+                    addresses = [a for a in addresses if a not in UART_OPTIONAL_REGS]
                 if not addresses:
                     continue
 
@@ -774,6 +784,8 @@ class ThesslaGreenDeviceScanner:
             for reg_type, (code, read_fn) in csv_register_maps.items():
                 addr_to_name = self._registers.get(code, {})
                 addresses = sorted(addr_to_name)
+                if reg_type == "holding_registers" and not self.scan_uart_settings:
+                    addresses = [a for a in addresses if a not in UART_OPTIONAL_REGS]
                 if not addresses:
                     continue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,7 @@ def mock_config_entry():
         "scan_interval": 30,
         "timeout": 10,
         "retry": 3,
+        "scan_uart_settings": False,
     }
     return config_entry
 

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -49,6 +49,7 @@ class TestThesslaGreenIntegration:
             "scan_interval": 30,
             "timeout": 10,
             "retry": 3,
+            "scan_uart_settings": False,
         }
         entry.add_update_listener = MagicMock()
         entry.async_on_unload = MagicMock()


### PR DESCRIPTION
## Summary
- flag UART1 configuration registers as optional
- add `scan_uart_settings` option to control reading optional UART registers
- document UART scanning option and default

## Testing
- `python tools/generate_registers.py`
- `pytest` *(fails: ImportError: cannot import name 'translation' from 'homeassistant.helpers')*


------
https://chatgpt.com/codex/tasks/task_e_689ced660b788326b6ee44c86eac6ad8