### PR TITLE
Fix schedule/setting decoding in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -32,7 +32,10 @@ REGISTER_ALLOWED_VALUES: Dict[str, Set[int]] = {
 }
 
 # Registers storing times as BCD HHMM values
-BCD_TIME_PREFIXES: Tuple[str, ...] = ("schedule_", "setting_", "airing_")
+BCD_TIME_PREFIXES: Tuple[str, ...] = ("schedule_", "airing_")
+
+# Registers storing combined airflow and temperature settings
+SETTING_PREFIX = "setting_"
 
 
 def _decode_bcd_time(value: int) -> Optional[int]:
@@ -46,23 +49,61 @@ def _decode_bcd_time(value: int) -> Optional[int]:
     if value < 0:
         return None
 
-    # First try plain decimal HHMM representation (e.g. 800 -> 08:00)
+    # First attempt BCD decoding
+    nibbles = [(value >> shift) & 0xF for shift in (12, 8, 4, 0)]
+    if all(nibble <= 9 for nibble in nibbles):
+        hours = nibbles[0] * 10 + nibbles[1]
+        minutes = nibbles[2] * 10 + nibbles[3]
+        if hours <= 23 and minutes <= 59:
+            return hours * 100 + minutes
+
+    # Fallback to plain decimal HHMM representation (e.g. 800 -> 08:00)
     hours_dec = value // 100
     minutes_dec = value % 100
     if 0 <= hours_dec <= 23 and 0 <= minutes_dec <= 59:
         return hours_dec * 100 + minutes_dec
 
-    # Fall back to BCD decoding
-    nibbles = [(value >> shift) & 0xF for shift in (12, 8, 4, 0)]
-    if any(nibble > 9 for nibble in nibbles):
+    return None
+
+
+def _decode_setting_value(value: int) -> Optional[Tuple[int, float]]:
+    """Decode a register storing airflow and temperature as ``0xAATT``.
+
+    ``AA`` is the airflow in percent and ``TT`` is twice the desired supply
+    temperature in degrees Celsius. ``None`` is returned if the value cannot be
+    decoded or falls outside expected ranges.
+    """
+
+    if value < 0:
         return None
 
-    hours = nibbles[0] * 10 + nibbles[1]
-    minutes = nibbles[2] * 10 + nibbles[3]
-    if hours > 23 or minutes > 59:
+    airflow = (value >> 8) & 0xFF
+    temp_double = value & 0xFF
+
+    if airflow > 100 or temp_double > 200:
         return None
 
-    return hours * 100 + minutes
+    return airflow, temp_double / 2
+
+
+def _format_register_value(name: str, value: int) -> int | str:
+    """Return a human-readable representation of a register value."""
+
+    if name.startswith(BCD_TIME_PREFIXES):
+        decoded = _decode_bcd_time(value)
+        if decoded is None:
+            return value
+        return f"{decoded // 100:02d}:{decoded % 100:02d}"
+
+    if name.startswith(SETTING_PREFIX):
+        decoded = _decode_setting_value(value)
+        if decoded is None:
+            return value
+        airflow, temp = decoded
+        temp_str = f"{temp:g}"
+        return f"{airflow}% @ {temp_str}°C"
+
+    return value
 
 
 # Maximum registers per batch read (Modbus limit)
@@ -178,7 +219,14 @@ class ThesslaGreenDeviceScanner:
     ) -> "ThesslaGreenDeviceScanner":
         """Factory to create an initialized scanner instance."""
         self = cls(
-            host, port, slave_id, timeout, retry, backoff, verbose_invalid_values, scan_uart_settings
+            host,
+            port,
+            slave_id,
+            timeout,
+            retry,
+            backoff,
+            verbose_invalid_values,
+            scan_uart_settings,
         )
         await self._async_setup()
         return self
@@ -218,9 +266,7 @@ class ThesslaGreenDeviceScanner:
                         min_raw = row.get("Min")
                         max_raw = row.get("Max")
 
-                        def _parse_range(
-                            label: str, raw: Optional[str]
-                        ) -> Optional[int]:
+                        def _parse_range(label: str, raw: Optional[str]) -> Optional[int]:
                             if raw in (None, ""):
                                 return None
                             text = str(raw).split("#", 1)[0]
@@ -354,15 +400,12 @@ class ThesslaGreenDeviceScanner:
             self.retry,
         )
         self._failed_input.update(range(start, end + 1))
-        _LOGGER.debug(
-            "Caching failed input registers 0x%04X-0x%04X", start, end
-        )
+        _LOGGER.debug("Caching failed input registers 0x%04X-0x%04X", start, end)
         return None
 
     async def _read_holding(
         self, client: "AsyncModbusTcpClient", address: int, count: int
     ) -> Optional[List[int]]:
-
         """Read holding registers with retry and per-register failure tracking."""
         failures = self._holding_failures.get(address, 0)
         if failures >= self.retry:
@@ -370,9 +413,7 @@ class ThesslaGreenDeviceScanner:
 
         """Read holding registers with retry, backoff and failure tracking."""
         if address in self._failed_holding:
-            _LOGGER.debug(
-                "Skipping cached failed holding register 0x%04X", address
-            )
+            _LOGGER.debug("Skipping cached failed holding register 0x%04X", address)
 
             return None
 
@@ -403,7 +444,6 @@ class ThesslaGreenDeviceScanner:
                     exc_info=True,
                 )
                 break
-
 
             if self.backoff and attempt < self.retry:
                 await asyncio.sleep(self.backoff * (2 ** (attempt - 1)))
@@ -497,24 +537,31 @@ class ThesslaGreenDeviceScanner:
         flag is ``True`` the first occurrence is logged at ``INFO`` level and
         further occurrences are logged at ``DEBUG`` level.
         """
+        formatted = _format_register_value(register_name, value)
         if register_name not in self._reported_invalid:
             level = logging.INFO if self.verbose_invalid_values else logging.DEBUG
-            _LOGGER.log(level, "Invalid value for %s: %s", register_name, value)
+            _LOGGER.log(level, "Invalid value for %s: %s", register_name, formatted)
             self._reported_invalid.add(register_name)
         elif self.verbose_invalid_values:
-            _LOGGER.debug("Invalid value for %s: %s", register_name, value)
+            _LOGGER.debug("Invalid value for %s: %s", register_name, formatted)
 
     def _is_valid_register_value(self, register_name: str, value: int) -> bool:
         """Check if register value is valid (not a sensor error/missing value)."""
         name = register_name.lower()
 
-        # Decode BCD time values before validation
+        # Validate registers storing schedule times
         if name.startswith(BCD_TIME_PREFIXES):
-            decoded = _decode_bcd_time(value)
-            if decoded is None:
+            if _decode_bcd_time(value) is None:
                 self._log_invalid_value(register_name, value)
                 return False
-            value = decoded
+            return True
+
+        # Validate registers storing combined airflow/temperature settings
+        if name.startswith(SETTING_PREFIX):
+            if _decode_setting_value(value) is None:
+                self._log_invalid_value(register_name, value)
+                return False
+            return True
 
         # Temperature sensors use a sentinel value to indicate no sensor
         if "temperature" in name:

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -13,6 +13,8 @@ from custom_components.thessla_green_modbus.const import (
 from custom_components.thessla_green_modbus.device_scanner import (
     ThesslaGreenDeviceScanner,
     _decode_bcd_time,
+    _decode_setting_value,
+    _format_register_value,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusException
 from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS, INPUT_REGISTERS
@@ -37,10 +39,13 @@ async def test_read_holding_skips_after_failure():
     mock_client = AsyncMock()
 
     # Initial failing scan
-    with patch(
-        "custom_components.thessla_green_modbus.device_scanner._call_modbus",
-        AsyncMock(side_effect=ModbusException("boom")),
-    ) as call_mock1, patch("asyncio.sleep", AsyncMock()):
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+            AsyncMock(side_effect=ModbusException("boom")),
+        ) as call_mock1,
+        patch("asyncio.sleep", AsyncMock()),
+    ):
         result = await scanner._read_holding(mock_client, 0x00A8, 1)
         assert result is None
         assert call_mock1.await_count == scanner.retry
@@ -443,8 +448,11 @@ async def test_scan_device_batch_fallback():
     batch_calls = [call for call in ri.await_args_list if call.args[1] == 0x10]
     assert any(call.args[2] == 2 for call in batch_calls)
     assert any(call.args[2] == 1 for call in batch_calls)
+
+
 async def test_temperature_register_unavailable_skipped():
     """Temperature registers with SENSOR_UNAVAILABLE should be skipped."""
+
 
 async def test_temperature_register_unavailable_kept():
     """Temperature registers with SENSOR_UNAVAILABLE should remain available."""
@@ -490,7 +498,6 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("test_register", 100) is True
     assert scanner._is_valid_register_value("test_register", 0) is True
 
-
     # SENSOR_UNAVAILABLE should be treated as unavailable for temperature sensors
     assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
 
@@ -527,9 +534,26 @@ async def test_is_valid_register_value():
 async def test_decode_bcd_time():
     """Verify time decoding for both BCD and decimal values."""
     assert _decode_bcd_time(0x1234) == 1234
-    assert _decode_bcd_time(800) == 800
+    assert _decode_bcd_time(0x0800) == 800
     assert _decode_bcd_time(0x2460) is None
     assert _decode_bcd_time(2400) is None
+
+
+async def test_decode_setting_value():
+    """Verify decoding of combined airflow and temperature settings."""
+    assert _decode_setting_value(0x3C28) == (60, 20.0)
+    assert _decode_setting_value(-1) is None
+    assert _decode_setting_value(0xFF28) is None
+
+
+async def test_format_register_value_schedule():
+    """Formatted schedule registers should render as HH:MM."""
+    assert _format_register_value("schedule_summer_mon_1", 0x0615) == "06:15"
+
+
+async def test_format_register_value_setting():
+    """Formatted setting registers should show percent and temperature."""
+    assert _format_register_value("setting_winter_mon_1", 0x3C28) == "60% @ 20°C"
 
 
 async def test_scan_excludes_unavailable_temperature():
@@ -661,8 +685,7 @@ async def test_load_registers_missing_range_warning(tmp_path, caplog):
 async def test_load_registers_sanitize_range_values(tmp_path):
     """Ensure Min/Max values are sanitized before conversion."""
     csv_content = (
-        "Function_Code,Address_DEC,Register_Name,Min,Max\n"
-        "04,1,reg_a,0 # comment,10abc\n"
+        "Function_Code,Address_DEC,Register_Name,Min,Max\n" "04,1,reg_a,0 # comment,10abc\n"
     )
     data_dir = tmp_path / "data"
     data_dir.mkdir()
@@ -688,10 +711,7 @@ async def test_load_registers_sanitize_range_values(tmp_path):
 
 async def test_load_registers_invalid_range_logs(tmp_path, caplog):
     """Warn when Min/Max cannot be parsed even after sanitization."""
-    csv_content = (
-        "Function_Code,Address_DEC,Register_Name,Min,Max\n"
-        "04,1,reg_a,abc,#comment\n"
-    )
+    csv_content = "Function_Code,Address_DEC,Register_Name,Min,Max\n" "04,1,reg_a,abc,#comment\n"
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "modbus_registers.csv").write_text(csv_content)


### PR DESCRIPTION
## Summary
- decode schedule registers as BCD times
- parse setting registers into airflow percentage and temperature
- expose formatted register values for clearer logging

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py`
- `pytest tests/test_device_scanner.py::test_decode_setting_value tests/test_device_scanner.py::test_format_register_value_schedule tests/test_device_scanner.py::test_format_register_value_setting tests/test_device_scanner.py::test_decode_bcd_time -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf4c233d48326b810c0763a883ddc