### PR TITLE
Decode schedule times from byte registers

### DIFF
--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -231,9 +231,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         }
         day_index = day_map[day]
 
-        # Convert time to HHMM format
-        start_hhmm = start_time.hour * 100 + start_time.minute
-        end_hhmm = end_time.hour * 100 + end_time.minute
+        # Encode time as HH:MM bytes
+        start_value = (start_time.hour << 8) | start_time.minute
+        end_value = (end_time.hour << 8) | end_time.minute
 
         for entity_id in entity_ids:
             coordinator = _get_coordinator_from_entity_id(hass, entity_id)
@@ -258,12 +258,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 # Write schedule values with proper scaling
                 await coordinator.async_write_register(
                     start_register,
-                    start_hhmm,
+                    start_value,
                     refresh=False,
                 )
                 await coordinator.async_write_register(
                     end_register,
-                    end_hhmm,
+                    end_value,
                     refresh=False,
                 )
                 await coordinator.async_write_register(

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -12,7 +12,7 @@ from custom_components.thessla_green_modbus.const import (
 )
 from custom_components.thessla_green_modbus.device_scanner import (
     ThesslaGreenDeviceScanner,
-    _decode_bcd_time,
+    _decode_register_time,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusException
 from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS, INPUT_REGISTERS
@@ -37,10 +37,13 @@ async def test_read_holding_skips_after_failure():
     mock_client = AsyncMock()
 
     # Initial failing scan
-    with patch(
-        "custom_components.thessla_green_modbus.device_scanner._call_modbus",
-        AsyncMock(side_effect=ModbusException("boom")),
-    ) as call_mock1, patch("asyncio.sleep", AsyncMock()):
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+            AsyncMock(side_effect=ModbusException("boom")),
+        ) as call_mock1,
+        patch("asyncio.sleep", AsyncMock()),
+    ):
         result = await scanner._read_holding(mock_client, 0x00A8, 1)
         assert result is None
         assert call_mock1.await_count == scanner.retry
@@ -443,8 +446,11 @@ async def test_scan_device_batch_fallback():
     batch_calls = [call for call in ri.await_args_list if call.args[1] == 0x10]
     assert any(call.args[2] == 2 for call in batch_calls)
     assert any(call.args[2] == 1 for call in batch_calls)
+
+
 async def test_temperature_register_unavailable_skipped():
     """Temperature registers with SENSOR_UNAVAILABLE should be skipped."""
+
 
 async def test_temperature_register_unavailable_kept():
     """Temperature registers with SENSOR_UNAVAILABLE should remain available."""
@@ -490,7 +496,6 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("test_register", 100) is True
     assert scanner._is_valid_register_value("test_register", 0) is True
 
-
     # SENSOR_UNAVAILABLE should be treated as unavailable for temperature sensors
     assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
 
@@ -516,20 +521,20 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("max_percentage", 120) is True
     assert scanner._is_valid_register_value("min_percentage", -1) is False
     assert scanner._is_valid_register_value("max_percentage", 200) is False
-    # BCD time registers
+    # HH:MM time registers
     scanner._register_ranges["schedule_start_time"] = (0, 2359)
-    assert scanner._is_valid_register_value("schedule_start_time", 0x1234) is True
+    assert scanner._is_valid_register_value("schedule_start_time", 0x081E) is True
+    assert scanner._is_valid_register_value("schedule_start_time", 0x0800) is True
     assert scanner._is_valid_register_value("schedule_start_time", 0x2460) is False
-    assert scanner._is_valid_register_value("schedule_start_time", 800) is True
-    assert scanner._is_valid_register_value("schedule_start_time", 2400) is False
+    assert scanner._is_valid_register_value("schedule_start_time", 0x0960) is False
 
 
-async def test_decode_bcd_time():
-    """Verify time decoding for both BCD and decimal values."""
-    assert _decode_bcd_time(0x1234) == 1234
-    assert _decode_bcd_time(800) == 800
-    assert _decode_bcd_time(0x2460) is None
-    assert _decode_bcd_time(2400) is None
+async def test_decode_register_time():
+    """Verify time decoding for HH:MM byte-encoded values."""
+    assert _decode_register_time(0x081E) == 830
+    assert _decode_register_time(0x1234) == 1852
+    assert _decode_register_time(0x2460) is None
+    assert _decode_register_time(0x0960) is None
 
 
 async def test_scan_excludes_unavailable_temperature():
@@ -661,8 +666,7 @@ async def test_load_registers_missing_range_warning(tmp_path, caplog):
 async def test_load_registers_sanitize_range_values(tmp_path):
     """Ensure Min/Max values are sanitized before conversion."""
     csv_content = (
-        "Function_Code,Address_DEC,Register_Name,Min,Max\n"
-        "04,1,reg_a,0 # comment,10abc\n"
+        "Function_Code,Address_DEC,Register_Name,Min,Max\n" "04,1,reg_a,0 # comment,10abc\n"
     )
     data_dir = tmp_path / "data"
     data_dir.mkdir()
@@ -688,10 +692,7 @@ async def test_load_registers_sanitize_range_values(tmp_path):
 
 async def test_load_registers_invalid_range_logs(tmp_path, caplog):
     """Warn when Min/Max cannot be parsed even after sanitization."""
-    csv_content = (
-        "Function_Code,Address_DEC,Register_Name,Min,Max\n"
-        "04,1,reg_a,abc,#comment\n"
-    )
+    csv_content = "Function_Code,Address_DEC,Register_Name,Min,Max\n" "04,1,reg_a,abc,#comment\n"
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "modbus_registers.csv").write_text(csv_content)

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -328,7 +328,8 @@ class TestThesslaGreenConfigFlow:
         }
 
         with patch(
-            "custom_components.thessla_green_modbus.device_scanner.ThesslaGreenDeviceScanner.scan_device",
+            "custom_components.thessla_green_modbus.device_scanner."
+            "ThesslaGreenDeviceScanner.scan_device",
             return_value=scanner_result,
         ):
             yield
@@ -471,12 +472,12 @@ class TestThesslaGreenDeviceScanner:
         # Invalid mode value
         assert scanner._is_valid_register_value("mode", 5) is False
 
-        # Schedule registers accept both BCD and decimal times
+        # Schedule registers decode HH:MM byte values
         scanner._register_ranges["schedule_start_time"] = (0, 2359)
-        assert scanner._is_valid_register_value("schedule_start_time", 0x1234) is True
-        assert scanner._is_valid_register_value("schedule_start_time", 800) is True
+        assert scanner._is_valid_register_value("schedule_start_time", 0x081E) is True
+        assert scanner._is_valid_register_value("schedule_start_time", 0x0800) is True
         assert scanner._is_valid_register_value("schedule_start_time", 0x2460) is False
-        assert scanner._is_valid_register_value("schedule_start_time", 2400) is False
+        assert scanner._is_valid_register_value("schedule_start_time", 0x0960) is False
 
     def test_capability_analysis(self):
         """Test capability analysis logic."""

--- a/tests/test_services_scaling.py
+++ b/tests/test_services_scaling.py
@@ -69,12 +69,12 @@ async def test_airflow_schedule_service_passes_user_values(monkeypatch):
 
     assert writes[0] == (
         HOLDING_REGISTERS["schedule_monday_period1_start"],
-        630,
+        0x0630,
         1,
     )  # nosec: B101
     assert writes[1] == (
         HOLDING_REGISTERS["schedule_monday_period1_end"],
-        800,
+        0x0800,
         1,
     )  # nosec: B101
     assert writes[2] == (


### PR DESCRIPTION
## Summary
- parse schedule and airing registers as hour/minute byte pairs
- encode service-supplied schedule times using new byte format
- adjust related tests to new representation

## Testing
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/services.py`
- `SKIP=bandit,mypy pre-commit run --files tests/test_device_scanner.py tests/test_optimized_integration.py tests/test_services_scaling.py`
- `pytest` *(fails: AttributeError and missing register mappings)*

------
https://chatgpt.com/codex/tasks/task_e_689cf419fc0883269510a402a13a2516