### PR TITLE
Handle invalid time register values in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -620,6 +620,9 @@ class ThesslaGreenDeviceScanner:
         if name.startswith(TIME_REGISTER_PREFIXES):
             decoded = _decode_register_time(value)
             if decoded is None:
+                self._log_invalid_value(register_name, value)
+                return False
+            value = decoded
 
         # Validate registers storing schedule times
         if name.startswith(BCD_TIME_PREFIXES):


### PR DESCRIPTION
## Summary
- log invalid time register values and skip them during device scanning
- use decoded HHMM values for subsequent register validation

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/device_scanner.py`
- `pytest` *(fails: ImportError: cannot import name 'translation' from 'homeassistant.helpers'; ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component'; ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689cfb92e750832691b5c20b56d203c3