### PR TITLE
Handle Modbus exception response

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -481,8 +481,12 @@ class ThesslaGreenDeviceScanner:
                 response = await _call_modbus(
                     client.read_holding_registers, self.slave_id, address, count=count
                 )
-                if response is None or response.isError():
+                if response is None:
                     raise ModbusException("No response")
+                if response.isError():
+                    raise ModbusException(
+                        f"Exception code {response.exception_code}"
+                    )
                 if address in self._holding_failures:
                     del self._holding_failures[address]
                 return response.registers

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -43,10 +43,6 @@ async def test_read_holding_skips_after_failure():
     mock_client = AsyncMock()
 
     # Initial failing scan
-    with patch(
-        "custom_components.thessla_green_modbus.device_scanner._call_modbus",
-        AsyncMock(side_effect=ModbusIOException("boom")),
-    ) as call_mock1, patch("asyncio.sleep", AsyncMock()):
     with (
         patch(
             "custom_components.thessla_green_modbus.device_scanner._call_modbus",
@@ -68,6 +64,30 @@ async def test_read_holding_skips_after_failure():
         call_mock2.assert_not_called()
 
     assert 0x00A8 in scanner._failed_holding
+
+
+async def test_read_holding_exception_response(caplog):
+    """Exception responses should include the exception code in logs."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+    mock_client = AsyncMock()
+
+    error_response = MagicMock()
+    error_response.isError.return_value = True
+    error_response.exception_code = 6
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+            AsyncMock(return_value=error_response),
+        ) as call_mock,
+        patch("asyncio.sleep", AsyncMock()),
+        caplog.at_level(logging.DEBUG),
+    ):
+        result = await scanner._read_holding(mock_client, 0x0001, 1)
+
+    assert result is None
+    assert call_mock.await_count == scanner.retry
+    assert f"Exception code {error_response.exception_code}" in caplog.text
 
 
 async def test_read_input_backoff():


### PR DESCRIPTION
## Summary
- Distinguish Modbus exception responses in device scanner
- Test handling of Modbus ExceptionResponse objects

## Testing
- `pytest` *(fails: 42 failed, 95 passed, 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cff9fd90083268d84bc5884f06896