### PR TITLE
Allow hexadecimal ranges in register CSV

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -299,14 +299,21 @@ class ThesslaGreenDeviceScanner:
                                 )
                                 return None
 
-                            if not re.fullmatch(r"[+-]?\d+(?:\.\d+)?", text):
+                            if not re.fullmatch(
+                                r"[+-]?(?:0[xX][0-9a-fA-F]+|\d+(?:\.\d+)?)",
+                                text,
+                            ):
                                 _LOGGER.warning(
                                     "Ignoring non-numeric %s for %s: %s", label, name, raw
                                 )
                                 return None
 
                             try:
-                                return int(float(text))
+                                return (
+                                    int(text, 0)
+                                    if text.lower().startswith(("0x", "+0x", "-0x"))
+                                    else int(float(text))
+                                )
                             except ValueError:
                                 _LOGGER.warning(
                                     "Ignoring non-numeric %s for %s: %s", label, name, raw
@@ -469,9 +476,7 @@ class ThesslaGreenDeviceScanner:
                 if response is None:
                     raise ModbusException("No response")
                 if response.isError():
-                    raise ModbusException(
-                        f"Exception code {response.exception_code}"
-                    )
+                    raise ModbusException(f"Exception code {response.exception_code}")
                 if address in self._holding_failures:
                     del self._holding_failures[address]
                 return response.registers


### PR DESCRIPTION
## Summary
- allow hexadecimal range values when parsing register CSV
- test decimal and hexadecimal range parsing

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py` *(fails: mypy reported duplicate module and bandit flagged assertions)*
- `pytest` *(fails: missing homeassistant and pytest_homeassistant_custom_component dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689d8cc1a27c83268618a22323d9c16e