### PR TITLE
Allow hex ranges in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -299,14 +299,14 @@ class ThesslaGreenDeviceScanner:
                                 )
                                 return None
 
-                            if not re.fullmatch(r"[+-]?\d+(?:\.\d+)?", text):
+                            if not re.fullmatch(r"[+-]?(?:0[xX][0-9A-Fa-f]+|\d+)", text):
                                 _LOGGER.warning(
                                     "Ignoring non-numeric %s for %s: %s", label, name, raw
                                 )
                                 return None
 
                             try:
-                                return int(float(text))
+                                return int(text, 0)
                             except ValueError:
                                 _LOGGER.warning(
                                     "Ignoring non-numeric %s for %s: %s", label, name, raw
@@ -469,9 +469,7 @@ class ThesslaGreenDeviceScanner:
                 if response is None:
                     raise ModbusException("No response")
                 if response.isError():
-                    raise ModbusException(
-                        f"Exception code {response.exception_code}"
-                    )
+                    raise ModbusException(f"Exception code {response.exception_code}")
                 if address in self._holding_failures:
                     del self._holding_failures[address]
                 return response.registers

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -12,8 +12,8 @@ from custom_components.thessla_green_modbus.const import (
 )
 from custom_components.thessla_green_modbus.device_scanner import (
     ThesslaGreenDeviceScanner,
-    _decode_register_time,
     _decode_bcd_time,
+    _decode_register_time,
     _decode_setting_value,
     _format_register_value,
 )
@@ -65,6 +65,7 @@ async def test_read_holding_skips_after_failure():
 
     assert 0x00A8 in scanner._failed_holding
 
+
 async def test_read_holding_exception_response(caplog):
     """Exception responses should include the exception code in logs."""
     scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
@@ -89,17 +90,13 @@ async def test_read_holding_exception_response(caplog):
     assert f"Exception code {error_response.exception_code}" in caplog.text
 
 
-async def test_read_input_backoff():
-
 @pytest.mark.parametrize(
     "method, address",
     [("_read_input", 0x0001), ("_read_holding", 0x0001)],
 )
-async def test_read_backoff_delay(method, address):```````
+async def test_read_backoff_delay(method, address):
     """Ensure exponential backoff delays between retries."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=3, backoff=0.1
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=3, backoff=0.1)
     mock_client = AsyncMock()
     sleep_mock = AsyncMock()
     with (
@@ -122,9 +119,7 @@ async def test_read_backoff_delay(method, address):```````
 )
 async def test_read_default_delay(method, address):
     """Use default delay when backoff is not specified."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=3
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=3)
     mock_client = AsyncMock()
     sleep_mock = AsyncMock()
     with (
@@ -143,9 +138,7 @@ async def test_read_default_delay(method, address):
 
 async def test_read_input_logs_warning_on_failure(caplog):
     """Warn when input registers cannot be read after retries."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=2
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=2)
     mock_client = AsyncMock()
 
     caplog.set_level(logging.WARNING)
@@ -165,9 +158,7 @@ async def test_read_input_logs_warning_on_failure(caplog):
 
 async def test_read_input_skips_cached_failures():
     """Input registers are cached after repeated failures."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=2
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=2)
     mock_client = AsyncMock()
 
     with (
@@ -562,14 +553,8 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("test_register", 0) is True
 
     # SENSOR_UNAVAILABLE should be treated as unavailable for temperature and airflow sensors
-    assert (
-        scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
-        is False
-    )
-    assert (
-        scanner._is_valid_register_value("supply_air_flow", SENSOR_UNAVAILABLE)
-        is False
-    )
+    assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
+    assert scanner._is_valid_register_value("supply_air_flow", SENSOR_UNAVAILABLE) is False
 
     # Invalid air flow value
     assert scanner._is_valid_register_value("supply_air_flow", 65535) is False
@@ -601,13 +586,14 @@ async def test_decode_register_time():
     assert _decode_register_time(0x1234) == 1852
     assert _decode_register_time(0x2460) is None
     assert _decode_register_time(0x0960) is None
+
+
 async def test_decode_bcd_time():
     """Verify time decoding for both BCD and decimal values."""
     assert _decode_bcd_time(0x1234) == 1234
     assert _decode_bcd_time(0x0800) == 800
     assert _decode_bcd_time(0x2460) is None
     assert _decode_bcd_time(2400) is None
-
 
 
 async def test_decode_setting_value():
@@ -780,6 +766,33 @@ async def test_load_registers_sanitize_range_values(tmp_path, caplog):
 
     assert scanner._register_ranges["reg_a"] == (0, None)
     assert any("non-numeric Max" in record.message for record in caplog.records)
+
+
+async def test_load_registers_hex_range(tmp_path, caplog):
+    """Parse hexadecimal Min/Max values without warnings."""
+    csv_content = "Function_Code,Address_DEC,Register_Name,Min,Max\n" "04,1,reg_a,0x0,0x423f\n"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "modbus_registers.csv").write_text(csv_content)
+
+    with (
+        patch("custom_components.thessla_green_modbus.device_scanner.files", return_value=tmp_path),
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner.INPUT_REGISTERS",
+            {"reg_a": 1},
+        ),
+        patch("custom_components.thessla_green_modbus.device_scanner.HOLDING_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.device_scanner.COIL_REGISTERS", {}),
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner.DISCRETE_INPUT_REGISTERS",
+            {},
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
+
+    assert scanner._register_ranges["reg_a"] == (0x0, 0x423F)
+    assert not caplog.records
 
 
 async def test_load_registers_invalid_range_logs(tmp_path, caplog):


### PR DESCRIPTION
## Summary
- parse hex min/max values in device scanner
- add test for hex range parsing

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py` *(fails: mypy: Source file found twice under different module names)*
- `SKIP=mypy,bandit pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py`
- `pytest tests/test_device_scanner.py::test_load_registers_hex_range -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8ccae780832687899e02c620a545