### PR TITLE
Condense logging for skipped input register ranges

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -210,6 +210,8 @@ class ThesslaGreenDeviceScanner:
         # avoid retrying them repeatedly during scanning
         self._input_failures: Dict[int, int] = {}
         self._failed_input: Set[int] = set()
+        # Track ranges that have already been logged as skipped in the current scan
+        self._input_skip_log_ranges: Set[Tuple[int, int]] = set()
 
         # Placeholder for register map and value ranges loaded asynchronously
         self._registers: Dict[str, Dict[int, str]] = {}
@@ -384,13 +386,20 @@ class ThesslaGreenDeviceScanner:
         """Read input registers with retry and backoff."""
         start = address
         end = address + count - 1
-
         if any(reg in self._failed_input for reg in range(start, end + 1)):
-            _LOGGER.debug(
-                "Skipping cached failed input registers 0x%04X-0x%04X",
-                start,
-                end,
-            )
+            first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
+            skip_start = skip_end = first
+            while skip_start - 1 in self._failed_input:
+                skip_start -= 1
+            while skip_end + 1 in self._failed_input:
+                skip_end += 1
+            if (skip_start, skip_end) not in self._input_skip_log_ranges:
+                _LOGGER.debug(
+                    "Skipping cached failed input registers 0x%04X-0x%04X",
+                    skip_start,
+                    skip_end,
+                )
+                self._input_skip_log_ranges.add((skip_start, skip_end))
             return None
 
         for attempt in range(1, self.retry + 1):
@@ -789,6 +798,7 @@ class ThesslaGreenDeviceScanner:
 
             _LOGGER.debug("Connected successfully, starting device scan")
             self._reported_invalid.clear()
+            self._input_skip_log_ranges.clear()
 
             info = DeviceInfo()
             present_blocks = {}

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -89,13 +89,11 @@ async def test_read_holding_exception_response(caplog):
     assert f"Exception code {error_response.exception_code}" in caplog.text
 
 
-async def test_read_input_backoff():
-
 @pytest.mark.parametrize(
     "method, address",
     [("_read_input", 0x0001), ("_read_holding", 0x0001)],
 )
-async def test_read_backoff_delay(method, address):```````
+async def test_read_backoff_delay(method, address):
     """Ensure exponential backoff delays between retries."""
     scanner = await ThesslaGreenDeviceScanner.create(
         "192.168.3.17", 8899, 10, retry=3, backoff=0.1
@@ -191,6 +189,29 @@ async def test_read_input_skips_cached_failures():
         result = await scanner._read_input(mock_client, 0x0001, 1)
         assert result is None
         call_mock2.assert_not_called()
+
+
+async def test_read_input_logs_once_per_skipped_range(caplog):
+    """Only one log message is emitted per skipped register range."""
+    scanner = await ThesslaGreenDeviceScanner.create(
+        "192.168.3.17", 8899, 10, retry=2
+    )
+    mock_client = AsyncMock()
+    scanner._failed_input.update({0x0001, 0x0002, 0x0003})
+
+    caplog.set_level(logging.DEBUG)
+    for addr in range(0x0001, 0x0004):
+        result = await scanner._read_input(mock_client, addr, 1)
+        assert result is None
+
+    messages = [
+        record.message
+        for record in caplog.records
+        if "Skipping cached failed input registers" in record.message
+    ]
+    assert messages == [
+        "Skipping cached failed input registers 0x0001-0x0003"
+    ]
 
 
 async def test_scan_device_success_dynamic():


### PR DESCRIPTION
## Summary
- group contiguous cached input registers into a single skip log
- throttle duplicate skip logs during a scan
- test that only one log message is emitted per skipped range

## Testing
- `pytest tests/test_device_scanner.py -q`
- `pytest -q` *(fails: ImportError cannot import name 'translation' from 'homeassistant.helpers')*


------
https://chatgpt.com/codex/tasks/task_e_689d8cc5b96c83268306915f90dc4983