### PR TITLE
Refactor single-register fallback in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -469,9 +469,7 @@ class ThesslaGreenDeviceScanner:
                 if response is None:
                     raise ModbusException("No response")
                 if response.isError():
-                    raise ModbusException(
-                        f"Exception code {response.exception_code}"
-                    )
+                    raise ModbusException(f"Exception code {response.exception_code}")
                 if address in self._holding_failures:
                     del self._holding_failures[address]
                 return response.registers
@@ -861,20 +859,6 @@ class ThesslaGreenDeviceScanner:
                                     self.available_registers[reg_type].add(name)
                             else:
                                 self.available_registers[reg_type].add(name)
-                        if count > 1:
-                            for addr in range(start, start + count):
-                                single = await read_fn(client, addr, 1)
-                                if single is None:
-                                    continue
-                                name = addr_to_name.get(addr)
-                                if not name:
-                                    continue
-                                value = single[0]
-                                if reg_type in ("input_registers", "holding_registers"):
-                                    if self._is_valid_register_value(name, value):
-                                        self.available_registers[reg_type].add(name)
-                                else:
-                                    self.available_registers[reg_type].add(name)
                         continue
                     for offset, value in enumerate(values):
                         addr = start + offset
@@ -928,20 +912,6 @@ class ThesslaGreenDeviceScanner:
                                     self.available_registers[reg_type].add(reg_name)
                             else:
                                 self.available_registers[reg_type].add(reg_name)
-                        if count > 1:
-                            for addr in range(start, start + count):
-                                single = await read_fn(client, addr, 1)
-                                if single is None:
-                                    continue
-                                reg_name = addr_to_name.get(addr)
-                                if not reg_name:
-                                    continue
-                                value = single[0]
-                                if reg_type in ("input_registers", "holding_registers"):
-                                    if self._is_valid_register_value(reg_name, value):
-                                        self.available_registers[reg_type].add(reg_name)
-                                else:
-                                    self.available_registers[reg_type].add(reg_name)
                         continue
                     for offset, value in enumerate(values):
                         addr = start + offset

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -12,8 +12,8 @@ from custom_components.thessla_green_modbus.const import (
 )
 from custom_components.thessla_green_modbus.device_scanner import (
     ThesslaGreenDeviceScanner,
-    _decode_register_time,
     _decode_bcd_time,
+    _decode_register_time,
     _decode_setting_value,
     _format_register_value,
 )
@@ -65,6 +65,7 @@ async def test_read_holding_skips_after_failure():
 
     assert 0x00A8 in scanner._failed_holding
 
+
 async def test_read_holding_exception_response(caplog):
     """Exception responses should include the exception code in logs."""
     scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
@@ -89,17 +90,13 @@ async def test_read_holding_exception_response(caplog):
     assert f"Exception code {error_response.exception_code}" in caplog.text
 
 
-async def test_read_input_backoff():
-
 @pytest.mark.parametrize(
     "method, address",
     [("_read_input", 0x0001), ("_read_holding", 0x0001)],
 )
-async def test_read_backoff_delay(method, address):```````
+async def test_read_backoff_delay(method, address):
     """Ensure exponential backoff delays between retries."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=3, backoff=0.1
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=3, backoff=0.1)
     mock_client = AsyncMock()
     sleep_mock = AsyncMock()
     with (
@@ -122,9 +119,7 @@ async def test_read_backoff_delay(method, address):```````
 )
 async def test_read_default_delay(method, address):
     """Use default delay when backoff is not specified."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=3
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=3)
     mock_client = AsyncMock()
     sleep_mock = AsyncMock()
     with (
@@ -143,9 +138,7 @@ async def test_read_default_delay(method, address):
 
 async def test_read_input_logs_warning_on_failure(caplog):
     """Warn when input registers cannot be read after retries."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=2
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=2)
     mock_client = AsyncMock()
 
     caplog.set_level(logging.WARNING)
@@ -165,9 +158,7 @@ async def test_read_input_logs_warning_on_failure(caplog):
 
 async def test_read_input_skips_cached_failures():
     """Input registers are cached after repeated failures."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=2
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=2)
     mock_client = AsyncMock()
 
     with (
@@ -510,7 +501,10 @@ async def test_scan_device_batch_fallback():
     # Ensure batch read was attempted and individual fallback reads occurred
     batch_calls = [call for call in ri.await_args_list if call.args[1] == 0x10]
     assert any(call.args[2] == 2 for call in batch_calls)
-    assert any(call.args[2] == 1 for call in batch_calls)
+
+    single_calls = [call.args[1] for call in ri.await_args_list if call.args[2] == 1]
+    assert single_calls.count(0x10) == 1
+    assert single_calls.count(0x11) == 1
 
 
 async def test_temperature_register_unavailable_skipped():
@@ -562,14 +556,8 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("test_register", 0) is True
 
     # SENSOR_UNAVAILABLE should be treated as unavailable for temperature and airflow sensors
-    assert (
-        scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE)
-        is False
-    )
-    assert (
-        scanner._is_valid_register_value("supply_air_flow", SENSOR_UNAVAILABLE)
-        is False
-    )
+    assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
+    assert scanner._is_valid_register_value("supply_air_flow", SENSOR_UNAVAILABLE) is False
 
     # Invalid air flow value
     assert scanner._is_valid_register_value("supply_air_flow", 65535) is False
@@ -601,13 +589,14 @@ async def test_decode_register_time():
     assert _decode_register_time(0x1234) == 1852
     assert _decode_register_time(0x2460) is None
     assert _decode_register_time(0x0960) is None
+
+
 async def test_decode_bcd_time():
     """Verify time decoding for both BCD and decimal values."""
     assert _decode_bcd_time(0x1234) == 1234
     assert _decode_bcd_time(0x0800) == 800
     assert _decode_bcd_time(0x2460) is None
     assert _decode_bcd_time(2400) is None
-
 
 
 async def test_decode_setting_value():


### PR DESCRIPTION
## Summary
- avoid duplicate single-register reads in device scanner
- ensure fallback read logging still captured
- test scanner batch fallback reads only once per register

## Testing
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py`
- `SKIP=bandit,mypy pre-commit run --files tests/test_device_scanner.py`
- `pytest tests/test_device_scanner.py::test_scan_device_batch_fallback -q`
- `pytest tests/test_device_scanner.py::test_scan_device_success_dynamic -q`

------
https://chatgpt.com/codex/tasks/task_e_689d8e7664dc8326a74f4affc331ba62