### PR TITLE
Avoid double single-register probes on failed batch read

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -904,20 +904,6 @@ class ThesslaGreenDeviceScanner:
                 for start, count in self._group_registers_for_batch_read(addresses):
                     values = await read_fn(client, start, count)
                     if values is None:
-                        for addr in range(start, start + count):
-                            single = await read_fn(client, addr, 1)
-                            if single is None:
-                                _LOGGER.debug("Failed to read %s register 0x%04X", reg_type, addr)
-                                continue
-                            name = addr_to_name.get(addr)
-                            if not name:
-                                continue
-                            value = single[0]
-                            if reg_type in ("input_registers", "holding_registers"):
-                                if self._is_valid_register_value(name, value):
-                                    self.available_registers[reg_type].add(name)
-                            else:
-                                self.available_registers[reg_type].add(name)
                         continue
                     for offset, value in enumerate(values):
                         addr = start + offset
@@ -957,20 +943,6 @@ class ThesslaGreenDeviceScanner:
                 for start, count in self._group_registers_for_batch_read(addresses):
                     values = await read_fn(client, start, count)
                     if values is None:
-                        for addr in range(start, start + count):
-                            single = await read_fn(client, addr, 1)
-                            if single is None:
-                                _LOGGER.debug("Failed to read %s register 0x%04X", reg_type, addr)
-                                continue
-                            reg_name = addr_to_name.get(addr)
-                            if not reg_name:
-                                continue
-                            value = single[0]
-                            if reg_type in ("input_registers", "holding_registers"):
-                                if self._is_valid_register_value(reg_name, value):
-                                    self.available_registers[reg_type].add(reg_name)
-                            else:
-                                self.available_registers[reg_type].add(reg_name)
                         continue
                     for offset, value in enumerate(values):
                         addr = start + offset


### PR DESCRIPTION
## Summary
- Remove redundant per-register retry loop in device scanner's `scan` method so failed batch reads are not re-read twice

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: Name "ConnectionException" already defined ...)*
- `pytest` *(fails: ImportError: cannot import name 'translation' from 'homeassistant.helpers')*


------
https://chatgpt.com/codex/tasks/task_e_689d903388648326897c49aaf75f0a75