### PR TITLE
Split batch groups around missing registers

### DIFF
--- a/tests/test_register_grouping.py
+++ b/tests/test_register_grouping.py
@@ -1,0 +1,26 @@
+import pytest
+
+from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.registers import INPUT_REGISTERS
+
+
+@pytest.mark.asyncio
+async def test_group_registers_split_known_missing():
+    """Known missing input registers are split into individual groups."""
+    scanner = ThesslaGreenDeviceScanner("host", 502)
+    missing_addr = INPUT_REGISTERS["compilation_days"]
+    addresses = [
+        missing_addr - 2,
+        missing_addr - 1,
+        missing_addr,
+        missing_addr + 1,
+        missing_addr + 2,
+    ]
+
+    groups = scanner._group_registers_for_batch_read(addresses)
+
+    assert groups == [
+        (missing_addr - 2, 2),
+        (missing_addr, 1),
+        (missing_addr + 1, 2),
+    ]  # nosec B101


### PR DESCRIPTION
## Summary
- split register groups when they include known-missing input registers
- document missing-register split logic
- test register grouping for known-missing registers

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_register_grouping.py` (fails: Source file found twice under different module names)
- `pytest tests/test_register_grouping.py`


------
https://chatgpt.com/codex/tasks/task_e_689d90382fa48326b8f570996f11a8e4