### PR TITLE
Handle cancellation during holding register retries

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -550,7 +550,13 @@ class ThesslaGreenDeviceScanner:
                 break
 
             if attempt < self.retry:
-                await asyncio.sleep((self.backoff or 1) * 2 ** (attempt - 1))
+                try:
+                    await asyncio.sleep((self.backoff or 1) * 2 ** (attempt - 1))
+                except asyncio.CancelledError:
+                    _LOGGER.debug(
+                        "Sleep cancelled while retrying holding 0x%04X", address
+                    )
+                    raise
 
         return None
 

--- a/tests/test_read_holding_cancel.py
+++ b/tests/test_read_holding_cancel.py
@@ -1,0 +1,36 @@
+"""Tests for cancellation handling in _read_holding."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.thessla_green_modbus.device_scanner import (
+    ThesslaGreenDeviceScanner,
+)
+from custom_components.thessla_green_modbus.modbus_exceptions import (
+    ModbusIOException,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_read_holding_cancellation_during_sleep(caplog):
+    """Cancellation during retry sleep propagates without error logging."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+    mock_client = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+            AsyncMock(side_effect=ModbusIOException("boom")),
+        ),
+        patch("asyncio.sleep", AsyncMock(side_effect=asyncio.CancelledError)),
+        caplog.at_level(logging.DEBUG),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await scanner._read_holding(mock_client, 0x0001, 1)
+
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+


### PR DESCRIPTION
## Summary
- propagate task cancellation when `_read_holding` is sleeping between retries
- add regression test for cancellation during holding register retry delay

## Testing
- `pytest tests/test_read_holding_cancel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689da9042bac8326b92baa76615cd054