### PR TITLE
Handle cancellation in register read helpers

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -460,6 +460,14 @@ class ThesslaGreenDeviceScanner:
                     exc,
                     exc_info=True,
                 )
+            except asyncio.CancelledError:
+                _LOGGER.debug(
+                    "Cancelled reading input registers 0x%04X-0x%04X on attempt %d",
+                    start,
+                    end,
+                    attempt,
+                )
+                raise
             except OSError as exc:
                 _LOGGER.error(
                     "Unexpected error reading input registers 0x%04X-0x%04X on attempt %d: %s",
@@ -472,7 +480,15 @@ class ThesslaGreenDeviceScanner:
                 break
 
             if attempt < self.retry:
-                await asyncio.sleep((self.backoff or 1) * 2 ** (attempt - 1))
+                try:
+                    await asyncio.sleep((self.backoff or 1) * 2 ** (attempt - 1))
+                except asyncio.CancelledError:
+                    _LOGGER.debug(
+                        "Sleep cancelled while retrying input registers 0x%04X-0x%04X",
+                        start,
+                        end,
+                    )
+                    raise
 
         _LOGGER.warning(
             "Failed to read input registers 0x%04X-0x%04X after %d retries",
@@ -540,6 +556,14 @@ class ThesslaGreenDeviceScanner:
                     exc,
                     exc_info=True,
                 )
+            except asyncio.CancelledError:
+                _LOGGER.debug(
+                    "Cancelled reading holding 0x%04X on attempt %d/%d",
+                    address,
+                    attempt,
+                    self.retry,
+                )
+                raise
             except OSError as exc:
                 _LOGGER.error(
                     "Unexpected error reading holding 0x%04X: %s",
@@ -579,6 +603,13 @@ class ThesslaGreenDeviceScanner:
                     exc,
                     exc_info=True,
                 )
+            except asyncio.CancelledError:
+                _LOGGER.debug(
+                    "Cancelled reading coil 0x%04X on attempt %d",
+                    address,
+                    attempt,
+                )
+                raise
             except OSError as exc:
                 _LOGGER.error(
                     "Unexpected error reading coil 0x%04X on attempt %d: %s",
@@ -590,7 +621,14 @@ class ThesslaGreenDeviceScanner:
                 break
 
             if attempt < self.retry:
-                await asyncio.sleep(2 ** (attempt - 1))
+                try:
+                    await asyncio.sleep(2 ** (attempt - 1))
+                except asyncio.CancelledError:
+                    _LOGGER.debug(
+                        "Sleep cancelled while retrying coil 0x%04X",
+                        address,
+                    )
+                    raise
 
         return None
 
@@ -613,6 +651,13 @@ class ThesslaGreenDeviceScanner:
                     exc,
                     exc_info=True,
                 )
+            except asyncio.CancelledError:
+                _LOGGER.debug(
+                    "Cancelled reading discrete 0x%04X on attempt %d",
+                    address,
+                    attempt,
+                )
+                raise
             except OSError as exc:
                 _LOGGER.error(
                     "Unexpected error reading discrete 0x%04X on attempt %d: %s",
@@ -624,7 +669,14 @@ class ThesslaGreenDeviceScanner:
                 break
 
             if attempt < self.retry:
-                await asyncio.sleep(2 ** (attempt - 1))
+                try:
+                    await asyncio.sleep(2 ** (attempt - 1))
+                except asyncio.CancelledError:
+                    _LOGGER.debug(
+                        "Sleep cancelled while retrying discrete 0x%04X",
+                        address,
+                    )
+                    raise
 
         return None
 

--- a/tests/test_read_cancellation.py
+++ b/tests/test_read_cancellation.py
@@ -1,4 +1,4 @@
-"""Tests for cancellation handling in _read_holding."""
+"""Tests for cancellation handling in register read helpers."""
 
 import asyncio
 import logging
@@ -6,17 +6,16 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from custom_components.thessla_green_modbus.device_scanner import (
-    ThesslaGreenDeviceScanner,
-)
-from custom_components.thessla_green_modbus.modbus_exceptions import (
-    ModbusIOException,
-)
+from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
 
 pytestmark = pytest.mark.asyncio
 
-
-async def test_read_holding_cancellation_during_sleep(caplog):
+@pytest.mark.parametrize(
+    "method",
+    ["_read_input", "_read_holding", "_read_coil", "_read_discrete"],
+)
+async def test_read_cancellation_during_sleep(method, caplog):
     """Cancellation during retry sleep propagates without error logging."""
     scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
     mock_client = AsyncMock()
@@ -29,8 +28,9 @@ async def test_read_holding_cancellation_during_sleep(caplog):
         patch("asyncio.sleep", AsyncMock(side_effect=asyncio.CancelledError)),
         caplog.at_level(logging.DEBUG),
     ):
+        func = getattr(scanner, method)
         with pytest.raises(asyncio.CancelledError):
-            await scanner._read_holding(mock_client, 0x0001, 1)
+            await func(mock_client, 0x0001, 1)
 
     assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 


### PR DESCRIPTION
## Summary
- handle `asyncio.CancelledError` in `_read_input`, `_read_holding`, `_read_coil`, and `_read_discrete`
- log and propagate cancellation to stop retry loops cleanly
- add tests covering cancellation mid-retry for all read helpers

## Testing
- `pytest tests/test_read_cancellation.py`


------
https://chatgpt.com/codex/tasks/task_e_689dab5d10d0832688ff4aa62a7ce75b