### PR TITLE
Add capability inference rules and expose on device info

### DIFF
--- a/custom_components/thessla_green_modbus/capability_rules.py
+++ b/custom_components/thessla_green_modbus/capability_rules.py
@@ -1,0 +1,16 @@
+"""Capability inference rules for device scanner.
+
+Maps capability attributes to keywords that indicate their presence when
+found in register names.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+CAPABILITY_PATTERNS: Mapping[str, Sequence[str]] = {
+    "heating_system": ("heating", "heater"),
+    "cooling_system": ("cooling", "cooler"),
+    "bypass_system": ("bypass",),
+    "gwc_system": ("gwc",),
+}


### PR DESCRIPTION
## Summary
- add CAPABILITY_PATTERNS helper for heating/bypass/etc detection
- expose detected capabilities on DeviceInfo and scan results
- test capability inference and device info exposure

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/capability_rules.py custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py` *(fails: mypy source file found twice, bandit asserts)*
- `pytest tests/test_device_scanner.py::test_scan_device_success_static tests/test_device_scanner.py::test_capability_rules_detect_heating_and_bypass tests/test_device_scanner.py::test_scan_device_includes_capabilities_in_device_info -q`


------
https://chatgpt.com/codex/tasks/task_e_689db17fd9948326a2de7c5b22ac9b2f