### PR TITLE
Skip unsupported input register ranges

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -429,12 +429,16 @@ class ThesslaGreenDeviceScanner:
                 self._input_skip_log_ranges.add((skip_start, skip_end))
             return None
 
+        exception_code: Optional[int] = None
         for attempt in range(1, self.retry + 1):
             try:
                 response = await _call_modbus(
                     client.read_input_registers, self.slave_id, address, count=count
                 )
-                if response is not None and not response.isError():
+                if response is not None:
+                    if response.isError():
+                        exception_code = getattr(response, "exception_code", None)
+                        break
                     return response.registers
             except ModbusIOException as exc:
                 _LOGGER.debug(
@@ -479,7 +483,7 @@ class ThesslaGreenDeviceScanner:
                 )
                 break
 
-            if attempt < self.retry:
+            if attempt < self.retry and exception_code is None:
                 try:
                     await asyncio.sleep((self.backoff or 1) * 2 ** (attempt - 1))
                 except asyncio.CancelledError:
@@ -489,6 +493,18 @@ class ThesslaGreenDeviceScanner:
                         end,
                     )
                     raise
+
+        if exception_code is not None:
+            self._failed_input.update(range(start, end + 1))
+            if (start, end) not in self._input_skip_log_ranges:
+                _LOGGER.warning(
+                    "Skipping unsupported input registers 0x%04X-0x%04X (exception code %d)",
+                    start,
+                    end,
+                    exception_code,
+                )
+                self._input_skip_log_ranges.add((start, end))
+            return None
 
         _LOGGER.warning(
             "Failed to read input registers 0x%04X-0x%04X after %d retries",
@@ -577,9 +593,7 @@ class ThesslaGreenDeviceScanner:
                 try:
                     await asyncio.sleep((self.backoff or 1) * 2 ** (attempt - 1))
                 except asyncio.CancelledError:
-                    _LOGGER.debug(
-                        "Sleep cancelled while retrying holding 0x%04X", address
-                    )
+                    _LOGGER.debug("Sleep cancelled while retrying holding 0x%04X", address)
                     raise
 
         return None


### PR DESCRIPTION
## Summary
- detect Modbus exception codes when reading input register blocks and skip the entire range after first failure
- log concise warning for skipped register ranges
- add unit test for skipping range on exception response

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py`
- `pytest tests/test_device_scanner.py::test_read_input_skips_range_on_exception_response`


------
https://chatgpt.com/codex/tasks/task_e_689db17afecc8326a5ae5f32acd99ff0