### PR TITLE
Return hex string on invalid time decoding

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -109,7 +109,13 @@ def _format_register_value(name: str, value: int) -> int | str:
     if name.startswith(BCD_TIME_PREFIXES):
         decoded = _decode_bcd_time(value)
         if decoded is None:
-            return value
+            return f"0x{value:04X} (invalid)"
+        return f"{decoded // 100:02d}:{decoded % 100:02d}"
+
+    if name.startswith(TIME_REGISTER_PREFIXES):
+        decoded = _decode_register_time(value)
+        if decoded is None:
+            return f"0x{value:04X} (invalid)"
         return f"{decoded // 100:02d}:{decoded % 100:02d}"
 
     if name.startswith(SETTING_PREFIX):
@@ -577,9 +583,7 @@ class ThesslaGreenDeviceScanner:
                 try:
                     await asyncio.sleep((self.backoff or 1) * 2 ** (attempt - 1))
                 except asyncio.CancelledError:
-                    _LOGGER.debug(
-                        "Sleep cancelled while retrying holding 0x%04X", address
-                    )
+                    _LOGGER.debug("Sleep cancelled while retrying holding 0x%04X", address)
                     raise
 
         return None


### PR DESCRIPTION
## Summary
- return `0xXXXX (invalid)` when time registers cannot be decoded
- test for invalid time formatting and logging

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py tests/test_device_scanner.py`
- `pytest tests/test_device_scanner.py::test_format_register_value_invalid_time tests/test_device_scanner.py::test_log_invalid_value_invalid_time`
- `pytest` *(fails: AttributeError: 'ThesslaGreenModbusCoordinator' object has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_689db16daef8832688e945cfaca72623