### PR TITLE
Add register decoder tests

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_exceptions.py
+++ b/custom_components/thessla_green_modbus/modbus_exceptions.py
@@ -3,6 +3,7 @@
 Provides ``ConnectionException`` and ``ModbusException`` classes even when
 pymodbus is not installed. This allows tests to run without the dependency.
 """
+
 from __future__ import annotations
 
 import logging
@@ -10,25 +11,23 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 try:  # pragma: no cover - handle missing or incompatible pymodbus
-    from pymodbus.exceptions import (
-        ConnectionException,
-        ModbusException,
-        ModbusIOException,
-    )
+    from pymodbus.exceptions import ConnectionException, ModbusException, ModbusIOException
 except (ModuleNotFoundError, ImportError):  # pragma: no cover
-    class ConnectionException(Exception):
+
+    class ConnectionException(Exception):  # type: ignore[no-redef]
         """Fallback exception when pymodbus is unavailable."""
 
         pass
 
-    class ModbusException(Exception):
+    class ModbusException(Exception):  # type: ignore[no-redef]
         """Fallback Modbus exception when pymodbus is unavailable."""
 
         pass
 
-    class ModbusIOException(ModbusException):
+    class ModbusIOException(ModbusException):  # type: ignore[no-redef]
         """Fallback Modbus I/O exception when pymodbus is unavailable."""
 
         pass
+
 
 __all__ = ["ConnectionException", "ModbusException", "ModbusIOException"]

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -1,0 +1,47 @@
+import pytest
+
+from custom_components.thessla_green_modbus.device_scanner import (
+    _decode_bcd_time,
+    _decode_register_time,
+    _decode_setting_value,
+)
+
+
+def test_decode_register_time_valid():
+    """Ensure byte-encoded HH:MM values decode correctly."""
+    assert _decode_register_time(0x081E) == 830
+    assert _decode_register_time(0x1234) == 1852
+    assert _decode_register_time(0x0000) == 0
+
+
+@pytest.mark.parametrize("value", [0x2460, 0x0960, -1])
+def test_decode_register_time_invalid(value):
+    """Values outside valid hour/minute ranges should return None."""
+    assert _decode_register_time(value) is None
+
+
+def test_decode_bcd_time_valid():
+    """BCD and decimal HHMM values should be decoded correctly."""
+    assert _decode_bcd_time(0x1234) == 1234
+    assert _decode_bcd_time(0x0800) == 800
+    # Decimal fallback: BCD path invalid due to minutes > 59
+    assert _decode_bcd_time(615) == 615
+
+
+@pytest.mark.parametrize("value", [0x2460, 2400, -1, 0x1A59])
+def test_decode_bcd_time_invalid(value):
+    """Invalid BCD or decimal times should return None."""
+    assert _decode_bcd_time(value) is None
+
+
+def test_decode_setting_value_valid():
+    """Verify combined airflow/temperature registers decode correctly."""
+    assert _decode_setting_value(0x3C28) == (60, 20.0)
+    assert _decode_setting_value(0x6432) == (100, 25.0)
+    assert _decode_setting_value(0x0000) == (0, 0.0)
+
+
+@pytest.mark.parametrize("value", [-1, 0xFF28, 0x3DFF])
+def test_decode_setting_value_invalid(value):
+    """Values outside expected ranges should return None."""
+    assert _decode_setting_value(value) is None


### PR DESCRIPTION
## Summary
- add focused tests for register time, BCD time and setting value decoders
- silence mypy redefinition warnings in `modbus_exceptions`

## Testing
- `pre-commit run --files tests/test_register_decoders.py` *(fails: mypy cannot process device_scanner and other modules)*
- `pytest tests/test_register_decoders.py`
- `pytest` *(fails: numerous missing attribute/errors in optimized integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_689db16c30dc832696e9d090c7ccc805