### PR TITLE
Fix range parsing in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -127,8 +127,6 @@ def _format_register_value(name: str, value: int) -> int | str:
         decoded = _decode_register_time(value)
         if decoded is None:
             return f"0x{value:04X} (invalid)"
-        return f"{decoded // 100:02d}:{decoded % 100:02d}"
-            return value
         return f"{decoded // 60:02d}:{decoded % 60:02d}"
 
     if name.startswith(SETTING_PREFIX):
@@ -369,8 +367,6 @@ class ThesslaGreenDeviceScanner:
                                 return None
 
                             try:
-
-                                return int(text, 0)
                                 return (
                                     int(text, 0)
                                     if text.lower().startswith(("0x", "+0x", "-0x"))


### PR DESCRIPTION
## Summary
- remove unreachable integer conversion
- tidy time register formatting to avoid syntax error

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: mypy errors in unrelated files)*
- `python -m py_compile custom_components/thessla_green_modbus/device_scanner.py`
- `pytest` *(fails: missing Home Assistant dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689dba3631b08326953d5a9fda380098