### PR TITLE
Fix time formatting in register value helper

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -121,14 +121,12 @@ def _format_register_value(name: str, value: int) -> int | str:
         decoded = _decode_bcd_time(value)
         if decoded is None:
             return f"0x{value:04X} (invalid)"
-        return f"{decoded // 100:02d}:{decoded % 100:02d}"
+        return f"{decoded // 60:02d}:{decoded % 60:02d}"
 
     if name.startswith(TIME_REGISTER_PREFIXES):
         decoded = _decode_register_time(value)
         if decoded is None:
             return f"0x{value:04X} (invalid)"
-        return f"{decoded // 100:02d}:{decoded % 100:02d}"
-            return value
         return f"{decoded // 60:02d}:{decoded % 60:02d}"
 
     if name.startswith(SETTING_PREFIX):


### PR DESCRIPTION
### Summary
- handle decoded time values in minutes correctly and clean up stray return

### Testing
- `python -m py_compile custom_components/thessla_green_modbus/device_scanner.py`
- `pytest -q` *(fails: AttributeError: 'int' object has no attribute 'total_seconds', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689dba3c3ed0832696e26da648a92f6c