### PR TITLE
refactor: unify input register cache check

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -121,14 +121,12 @@ def _format_register_value(name: str, value: int) -> int | str:
         decoded = _decode_bcd_time(value)
         if decoded is None:
             return f"0x{value:04X} (invalid)"
-        return f"{decoded // 100:02d}:{decoded % 100:02d}"
+        return f"{decoded // 60:02d}:{decoded % 60:02d}"
 
     if name.startswith(TIME_REGISTER_PREFIXES):
         decoded = _decode_register_time(value)
         if decoded is None:
             return f"0x{value:04X} (invalid)"
-        return f"{decoded // 100:02d}:{decoded % 100:02d}"
-            return value
         return f"{decoded // 60:02d}:{decoded % 60:02d}"
 
     if name.startswith(SETTING_PREFIX):
@@ -466,12 +464,6 @@ class ThesslaGreenDeviceScanner:
         end = address + count - 1
 
         if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
-            _LOGGER.debug(
-                "Skipping cached failed input registers 0x%04X-0x%04X",
-                start,
-                end,
-            )
-        if any(reg in self._failed_input for reg in range(start, end + 1)):
             first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
             skip_start = skip_end = first
             while skip_start - 1 in self._failed_input:


### PR DESCRIPTION
## Summary
- streamline cached input register skips into a single `skip_cache` block
- correct time register formatting to output `HH:MM`

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/device_scanner.py`
- `pytest tests/test_device_scanner.py tests/test_input_range_fallback.py tests/test_read_cancellation.py tests/test_scanner_close.py` *(fails: AttributeError: 'int' object has no attribute 'total_seconds'; 8 more failures)*

------
https://chatgpt.com/codex/tasks/task_e_689dba412e848326ae61dd2209658698