### PR TITLE
Track repeated holding register failures

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -463,12 +463,8 @@ class ThesslaGreenDeviceScanner:
 
         if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
             first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
-        if not skip_cache and any(
-            reg in self._failed_input for reg in range(start, end + 1)
-        ):
-            first = next(
-                reg for reg in range(start, end + 1) if reg in self._failed_input
-            )
+        if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
+            first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
             skip_start = skip_end = first
             while skip_start - 1 in self._failed_input:
                 skip_start -= 1
@@ -626,6 +622,12 @@ class ThesslaGreenDeviceScanner:
                     exc,
                     exc_info=True,
                 )
+                if count == 1:
+                    failures = self._holding_failures.get(address, 0) + 1
+                    self._holding_failures[address] = failures
+                    if failures >= self.retry and address not in self._failed_holding:
+                        self._failed_holding.add(address)
+                        _LOGGER.warning("Device does not expose register 0x%04X", address)
             except asyncio.CancelledError:
                 _LOGGER.debug(
                     "Cancelled reading holding 0x%04X on attempt %d/%d",


### PR DESCRIPTION
## Summary
- track repeated connection or timeout errors when reading holding registers
- skip unsupported holding registers after multiple failures

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: mypy - 66 errors)*
- `pytest` *(fails: ImportError: cannot import name 'translation' from 'homeassistant.helpers')*

------
https://chatgpt.com/codex/tasks/task_e_689dd124e05c8326928afd7c13365352