### PR TITLE
Handle little-endian manual airing register

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -117,6 +117,14 @@ def _decode_setting_value(value: int) -> Optional[Tuple[int, float]]:
 def _format_register_value(name: str, value: int) -> int | str:
     """Return a human-readable representation of a register value."""
 
+    if name == "manual_airing_time_to_start":
+        raw_value = value
+        value = ((value & 0xFF) << 8) | ((value >> 8) & 0xFF)
+        decoded = _decode_register_time(value)
+        if decoded is None:
+            return f"0x{raw_value:04X} (invalid)"
+        return f"{decoded // 60:02d}:{decoded % 60:02d}"
+
     if name.startswith(BCD_TIME_PREFIXES):
         decoded = _decode_bcd_time(value)
         if decoded is None:

--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -1,4 +1,9 @@
-"""Register definitions for the ThesslaGreen Modbus integration."""
+"""Register definitions for the ThesslaGreen Modbus integration.
+
+By default, multi-byte register values are encoded in big-endian order. A
+notable exception is ``manual_airing_time_to_start``, which stores its HH:MM
+time value in little-endian (minute-hour) format.
+"""
 
 from __future__ import annotations
 
@@ -223,7 +228,7 @@ HOLDING_REGISTERS: dict[str, int] = {
     "fan_speed_1_coef": 4216,
     "fan_speed_2_coef": 4217,
     "fan_speed_3_coef": 4218,
-    "manual_airing_time_to_start": 4219,
+    "manual_airing_time_to_start": 4219,  # little-endian HH:MM
     "special_mode": 4224,
     "hood_supply_coef": 4226,
     "hood_exhaust_coef": 4227,

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -742,6 +742,13 @@ async def test_format_register_value_schedule():
     assert _format_register_value("schedule_summer_mon_1", 0x0615) == "06:15"
 
 
+async def test_format_register_value_manual_airing_le():
+    """Little-endian manual airing times should decode correctly."""
+    assert (
+        _format_register_value("manual_airing_time_to_start", 0x1E08) == "08:30"
+    )
+
+
 async def test_format_register_value_setting():
     """Formatted setting registers should show percent and temperature."""
     assert _format_register_value("setting_winter_mon_1", 0x3C28) == "60% @ 20°C"


### PR DESCRIPTION
## Summary
- swap bytes for `manual_airing_time_to_start` so little-endian values decode correctly
- document register byte order and little-endian exception in `registers.py`
- test manual airing time decoding

## Testing
- `pytest -q` *(fails: module 'homeassistant.helpers' has no attribute 'script')*
- `pytest tests/test_device_scanner.py::test_format_register_value_manual_airing_le -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd1243bac83269e26258279c64d5c