### PR TITLE
Fix UART capability range

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -143,8 +143,13 @@ def _format_register_value(name: str, value: int) -> int | str:
 # Maximum registers per batch read (Modbus limit)
 MAX_BATCH_REGISTERS = 16
 
-# Optional UART configuration registers (Air++ port)
-UART_OPTIONAL_REGS = range(0x1168, 0x116C)
+# Optional UART configuration registers (Air-B and Air++ ports)
+# According to the Series 4 Modbus documentation, both the Air-B
+# (0x1164-0x1167) and Air++ (0x1168-0x116B) register blocks are
+# optional and may be absent on devices without the corresponding
+# hardware. They are skipped by default unless UART scanning is
+# explicitly enabled.
+UART_OPTIONAL_REGS = range(0x1164, 0x116C)
 
 
 @dataclass

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -1023,12 +1023,13 @@ async def test_analyze_capabilities_flag_presence():
         "input_registers": {"constant_flow_active", "outside_temperature"},
         "holding_registers": set(),
         "coil_registers": set(),
-        "discrete_inputs": set(),
+        "discrete_inputs": {"expansion"},
     }
     capabilities = scanner._analyze_capabilities()
 
     assert capabilities.constant_flow is True
     assert capabilities.sensor_outside_temperature is True
+    assert capabilities.expansion_module is True
 
     # Negative case: registers absent
     scanner.available_registers = {
@@ -1041,6 +1042,7 @@ async def test_analyze_capabilities_flag_presence():
 
     assert capabilities.constant_flow is False
     assert capabilities.sensor_outside_temperature is False
+    assert capabilities.expansion_module is False
 
 
 async def test_capability_rules_detect_heating_and_bypass():


### PR DESCRIPTION
## Summary
- include Air-B UART registers in optional scan range
- test expansion-module capability detection

## Testing
- `pytest tests/test_device_scanner.py::test_analyze_capabilities -q`
- `pytest tests/test_device_scanner.py::test_analyze_capabilities_flag_presence -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd11147888326b5c76559fdb18104