### PR TITLE
Expose supported coil registers as switch entities

### DIFF
--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import COIL_REGISTERS, DOMAIN, SPECIAL_FUNCTION_MAP
+from .const import COIL_REGISTERS, DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .modbus_exceptions import ConnectionException, ModbusException
@@ -20,41 +20,64 @@ _LOGGER = logging.getLogger(__name__)
 
 # Switch entities that can be controlled
 SWITCH_ENTITIES: Dict[str, Dict[str, Any]] = {
-    # System control switches from holding registers
-    "on_off_panel_mode": {
-        "icon": "mdi:power",
-        "register": "on_off_panel_mode",
-        "register_type": "holding_registers",
+    # Output controls from coil registers
+    "duct_water_heater_pump": {
+        "icon": "mdi:pump",
+        "register": "duct_water_heater_pump",
+        "register_type": "coil_registers",
         "category": None,
-        "translation_key": "on_off_panel_mode",
+        "translation_key": "duct_water_heater_pump",
+    },
+    "bypass": {
+        "icon": "mdi:pipe-leak",
+        "register": "bypass",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "bypass",
+    },
+    "info": {
+        "icon": "mdi:information",
+        "register": "info",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "info",
+    },
+    "power_supply_fans": {
+        "icon": "mdi:fan",
+        "register": "power_supply_fans",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "power_supply_fans",
+    },
+    "heating_cable": {
+        "icon": "mdi:heating-coil",
+        "register": "heating_cable",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "heating_cable",
+    },
+    "work_permit": {
+        "icon": "mdi:check-circle",
+        "register": "work_permit",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "work_permit",
+    },
+    "gwc": {
+        "icon": "mdi:pipe",
+        "register": "gwc",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "gwc",
+    },
+    "hood_output": {
+        "icon": "mdi:stove",
+        "register": "hood_output",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "hood_output",
     },
 }
-
-# Icon mapping for special modes
-SPECIAL_MODE_ICONS = {
-    "boost": "mdi:rocket-launch",
-    "eco": "mdi:leaf",
-    "away": "mdi:airplane",
-    "fireplace": "mdi:fireplace",
-    "hood": "mdi:range-hood",
-    "sleep": "mdi:weather-night",
-    "party": "mdi:party-popper",
-    "bathroom": "mdi:shower",
-    "kitchen": "mdi:chef-hat",
-    "summer": "mdi:white-balance-sunny",
-    "winter": "mdi:snowflake",
-}
-
-# Dynamically create switch entries for each special mode bit
-for mode, bit in SPECIAL_FUNCTION_MAP.items():
-    SWITCH_ENTITIES[mode] = {
-        "icon": SPECIAL_MODE_ICONS.get(mode, "mdi:toggle-switch"),
-        "register": "special_mode",
-        "register_type": "holding_registers",
-        "category": None,
-        "translation_key": mode,
-        "bit": bit,
-    }
 
 
 async def async_setup_entry(

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -271,41 +271,29 @@
       }
     },
     "switch": {
-      "on_off_panel_mode": {
-        "name": "Panel Power"
+      "duct_water_heater_pump": {
+        "name": "Water Heater Pump"
       },
-      "boost": {
-        "name": "Boost Mode"
+      "bypass": {
+        "name": "Bypass"
       },
-      "eco": {
-        "name": "Eco Mode"
+      "info": {
+        "name": "Unit Operation Confirmation"
       },
-      "sleep": {
-        "name": "Sleep Mode"
+      "power_supply_fans": {
+        "name": "Fan Power"
       },
-      "party": {
-        "name": "Party Mode"
+      "heating_cable": {
+        "name": "Heating Cable"
       },
-      "fireplace": {
-        "name": "Fireplace Mode"
+      "work_permit": {
+        "name": "Work Permit"
       },
-      "away": {
-        "name": "Away Mode"
+      "gwc": {
+        "name": "GWC"
       },
-      "hood": {
-        "name": "Hood Mode"
-      },
-      "bathroom": {
-        "name": "Bathroom Mode"
-      },
-      "kitchen": {
-        "name": "Kitchen Mode"
-      },
-      "summer": {
-        "name": "Summer Mode"
-      },
-      "winter": {
-        "name": "Winter Mode"
+      "hood_output": {
+        "name": "Hood Output"
       }
     },
     "select": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -271,41 +271,29 @@
       }
     },
     "switch": {
-      "on_off_panel_mode": {
-        "name": "Główne zasilanie"
+      "duct_water_heater_pump": {
+        "name": "Pompa obiegowa nagrzewnicy"
       },
-      "boost": {
-        "name": "Tryb boost"
+      "bypass": {
+        "name": "Obejście (bypass)"
       },
-      "eco": {
-        "name": "Tryb eco"
+      "info": {
+        "name": "Potwierdzenie pracy centrali"
       },
-      "sleep": {
-        "name": "Tryb nocny"
+      "power_supply_fans": {
+        "name": "Zasilanie wentylatorów"
       },
-      "party": {
-        "name": "Tryb party"
+      "heating_cable": {
+        "name": "Kabel grzejny"
       },
-      "fireplace": {
-        "name": "Tryb kominkowy"
+      "work_permit": {
+        "name": "Potwierdzenie pracy (Expansion)"
       },
-      "away": {
-        "name": "Tryb urlopowy"
+      "gwc": {
+        "name": "GWC"
       },
-      "hood": {
-        "name": "Tryb okapu"
-      },
-      "bathroom": {
-        "name": "Tryb łazienkowy"
-      },
-      "kitchen": {
-        "name": "Tryb kuchenny"
-      },
-      "summer": {
-        "name": "Tryb letni"
-      },
-      "winter": {
-        "name": "Tryb zimowy"
+      "hood_output": {
+        "name": "Wyjście okapu"
       }
     },
     "select": {

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -63,35 +63,33 @@ from custom_components.thessla_green_modbus.switch import (  # noqa: E402
 
 
 def test_switch_creation_and_state(mock_coordinator):
-    """Test creation and state changes of special mode switch."""
-    bit = SWITCH_ENTITIES["boost"]["bit"]
-    mock_coordinator.data["special_mode"] = bit
-    switch = ThesslaGreenSwitch(mock_coordinator, "boost", SWITCH_ENTITIES["boost"])
+    """Test creation and state changes of coil switch."""
+    mock_coordinator.data["bypass"] = 1
+    switch = ThesslaGreenSwitch(mock_coordinator, "bypass", SWITCH_ENTITIES["bypass"])
     assert switch.is_on is True  # nosec B101
 
-    mock_coordinator.data["special_mode"] = 0
+    mock_coordinator.data["bypass"] = 0
     assert switch.is_on is False  # nosec B101
 
 
 def test_switch_turn_on_off(mock_coordinator):
-    bit = SWITCH_ENTITIES["boost"]["bit"]
-    mock_coordinator.data["special_mode"] = 0
-    switch = ThesslaGreenSwitch(mock_coordinator, "boost", SWITCH_ENTITIES["boost"])
+    mock_coordinator.data["bypass"] = 0
+    switch = ThesslaGreenSwitch(mock_coordinator, "bypass", SWITCH_ENTITIES["bypass"])
     asyncio.run(switch.async_turn_on())
-    mock_coordinator.async_write_register.assert_awaited_with("special_mode", bit, refresh=False)
+    mock_coordinator.async_write_register.assert_awaited_with("bypass", 1, refresh=False)
     mock_coordinator.async_request_refresh.assert_awaited_once()
     mock_coordinator.async_write_register.reset_mock()
     mock_coordinator.async_request_refresh.reset_mock()
 
-    mock_coordinator.data["special_mode"] = bit
+    mock_coordinator.data["bypass"] = 1
     asyncio.run(switch.async_turn_off())
-    mock_coordinator.async_write_register.assert_awaited_with("special_mode", 0, refresh=False)
+    mock_coordinator.async_write_register.assert_awaited_with("bypass", 0, refresh=False)
     mock_coordinator.async_request_refresh.assert_awaited_once()
 
 
 def test_switch_turn_on_modbus_failure(mock_coordinator):
     """Ensure Modbus errors are surfaced when turning on the switch."""
-    switch = ThesslaGreenSwitch(mock_coordinator, "boost", SWITCH_ENTITIES["boost"])
+    switch = ThesslaGreenSwitch(mock_coordinator, "bypass", SWITCH_ENTITIES["bypass"])
     mock_coordinator.async_write_register = AsyncMock(side_effect=ConnectionException("fail"))
     with pytest.raises(ConnectionException):
         asyncio.run(switch.async_turn_on())

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 import yaml
 
-from custom_components.thessla_green_modbus.const import SPECIAL_FUNCTION_MAP
-
 ROOT = Path(__file__).resolve().parent.parent / "custom_components" / "thessla_green_modbus"
 
 with open(ROOT / "translations" / "en.json", "r", encoding="utf-8") as f:
@@ -62,7 +60,7 @@ def _load_keys(file: Path, var_name: str):
 
 SENSOR_KEYS = _load_translation_keys(ROOT / "sensor.py", "SENSOR_DEFINITIONS")
 BINARY_KEYS = _load_translation_keys(ROOT / "binary_sensor.py", "BINARY_SENSOR_DEFINITIONS")
-SWITCH_KEYS = _load_keys(ROOT / "switch.py", "SWITCH_ENTITIES") + list(SPECIAL_FUNCTION_MAP.keys())
+SWITCH_KEYS = _load_keys(ROOT / "switch.py", "SWITCH_ENTITIES")
 SELECT_KEYS = _load_keys(ROOT / "select.py", "SELECT_DEFINITIONS")
 NUMBER_KEYS = _load_keys(ROOT / "entity_mappings.py", "NUMBER_ENTITY_MAPPINGS")
 REGISTER_KEYS = _load_keys(ROOT / "registers.py", "HOLDING_REGISTERS")


### PR DESCRIPTION
## Summary
- replace dynamic special-mode switches with eight explicit coil-register switches
- update English and Polish translations for new switch entities
- adjust tests and translation checks for revised switch mapping

## Testing
- `SKIP=mypy,bandit,generate-registers pre-commit run --files custom_components/thessla_green_modbus/switch.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json tests/test_switch.py tests/test_translations.py`
- `pytest tests/test_switch.py tests/test_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_689dd5cf64b883268261532e259cf17d