### PR TITLE
Add hood switch binary sensor

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -92,6 +92,12 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "register_type": "discrete_inputs",
     },
+    "hood_switch": {
+        "translation_key": "hood_switch",
+        "icon": "mdi:toggle-switch",
+        "device_class": BinarySensorDeviceClass.RUNNING,
+        "register_type": "discrete_inputs",
+    },
     "airing_sensor": {
         "translation_key": "airing_sensor",
         "icon": "mdi:motion-sensor",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -204,6 +204,9 @@
       "dp_duct_filter_overflow": {
         "name": "Duct Filter Overflow"
       },
+      "hood_switch": {
+        "name": "Hood Switch"
+      },
       "airing_sensor": {
         "name": "Airing Sensor"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -204,6 +204,9 @@
       "dp_duct_filter_overflow": {
         "name": "Przepełnienie filtra kanałowego"
       },
+      "hood_switch": {
+        "name": "Przełącznik okapu"
+      },
       "airing_sensor": {
         "name": "Czujnik przewietrzania"
       },


### PR DESCRIPTION
## Summary
- expose hood function switch as binary sensor
- translate hood switch name in English and Polish

## Testing
- `pytest` *(fails: AttributeError 'int' object has no attribute 'total_seconds', and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dd5ce1e908326ab909e852ccdea07