### PR TITLE
Align binary sensors with documented status registers

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -164,26 +164,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.SAFETY,
         "register_type": "discrete_inputs",
     },
-    # Active modes (from input registers)
-    "constant_flow_active": {
-        "translation_key": "constant_flow_active",
-        "icon": "mdi:waves",
-        "device_class": BinarySensorDeviceClass.RUNNING,
-        "register_type": "input_registers",
-    },
-    "water_removal_active": {
-        "translation_key": "water_removal_active",
-        "icon": "mdi:water-off",
-        "device_class": BinarySensorDeviceClass.MOISTURE,
-        "register_type": "input_registers",
-    },
-    # Device main status (from holding registers)
-    "on_off_panel_mode": {
-        "translation_key": "on_off_panel_mode",
-        "icon": "mdi:power",
-        "device_class": BinarySensorDeviceClass.POWER,
-        "register_type": "holding_registers",
-    },
 }
 
 

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -204,9 +204,6 @@
       "heating_cable": {
         "name": "Heating Cable"
       },
-      "constant_flow_active": {
-        "name": "Constant Flow"
-      },
       "duct_water_heater_pump": {
         "name": "Water Heater Pump"
       },
@@ -264,14 +261,8 @@
       "empty_house": {
         "name": "Empty House"
       },
-      "water_removal_active": {
-        "name": "Water Removal Active"
-      },
       "fire_alarm": {
         "name": "Fire Alarm"
-      },
-      "on_off_panel_mode": {
-        "name": "Panel Power"
       }
     },
     "climate": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -263,15 +263,6 @@
       },
       "empty_house": {
         "name": "Pusty dom"
-      },
-      "water_removal_active": {
-        "name": "Aktywne odprowadzanie wody"
-      },
-      "constant_flow_active": {
-        "name": "Stały przepływ"
-      },
-      "on_off_panel_mode": {
-        "name": "Zasilanie główne"
       }
     },
     "climate": {

--- a/tests/test_unused_translations.py
+++ b/tests/test_unused_translations.py
@@ -11,9 +11,14 @@ from tests.test_translations import (
     SELECT_KEYS,
     SENSOR_KEYS,
     SERVICES,
+    SWITCH_KEYS as SWITCH_ENTITY_KEYS,
 )
 
-SWITCH_KEYS = ["on_off_panel_mode"] + list(SPECIAL_FUNCTION_MAP.keys())
+SWITCH_KEYS = (
+    SWITCH_ENTITY_KEYS
+    + ["on_off_panel_mode"]
+    + list(SPECIAL_FUNCTION_MAP.keys())
+)
 
 
 def _assert_no_extra_keys(trans, entity_type, valid_keys) -> None:


### PR DESCRIPTION
## Summary
- drop non-status entries from `BINARY_SENSOR_DEFINITIONS`
- ensure all 24 coil/discrete status registers are represented, including `hood_switch`
- clean translation tables and update translation tests

## Testing
- `pytest tests/test_unused_translations.py`
- `pytest` *(fails: AttributeError: 'int' object has no attribute 'total_seconds', and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ddeabf16883268ebe96f350dfb2f8