### PR TITLE
Handle missing Modbus client in optimized read and test cancellations

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -526,6 +526,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         if "holding_registers" not in self._register_groups:
             return data
 
+        if self.client is None:
+            _LOGGER.debug("Modbus client is not connected")
+            return data
+
         for start_addr, count in self._register_groups["holding_registers"]:
             try:
                 # Pass "count" as a keyword argument to ensure compatibility with

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,7 @@
 """Tests for ThesslaGreenModbusCoordinator - HA 2025.7.1+ & pymodbus 3.5+ Compatible."""
 
+import asyncio
+import logging
 import os
 import sys
 import types
@@ -195,6 +197,32 @@ async def test_async_write_valid_register(coordinator):
     assert result is True
     coordinator.async_request_refresh.assert_called_once()
     assert lock_state_during_refresh is False
+
+
+@pytest.mark.asyncio
+async def test_read_holding_registers_none_client(coordinator, caplog):
+    """Return empty data when no Modbus client is present."""
+    coordinator.client = None
+    coordinator._register_groups = {"holding_registers": [(0x0000, 1)]}
+
+    with caplog.at_level(logging.DEBUG):
+        result = await coordinator._read_holding_registers_optimized()
+
+    assert result == {}
+    assert "Modbus client is not connected" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_read_holding_registers_cancelled_error(coordinator, caplog):
+    """Propagate cancellation without logging noise."""
+    coordinator.client = MagicMock()
+    coordinator._register_groups = {"holding_registers": [(0x0000, 1)]}
+    coordinator._call_modbus = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator._read_holding_registers_optimized()
+    assert caplog.text == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- guard optimized holding register reads when the Modbus client is missing
- test optimized holding register reads with no client and cancelled operations

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py tests/test_coordinator.py`
- `pytest tests/test_coordinator.py::test_read_holding_registers_none_client tests/test_coordinator.py::test_read_holding_registers_cancelled_error -q`


------
https://chatgpt.com/codex/tasks/task_e_689de50216fc83268a788cdb618c5e3d