### PR TITLE
Handle missing modbus client when reading holding registers

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -523,6 +523,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         """Read holding registers using optimized batch reading."""
         data = {}
 
+        if self.client is None:
+            _LOGGER.debug("Modbus client not available; skipping holding register read")
+            raise UpdateFailed("Modbus client is not initialized")
+
         if "holding_registers" not in self._register_groups:
             return data
 


### PR DESCRIPTION
## Summary
- avoid AttributeError when Modbus client is missing by verifying `self.client` before reading holding registers

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` *(fails: mypy error and generate-registers hook modifications)*
- `pytest` *(fails: 51 failed, 126 passed, 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689de4fef1dc83268498fac09b909969