### PR TITLE
Add airflow rate sensors

### DIFF
--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -197,6 +197,20 @@ SENSOR_DEFINITIONS = {
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "holding_registers",
     },
+    "air_flow_rate_manual": {
+        "translation_key": "air_flow_rate_manual",
+        "icon": "mdi:fan",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+        "register_type": "holding_registers",
+    },
+    "air_flow_rate_temporary_2": {
+        "translation_key": "air_flow_rate_temporary_2",
+        "icon": "mdi:fan-clock",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+        "register_type": "holding_registers",
+    },
     "bypass_off": {
         "translation_key": "bypass_off",
         "icon": "mdi:thermometer-off",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -106,6 +106,12 @@
       "nominal_exhaust_air_flow": {
         "name": "Nominal Exhaust Airflow"
       },
+      "air_flow_rate_manual": {
+        "name": "Manual Airflow Rate"
+      },
+      "air_flow_rate_temporary_2": {
+        "name": "Temporary Airflow Rate 2"
+      },
       "bypass_off": {
         "name": "Bypass Off Temperature"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -106,6 +106,12 @@
       "nominal_exhaust_air_flow": {
         "name": "Nominalny przepływ wywiewu"
       },
+      "air_flow_rate_manual": {
+        "name": "Ręczny przepływ powietrza"
+      },
+      "air_flow_rate_temporary_2": {
+        "name": "Tymczasowy przepływ powietrza 2"
+      },
       "bypass_off": {
         "name": "Temperatura wyłączenia bypassu"
       },

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -92,8 +92,8 @@ def test_async_setup_creates_all_sensors(mock_coordinator, mock_config_entry):
         await async_setup_entry(hass, mock_config_entry, add_entities)
 
         entities = add_entities.call_args[0][0]
-        assert len(SENSOR_DEFINITIONS) == 44  # nosec B101
-        assert len(entities) == 44  # nosec B101
+        assert len(SENSOR_DEFINITIONS) == 46  # nosec B101
+        assert len(entities) == 46  # nosec B101
 
     asyncio.run(run_test())
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -147,6 +147,8 @@ def test_new_translation_keys_present():
         "nominal_supply_air_flow",
         "nominal_exhaust_air_flow",
         "bypass_off",
+        "air_flow_rate_manual",
+        "air_flow_rate_temporary_2",
     ]
     for trans in (EN, PL):
         for key in new_keys:


### PR DESCRIPTION
## Summary
- add manual and temporary airflow rate sensors
- provide translations for new sensors
- adjust tests for added sensors

## Testing
- `pytest` *(fails: AttributeError: 'int' object has no attribute 'total_seconds' and additional errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c28092083269eedb21aad6b03f4