### PR TITLE
Add sensor register mapping test

### DIFF
--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -212,7 +212,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_exhaust": {
         "translation_key": "dac_exhaust",
@@ -220,7 +220,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_heater": {
         "translation_key": "dac_heater",
@@ -228,7 +228,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_cooler": {
         "translation_key": "dac_cooler",
@@ -236,7 +236,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     # Percentage sensors
     "supply_percentage": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,11 +31,29 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
     cv = types.ModuleType("homeassistant.helpers.config_validation")
     selector = types.ModuleType("homeassistant.helpers.selector")
+    translation = types.ModuleType("homeassistant.helpers.translation")
+    async def async_get_translations(*args, **kwargs):  # pragma: no cover - stub
+        return {}
+    translation.async_get_translations = async_get_translations
     pymodbus = types.ModuleType("pymodbus")
     pymodbus_client = types.ModuleType("pymodbus.client")
     pymodbus_client_tcp = types.ModuleType("pymodbus.client.tcp")
     pymodbus_exceptions = types.ModuleType("pymodbus.exceptions")
     pymodbus_pdu = types.ModuleType("pymodbus.pdu")
+    hacc_common = types.ModuleType("pytest_homeassistant_custom_component.common")
+
+    class MockConfigEntry:  # pragma: no cover - simplified stub
+        def __init__(self, *, domain, data, options=None):
+            self.domain = domain
+            self.data = data
+            self.options = options or {}
+            self.entry_id = "mock_entry"
+            self.title = data.get("name", "")
+
+        def add_to_hass(self, _hass):
+            return None
+
+    hacc_common.MockConfigEntry = MockConfigEntry
 
     class HomeAssistant:  # type: ignore[override]
         async def async_add_executor_job(self, func, *args):  # minimal stub
@@ -234,11 +252,14 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
     sys.modules["homeassistant.helpers.config_validation"] = cv
     sys.modules["homeassistant.helpers.selector"] = selector
+    sys.modules["homeassistant.helpers.translation"] = translation
+    helpers_pkg.translation = translation
     sys.modules["pymodbus"] = pymodbus
     sys.modules["pymodbus.client"] = pymodbus_client
     sys.modules["pymodbus.client.tcp"] = pymodbus_client_tcp
     sys.modules["pymodbus.exceptions"] = pymodbus_exceptions
     sys.modules["pymodbus.pdu"] = pymodbus_pdu
+    sys.modules["pytest_homeassistant_custom_component.common"] = hacc_common
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 


### PR DESCRIPTION
## Summary
- add test verifying sensors map to correct register types
- fix DAC sensor register_type to holding registers
- stub translation and MockConfigEntry for tests

## Testing
- `pytest tests/test_sensor_register_mapping.py -q`
- `pytest -q` *(fails: ImportError cannot import name 'ThesslaGreenDeviceScanner' and assertion failures, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c1df6a08326a9ffb2c4153c7c3d