### PR TITLE
Fix DAC sensor register types

### DIFF
--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -212,7 +212,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_exhaust": {
         "translation_key": "dac_exhaust",
@@ -220,7 +220,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_heater": {
         "translation_key": "dac_heater",
@@ -228,7 +228,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     "dac_cooler": {
         "translation_key": "dac_cooler",
@@ -236,7 +236,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfElectricPotential.VOLT,
-        "register_type": "input_registers",
+        "register_type": "holding_registers",
     },
     # Percentage sensors
     "supply_percentage": {


### PR DESCRIPTION
## Summary
- use `holding_registers` for DAC sensors
- assert DAC sensors mapped to holding registers
- add cross-check of sensor definitions against register map

## Testing
- `pytest tests/test_sensor_platform.py -q`
- `pytest tests/test_registers.py -q`
- `pytest -q` *(fails: AttributeError: 'int' object has no attribute 'total_seconds', AsyncModbusTcpClient missing, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e1c1b4ae0832691dcf5089dcaa420