### PR TITLE
Add season mode select and airflow/temperature translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Adresy rejestrów, które wielokrotnie nie odpowiadają, są automatycznie pomij
 - **Climate**: Kompletna kontrola HVAC z preset modes
 - **Switches**: Wszystkie systemy, tryby, konfiguracja
 - **Numbers**: Temperatury, intensywności, czasy, limity alarmów
-- **Selects**: Tryby pracy, harmonogram, komunikacja, język
+- **Selects**: Tryby pracy, tryb sezonowy, harmonogram, komunikacja, język
 
 ## 🛠️ Serwisy (13 kompletnych serwisów)
 

--- a/README_en.md
+++ b/README_en.md
@@ -106,7 +106,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Climate**: full HVAC control with preset modes
 - **Switches**: all systems, modes and configuration
 - **Numbers**: temperatures, intensities, times, alarm limits
-- **Selects**: work modes, schedule, communication, language
+- **Selects**: work modes, season mode, schedule, communication, language
 
 ## 🛠️ Services (13 complete services)
 

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -37,6 +37,12 @@ SELECT_DEFINITIONS = {
         "states": {"off": 0, "auto": 1, "forced": 2},
         "register_type": "holding_registers",
     },
+    "season_mode": {
+        "icon": "mdi:weather-partly-snowy",
+        "translation_key": "season_mode",
+        "states": {"winter": 0, "summer": 1},
+        "register_type": "holding_registers",
+    },
     "filter_change": {
         "icon": "mdi:filter-variant",
         "translation_key": "filter_change",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -342,6 +342,13 @@
           "forced": "Forced"
         }
       },
+      "season_mode": {
+        "name": "Season Mode",
+        "state": {
+          "winter": "Winter",
+          "summer": "Summer"
+        }
+      },
       "filter_change": {
         "name": "Filter Type",
         "state": {
@@ -379,6 +386,24 @@
       },
       "access_level": {
         "name": "Access Level"
+      },
+      "air_flow_rate_manual": {
+        "name": "Manual Air Flow Rate"
+      },
+      "air_flow_rate_temporary_1": {
+        "name": "Temporary Air Flow Rate 1"
+      },
+      "air_flow_rate_temporary_2": {
+        "name": "Temporary Air Flow Rate 2"
+      },
+      "supply_air_temperature_manual": {
+        "name": "Manual Supply Air Temperature"
+      },
+      "supply_air_temperature_temporary_1": {
+        "name": "Temporary Supply Air Temperature 1"
+      },
+      "supply_air_temperature_temporary_2": {
+        "name": "Temporary Supply Air Temperature 2"
       },
       "schedule_summer_mon_1": {
         "name": "Schedule Summer Mon 1"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -342,6 +342,13 @@
           "forced": "Wymuszony"
         }
       },
+      "season_mode": {
+        "name": "Tryb sezonowy",
+        "state": {
+          "winter": "Zima",
+          "summer": "Lato"
+        }
+      },
       "filter_change": {
         "name": "Typ filtrów",
         "state": {
@@ -379,6 +386,24 @@
       },
       "access_level": {
         "name": "Access Level"
+      },
+      "air_flow_rate_manual": {
+        "name": "Ręczna intensywność wentylacji"
+      },
+      "air_flow_rate_temporary_1": {
+        "name": "Intensywność wentylacji chwilowa 1"
+      },
+      "air_flow_rate_temporary_2": {
+        "name": "Intensywność wentylacji chwilowa 2"
+      },
+      "supply_air_temperature_manual": {
+        "name": "Ręczna temperatura nawiewu"
+      },
+      "supply_air_temperature_temporary_1": {
+        "name": "Tymczasowa temperatura nawiewu 1"
+      },
+      "supply_air_temperature_temporary_2": {
+        "name": "Tymczasowa temperatura nawiewu 2"
       },
       "schedule_summer_mon_1": {
         "name": "Schedule Summer Mon 1"


### PR DESCRIPTION
## Summary
- expose `season_mode` as a selectable entity
- provide translations for manual and temporary airflow/temperature numbers
- mention season mode select in docs

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/select.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json README.md README_en.md` *(mypy skipped)*
- `pytest` *(fails: AttributeError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c28dde48326a7889e85c2c4e1ea