### PR TITLE
Add firmware version sensors

### DIFF
--- a/custom_components/thessla_green_modbus/data/modbus_registers.csv
+++ b/custom_components/thessla_green_modbus/data/modbus_registers.csv
@@ -29,6 +29,9 @@ Function_Code,Address_HEX,Address_DEC,Access,Register_Name,Description,Min,Max,D
 02,0x0015,21,R/-,empty_house,Stan wejścia sygnału załączenia funkcji PUSTY DOM,0,1,,,"0 - OFF; 1 - ON",,
 
 # 04 - READ INPUT REGISTER
+04,0x0000,0,R/-,version_major,Główna wersja oprogramowania,0,65535,,1,,,,
+04,0x0001,1,R/-,version_minor,Wersja poboczna oprogramowania,0,65535,,1,,,,
+04,0x0004,4,R/-,version_patch,Wersja poprawki oprogramowania,0,65535,,1,,,,
 04,0x0002,2,R/-,day_of_week,Bieżący dzień tygodnia dla trybu automatycznego,0,6,1,1,"0 - Poniedziałek; 1 - Wtorek; 2 - Środa; 3 - Czwartek; 4 - Piątek; 5 - Sobota; 6 - Niedziela",3.00,
 04,0x0003,3,R/-,period,Bieżący odcinek czasowy dla trybu automatycznego,0,3,1,1,"0 - Odcinek czasowy 1; 1 - Odcinek czasowy 2; 2 - Odcinek czasowy 3; 3 - Odcinek czasowy 4",3.00,
 04,0x000E,14,R/-,compilation_days,Data kompilacji oprogramowania Basic,0,65535,,1,d,"Liczba dni od 01.01.2000",,

--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -35,8 +35,11 @@ DISCRETE_INPUT_REGISTERS: dict[str, int] = {
 }
 
 INPUT_REGISTERS: dict[str, int] = {
+    "version_major": 0,
+    "version_minor": 1,
     "day_of_week": 2,
     "period": 3,
+    "version_patch": 4,
     "compilation_days": 14,
     "compilation_seconds": 15,
     "outside_temperature": 16,

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -90,6 +90,21 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     # System information
+    "version_major": {
+        "translation_key": "version_major",
+        "icon": "mdi:counter",
+        "register_type": "input_registers",
+    },
+    "version_minor": {
+        "translation_key": "version_minor",
+        "icon": "mdi:counter",
+        "register_type": "input_registers",
+    },
+    "version_patch": {
+        "translation_key": "version_patch",
+        "icon": "mdi:counter",
+        "register_type": "input_registers",
+    },
     "day_of_week": {
         "translation_key": "day_of_week",
         "icon": "mdi:calendar-week",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -139,6 +139,15 @@
       "compilation_seconds": {
         "name": "Compilation Seconds"
       },
+      "version_major": {
+        "name": "Firmware Version Major"
+      },
+      "version_minor": {
+        "name": "Firmware Version Minor"
+      },
+      "version_patch": {
+        "name": "Firmware Version Patch"
+      },
       "serial_number_1": {
         "name": "Serial Number Part 1"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -139,6 +139,15 @@
       "compilation_seconds": {
         "name": "Sekundy kompilacji"
       },
+      "version_major": {
+        "name": "Główna wersja oprogramowania"
+      },
+      "version_minor": {
+        "name": "Wersja poboczna oprogramowania"
+      },
+      "version_patch": {
+        "name": "Wersja poprawki oprogramowania"
+      },
       "serial_number_1": {
         "name": "Numer seryjny część 1"
       },


### PR DESCRIPTION
## Summary
- add Modbus register entries for major, minor and patch firmware values
- expose firmware version numbers as sensors with translations

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers.py custom_components/thessla_green_modbus/sensor.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e21c76bd08326b16d1dffc043568a