### PR TITLE
Rename antifreeze mode key

### DIFF
--- a/custom_components/thessla_green_modbus/data/modbus_registers.csv
+++ b/custom_components/thessla_green_modbus/data/modbus_registers.csv
@@ -220,7 +220,7 @@ Function_Code,Address_HEX,Address_DEC,Access,Register_Name,Description,Min,Max,D
 03,0x1016,4118,R/W,maxSupplyAirFlowRateGwc,Maksymalna możliwa do ustawienia intensywność wentylacji dla instalacji z GWC (nawiew),100,150,100,1,%,"Wartość wyznaczona podczas procedury kalibracji",,
 03,0x1017,4119,R/W,maxExhaustAirFlowRate,Maksymalna możliwa do ustawienia intensywność wentylacji (wywiew),100,150,100,1,%,"Wartość wyznaczona podczas procedury kalibracji",,
 03,0x1018,4120,R/W,maxExhaustAirFlowRateGwc,Maksymalna możliwa do ustawienia intensywność wentylacji dla instalacji z GWC (wywiew),100,150,100,1,%,"Wartość wyznaczona podczas procedury kalibracji",,
-03,0x1060,4192,R/-,antifreezMode,Flaga uruchomienia systemu FPX,0,1,,1,"0 - brak; 1 - jest",,
+03,0x1060,4192,R/-,antifreezeMode,Flaga uruchomienia systemu FPX,0,1,,1,"0 - brak; 1 - jest",,
 03,0x1066,4198,R/-,antifreezStage,Tryb działania systemu FPX,0,2,,1,"0 - OFF; 1 - tryb FPX1; 2 - tryb FPX2",,
 03,0x1070,4208,R/W,mode,Tryb pracy AirPack,0,2,0,1,"0 - automatyczny; 1 - manualny; 2 - chwilowy",,
 03,0x1071,4209,R/W,seasonMode,Wybór harmonogramu - tryb AUTOMATYCZNY,0,1,0,1,"0 - LATO; 1 - ZIMA",,

--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -35,7 +35,7 @@ REGISTER_ALLOWED_VALUES: dict[str, set[int]] = {
     "mode": {0, 1, 2},
     "season_mode": {0, 1},
     "special_mode": set(range(0, 12)),
-    "antifreez_mode": {0, 1},
+    "antifreeze_mode": {0, 1},
 }
 
 

--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -212,7 +212,7 @@ HOLDING_REGISTERS: dict[str, int] = {
     "max_supply_air_flow_rate_gwc": 4118,
     "max_exhaust_air_flow_rate": 4119,
     "max_exhaust_air_flow_rate_gwc": 4120,
-    "antifreez_mode": 4192,
+    "antifreeze_mode": 4192,
     "antifreez_stage": 4198,
     "mode": 4208,
     "season_mode": 4209,

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -306,8 +306,8 @@ SENSOR_DEFINITIONS = {
         "unit": None,
         "register_type": "holding_registers",
     },
-    "antifreez_mode": {
-        "translation_key": "antifreez_mode",
+    "antifreeze_mode": {
+        "translation_key": "antifreeze_mode",
         "icon": "mdi:snowflake",
         "device_class": None,
         "state_class": None,

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -178,7 +178,7 @@
       "cf_version": {
         "name": "CF Module Version"
       },
-      "antifreez_mode": {
+      "antifreeze_mode": {
         "name": "Antifreeze Mode"
       },
       "antifreez_stage": {
@@ -825,8 +825,8 @@
       "max_exhaust_air_flow_rate_gwc": {
         "name": "Max Exhaust Air Flow Rate Gwc"
       },
-      "antifreez_mode": {
-        "name": "Antifreez Mode"
+      "antifreeze_mode": {
+        "name": "Antifreeze Mode"
       },
       "antifreez_stage": {
         "name": "Antifreez Stage"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -178,7 +178,7 @@
       "cf_version": {
         "name": "Wersja modułu CF"
       },
-      "antifreez_mode": {
+      "antifreeze_mode": {
         "name": "Tryb antyzamrożeniowy"
       },
       "antifreez_stage": {
@@ -825,8 +825,8 @@
       "max_exhaust_air_flow_rate_gwc": {
         "name": "Max Exhaust Air Flow Rate Gwc"
       },
-      "antifreez_mode": {
-        "name": "Antifreez Mode"
+      "antifreeze_mode": {
+        "name": "Antifreeze Mode"
       },
       "antifreez_stage": {
         "name": "Antifreez Stage"


### PR DESCRIPTION
## Summary
- fix typo antifreez_mode -> antifreeze_mode in register and sensor definitions
- update translations and documentation for antifreeze mode key

## Testing
- `pytest` *(fails: async def functions are not native coroutines; many other assertions)*
- `pre-commit run --files custom_components/thessla_green_modbus/registers.py custom_components/thessla_green_modbus/sensor.py custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json custom_components/thessla_green_modbus/data/modbus_registers.csv` *(fails: mypy type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e21c8ff288326a9c3cff85539a281