### PR TITLE
Move constant flow and water removal to binary sensors

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -164,6 +164,19 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.SAFETY,
         "register_type": "discrete_inputs",
     },
+    # System modes (from input registers)
+    "constant_flow_active": {
+        "translation_key": "constant_flow_active",
+        "icon": "mdi:waves",
+        "device_class": BinarySensorDeviceClass.RUNNING,
+        "register_type": "input_registers",
+    },
+    "water_removal_active": {
+        "translation_key": "water_removal_active",
+        "icon": "mdi:water-off",
+        "device_class": BinarySensorDeviceClass.RUNNING,
+        "register_type": "input_registers",
+    },
 }
 
 

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -297,22 +297,6 @@ SENSOR_DEFINITIONS = {
         "register_type": "input_registers",
     },
     # System modes and versions
-    "constant_flow_active": {
-        "translation_key": "constant_flow_active",
-        "icon": "mdi:waves",
-        "device_class": None,
-        "state_class": None,
-        "unit": None,
-        "register_type": "input_registers",
-    },
-    "water_removal_active": {
-        "translation_key": "water_removal_active",
-        "icon": "mdi:water-off",
-        "device_class": None,
-        "state_class": None,
-        "unit": None,
-        "register_type": "input_registers",
-    },
     "cf_version": {
         "translation_key": "cf_version",
         "icon": "mdi:chip",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -178,12 +178,6 @@
       "max_percentage": {
         "name": "Maximum Percentage"
       },
-      "constant_flow_active": {
-        "name": "Constant Flow Status"
-      },
-      "water_removal_active": {
-        "name": "Water Removal Status"
-      },
       "cf_version": {
         "name": "CF Module Version"
       },
@@ -312,6 +306,12 @@
       },
       "fire_alarm": {
         "name": "Fire Alarm"
+      },
+      "constant_flow_active": {
+        "name": "Constant Flow Status"
+      },
+      "water_removal_active": {
+        "name": "Water Removal Status"
       }
     },
     "climate": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -178,12 +178,6 @@
       "max_percentage": {
         "name": "Maksymalny procent"
       },
-      "constant_flow_active": {
-        "name": "Status Constant Flow"
-      },
-      "water_removal_active": {
-        "name": "Status usuwania wody"
-      },
       "cf_version": {
         "name": "Wersja modułu CF"
       },
@@ -312,6 +306,12 @@
       },
       "empty_house": {
         "name": "Pusty dom"
+      },
+      "constant_flow_active": {
+        "name": "Status Constant Flow"
+      },
+      "water_removal_active": {
+        "name": "Status usuwania wody"
       }
     },
     "climate": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -150,7 +150,10 @@ def test_new_translation_keys_present():
         "air_flow_rate_manual",
         "air_flow_rate_temporary_2",
     ]
+    new_binary_keys = ["constant_flow_active", "water_removal_active"]
     for trans in (EN, PL):
         for key in new_keys:
             assert key in trans["entity"]["sensor"]
             assert key in trans["entity"]["number"]
+        for key in new_binary_keys:
+            assert key in trans["entity"]["binary_sensor"]


### PR DESCRIPTION
## Summary
- move constant flow and water removal flags from sensors to binary sensors
- localize new binary sensor entities in English and Polish
- update translation tests for new binary sensors

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/sensor.py custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json tests/test_translations.py`
- `pytest tests/test_binary_sensor.py::test_async_setup_creates_all_binary_sensors tests/test_translations.py::test_new_translation_keys_present`

------
https://chatgpt.com/codex/tasks/task_e_689e3fee71f48326b7b85f0eedb0591a