### PR TITLE
Use deep copy for diagnostics redaction

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import ipaddress
 import logging
 import re
@@ -48,8 +49,8 @@ async def async_get_config_entry_diagnostics(
 
 def _redact_sensitive_data(data: dict[str, Any]) -> dict[str, Any]:
     """Redact sensitive information from diagnostics."""
-    # Create a copy to avoid modifying original data
-    safe_data = data.copy()
+    # Create a deep copy to avoid modifying the original data
+    safe_data = copy.deepcopy(data)
 
     def mask_ip(ip_str: str) -> str:
         """Return a redacted representation of an IP address."""
@@ -64,11 +65,8 @@ def _redact_sensitive_data(data: dict[str, Any]) -> dict[str, Any]:
         return ":".join([segments[0]] + ["xxxx"] * 6 + [segments[-1]])
 
     # Redact sensitive connection information
-    if "connection" in safe_data:
-        connection = safe_data["connection"].copy()
-        if "host" in connection:
-            connection["host"] = mask_ip(connection["host"])
-        safe_data["connection"] = connection
+    if "connection" in safe_data and "host" in safe_data["connection"]:
+        safe_data["connection"]["host"] = mask_ip(safe_data["connection"]["host"])
 
     # Redact serial number if present
     if "device_info" in safe_data and "serial_number" in safe_data["device_info"]:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,3 +1,5 @@
+import copy
+
 from custom_components.thessla_green_modbus.diagnostics import _redact_sensitive_data
 
 
@@ -21,3 +23,17 @@ def test_redact_ipv6_connection():
     redacted = _redact_sensitive_data(data)
 
     assert redacted["connection"]["host"] == ("2001:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:7334")
+
+
+def test_original_diagnostics_unchanged():
+    """Ensure the input diagnostics dict is not modified by redaction."""
+    data = {
+        "connection": {"host": "192.168.0.17"},
+        "device_info": {"serial_number": "123456"},
+    }
+
+    original = copy.deepcopy(data)
+
+    _redact_sensitive_data(data)
+
+    assert data == original


### PR DESCRIPTION
## Summary
- copy diagnostics deeply during redaction to avoid mutating original data
- add regression test ensuring diagnostics input remains unchanged

## Testing
- ⚠️ `pre-commit run --files custom_components/thessla_green_modbus/diagnostics.py tests/test_diagnostics.py` (mypy errors across repository)
- ✅ `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/diagnostics.py`
- ✅ `SKIP=mypy,bandit pre-commit run --files tests/test_diagnostics.py`
- ✅ `pytest tests/test_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_689e5232061c8326b187a75239e2b592