### PR TITLE
refactor: centralize snake case utility

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -3,26 +3,12 @@
 from __future__ import annotations
 
 import csv
-import re
 from pathlib import Path
 from typing import Any
 
+from .utils import _to_snake_case
+
 CSV_PATH = Path(__file__).parent / "data" / "modbus_registers.csv"
-
-
-def _to_snake_case(name: str) -> str:
-    """Convert a register name from the CSV to ``snake_case``."""
-    replacements = {"flowrate": "flow_rate"}
-    for old, new in replacements.items():
-        name = name.replace(old, new)
-    name = re.sub(r"[\s\-/]", "_", name)
-    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
-    name = re.sub(r"(?<=\D)(\d)", r"_\1", name)
-    name = re.sub(r"__+", "_", name)
-    name = name.lower()
-    token_map = {"temp": "temperature"}
-    tokens = [token_map.get(token, token) for token in name.split("_")]
-    return "_".join(tokens)
 
 
 def _parse_float(value: str) -> float:


### PR DESCRIPTION
## Summary
- reuse `_to_snake_case` from utils in entity mappings

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity_mappings.py custom_components/thessla_green_modbus/utils.py` *(fails: mypy errors in unrelated files)*
- `pytest` *(fails: multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e522c27cc83269949cfc410ea0eb1