### PR TITLE
docs: document register generation and add validation to CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,13 +161,16 @@ custom_components/thessla_green_modbus/
 
 ### Regenerating register definitions
 
-Whenever `custom_components/thessla_green_modbus/data/modbus_registers.csv` is modified, regenerate `custom_components/thessla_green_modbus/registers.py`:
+Whenever `custom_components/thessla_green_modbus/data/modbus_registers.csv` is modified, regenerate
+`custom_components/thessla_green_modbus/registers.py` and validate it:
 
 ```bash
 python tools/generate_registers.py
+python tools/validate_registers.py
 ```
 
-Commit the updated CSV and Python files together.
+Commit the updated CSV and Python files together. The `generate-registers` and `validate-registers`
+pre-commit hooks run these checks automatically.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -374,10 +374,12 @@ python3 tools/cleanup_old_entities.py \
 - 🤝 [Contributing](CONTRIBUTING.md)
 
 ### Regenerating registers.py
-If you modify `custom_components/thessla_green_modbus/data/modbus_registers.csv`, rebuild the generated module:
+Whenever `custom_components/thessla_green_modbus/data/modbus_registers.csv` changes, regenerate and
+validate the Python module:
 
 ```bash
 python tools/generate_registers.py
+python tools/validate_registers.py  # optional consistency check
 ```
 
 Commit the updated `custom_components/thessla_green_modbus/registers.py` along with the CSV changes.

--- a/validate.yaml
+++ b/validate.yaml
@@ -18,5 +18,7 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: pip install pytest
+      - name: Validate register definitions
+        run: python tools/validate_registers.py
       - name: Run tests
         run: pytest -ra


### PR DESCRIPTION
## Summary
- document regenerating and validating register mappings when modbus_registers.csv changes
- run register coverage validation in CI

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md validate.yaml`
- `python tools/validate_registers.py`
- `pytest -q` *(fails: register mismatch & climate tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e522a2f0c8326ad13e11f5bacc443