### PR TITLE
docs: document unsupported register warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,25 @@ logger:
     pymodbus: info
 ```
 
+### Komunikaty „Skipping unsupported … registers”
+Podczas skanowania integracja próbuje odczytać grupy rejestrów.  
+Jeśli rekuperator nie obsługuje danego zakresu, w logach pojawia się ostrzeżenie w stylu:
+
+```
+Skipping unsupported input registers 0x0100-0x0102 (exception code 2)
+```
+
+Kody wyjątków Modbus informują, dlaczego odczyt się nie powiódł:
+
+- **2 – Illegal Data Address** – rejestry nie istnieją w tym modelu
+- **3 – Illegal Data Value** – rejestry istnieją, ale urządzenie odrzuciło żądanie (np. funkcja wyłączona)
+- **4 – Slave Device Failure** – urządzenie nie potrafiło obsłużyć żądania
+
+Jednorazowe ostrzeżenia pojawiające się przy początkowym skanowaniu lub
+dotyczące opcjonalnych funkcji można zwykle zignorować.  
+Jeśli jednak powtarzają się dla kluczowych rejestrów, sprawdź konfigurację,
+podłączenie i wersję firmware.
+
 ## 📋 Specyfikacja techniczna
 
 ### Obsługiwane rejestry

--- a/README_en.md
+++ b/README_en.md
@@ -192,6 +192,24 @@ logger:
     pymodbus: info
 ```
 
+### "Skipping unsupported … registers" warnings
+During scanning the integration tries many register ranges. If the unit
+doesn't support a range, the logs show a warning like:
+
+```
+Skipping unsupported input registers 0x0100-0x0102 (exception code 2)
+```
+
+Modbus exception codes explain why the read failed:
+
+- **2 – Illegal Data Address** – register range not implemented
+- **3 – Illegal Data Value** – register exists but rejected the request (e.g. feature disabled)
+- **4 – Slave Device Failure** – the device could not process the request
+
+Warnings that only appear during the initial scan or for optional features
+can usually be ignored. Persistent warnings for important registers may
+indicate a configuration or firmware mismatch.
+
 ## 📋 Technical specification
 
 ### Supported registers


### PR DESCRIPTION
## Summary
- explain "Skipping unsupported … registers" messages
- clarify Modbus exception codes 2, 3, and 4
- note when these warnings can be ignored

## Testing
- `pytest` *(fails: AttributeError: 'ThesslaGreenModbusCoordinator' object has no attribute '_disconnect')*

------
https://chatgpt.com/codex/tasks/task_e_689e5a5c2cd08326869029d225bdaeca