### PR TITLE
Handle platform setup cancellation

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -89,9 +89,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     timeout = entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
     retry = entry.options.get(CONF_RETRY, DEFAULT_RETRY)
     force_full_register_list = entry.options.get(CONF_FORCE_FULL_REGISTER_LIST, False)
-    scan_uart_settings = entry.options.get(
-        CONF_SCAN_UART_SETTINGS, DEFAULT_SCAN_UART_SETTINGS
-    )
+    scan_uart_settings = entry.options.get(CONF_SCAN_UART_SETTINGS, DEFAULT_SCAN_UART_SETTINGS)
     skip_missing_registers = entry.options.get(
         CONF_SKIP_MISSING_REGISTERS, DEFAULT_SKIP_MISSING_REGISTERS
     )
@@ -156,7 +154,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _async_migrate_unique_ids(hass, entry)
 
     # Setup platforms
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _LOGGER.debug("Setting up platforms: %s", PLATFORMS)
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except asyncio.CancelledError:
+        _LOGGER.debug("Platform setup cancelled: %s", PLATFORMS)
+        raise
 
     # Setup services (only once for first entry)
     if len(hass.data[DOMAIN]) == 1:

--- a/tests/test_platform_setup_cancellation.py
+++ b/tests/test_platform_setup_cancellation.py
@@ -1,0 +1,49 @@
+"""Tests for cancellation during platform setup."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from custom_components.thessla_green_modbus import async_setup_entry
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_platform_setup_cancellation(caplog):
+    """Cancellation during platform setup is logged without errors."""
+    hass = MagicMock()
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock(side_effect=asyncio.CancelledError)
+
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry"
+    entry.title = "Test Entry"
+    entry.data = {CONF_HOST: "192.168.1.100", CONF_PORT: 502, "slave_id": 10}
+    entry.options = {}
+    entry.add_update_listener = MagicMock()
+    entry.async_on_unload = MagicMock()
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator"
+        ) as mock_coordinator_class,
+        patch(
+            "custom_components.thessla_green_modbus._async_migrate_unique_ids",
+            AsyncMock(),
+        ),
+        caplog.at_level(logging.DEBUG),
+    ):
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_setup = AsyncMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator_class.return_value = mock_coordinator
+
+        with pytest.raises(asyncio.CancelledError):
+            await async_setup_entry(hass, entry)
+
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+    assert any("cancelled" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
## Summary
- handle cancellation during platform setup and log debug message
- test platform setup cancellation handling to avoid error logs

## Testing
- `SKIP=mypy,bandit pre-commit run --files custom_components/thessla_green_modbus/__init__.py tests/test_platform_setup_cancellation.py`
- `pytest tests/test_platform_setup_cancellation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e5a3713b883269ae7c1646ea9206a