### PR TITLE
Consolidate input register cache checks

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -487,11 +487,6 @@ class ThesslaGreenDeviceScanner:
 
         if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
             first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
-
-        if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
-            first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
-        if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
-            first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
             skip_start = skip_end = first
             while skip_start - 1 in self._failed_input:
                 skip_start -= 1


### PR DESCRIPTION
## Summary
- simplify `_read_input` by merging repeated cached register checks

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: mypy reports errors in unrelated files)*
- `pytest` *(fails: IndentationError in tests/test_platform_setup_cancellation.py)*

------
https://chatgpt.com/codex/tasks/task_e_689efc8d1710832698de8a4574f55a84