### PR TITLE
Simplify platform setup call

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -154,16 +154,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _async_migrate_unique_ids(hass, entry)
 
     # Setup platforms
-    try:
-        _LOGGER.debug("Forwarding setup to platforms: %s", PLATFORMS)
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    except asyncio.CancelledError:
-        _LOGGER.info("Platform setup cancelled for %s", PLATFORMS)
     _LOGGER.debug("Setting up platforms: %s", PLATFORMS)
     try:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     except asyncio.CancelledError:
-        _LOGGER.debug("Platform setup cancelled: %s", PLATFORMS)
+        _LOGGER.info("Platform setup cancelled for %s", PLATFORMS)
         raise
 
     # Setup services (only once for first entry)


### PR DESCRIPTION
## Summary
- remove redundant platform setup call during integration initialization

## Testing
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/__init__.py`
- `pytest` *(fails: IndentationError in tests/test_platform_setup_cancellation.py)*

------
https://chatgpt.com/codex/tasks/task_e_689efc8a10688326ac82ff1c0f54b37f