### PR TITLE
Fix statistics type annotation

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -163,7 +163,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         self.device_scan_result: dict[str, Any] | None = None
 
         # Statistics and diagnostics
-        self.statistics: Dict[str, Any] = {
+        self.statistics: dict[str, Any] = {
             "successful_reads": 0,
             "failed_reads": 0,
             "connection_errors": 0,


### PR DESCRIPTION
## Summary
- use `dict` for statistics type annotation to avoid missing `Dict` import

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` *(fails: Function is missing a type annotation, Need type annotation...)*
- `pytest tests/test_coordinator.py` *(fails: module 'homeassistant.helpers' has no attribute 'script')*
- `python - <<'PY'\nimport custom_components.thessla_green_modbus.coordinator as coord\nprint('Imported', coord.__name__)\nPY`


------
https://chatgpt.com/codex/tasks/task_e_689efc8e9434832697c659db83a13539