### PR TITLE
chore: drop unsupported assets from manifest

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "thessla_green_modbus",
   "name": "ThesslaGreen Modbus",
-  "codeowners": ["@thesslagreen"],
+  "codeowners": [
+    "@thesslagreen"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
@@ -13,7 +15,6 @@
     "pymodbus>=3.5.0,<4.0.0",
     "voluptuous>=0.13.1"
   ],
-  "assets": ["data/modbus_registers.csv"],
   "version": "2.1.1",
   "integration_type": "device",
   "dhcp": [


### PR DESCRIPTION
## Summary
- remove obsolete `assets` field from manifest

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json`
- `python -m homeassistant --script check_config -c /tmp/ha_config`


------
https://chatgpt.com/codex/tasks/task_e_689efc9af81883268d6054033007eee3