### PR TITLE
Prevent duplicate config entries

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -156,6 +156,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_confirm(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the confirm step."""
         if user_input is not None:
+            self._abort_if_unique_id_configured()
             # Create entry with all data
             # Use both 'slave_id' and 'unit' for compatibility
             return self.async_create_entry(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test config flow for ThesslaGreen Modbus integration."""
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -179,6 +180,66 @@ async def test_unique_id_sanitized():
         )
 
     mock_set_unique_id.assert_called_once_with("fe80--1:502:10")
+
+
+async def test_confirm_step_aborts_on_existing_entry():
+    """Ensure confirming a second flow aborts if unique ID already configured."""
+
+    user_input = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "My Device",
+    }
+
+    validation_result = {
+        "title": "ThesslaGreen 192.168.1.100",
+        "device_info": {},
+        "scan_result": {},
+    }
+
+    class AbortFlow(Exception):
+        def __init__(self, reason: str) -> None:
+            self.reason = reason
+
+    entries: set[str] = set()
+
+    async def async_set_unique_id(self, unique_id: str, **_: Any) -> None:
+        self._unique_id = unique_id
+
+    def abort_if_unique_id_configured(self) -> None:
+        if getattr(self, "_unique_id", None) in entries:
+            raise AbortFlow("already_configured")
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            return_value=validation_result,
+        ),
+        patch(
+            "homeassistant.helpers.translation.async_get_translations",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(ConfigFlow, "async_set_unique_id", async_set_unique_id),
+        patch.object(
+            ConfigFlow, "_abort_if_unique_id_configured", abort_if_unique_id_configured
+        ),
+    ):
+        flow1 = ConfigFlow()
+        flow1.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+        flow2 = ConfigFlow()
+        flow2.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+        await flow1.async_step_user(user_input)
+        await flow2.async_step_user(user_input)
+
+        result1 = await flow1.async_step_confirm({})
+        assert result1["type"] == "create_entry"
+        entries.add(f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}:{user_input['slave_id']}")
+
+        with pytest.raises(AbortFlow) as err:
+            await flow2.async_step_confirm({})
+        assert err.value.reason == "already_configured"
 
 
 async def test_form_user_cannot_connect():


### PR DESCRIPTION
## Summary
- avoid creating duplicate config entries by aborting when unique_id already configured in confirm step
- add regression test to ensure second flow with identical parameters aborts

## Testing
- `pytest tests/test_config_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689f0512ad78832687b7c37e788587de