### PR TITLE
Check unique ID before confirming config

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -156,6 +156,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_confirm(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the confirm step."""
         if user_input is not None:
+            # Ensure unique ID is set and not already configured
+            unique_host = self._data[CONF_HOST].replace(":", "-")
+            await self.async_set_unique_id(
+                f"{unique_host}:{self._data[CONF_PORT]}:{self._data[CONF_SLAVE_ID]}"
+            )
+            self._abort_if_unique_id_configured()
+
             # Create entry with all data
             # Use both 'slave_id' and 'unit' for compatibility
             return self.async_create_entry(


### PR DESCRIPTION
## Summary
- Re-run unique ID registration and duplicate check during confirmation
- Add test to ensure duplicate host/port/slave setups abort the flow

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py tests/test_config_flow.py` *(fails: mypy found module mapping issue; bandit flagged asserts)*
- `pytest tests/test_config_flow.py::test_duplicate_configuration_aborts -q`


------
https://chatgpt.com/codex/tasks/task_e_689f050217b883268fc634980401e16a