### PR TITLE
Fix syntax error in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -162,8 +162,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 f"{unique_host}:{self._data[CONF_PORT]}:{self._data[CONF_SLAVE_ID]}"
             )
             self._abort_if_unique_id_configured()
-
-            self._abort_if_unique_id_configured()````````````````````
             # Create entry with all data
             # Use both 'slave_id' and 'unit' for compatibility
             return self.async_create_entry(


### PR DESCRIPTION
## Summary
- remove stray text causing SyntaxError in config flow confirmation step

## Testing
- `python -m pre_commit run --files custom_components/thessla_green_modbus/config_flow.py` *(fails: mypy reports errors in unrelated files)*
- `pytest` *(fails: SyntaxError in tests/test_config_flow.py)*

------
https://chatgpt.com/codex/tasks/task_e_689f0bf26e4083268600dd70e299479e