### PR TITLE
Handle supply flow rate fallback

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -112,6 +112,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         # Priority order for reading current flow rate
         flow_registers = [
             "supply_air_flow",  # Supply air flow rate
+            "supply_flow_rate",  # CF measured supply flow rate
             "supply_percentage",  # Supply air percentage
             "air_flow_rate_manual",  # Manual flow rate setting
             "air_flow_rate_temporary_2",  # Temporary flow rate setting

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -80,6 +80,16 @@ def test_fan_creation_and_state(mock_coordinator):
     assert fan.percentage == 0
 
 
+def test_flow_rate_uses_supply_flow_rate(mock_coordinator):
+    """Ensure supply_flow_rate is used when other registers unavailable."""
+    mock_coordinator.data.pop("supply_percentage", None)
+    mock_coordinator.data["supply_flow_rate"] = 80
+    fan = ThesslaGreenFan(mock_coordinator)
+    assert fan._get_current_flow_rate() == 80.0
+    assert fan.percentage == 80
+    assert fan.is_on is True
+
+
 def test_fan_turn_on_modbus_failure(mock_coordinator):
     """Ensure connection errors during turn on are raised."""
     fan = ThesslaGreenFan(mock_coordinator)


### PR DESCRIPTION
## Summary
- support `supply_flow_rate` when reading current fan flow
- test fan flow retrieval using only `supply_flow_rate`

## Testing
- `SKIP=mypy,bandit pre-commit run --files custom_components/thessla_green_modbus/fan.py tests/test_fan.py`
- `pytest` *(fails: SyntaxError in tests/test_config_flow.py)*
- `pytest tests/test_fan.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5620890c83268dadcf0d4ff7ff25