### PR TITLE
Handle missing Modbus write responses

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -914,7 +914,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
                     _LOGGER.error("Unknown register for writing: %s", register_name)
                     return False
 
-                if response.isError():
+                if response is None or response.isError():
                     _LOGGER.error("Error writing to register %s: %s", register_name, response)
                     return False
 


### PR DESCRIPTION
## Summary
- ensure `async_write_register` handles missing Modbus responses

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` *(fails: mypy reports 39 errors in repository)*
- `pytest` *(fails: SyntaxError in tests/test_config_flow.py)*

------
https://chatgpt.com/codex/tasks/task_e_689f561e8ef48326829ecc6446814f2b