### PR TITLE
feat: add diagnostic logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Retry**: 1-5 prób (domyślnie 3)
 - **Pełna lista rejestrów**: Pomiń skanowanie (może powodować błędy)
 
+### Włączanie logów debug
+W razie problemów możesz włączyć szczegółowe logi tej integracji. Dodaj poniższą konfigurację do `configuration.yaml` i zrestartuj Home Assistant:
+
+```yaml
+logger:
+  logs:
+    custom_components.thessla_green_modbus: debug
+```
+
+Poziom `debug` pokaże m.in. surowe i przetworzone wartości rejestrów oraz ostrzeżenia o niedostępnych czujnikach lub wartościach poza zakresem.
+
 ## 📊 Dostępne encje
 
 ### Sensory (50+ automatycznie wykrywanych)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for ThesslaGreenModbusCoordinator - HA 2025.7.1+ & pymodbus 3.5+ Compatible."""
 
+import logging
 import os
 import sys
 import types
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.thessla_green_modbus.const import SENSOR_UNAVAILABLE
 from custom_components.thessla_green_modbus.modbus_exceptions import (
     ConnectionException,
     ModbusException,
@@ -373,6 +375,25 @@ def test_register_value_processing(coordinator):
 
     mode_result = coordinator._process_register_value("mode", 1)
     assert mode_result == 1
+
+
+def test_register_value_logging(coordinator, caplog):
+    """Test debug and warning logging for register processing."""
+
+    with caplog.at_level(logging.DEBUG):
+        caplog.clear()
+        coordinator._process_register_value("outside_temperature", 250)
+        assert "raw=250" in caplog.text
+        assert "value=25.0" in caplog.text
+
+    with caplog.at_level(logging.WARNING):
+        caplog.clear()
+        coordinator._process_register_value("outside_temperature", SENSOR_UNAVAILABLE)
+        assert "SENSOR_UNAVAILABLE" in caplog.text
+
+        caplog.clear()
+        coordinator._process_register_value("supply_percentage", 150)
+        assert "Out-of-range value for supply_percentage" in caplog.text
 
 
 def test_post_process_data(coordinator):


### PR DESCRIPTION
## Summary
- log raw and processed register values for easier troubleshooting
- warn when sensors are unavailable or values exceed expected ranges
- document how to enable debug logging via `configuration.yaml`

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py tests/test_coordinator.py README.md`
- `pytest` *(fails: ImportError: cannot import name 'PERCENTAGE' from 'homeassistant.const')*

------
https://chatgpt.com/codex/tasks/task_e_68a051e9d85c83268a83fcbb6c6d4b5f