### PR TITLE
Add DAC register validation and scaling

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -32,6 +32,9 @@ DEFAULT_RETRY = 3
 # Sensor constants
 SENSOR_UNAVAILABLE = 0x8000  # Indicates missing/invalid sensor reading
 
+# DAC output registers that use 0-10V scaling
+DAC_REGISTERS = {"dac_supply", "dac_exhaust", "dac_heater", "dac_cooler"}
+
 # Configuration options
 CONF_SLAVE_ID = "slave_id"
 CONF_SCAN_INTERVAL = "scan_interval"

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -46,10 +46,13 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover
                 raise AttributeError(item) from exc
 
 
+from ctypes import c_short
+
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     COIL_REGISTERS,
+    DAC_REGISTERS,
     DISCRETE_INPUT_REGISTERS,
     DOMAIN,
     MANUFACTURER,
@@ -672,7 +675,16 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
         if value == SENSOR_UNAVAILABLE and "flow" in register_name.lower():
             return None  # No sensor
 
-        # Apply multiplier
+        # DAC registers are unsigned 0-4095 values representing 0-10V
+        if register_name in DAC_REGISTERS:
+            if not 0 <= value <= 4095:
+                _LOGGER.warning("DAC value %s for %s out of range", value, register_name)
+                return None
+        else:
+            # Convert to signed 16-bit for all other registers
+            value = c_short(value).value
+
+        # Apply multiplier if defined
         if register_name in REGISTER_MULTIPLIERS:
             value = value * REGISTER_MULTIPLIERS[register_name]
 


### PR DESCRIPTION
## Summary
- define `DAC_REGISTERS` and use them in processing
- handle unsigned DAC values and range-check 0-4095
- test DAC conversion and out-of-range handling

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/const.py custom_components/thessla_green_modbus/coordinator.py tests/test_coordinator.py` (fails: mypy errors and Bandit asserts)
- `pytest tests/test_coordinator.py::test_dac_value_processing -q`
- `pytest -q` (fails: ModuleNotFoundError: No module named 'homeassistant.components'; 'homeassistant' is not a package)


------
https://chatgpt.com/codex/tasks/task_e_68a051ed18048326ace7358497621187