### PR TITLE
docs: explain modbus exceptions and unsupported registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,23 @@ logger:
     pymodbus: info
 ```
 
+### Kody wyjątków Modbus i brakujące rejestry
+Podczas skanowania urządzenia mogą pojawić się odpowiedzi z kodami wyjątków Modbus,
+gdy dany rejestr nie jest obsługiwany. Najczęściej spotykane kody to:
+
+- `2` – Illegal Data Address (rejestr nie istnieje)
+- `3` – Illegal Data Value (wartość poza zakresem)
+- `4` – Slave Device Failure (błąd urządzenia)
+
+W takich przypadkach integracja zapisuje w logach komunikaty w stylu:
+
+```
+Skipping unsupported input registers 120-130
+```
+
+Są to wpisy informacyjne i zazwyczaj oznaczają, że urządzenie po prostu nie posiada
+tych rejestrów. Można je bezpiecznie zignorować.
+
 ## 📋 Specyfikacja techniczna
 
 ### Obsługiwane rejestry


### PR DESCRIPTION
## Summary
- document Modbus exception codes 2, 3 and 4 in troubleshooting
- clarify why integration logs "Skipping unsupported ... registers"

## Testing
- `pre-commit run --files README.md`
- `pytest` *(fails: cannot import name 'PERCENTAGE' from 'homeassistant.const')*
- `python run_optimization_tests.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a05ad581bc8326a5cb1e2130178188