### PR TITLE
refactor: consolidate typing imports

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -8,7 +8,6 @@ import inspect
 import logging
 from dataclasses import asdict, dataclass, field
 from importlib.resources import files
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple
 
 from .modbus_exceptions import ConnectionException, ModbusException


### PR DESCRIPTION
## Summary
- merge duplicate typing imports in device_scanner

## Testing
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py`
- `pytest` *(fails: AttributeError and missing registers)*

------
https://chatgpt.com/codex/tasks/task_e_68a05ad17ee483268c403f617730330d