### PR TITLE
Log input registers and summarize temperature sensors

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -606,6 +606,12 @@ class ThesslaGreenDeviceScanner:
                     if reg_type in ("input_registers", "holding_registers"):
                         if self._is_valid_register_value(name, value):
                             self.available_registers[reg_type].add(name)
+                            if reg_type == "input_registers":
+                                _LOGGER.debug(
+                                    "Input register available: %s at address 0x%04X",
+                                    name,
+                                    addr,
+                                )
                     else:
                         self.available_registers[reg_type].add(name)
 


### PR DESCRIPTION
## Summary
- log input register names and addresses during device scanning
- report how many temperature sensors were instantiated or skipped in sensor setup

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/sensor.py` (fails: Returning Any, missing attributes)
- `pytest` (fails: cannot import name 'PERCENTAGE' from 'homeassistant.const')


------
https://chatgpt.com/codex/tasks/task_e_68a18b7f2568832693c27c1718e9f870