### PR TITLE
feat: centralize schedule time decoding

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -67,6 +67,7 @@ from .device_scanner import DeviceCapabilities, ThesslaGreenDeviceScanner
 from .modbus_helpers import _call_modbus
 from .multipliers import REGISTER_MULTIPLIERS
 from .registers import HOLDING_REGISTERS, INPUT_REGISTERS
+from .utils import TIME_REGISTER_PREFIXES, _decode_bcd_time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -786,6 +787,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator):
             return None  # No sensor
         if value == SENSOR_UNAVAILABLE and "flow" in register_name.lower():
             return None  # No sensor
+
+        if register_name.startswith(TIME_REGISTER_PREFIXES):
+            decoded = _decode_bcd_time(value)
+            return decoded if decoded is not None else value
 
         # Apply multiplier
         if register_name in REGISTER_MULTIPLIERS:

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -25,7 +25,7 @@ from . import registers
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
-from .utils import _to_snake_case
+from .utils import TIME_REGISTER_PREFIXES, _to_snake_case
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -184,6 +184,10 @@ class ThesslaGreenSensor(ThesslaGreenEntity, SensorEntity):
 
         if value is None:
             return None
+        if self._register_name.startswith(TIME_REGISTER_PREFIXES):
+            if isinstance(value, int):
+                return f"{value // 60:02d}:{value % 60:02d}"
+            return value
         value_map = self._sensor_def.get("value_map")
         if value_map is not None:
             return value_map.get(value, value)

--- a/custom_components/thessla_green_modbus/utils.py
+++ b/custom_components/thessla_green_modbus/utils.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import re
 
-__all__ = ["_to_snake_case"]
+__all__ = [
+    "_to_snake_case",
+    "_decode_register_time",
+    "_decode_bcd_time",
+    "TIME_REGISTER_PREFIXES",
+]
 
 
 def _to_snake_case(name: str) -> str:
@@ -20,3 +25,54 @@ def _to_snake_case(name: str) -> str:
     token_map = {"temp": "temperature"}
     tokens = [token_map.get(token, token) for token in name.split("_")]
     return "_".join(tokens)
+
+
+def _decode_register_time(value: int) -> int | None:
+    """Decode HH:MM byte-encoded value to minutes since midnight.
+
+    The most significant byte stores the hour and the least significant byte
+    stores the minute. ``None`` is returned if the value is negative or if the
+    extracted hour/minute fall outside of valid ranges.
+    """
+
+    if value < 0:
+        return None
+
+    hour = (value >> 8) & 0xFF
+    minute = value & 0xFF
+    if 0 <= hour <= 23 and 0 <= minute <= 59:
+        return hour * 60 + minute
+
+    return None
+
+
+def _decode_bcd_time(value: int) -> int | None:
+    """Decode BCD or decimal HHMM values to minutes since midnight."""
+
+    if value < 0:
+        return None
+
+    nibbles = [(value >> shift) & 0xF for shift in (12, 8, 4, 0)]
+    if all(n <= 9 for n in nibbles):
+        hours = nibbles[0] * 10 + nibbles[1]
+        minutes = nibbles[2] * 10 + nibbles[3]
+        if hours <= 23 and minutes <= 59:
+            return hours * 60 + minutes
+
+    hours_dec = value // 100
+    minutes_dec = value % 100
+    if 0 <= hours_dec <= 23 and 0 <= minutes_dec <= 59:
+        return hours_dec * 60 + minutes_dec
+    return None
+
+
+# Registers storing times encoded as HH:MM bytes
+TIME_REGISTER_PREFIXES: tuple[str, ...] = (
+    "schedule_",
+    "airing_summer_",
+    "airing_winter_",
+    "manual_airing_time_to_start",
+    "pres_check_time",
+    "start_gwc_regen",
+    "stop_gwc_regen",
+)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -405,6 +405,9 @@ def test_register_value_processing(coordinator):
     mode_result = coordinator._process_register_value("mode", 1)
     assert mode_result == 1
 
+    time_result = coordinator._process_register_value("schedule_summer_mon_1", 0x0815)
+    assert time_result == 8 * 60 + 15
+
 
 def test_post_process_data(coordinator):
     """Test data post-processing."""

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -14,8 +14,6 @@ from custom_components.thessla_green_modbus.device_scanner import (
     DeviceCapabilities,
     DeviceInfo,
     ThesslaGreenDeviceScanner,
-    _decode_bcd_time,
-    _decode_register_time,
     _decode_setting_value,
     _format_register_value,
 )
@@ -24,6 +22,7 @@ from custom_components.thessla_green_modbus.modbus_exceptions import (
     ModbusIOException,
 )
 from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS, INPUT_REGISTERS
+from custom_components.thessla_green_modbus.utils import _decode_bcd_time, _decode_register_time
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -1,10 +1,7 @@
 import pytest
 
-from custom_components.thessla_green_modbus.device_scanner import (
-    _decode_bcd_time,
-    _decode_register_time,
-    _decode_setting_value,
-)
+from custom_components.thessla_green_modbus.device_scanner import _decode_setting_value
+from custom_components.thessla_green_modbus.utils import _decode_bcd_time, _decode_register_time
 
 
 def test_decode_register_time_valid():
@@ -32,6 +29,13 @@ def test_decode_bcd_time_valid():
 def test_decode_bcd_time_invalid(value):
     """Invalid BCD or decimal times should return None."""
     assert _decode_bcd_time(value) is None
+
+
+def test_schedule_register_time_format():
+    """Schedule registers decode to HH:MM string representation."""
+    minutes = _decode_bcd_time(0x0815)
+    assert minutes == 8 * 60 + 15
+    assert f"{minutes // 60:02d}:{minutes % 60:02d}" == "08:15"
 
 
 def test_decode_setting_value_valid():

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -2,10 +2,10 @@ import csv
 import importlib.util
 import pathlib
 
-from custom_components.thessla_green_modbus.utils import _to_snake_case
-from custom_components.thessla_green_modbus.device_scanner import (
+from custom_components.thessla_green_modbus.utils import (
     _decode_bcd_time,
     _decode_register_time,
+    _to_snake_case,
 )
 
 
@@ -81,6 +81,7 @@ def test_register_definitions_match_csv() -> None:
     assert len(mod_input) == 26  # nosec B101
     assert len(mod_holding) == 281  # nosec B101
 
+
 def test_time_decoding_helpers() -> None:
     """Ensure time decoding helpers map to minutes since midnight."""
     assert _decode_register_time(0x081E) == 510
@@ -92,11 +93,11 @@ def test_time_decoding_helpers() -> None:
     assert _decode_bcd_time(0x0800) == 480
     assert _decode_bcd_time(0x2460) is None
     assert _decode_bcd_time(2400) is None
+
+
 def test_all_registers_have_units() -> None:
     """Ensure every register in the CSV specifies a unit."""
-    csv_path = pathlib.Path(
-        "custom_components/thessla_green_modbus/data/modbus_registers.csv"
-    )
+    csv_path = pathlib.Path("custom_components/thessla_green_modbus/data/modbus_registers.csv")
     with csv_path.open(encoding="utf-8", newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:


### PR DESCRIPTION
## Summary
- share time decoding helpers in utils
- decode schedule registers to minutes during data processing
- format time registers as HH:MM in sensors

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/utils.py custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/sensor.py tests/test_device_scanner.py tests/test_registers.py tests/test_register_decoders.py tests/test_coordinator.py tests/test_sensor_platform.py`
- `pytest tests/test_register_decoders.py tests/test_sensor_platform.py::test_time_sensor_formats_value tests/test_coordinator.py::test_register_value_processing`

------
https://chatgpt.com/codex/tasks/task_e_68a190a1a8008326a905645148037212