### PR TITLE
refactor: deduplicate number mappings

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -135,107 +135,7 @@ def _load_number_mappings():
     return number_configs
 
 
-# Static number entity mappings with fallback values
-NUMBER_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
-    # Temperature control
-    "required_temperature": {
-        "unit": "°C",
-        "min": 5,
-        "max": 30,
-        "step": 0.5,
-        "scale": 0.5,
-    },
-    "supply_air_temperature_manual": {
-        "unit": "°C",
-        "min": 5,
-        "max": 40,
-        "step": 0.5,
-        "scale": 0.5,
-    },
-    "supply_air_temperature_temporary": {
-        "unit": "°C",
-        "min": 5,
-        "max": 40,
-        "step": 0.5,
-        "scale": 0.5,
-
-from __future__ import annotations
-
-import csv
-from pathlib import Path
-from typing import Any
-
-from .utils import _to_snake_case
-
-CSV_PATH = Path(__file__).parent / "data" / "modbus_registers.csv"
-
-
-def _parse_float(value: str) -> float:
-    """Parse a numeric value which may be in decimal or hexadecimal format."""
-    if not value:
-        return 0.0
-    try:
-        return float(value)
-    except ValueError:
-        try:
-            return float(int(value, 0))
-        except ValueError:
-            return 0.0
-
-
-def _load_number_mappings() -> dict[str, dict[str, Any]]:
-    """Load writable register metadata from the CSV file."""
-    with CSV_PATH.open(encoding="utf-8", newline="") as csvfile:
-        reader = csv.DictReader(
-            row for row in csvfile if row.strip() and not row.lstrip().startswith("#")
-        )
-
-        rows: list[tuple[str, int, dict[str, Any]]] = []
-        for row in reader:
-            if row["Function_Code"] != "03" or row["Access"] != "R/W":
-                continue
-
-            name = _to_snake_case(row["Register_Name"])
-            addr = int(row["Address_DEC"])
-            step = _parse_float(row["Multiplier"])
-            step = step if step else 1.0
-
-            config: dict[str, Any] = {
-                "min": _parse_float(row["Min"]),
-                "max": _parse_float(row["Max"]),
-                "step": step,
-            }
-
-            if step not in (0, 1):
-                config["scale"] = step
-
-            unit = row.get("Unit")
-            if unit:
-                config["unit"] = unit
-
-            rows.append((name, addr, config))
-
-    # Ensure unique register names
-    rows.sort(key=lambda r: r[1])
-    counts: dict[str, int] = {}
-    for name, _, _ in rows:
-        counts[name] = counts.get(name, 0) + 1
-
-    seen: dict[str, int] = {}
-    mapping: dict[str, dict[str, Any]] = {}
-    for name, _, cfg in rows:
-        if counts[name] > 1:
-            idx = seen.get(name, 0) + 1
-            seen[name] = idx
-            key = f"{name}_{idx}"
-        else:
-            key = name
-        mapping[key] = cfg
-
-    return mapping
-
-
-# Mapping of read-only registers to sensor metadata
+# Number entity mappings loaded from register metadata
 NUMBER_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = _load_number_mappings()
 SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     # Temperature sensors
@@ -259,14 +159,12 @@ SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
         "state_class": "measurement",
         "unit": "°C",
         "register_type": "input_registers",
-
     },
     "fpx_temperature": {
         "translation_key": "fpx_temperature",
         "device_class": "temperature",
         "state_class": "measurement",
         "unit": "°C",
-
         "min": -20,
         "max": 20,
         "step": 0.5,
@@ -292,63 +190,6 @@ SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
         "min": 0,
         "max": 2,
         "step": 1,
-    },
-    # Air flow rates
-    "air_flow_rate_manual": {
-        "unit": "m³/h",
-        "min": 50,
-        "max": 500,
-        "step": 5,
-    },
-    "max_supply_air_flow_rate": {
-        "unit": "m³/h",
-        "min": 0,
-        "max": 500,
-        "step": 5,
-    },
-    "max_exhaust_air_flow_rate": {
-        "unit": "m³/h",
-        "min": 0,
-        "max": 500,
-        "step": 5,
-    },
-    "nominal_supply_air_flow": {
-        "unit": "m³/h",
-        "min": 0,
-        "max": 500,
-        "step": 5,
-    },
-    "nominal_exhaust_air_flow": {
-        "unit": "m³/h",
-        "min": 0,
-        "max": 500,
-        "step": 5,
-    },
-    "max_supply_air_flow_rate_gwc": {
-        "unit": "m³/h",
-        "min": 0,
-        "max": 500,
-        "step": 5,
-    },
-    "max_exhaust_air_flow_rate_gwc": {
-        "unit": "m³/h",
-        "min": 0,
-        "max": 500,
-        "step": 5,
-    },
-    "nominal_supply_air_flow_gwc": {
-        "unit": "m³/h",
-        "min": 0,
-        "max": 500,
-        "step": 5,
-    },
-    "nominal_exhaust_air_flow_gwc": {
-        "unit": "m³/h",
-        "min": 0,
-        "max": 500,
-        "step": 5,
-
-        "register_type": "input_registers",
     },
     "duct_supply_temperature": {
         "translation_key": "duct_supply_temperature",
@@ -491,7 +332,6 @@ SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
         "state_class": "measurement",
         "unit": "m3/h",
         "register_type": "holding_registers",
-
     },
     "bypass_off": {
         "translation_key": "bypass_off",
@@ -1232,16 +1072,10 @@ for mode, bit in SPECIAL_FUNCTION_MAP.items():
         "bit": bit,
     }
 
-ENTITY_MAPPINGS: Dict[str, Dict[str, Dict[str, Any]]] = {
-
 ENTITY_MAPPINGS: dict[str, dict[str, dict[str, Any]]] = {
-
     "number": NUMBER_ENTITY_MAPPINGS,
     "sensor": SENSOR_ENTITY_MAPPINGS,
     "binary_sensor": BINARY_SENSOR_ENTITY_MAPPINGS,
     "switch": SWITCH_ENTITY_MAPPINGS,
-
-
     "select": SELECT_ENTITY_MAPPINGS,
-
 }


### PR DESCRIPTION
## Summary
- remove stale static number mappings and redundant loader
- keep single `_load_number_mappings` implementation and expose `NUMBER_ENTITY_MAPPINGS`

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity_mappings.py` *(fails: closing parenthesis ')' does not match opening '{' in coordinator.py)*
- `pytest tests/test_translations.py` *(fails: JSONDecodeError in translations)*

------
https://chatgpt.com/codex/tasks/task_e_68a1951a9dac8326b3054859de65c0c2