### PR TITLE
ci: run register generator and coverage test

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
 """Test runner for ThesslaGreen Modbus integration."""
+import subprocess  # nosec B404
 import sys
-import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
-def run_tests():
+def run_tests() -> int:
     """Run all tests for the integration."""
     print("🧪 Running ThesslaGreen Modbus Integration Tests...")
-    
+
     try:
+        # Ensure registers are generated from the CSV
+        subprocess.run(  # nosec B603
+            [sys.executable, str(ROOT / "tools" / "generate_registers.py")],
+            check=True,
+        )
+
         # Run pytest with coverage
-        subprocess.run(
+        subprocess.run(  # nosec B603
             [
                 sys.executable,
                 "-m",
@@ -25,7 +34,7 @@ def run_tests():
 
         print("✅ All tests passed!")
         return 0
-        
+
     except subprocess.CalledProcessError as e:
         print(f"❌ Tests failed with exit code {e.returncode}")
         return e.returncode

--- a/validate.yaml
+++ b/validate.yaml
@@ -18,7 +18,11 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: pip install pytest
+      - name: Generate registers
+        run: python tools/generate_registers.py
       - name: Validate register definitions
         run: python tools/validate_registers.py
+      - name: Run register coverage test
+        run: pytest tests/test_register_coverage.py -ra
       - name: Run tests
-        run: pytest -ra
+        run: pytest -ra --ignore=tests/test_register_coverage.py


### PR DESCRIPTION
## Summary
- run `tools/generate_registers.py` in CI and developer test runner
- execute register coverage test in workflow

## Testing
- `pre-commit run --files validate.yaml tests/run_tests.py`
- `pytest tests/test_register_coverage.py -q`
- `pytest -q` *(fails: SyntaxError in custom_components/coordinator.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a1951fce848326940b1fd6d0ea73a9