### PR TITLE
Refactor switch entity mapping

### DIFF
--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Dict
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -21,68 +21,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 SWITCH_ENTITIES: Dict[str, Dict[str, Any]] = ENTITY_MAPPINGS.get("switch", {})
-
-# Switch entities that can be controlled
-SWITCH_ENTITIES: dict[str, dict[str, Any]] = {
-    # Output controls from coil registers
-    "duct_water_heater_pump": {
-        "icon": "mdi:pump",
-        "register": "duct_water_heater_pump",
-        "register_type": "coil_registers",
-        "category": None,
-        "translation_key": "duct_water_heater_pump",
-    },
-    "bypass": {
-        "icon": "mdi:pipe-leak",
-        "register": "bypass",
-        "register_type": "coil_registers",
-        "category": None,
-        "translation_key": "bypass",
-    },
-    "info": {
-        "icon": "mdi:information",
-        "register": "info",
-        "register_type": "coil_registers",
-        "category": None,
-        "translation_key": "info",
-    },
-    "power_supply_fans": {
-        "icon": "mdi:fan",
-        "register": "power_supply_fans",
-        "register_type": "coil_registers",
-        "category": None,
-        "translation_key": "power_supply_fans",
-    },
-    "heating_cable": {
-        "icon": "mdi:heating-coil",
-        "register": "heating_cable",
-        "register_type": "coil_registers",
-        "category": None,
-        "translation_key": "heating_cable",
-    },
-    "work_permit": {
-        "icon": "mdi:check-circle",
-        "register": "work_permit",
-        "register_type": "coil_registers",
-        "category": None,
-        "translation_key": "work_permit",
-    },
-    "gwc": {
-        "icon": "mdi:pipe",
-        "register": "gwc",
-        "register_type": "coil_registers",
-        "category": None,
-        "translation_key": "gwc",
-    },
-    "hood_output": {
-        "icon": "mdi:stove",
-        "register": "hood_output",
-        "register_type": "coil_registers",
-        "category": None,
-        "translation_key": "hood_output",
-    },
-}
-
 
 
 async def async_setup_entry(


### PR DESCRIPTION
## Summary
- import typing.Dict for switch entity type hints
- rely on ENTITY_MAPPINGS for switch definitions, removing duplicated mapping

## Testing
- `SKIP=mypy pre-commit run --files custom_components/thessla_green_modbus/switch.py`
- `pytest tests/test_switch.py` *(fails: SyntaxError in device_scanner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a197bd23248326ad3a937470599c7e