### PR TITLE
refactor: deduplicate coordinator helpers

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1013,7 +1013,12 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return diagnostics
 
     def get_device_info(self) -> DeviceInfo:
-        """Get device information for Home Assistant."""
+        """Return a ``DeviceInfo`` object for the connected unit.
+
+        The data is used by Home Assistant to uniquely identify the device
+        and to group all entities originating from it in the device registry.
+        """
+
         return DeviceInfo(
             identifiers={(DOMAIN, f"{self.host}:{self.port}:{self.slave_id}")},
             name=self.device_name,


### PR DESCRIPTION
## Summary
- document DeviceInfo generation

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` *(fails: ThesslaGreenDeviceScanner has no attribute close; mypy type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b88cfb48326ba7efa0cd5987ef3