### PR TITLE
Use centralized binary sensor mappings

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -13,11 +13,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
-from .entity_mappings import ENTITY_MAPPINGS
+
+# Binary sensor mappings are defined centrally in entity_mappings
+from .entity_mappings import BINARY_SENSOR_ENTITY_MAPPINGS
 
 _LOGGER = logging.getLogger(__name__)
 
-BINARY_SENSOR_DEFINITIONS: Dict[str, Dict[str, Any]] = ENTITY_MAPPINGS.get("binary_sensor", {})
+BINARY_SENSOR_DEFINITIONS: Dict[str, Dict[str, Any]] = BINARY_SENSOR_ENTITY_MAPPINGS
 
 
 async def async_setup_entry(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -112,7 +112,7 @@ class AddEntitiesCallback:  # pragma: no cover - simple stub
 entity_platform.AddEntitiesCallback = AddEntitiesCallback
 sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 
-from custom_components.thessla_green_modbus.sensor import SENSOR_DEFINITIONS
+from custom_components.thessla_green_modbus.sensor import SENSOR_DEFINITIONS  # noqa: E402
 
 SENSOR_KEYS = [v["translation_key"] for v in SENSOR_DEFINITIONS.values()]
 BINARY_KEYS = _load_translation_keys(ROOT / "binary_sensor.py", "BINARY_SENSOR_DEFINITIONS")


### PR DESCRIPTION
## Summary
- Rely on centralized `BINARY_SENSOR_ENTITY_MAPPINGS` for binary sensor definitions
- Silence E402 warning in translation test import

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py tests/test_binary_sensor.py tests/test_translations.py` (failed: mypy, bandit)
- `pytest tests/test_binary_sensor.py tests/test_translations.py` (failed: module and JSON errors)


------
https://chatgpt.com/codex/tasks/task_e_68a19b98b1908326a18ddf074e0d120b