### PR TITLE
Define static switch entities

### DIFF
--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -10,17 +10,107 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import COIL_REGISTERS, DOMAIN
+from .const import COIL_REGISTERS, DOMAIN, SPECIAL_FUNCTION_MAP
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
-from .entity_mappings import ENTITY_MAPPINGS
 from .modbus_exceptions import ConnectionException, ModbusException
 from .registers import HOLDING_REGISTERS
 
 _LOGGER = logging.getLogger(__name__)
 
 
-SWITCH_ENTITIES: Dict[str, Dict[str, Any]] = ENTITY_MAPPINGS.get("switch", {})
+# Static switch entity definitions
+SWITCH_ENTITIES: Dict[str, Dict[str, Any]] = {
+    # Coil register switches
+    "duct_water_heater_pump": {
+        "icon": "mdi:pump",
+        "register": "duct_water_heater_pump",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "duct_water_heater_pump",
+    },
+    "bypass": {
+        "icon": "mdi:pipe-leak",
+        "register": "bypass",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "bypass",
+    },
+    "info": {
+        "icon": "mdi:information",
+        "register": "info",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "info",
+    },
+    "power_supply_fans": {
+        "icon": "mdi:fan",
+        "register": "power_supply_fans",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "power_supply_fans",
+    },
+    "heating_cable": {
+        "icon": "mdi:heating-coil",
+        "register": "heating_cable",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "heating_cable",
+    },
+    "work_permit": {
+        "icon": "mdi:check-circle",
+        "register": "work_permit",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "work_permit",
+    },
+    "gwc": {
+        "icon": "mdi:pipe",
+        "register": "gwc",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "gwc",
+    },
+    "hood_output": {
+        "icon": "mdi:stove",
+        "register": "hood_output",
+        "register_type": "coil_registers",
+        "category": None,
+        "translation_key": "hood_output",
+    },
+    # System control switch from holding register
+    "on_off_panel_mode": {
+        "icon": "mdi:power",
+        "register": "on_off_panel_mode",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "on_off_panel_mode",
+    },
+}
+
+SPECIAL_MODE_ICONS = {
+    "boost": "mdi:rocket-launch",
+    "eco": "mdi:leaf",
+    "away": "mdi:airplane",
+    "fireplace": "mdi:fireplace",
+    "hood": "mdi:range-hood",
+    "sleep": "mdi:weather-night",
+    "party": "mdi:party-popper",
+    "bathroom": "mdi:shower",
+    "kitchen": "mdi:chef-hat",
+    "summer": "mdi:white-balance-sunny",
+    "winter": "mdi:snowflake",
+}
+
+for mode, bit in SPECIAL_FUNCTION_MAP.items():
+    SWITCH_ENTITIES[mode] = {
+        "icon": SPECIAL_MODE_ICONS.get(mode, "mdi:toggle-switch"),
+        "register": "special_mode",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": mode,
+        "bit": bit,
+    }
 
 
 async def async_setup_entry(


### PR DESCRIPTION
## Summary
- define static switch entity map and add special mode icons
- reference register definitions directly instead of ENTITY_MAPPINGS

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/switch.py` *(fails: Need type annotation for data...)*
- `pytest tests/test_switch.py -q` *(fails: type 'DataUpdateCoordinator' is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b9a60708326a995c54d4919de19