### PR TITLE
Clean up device scanner imports

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -8,31 +8,10 @@ import logging
 import re
 from dataclasses import asdict, dataclass, field
 from importlib.resources import files
-
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple
-
-
-from . import utils
-from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
-
-
-if TYPE_CHECKING:  # pragma: no cover
-    from pymodbus.client import AsyncModbusTcpClient
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
 from .const import COIL_REGISTERS, DEFAULT_SLAVE_ID, DISCRETE_INPUT_REGISTERS
-from .modbus_helpers import _call_modbus
-from .registers import HOLDING_REGISTERS, INPUT_REGISTERS
-
-_LOGGER = logging.getLogger(__name__)
-
-from .capability_rules import CAPABILITY_PATTERNS
-from .const import (
-    COIL_REGISTERS,
-    DEFAULT_SLAVE_ID,
-    DISCRETE_INPUT_REGISTERS,
-    KNOWN_MISSING_REGISTERS,
-    SENSOR_UNAVAILABLE_REGISTERS,
-)
+from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
 from .modbus_helpers import _call_modbus
 from .registers import HOLDING_REGISTERS, INPUT_REGISTERS
 from .utils import (
@@ -43,6 +22,9 @@ from .utils import (
     _to_snake_case,
 )
 
+if TYPE_CHECKING:  # pragma: no cover
+    from pymodbus.client import AsyncModbusTcpClient
+
 _LOGGER = logging.getLogger(__name__)
 
 # Specific registers may only accept discrete values
@@ -52,7 +34,6 @@ REGISTER_ALLOWED_VALUES: dict[str, set[int]] = {
     "special_mode": set(range(0, 12)),
     "antifreeze_mode": {0, 1},
 }
-
 
 
 # Registers storing combined airflow and temperature settings
@@ -85,19 +66,19 @@ def _format_register_value(name: str, value: int) -> int | str:
     if name == "manual_airing_time_to_start":
         raw_value = value
         value = ((value & 0xFF) << 8) | ((value >> 8) & 0xFF)
-        decoded = utils._decode_register_time(value)
+        decoded = _decode_register_time(value)
         if decoded is None:
             return f"0x{raw_value:04X} (invalid)"
         return f"{decoded // 60:02d}:{decoded % 60:02d}"
 
-    if name.startswith(utils.BCD_TIME_PREFIXES):
-        decoded = utils._decode_bcd_time(value)
+    if name.startswith(BCD_TIME_PREFIXES):
+        decoded = _decode_bcd_time(value)
         if decoded is None:
             return f"0x{value:04X} (invalid)"
         return f"{decoded // 60:02d}:{decoded % 60:02d}"
 
-    if name.startswith(utils.TIME_REGISTER_PREFIXES):
-        decoded = utils._decode_register_time(value)
+    if name.startswith(TIME_REGISTER_PREFIXES):
+        decoded = _decode_register_time(value)
         if decoded is None:
             return f"0x{value:04X} (invalid)"
         return f"{decoded // 60:02d}:{decoded % 60:02d}"
@@ -352,7 +333,7 @@ class ThesslaGreenDeviceScanner:
                         name_raw = row.get("Register_Name")
                         if not isinstance(name_raw, str) or not name_raw.strip():
                             continue
-                        name = utils._to_snake_case(name_raw)
+                        name = _to_snake_case(name_raw)
                         try:
                             addr = int(row.get("Address_DEC", 0))
                         except (TypeError, ValueError):
@@ -394,7 +375,7 @@ class ThesslaGreenDeviceScanner:
                                 "Incomplete range for %s: Min=%s Max=%s", name, min_raw, max_raw
                             )
 
-                        if name.startswith(utils.BCD_TIME_PREFIXES):
+                        if name.startswith(BCD_TIME_PREFIXES):
                             min_val = (min_val * 100) if min_val is not None else 0
                             max_val = (max_val * 100) if max_val is not None else 2359
 


### PR DESCRIPTION
## Summary
- simplify and deduplicate imports in device scanner
- drop unused utility references

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: mypy syntax error in coordinator.py; generate-registers modified registers.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b0b589c08326bb9d0e8c787dbb78