### PR TITLE
Fix capabilities initialization and cleanup duplicate register assignments

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -210,21 +210,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.device_info = self.device_scan_result.get("device_info", {})
                 self.capabilities = DeviceCapabilities(
                     **self.device_scan_result.get("capabilities", {})
-                scan_regs = self.device_scan_result.get("available_registers", {})
-                for reg_type in self.available_registers:
-                    self.available_registers[reg_type].clear()
-                    self.available_registers[reg_type].update(
-                        scan_regs.get(reg_type, set())
-                    )
-                if self.skip_missing_registers:
-                    for reg_type, names in KNOWN_MISSING_REGISTERS.items():
-                        self.available_registers[reg_type].difference_update(names)
-                self.device_info.clear()
-                self.device_info.update(
-                    self.device_scan_result.get("device_info", {})
                 )
-                for key, value in self.device_scan_result.get("capabilities", {}).items():
-                    setattr(self.capabilities, key, value)
 
                 _LOGGER.info(
                     "Device scan completed: %d registers found, model: %s, firmware: %s",


### PR DESCRIPTION
## Summary
- properly close DeviceCapabilities initialization
- remove duplicated register, device info, and capabilities assignments after device scan

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py`
- `pytest -q` *(fails: NameError: name 'TYPE_CHECKING' is not defined, ModuleNotFoundError: No module named 'homeassistant.components', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a1b0b8d4e08326866bbfe79f5ea598