### PR TITLE
Fix coordinator setup duplication and close capabilities call

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -207,24 +207,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if self.skip_missing_registers:
                     for reg_type, names in KNOWN_MISSING_REGISTERS.items():
                         self.available_registers[reg_type].difference_update(names)
+
                 self.device_info = self.device_scan_result.get("device_info", {})
                 self.capabilities = DeviceCapabilities(
                     **self.device_scan_result.get("capabilities", {})
-                scan_regs = self.device_scan_result.get("available_registers", {})
-                for reg_type in self.available_registers:
-                    self.available_registers[reg_type].clear()
-                    self.available_registers[reg_type].update(
-                        scan_regs.get(reg_type, set())
-                    )
-                if self.skip_missing_registers:
-                    for reg_type, names in KNOWN_MISSING_REGISTERS.items():
-                        self.available_registers[reg_type].difference_update(names)
-                self.device_info.clear()
-                self.device_info.update(
-                    self.device_scan_result.get("device_info", {})
                 )
-                for key, value in self.device_scan_result.get("capabilities", {}).items():
-                    setattr(self.capabilities, key, value)
 
                 _LOGGER.info(
                     "Device scan completed: %d registers found, model: %s, firmware: %s",
@@ -273,9 +260,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.available_registers["input_registers"].update(INPUT_REGISTERS.keys())
         self.available_registers["holding_registers"].update(HOLDING_REGISTERS.keys())
         self.available_registers["coil_registers"].update(COIL_REGISTERS.keys())
-        self.available_registers["discrete_inputs"].update(
-            DISCRETE_INPUT_REGISTERS.keys()
-        )
+        self.available_registers["discrete_inputs"].update(DISCRETE_INPUT_REGISTERS.keys())
 
         if self.skip_missing_registers:
             for reg_type, names in KNOWN_MISSING_REGISTERS.items():


### PR DESCRIPTION
## Summary
- properly close DeviceCapabilities initialization in coordinator async setup
- remove duplicate available_registers and device_info handling

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py`
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` *(fails: mypy errors, generate-registers modifies registers.py)*
- `pytest` *(fails: missing TYPE_CHECKING, import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b0c255f083268bd4f1b36767e342