### PR TITLE
Remove duplicate time register prefixes

### DIFF
--- a/custom_components/thessla_green_modbus/utils.py
+++ b/custom_components/thessla_green_modbus/utils.py
@@ -67,20 +67,8 @@ def _decode_bcd_time(value: int) -> int | None:
     return None
 
 
-
 # Registers storing times as BCD HHMM values
 BCD_TIME_PREFIXES: tuple[str, ...] = (
-    "schedule_",
-    "airing_summer_",
-    "airing_winter_",
-    "pres_check_time",
-    "start_gwc_regen",
-    "stop_gwc_regen",
-)
-
-# Registers storing times encoded as HH:MM bytes
-TIME_REGISTER_PREFIXES: tuple[str, ...] = (
-
     "schedule_",
     "airing_summer_",
     "airing_winter_",


### PR DESCRIPTION
## Summary
- remove redundant TIME_REGISTER_PREFIXES declaration
- rely on BCD_TIME_PREFIXES + manual_airing_time_to_start for TIME_REGISTER_PREFIXES

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/utils.py` *(fails: mypy syntax error in coordinator; generate-registers modified registers.py)*
- `pytest` *(fails: missing dependencies / syntax errors, 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b0d1b2808326b2dcbb8941702751