### PR TITLE
Fix time decoding imports in device scanner

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -19,7 +19,13 @@ from typing import (
     Tuple,
 )
 
-from . import utils
+from .utils import (
+    BCD_TIME_PREFIXES,
+    TIME_REGISTER_PREFIXES,
+    _decode_bcd_time,
+    _decode_register_time,
+    _to_snake_case,
+)
 from .const import COIL_REGISTERS, DEFAULT_SLAVE_ID, DISCRETE_INPUT_REGISTERS
 from .modbus_exceptions import (
     ConnectionException,


### PR DESCRIPTION
## Summary
- import time decoding helpers directly from utils
- remove unused utils module import

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/device_scanner.py`
- `pytest -q` *(fails: No module named 'homeassistant')*
- `python - <<'PY'
import sys, types, importlib.util, importlib.machinery, pathlib
package_name = 'custom_components.thessla_green_modbus'
package_path = pathlib.Path('custom_components/thessla_green_modbus')
# Create package hierarchy
sys.modules['custom_components'] = types.ModuleType('custom_components')
subpkg = types.ModuleType(package_name)
subpkg.__path__ = [str(package_path)]
sys.modules[package_name] = subpkg

def load_module(fullname, path):
    loader = importlib.machinery.SourceFileLoader(fullname, path)
    spec = importlib.util.spec_from_loader(fullname, loader, origin=path)
    module = importlib.util.module_from_spec(spec)
    sys.modules[fullname] = module
    loader.exec_module(module)
    return module

load_module(f'{package_name}.utils', 'custom_components/thessla_green_modbus/utils.py')
scanner = load_module(f'{package_name}.device_scanner', 'custom_components/thessla_green_modbus/device_scanner.py')
print('BCD', scanner._format_register_value('schedule_morning', 0x0830))
print('REG', scanner._format_register_value('manual_airing_time_to_start', 0x0304))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a1dc80e0bc8326bbb13161495f26d5