### PR TITLE
refactor: simplify unique id f-string

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -23,9 +23,7 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
         host = self.coordinator.host.replace(":", "-")
-        return (
-            f"{DOMAIN}_{host}_{self.coordinator.port}_" f"{self.coordinator.slave_id}_{self._key}"
-        )
+        return f"{DOMAIN}_{host}_{self.coordinator.port}_{self.coordinator.slave_id}_{self._key}"
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
## Summary
- simplify ThesslaGreenEntity unique_id generation into a single f-string

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity.py` *(fails: mypy errors, generate-registers modified files)*
- `pytest` *(fails: missing dependencies and syntax errors during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dc93d9188326aa71dacea3c85391