### PR TITLE
Fix patch context in device scanner tests

### DIFF
--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -1041,10 +1041,6 @@ async def test_read_input_fallback_detects_temperature(caplog):
             "custom_components.thessla_green_modbus.device_scanner.COIL_REGISTERS",
             {},
         ),
-
-    ):
-        await ThesslaGreenDeviceScanner.create("host", 502, 10)
-
         patch(
             "custom_components.thessla_green_modbus.device_scanner.DISCRETE_INPUT_REGISTERS",
             {},


### PR DESCRIPTION
## Summary
- fix unbalanced patch context managers in `test_read_input_fallback_detects_temperature`

## Testing
- `python -m py_compile tests/test_device_scanner.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1f16b18048326b465806d4fd3d41e