### PR TITLE
Handle missing airflow data in fan_mode

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -179,13 +179,15 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
     def fan_mode(self) -> str | None:
         """Return current fan mode."""
         # Get airflow rate from manual or current setting
-        airflow = (
-            self.coordinator.data.get("air_flow_rate_manual")
-            or self.coordinator.data.get("air_flow_rate_temporary_2")
-            or 50
-        )
+        airflow = self.coordinator.data.get("air_flow_rate_manual")
+        if not airflow:
+            airflow = self.coordinator.data.get("air_flow_rate_temporary_2")
+
+        if not airflow:
+            return None
+
         # Round to nearest 10%
-        rounded = round(airflow / 10) * 10
+        rounded = int((airflow + 5) / 10) * 10
         return f"{max(10, min(100, rounded))}%"
 
     @property

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -203,7 +203,9 @@ class TestThesslaGreenModbusCoordinator:
     @pytest.fixture
     def coordinator_data(self):
         """Create coordinator with test data."""
-        from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+        from custom_components.thessla_green_modbus.coordinator import (
+            ThesslaGreenModbusCoordinator,
+        )
 
         hass = MagicMock()
         coordinator = ThesslaGreenModbusCoordinator(
@@ -354,7 +356,9 @@ class TestThesslaGreenConfigFlow:
     @pytest.mark.asyncio
     async def test_config_flow_user_step(self, mock_scanner):
         """Test the user configuration step."""
-        from custom_components.thessla_green_modbus.config_flow import ConfigFlow
+        from custom_components.thessla_green_modbus.config_flow import (
+            ConfigFlow,
+        )
 
         flow = ConfigFlow()
         flow.hass = MagicMock()
@@ -367,7 +371,9 @@ class TestThesslaGreenConfigFlow:
     @pytest.mark.asyncio
     async def test_config_flow_user_input_success(self, mock_scanner):
         """Test successful user input processing."""
-        from custom_components.thessla_green_modbus.config_flow import ConfigFlow
+        from custom_components.thessla_green_modbus.config_flow import (
+            ConfigFlow,
+        )
 
         flow = ConfigFlow()
         flow.hass = MagicMock()
@@ -391,7 +397,10 @@ class TestThesslaGreenConfigFlow:
     @pytest.mark.asyncio
     async def test_config_flow_cannot_connect(self):
         """Test connection failure handling."""
-        from custom_components.thessla_green_modbus.config_flow import CannotConnect, ConfigFlow
+        from custom_components.thessla_green_modbus.config_flow import (
+            CannotConnect,
+            ConfigFlow,
+        )
 
         flow = ConfigFlow()
         flow.hass = MagicMock()
@@ -438,7 +447,9 @@ class TestThesslaGreenDeviceScanner:
     @pytest.mark.asyncio
     async def test_device_scanner_success(self, mock_modbus_client):
         """Test successful device scanning."""
-        from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+        from custom_components.thessla_green_modbus.device_scanner import (
+            ThesslaGreenDeviceScanner,
+        )
 
         scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 
@@ -453,7 +464,9 @@ class TestThesslaGreenDeviceScanner:
     @pytest.mark.asyncio
     async def test_device_scanner_connection_failure(self):
         """Test scanner behavior on connection failure."""
-        from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+        from custom_components.thessla_green_modbus.device_scanner import (
+            ThesslaGreenDeviceScanner,
+        )
 
         scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 
@@ -466,7 +479,9 @@ class TestThesslaGreenDeviceScanner:
 
     def test_register_value_validation(self):
         """Test register value validation logic."""
-        from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+        from custom_components.thessla_green_modbus.device_scanner import (
+            ThesslaGreenDeviceScanner,
+        )
 
         scanner = asyncio.run(ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10))
 
@@ -476,13 +491,11 @@ class TestThesslaGreenDeviceScanner:
         assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x0400) is True
         assert scanner._is_valid_register_value("schedule_summer_mon_1", 0x2200) is True
 
-
         # Temperature sensor marked unavailable should still be considered valid
         assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is True
 
         # SENSOR_UNAVAILABLE should be treated as unavailable for temperature sensors
         assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
-
 
         # SENSOR_UNAVAILABLE should still be treated as valid for temperature sensors
         assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is True
@@ -505,7 +518,9 @@ class TestThesslaGreenDeviceScanner:
 
     def test_capability_analysis(self):
         """Test capability analysis logic."""
-        from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+        from custom_components.thessla_green_modbus.device_scanner import (
+            ThesslaGreenDeviceScanner,
+        )
 
         scanner = asyncio.run(ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10))
         scanner.available_registers = {
@@ -565,7 +580,9 @@ class TestThesslaGreenClimate:
         """Test climate entity creation and basic properties."""
         from homeassistant.components.climate import HVACMode
 
-        from custom_components.thessla_green_modbus.climate import ThesslaGreenClimate
+        from custom_components.thessla_green_modbus.climate import (
+            ThesslaGreenClimate,
+        )
 
         climate = ThesslaGreenClimate(mock_climate_coordinator)
 
@@ -580,7 +597,9 @@ class TestThesslaGreenClimate:
         """Test setting HVAC mode."""
         from homeassistant.components.climate import HVACMode
 
-        from custom_components.thessla_green_modbus.climate import ThesslaGreenClimate
+        from custom_components.thessla_green_modbus.climate import (
+            ThesslaGreenClimate,
+        )
 
         climate = ThesslaGreenClimate(mock_climate_coordinator)
 
@@ -601,7 +620,9 @@ class TestThesslaGreenClimate:
         """Abort mode change if enabling fails."""
         from homeassistant.components.climate import HVACMode
 
-        from custom_components.thessla_green_modbus.climate import ThesslaGreenClimate
+        from custom_components.thessla_green_modbus.climate import (
+            ThesslaGreenClimate,
+        )
 
         climate = ThesslaGreenClimate(mock_climate_coordinator)
         mock_climate_coordinator.async_write_register = AsyncMock(side_effect=[False, False])
@@ -625,7 +646,9 @@ class TestThesslaGreenClimate:
         """Test setting preset mode."""
         from homeassistant.components.climate import PRESET_ECO
 
-        from custom_components.thessla_green_modbus.climate import ThesslaGreenClimate
+        from custom_components.thessla_green_modbus.climate import (
+            ThesslaGreenClimate,
+        )
 
         climate = ThesslaGreenClimate(mock_climate_coordinator)
 
@@ -636,7 +659,9 @@ class TestThesslaGreenClimate:
 
     def test_climate_fan_mode_calculation(self, mock_climate_coordinator):
         """Test fan mode calculation."""
-        from custom_components.thessla_green_modbus.climate import ThesslaGreenClimate
+        from custom_components.thessla_green_modbus.climate import (
+            ThesslaGreenClimate,
+        )
 
         climate = ThesslaGreenClimate(mock_climate_coordinator)
 
@@ -647,6 +672,29 @@ class TestThesslaGreenClimate:
         fan_mode = climate.fan_mode
         assert fan_mode == "70%"  # Should round to nearest 10%
 
+    def test_climate_fan_mode_no_data(self, mock_climate_coordinator):
+        """Return None when no airflow registers are available."""
+        from custom_components.thessla_green_modbus.climate import (
+            ThesslaGreenClimate,
+        )
+
+        climate = ThesslaGreenClimate(mock_climate_coordinator)
+        mock_climate_coordinator.data.pop("air_flow_rate_manual", None)
+        mock_climate_coordinator.data.pop("air_flow_rate_temporary_2", None)
+
+        assert climate.fan_mode is None
+
+    def test_climate_fan_mode_zero_airflow(self, mock_climate_coordinator):
+        """Return None when airflow value is zero."""
+        from custom_components.thessla_green_modbus.climate import (
+            ThesslaGreenClimate,
+        )
+
+        climate = ThesslaGreenClimate(mock_climate_coordinator)
+        mock_climate_coordinator.data["air_flow_rate_manual"] = 0
+
+        assert climate.fan_mode is None
+
 
 class TestPerformanceOptimizations:
     """Test performance optimizations and benchmarks."""
@@ -654,7 +702,9 @@ class TestPerformanceOptimizations:
     @pytest.mark.asyncio
     async def test_register_grouping_performance(self):
         """Test that register grouping reduces Modbus calls."""
-        from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+        from custom_components.thessla_green_modbus.coordinator import (
+            ThesslaGreenModbusCoordinator,
+        )
 
         # Create coordinator with many registers
         hass = MagicMock()
@@ -683,7 +733,9 @@ class TestPerformanceOptimizations:
     @pytest.mark.asyncio
     async def test_scan_optimization_stats(self):
         """Test that device scanner provides optimization statistics."""
-        from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+        from custom_components.thessla_green_modbus.device_scanner import (
+            ThesslaGreenDeviceScanner,
+        )
 
         scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 


### PR DESCRIPTION
## Summary
- Return `None` for `fan_mode` when airflow registers are missing or report zero
- Clamp fan mode airflow values to 10–100% and round correctly
- Add tests for fan mode without airflow data and zero airflow

## Testing
- `SKIP=generate-registers pre-commit run --files custom_components/thessla_green_modbus/climate.py tests/test_optimized_integration.py`
- `pytest` *(fails: json.decoder.JSONDecodeError in translations)*
- `pytest tests/test_optimized_integration.py::TestThesslaGreenClimate::test_climate_fan_mode_calculation tests/test_optimized_integration.py::TestThesslaGreenClimate::test_climate_fan_mode_no_data tests/test_optimized_integration.py::TestThesslaGreenClimate::test_climate_fan_mode_zero_airflow`

------
https://chatgpt.com/codex/tasks/task_e_68a1f184a1b08326a94705cf7be26fd0