### PR TITLE
Handle missing binary sensor icons

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -134,26 +134,29 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
     @property
     def icon(self) -> str:
         """Return the icon for the binary sensor."""
-        base_icon = self._attr_icon
+        # Ensure base_icon is a string before using it
+        base_icon = self._attr_icon if isinstance(self._attr_icon, str) else None
 
         # Dynamic icon changes for certain sensors
-        if self._register_name in ["bypass", "gwc", "power_supply_fans", "heating_cable"]:
+        if base_icon and self._register_name in [
+            "bypass",
+            "gwc",
+            "power_supply_fans",
+            "heating_cable",
+        ]:
             if self.is_on:
                 return base_icon
-            else:
-                # Return "off" version of icon
-                if "fan" in base_icon:
-                    return base_icon.replace("fan", "fan-off")
-                elif "heating" in base_icon:
-                    return "mdi:radiator-off"
-                elif "pipe" in base_icon:
-                    return "mdi:pipe"
+            # Return "off" version of icon
+            if "fan" in base_icon:
+                return base_icon.replace("fan", "fan-off")
+            if "heating" in base_icon:
+                return "mdi:radiator-off"
+            if "pipe" in base_icon:
+                return "mdi:pipe"
 
         # Dynamic icon for alarms and errors
         if "alarm" in self._register_name or "error" in self._register_name:
-            if self.is_on:
-                return "mdi:alert-circle"
-            else:
-                return "mdi:check-circle"
+            return "mdi:alert-circle" if self.is_on else "mdi:check-circle"
 
-        return base_icon
+        # Fallback icon when no icon is configured
+        return base_icon or "mdi:fan-off"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -100,6 +100,17 @@ def test_binary_sensor_icons(mock_coordinator):
     assert bypass_sensor.icon == "mdi:pipe"  # nosec B101
 
 
+def test_binary_sensor_icon_fallback(mock_coordinator):
+    """Sensors without icons should return a sensible default."""
+    mock_coordinator.data["bypass"] = 1
+    sensor_def = BINARY_SENSOR_DEFINITIONS["bypass"].copy()
+    sensor_def.pop("icon", None)
+    sensor_without_icon = ThesslaGreenBinarySensor(
+        mock_coordinator, "bypass", sensor_def
+    )
+    assert sensor_without_icon.icon == "mdi:fan-off"  # nosec B101
+
+
 @pytest.mark.asyncio
 async def test_async_setup_creates_all_binary_sensors(mock_coordinator, mock_config_entry):
     """Ensure entities are created for all available binary sensor registers."""


### PR DESCRIPTION
## Summary
- Guard binary sensor icon handling with a string check and provide a fallback icon
- Add regression test for sensors missing icon definitions

## Testing
- `pytest tests/test_binary_sensor.py -p pytest_homeassistant_custom_component`
- `pytest -p pytest_homeassistant_custom_component` *(fails: JSONDecodeError in translation tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f16e8abc832686e1b0dbe23e607f