### PR TITLE
fix: remove duplicate register assignments in coordinator setup

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -216,19 +216,6 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     **self.device_scan_result.get("capabilities", {})
                 )
 
-                scan_regs = self.device_scan_result.get("available_registers", {})
-                for reg_type in self.available_registers:
-                    self.available_registers[reg_type].clear()
-                    self.available_registers[reg_type].update(scan_regs.get(reg_type, set()))
-                if self.skip_missing_registers:
-                    for reg_type, names in KNOWN_MISSING_REGISTERS.items():
-                        self.available_registers[reg_type].difference_update(names)
-                self.device_info.clear()
-                self.device_info.update(self.device_scan_result.get("device_info", {}))
-                for key, value in self.device_scan_result.get("capabilities", {}).items():
-                    setattr(self.capabilities, key, value)
-
-
                 _LOGGER.info(
                     "Device scan completed: %d registers found, model: %s, firmware: %s",
                     self.device_scan_result.get("register_count", 0),


### PR DESCRIPTION
## Summary
- run initial scan only once and populate available registers, device info and capabilities in one step

## Testing
- `ruff check custom_components/thessla_green_modbus/coordinator.py`
- `pytest` *(fails: JSONDecodeError in tests/test_translations.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f16fd92c83269220bf193d39d0eb