### PR TITLE
Handle scanner compatibility in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -62,7 +62,10 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
     )
 
     try:
-        scan_result = await scanner.scan_device()
+        if hasattr(scanner, "scan_device"):
+            scan_result = await scanner.scan_device()
+        else:
+            scan_result = await scanner.scan()
 
         if not scan_result:
             raise CannotConnect("Device scan failed - no data received")
@@ -82,7 +85,8 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
         _LOGGER.exception("Unexpected error during device validation: %s", exc)
         raise CannotConnect from exc
     finally:
-        await scanner.close()
+        if hasattr(scanner, "close"):
+            await scanner.close()
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -567,3 +567,67 @@ async def test_validate_input_scanner_closed_on_exception():
             await validate_input(None, data)
 
     scanner_instance.close.assert_awaited_once()
+
+
+async def test_validate_input_uses_scan_device_and_closes():
+    """Test validate_input uses scan_device when available and closes scanner."""
+    from custom_components.thessla_green_modbus.config_flow import validate_input
+
+    data = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "Test",
+    }
+
+    scan_result = {
+        "device_info": {"device_name": "Device"},
+        "available_registers": {},
+        "capabilities": {},
+    }
+
+    scanner_instance = SimpleNamespace(
+        scan_device=AsyncMock(return_value=scan_result),
+        close=AsyncMock(),
+    )
+
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",
+        AsyncMock(return_value=scanner_instance),
+    ):
+        result = await validate_input(None, data)
+
+    assert result["scan_result"] == scan_result
+    scanner_instance.scan_device.assert_awaited_once()
+    scanner_instance.close.assert_awaited_once()
+
+
+async def test_validate_input_fallback_to_scan_without_close():
+    """Test validate_input falls back to scan() when scan_device is unavailable."""
+    from custom_components.thessla_green_modbus.config_flow import validate_input
+
+    data = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "Test",
+    }
+
+    scan_result = {
+        "device_info": {"device_name": "Device"},
+        "available_registers": {},
+        "capabilities": {},
+    }
+
+    scanner_instance = SimpleNamespace(
+        scan=AsyncMock(return_value=scan_result)
+    )
+
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",
+        AsyncMock(return_value=scanner_instance),
+    ):
+        result = await validate_input(None, data)
+
+    assert result["scan_result"] == scan_result
+    scanner_instance.scan.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Support scanners lacking `scan_device` and `close` in config flow
- Add tests for scanner compatibility scenarios

## Testing
- `pytest tests/test_config_flow.py::test_validate_input_uses_scan_device_and_closes tests/test_config_flow.py::test_validate_input_fallback_to_scan_without_close -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1f89e44408326a83b869e438ba29d