### PR TITLE
Refactor scanner client closing logic and tests

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -312,26 +312,20 @@ class ThesslaGreenDeviceScanner:
         return self
 
     async def close(self) -> None:
-
         """Close the underlying Modbus client connection."""
+
         client = self._client
-        # Prevent further use even if closing fails
-        self._client = None
         if client is None:
             return
+
         try:
             result = client.close()
             if inspect.isawaitable(result):
                 await result
         except (OSError, ConnectionException, ModbusIOException):
             _LOGGER.debug("Error closing Modbus client", exc_info=True)
-
-        """Close the underlying Modbus client if it is open."""
-        if self._client is not None:
-            try:
-                await self._client.close()
-            finally:
-                self._client = None
+        finally:
+            self._client = None
 
     def _is_valid_register_value(self, name: str, value: int) -> bool:
         """Validate a register value against known constraints.

--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -382,3 +382,26 @@ def test_close_handles_io_error():
     import asyncio
 
     asyncio.run(run_test())
+
+
+def test_close_closes_existing_client():
+    """Scanner.close should await client.close and clear reference."""
+
+    async def run_test():
+        scanner = await ThesslaGreenDeviceScanner.create("localhost", 502)
+        client = AsyncMock()
+
+        async def close_side_effect():
+            # _client should still point to client when close is called
+            assert scanner._client is client
+            return None
+
+        client.close.side_effect = close_side_effect
+        scanner._client = client
+
+        await scanner.close()
+
+        client.close.assert_awaited_once()
+        assert scanner._client is None
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Simplify device scanner `close` by removing duplicate logic and closing the captured client once
- Extend unit tests to verify scanner close waits for client closure and clears reference

## Testing
- `pytest tests/test_scanner_close.py::test_close_closes_existing_client -q`
- `pytest tests/test_scanner_close.py::test_close_handles_io_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1f8a031f48326b37c636570f0feba