### PR TITLE
Handle unexpected errors during config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -138,6 +138,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except KeyError as err:
                 _LOGGER.error("Missing required data: %s", err)
                 errors["base"] = "invalid_input"
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected error during configuration: %s", err)
+                errors["base"] = "unknown"
 
         # Show form
         data_schema = vol.Schema(


### PR DESCRIPTION
## Summary
- handle unexpected exceptions in `async_step_user`

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py` (failed: mypy, bandit, generate-registers)
- `pytest` (failed: JSONDecodeError and DataUpdateCoordinator type errors)


------
https://chatgpt.com/codex/tasks/task_e_68a1fd561eb48326afd0411e7d8b562e