### PR TITLE
Implement batched register scanning

### DIFF
--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -12,22 +12,15 @@ from custom_components.thessla_green_modbus.const import (
 )
 from custom_components.thessla_green_modbus.device_scanner import (
     DeviceCapabilities,
-
-    ThesslaGreenDeviceScanner,
-)
-from custom_components.thessla_green_modbus.modbus_exceptions import (
-    ConnectionException,
-    ModbusException,
-
     DeviceInfo,
     ThesslaGreenDeviceScanner,
     _decode_setting_value,
     _format_register_value,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import (
+    ConnectionException,
     ModbusException,
     ModbusIOException,
-
 )
 from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS, INPUT_REGISTERS
 from custom_components.thessla_green_modbus.utils import _decode_bcd_time, _decode_register_time


### PR DESCRIPTION
## Summary
- group contiguous register addresses for batch reads
- batch scan input, holding, coil and discrete registers with per-register fallback
- adjust device scanner tests to import from the correct modules

## Testing
- `pytest tests/test_register_grouping.py tests/test_device_scanner.py` *(fails: AttributeError: 'ThesslaGreenDeviceScanner' object has no attribute '_read_input')*


------
https://chatgpt.com/codex/tasks/task_e_68a1fd599374832697f4aab5841d10ab