### PR TITLE
Add base register aliases and multi-register mapping

### DIFF
--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -40,11 +40,14 @@ DISCRETE_INPUT_REGISTERS: dict[str, int] = {
 MULTI_REGISTER_SIZES: dict[str, int] = {
     "date_time_1": 4,
     "lock_date_1": 3,
-    "date_time_2": 4,
-    "date_time_3": 4,
-    "date_time_4": 4,
-    "lock_date_2": 3,
-    "lock_date_3": 3,
+    "device_name_1": 8,
+}
+
+# Base aliases for multi-register blocks where registers share a common name.
+BASE_REGISTER_ALIASES: dict[str, str] = {
+    "date_time": "date_time_1",
+    "lock_date": "lock_date_1",
+    "device_name": "device_name_1",
 }
 
 INPUT_REGISTERS: dict[str, int] = {
@@ -81,10 +84,12 @@ INPUT_REGISTERS: dict[str, int] = {
 
 
 HOLDING_REGISTERS: dict[str, int] = {
+    "date_time": 0,
     "date_time_1": 0,
     "date_time_2": 1,
     "date_time_3": 2,
     "date_time_4": 3,
+    "lock_date": 7,
     "lock_date_1": 7,
     "lock_date_2": 8,
     "lock_date_3": 9,
@@ -304,6 +309,7 @@ HOLDING_REGISTERS: dict[str, int] = {
     "uart_1_baud": 4457,
     "uart_1_parity": 4458,
     "uart_1_stop": 4459,
+    "device_name": 8144,
     "device_name_1": 8144,
     "device_name_2": 8145,
     "device_name_3": 8146,


### PR DESCRIPTION
## Summary
- track sizes for multi-register blocks
- expose base register names like `device_name` and `lock_date`

## Testing
- `python tools/generate_registers.py`
- `python tools/validate_registers.py`
- `python -m py_compile custom_components/thessla_green_modbus/registers.py`
- `pytest -q` *(fails: SyntaxError in device_scanner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a201c992c4832680bc55a406fc3acb