### PR TITLE
Rename antifreeze mode identifiers

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -328,8 +328,8 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "register_type": "input_registers",
     },
     # Mode and status sensors
-    "antifreez_mode": {
-        "translation_key": "antifreez_mode",
+    "antifreeze_mode": {
+        "translation_key": "antifreeze_mode",
         "icon": "mdi:snowflake-alert",
         "register_type": "input_registers",
     },

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -163,9 +163,9 @@
       "serial_number_6": {
         "name": "Serial Number 6"
       },
-      "antifreez_mode": {
-        "name": "Antifreeze Mode"
-      },
+        "antifreeze_mode": {
+          "name": "Antifreeze Mode"
+        },
       "mode": {
         "name": "Operating Mode"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -133,9 +133,9 @@
       "serial_number_6": {
         "name": "Numer seryjny 6"
       },
-      "antifreez_mode": {
-        "name": "Tryb przeciwzamrożeniowy"
-      },
+        "antifreeze_mode": {
+          "name": "Tryb przeciwzamrożeniowy"
+        },
       "mode": {
         "name": "Tryb pracy"
       },


### PR DESCRIPTION
## Summary
- fix typo `antifreez_mode` -> `antifreeze_mode`
- update English and Polish translations for antifreeze mode sensor

## Testing
- `pytest tests/test_register_decoders.py tests/test_entity_unique_id.py` *(fails: SyntaxError: invalid syntax in device_scanner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a201b3f3408326986f916e8c0486b0