### PR TITLE
Remove duplicate _read_input definition

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -811,7 +811,6 @@ class ThesslaGreenDeviceScanner:
             return 0
         return self.backoff * 2 ** (attempt - 1)
 
-
     async def _read_input(
         self,
         client: "AsyncModbusTcpClient",
@@ -831,35 +830,16 @@ class ThesslaGreenDeviceScanner:
         start = address
         end = address + count - 1
 
-
         for skip_start, skip_end in self._unsupported_input_ranges:
             if skip_start <= start and end <= skip_end:
                 return None
 
-
-async def _read_input(
-    self,
-    client: "AsyncModbusTcpClient",
-    address: int,
-    count: int,
-    *,
-    skip_cache: bool = False,
-    log_exceptions: bool = True,
-) -> list[int] | None:
-    """Read input registers with retry and backoff.
-
-    ``skip_cache`` is used when probing individual registers after a block
-    read failed. When ``True`` the cached set of failed registers is not
-    checked, allowing each register to be queried once before being cached
-    as missing.
-    """
-    start = address
-    end = address + count - 1
-
-    for skip_start, skip_end in self._unsupported_input_ranges:
-        if skip_start <= start and end <= skip_end:
-        if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
-            first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
+        if not skip_cache and any(
+            reg in self._failed_input for reg in range(start, end + 1)
+        ):
+            first = next(
+                reg for reg in range(start, end + 1) if reg in self._failed_input
+            )
             skip_start = skip_end = first
             while skip_start - 1 in self._failed_input:
                 skip_start -= 1
@@ -874,117 +854,101 @@ async def _read_input(
                 self._input_skip_log_ranges.add((skip_start, skip_end))
             return None
 
-    if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
-        first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
-        skip_start = skip_end = first
-        while skip_start - 1 in self._failed_input:
-            skip_start -= 1
-        while skip_end + 1 in self._failed_input:
-            skip_end += 1
-        if (skip_start, skip_end) not in self._input_skip_log_ranges:
+        for attempt in range(1, self.retry + 1):
+            try:
+                response = await _call_modbus(
+                    client.read_input_registers, self.slave_id, address, count=count
+                )
+                if response is not None and not response.isError():
+                    return response.registers
+                _LOGGER.debug(
+                    "Attempt %d failed to read input 0x%04X: %s",
+                    attempt,
+                    address,
+                    response,
+                )
+            except (ModbusException, ConnectionException) as exc:
+                _LOGGER.debug(
+                    "Attempt %d failed to read input 0x%04X: %s",
+                    attempt,
+                    address,
+                    exc,
+                    exc_info=True,
+                )
+            except (OSError, asyncio.TimeoutError) as exc:
+                _LOGGER.error(
+                    "Unexpected error reading input 0x%04X on attempt %d: %s",
+                    address,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                break
+            except ModbusIOException as exc:
+                _LOGGER.debug(
+                    "Modbus IO error reading input registers 0x%04X-0x%04X on attempt %d: %s",
+                    start,
+                    end,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                if count == 1:
+                    failures = self._input_failures.get(address, 0) + 1
+                    self._input_failures[address] = failures
+                    if failures >= self.retry and address not in self._failed_input:
+                        self._failed_input.add(address)
+                        _LOGGER.warning("Device does not expose register 0x%04X", address)
+            except (ModbusException, ConnectionException, asyncio.TimeoutError) as exc:
+                _LOGGER.debug(
+                    "Failed to read input registers 0x%04X-0x%04X on attempt %d: %s",
+                    start,
+                    end,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                break
+
             _LOGGER.debug(
-                "Skipping cached failed input registers 0x%04X-0x%04X",
-                skip_start,
-                skip_end,
+                "Falling back to holding registers for input 0x%04X (attempt %d)",
+                address,
+                attempt,
             )
-            self._input_skip_log_ranges.add((skip_start, skip_end))
+            try:
+                response = await _call_modbus(
+                    client.read_holding_registers, self.slave_id, address, count=count
+                )
+                if response is not None and not response.isError():
+                    return response.registers
+                _LOGGER.debug(
+                    "Fallback attempt %d failed to read holding 0x%04X: %s",
+                    attempt,
+                    address,
+                    response,
+                )
+            except (ModbusException, ConnectionException) as exc:
+                _LOGGER.debug(
+                    "Fallback attempt %d failed to read holding 0x%04X: %s",
+                    attempt,
+                    address,
+                    exc,
+                    exc_info=True,
+                )
+            except (OSError, asyncio.TimeoutError) as exc:
+                _LOGGER.error(
+                    "Unexpected error reading holding 0x%04X on attempt %d: %s",
+                    address,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                break
+
+            if attempt < self.retry:
+                await asyncio.sleep(0.5)
+
         return None
-
-    for attempt in range(1, self.retry + 1):
-        try:
-            response = await _call_modbus(
-                client.read_input_registers, self.slave_id, address, count=count
-            )
-            if response is not None and not response.isError():
-                return response.registers
-            _LOGGER.debug(
-                "Attempt %d failed to read input 0x%04X: %s",
-                attempt,
-                address,
-                response,
-            )
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.debug(
-                "Attempt %d failed to read input 0x%04X: %s",
-                attempt,
-                address,
-                exc,
-                exc_info=True,
-            )
-        except (OSError, asyncio.TimeoutError) as exc:
-            _LOGGER.error(
-                "Unexpected error reading input 0x%04X on attempt %d: %s",
-                address,
-                attempt,
-                exc,
-                exc_info=True,
-            )
-            break
-        except ModbusIOException as exc:
-            _LOGGER.debug(
-                "Modbus IO error reading input registers 0x%04X-0x%04X on attempt %d: %s",
-                start,
-                end,
-                attempt,
-                exc,
-                exc_info=True,
-            )
-            if count == 1:
-                failures = self._input_failures.get(address, 0) + 1
-                self._input_failures[address] = failures
-                if failures >= self.retry and address not in self._failed_input:
-                    self._failed_input.add(address)
-                    _LOGGER.warning("Device does not expose register 0x%04X", address)
-        except (ModbusException, ConnectionException, asyncio.TimeoutError) as exc:
-            _LOGGER.debug(
-                "Failed to read input registers 0x%04X-0x%04X on attempt %d: %s",
-                start,
-                end,
-                attempt,
-                exc,
-                exc_info=True,
-            )
-            break
-
-        _LOGGER.debug(
-            "Falling back to holding registers for input 0x%04X (attempt %d)",
-            address,
-            attempt,
-        )
-        try:
-            response = await _call_modbus(
-                client.read_holding_registers, self.slave_id, address, count=count
-            )
-            if response is not None and not response.isError():
-                return response.registers
-            _LOGGER.debug(
-                "Fallback attempt %d failed to read holding 0x%04X: %s",
-                attempt,
-                address,
-                response,
-            )
-        except (ModbusException, ConnectionException) as exc:
-            _LOGGER.debug(
-                "Fallback attempt %d failed to read holding 0x%04X: %s",
-                attempt,
-                address,
-                exc,
-                exc_info=True,
-            )
-        except (OSError, asyncio.TimeoutError) as exc:
-            _LOGGER.error(
-                "Unexpected error reading holding 0x%04X on attempt %d: %s",
-                address,
-                attempt,
-                exc,
-                exc_info=True,
-            )
-            break
-
-        if attempt < self.retry:
-            await asyncio.sleep(0.5)
-
-    return None
 
 
 async def _read_holding(
@@ -1177,3 +1141,10 @@ async def _read_discrete(
                 _LOGGER.debug("Sleep cancelled while retrying discrete 0x%04X", address)
                 raise
     return None
+
+
+# Bind module-level helpers to the scanner class and expose _read_input for tests
+ThesslaGreenDeviceScanner._read_holding = _read_holding
+ThesslaGreenDeviceScanner._read_coil = _read_coil
+ThesslaGreenDeviceScanner._read_discrete = _read_discrete
+_read_input = ThesslaGreenDeviceScanner._read_input


### PR DESCRIPTION
## Summary
- remove duplicate `_read_input` implementation and consolidate logic
- ensure unsupported input ranges are skipped with proper return
- expose helper functions for tests and bind them to the scanner class

## Testing
- `ruff check custom_components/thessla_green_modbus/device_scanner.py`
- `pytest` *(fails: json.decoder.JSONDecodeError in tests/test_translations.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a2064ab3ec8326bbc9a53987a92b9c