### PR TITLE
Fix invalid English translation JSON

### DIFF
--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1,14 +1,4 @@
 {
-  "config": {
-    "step": {
-      "user": {
-        "title": "ThesslaGreen Modbus Configuration",
-        "data": {
-          "host": "IP Address",
-          "port": "Port",
-          "slave_id": "Device ID",
-          "name": "Name"
-        }
   "auto_detected_note_limited": "Limited auto-detection - some registers may be missing.",
   "auto_detected_note_success": "Auto-detection successful!",
   "config": {
@@ -49,6 +39,7 @@
       "outside_temperature": {
         "name": "Outside Temperature"
       }
+    },
     "binary_sensor": {
       "ahu_filter_protection": {
         "name": "AHU Filter Protection"
@@ -180,11 +171,12 @@
       "airing_bathroom_coef": {
         "name": "Airing Bathroom Coef"
       },
-        "antifreeze_mode": {
-          "name": "Antifreeze Mode"
-        },
+      "antifreeze_mode": {
+        "name": "Antifreeze Mode"
+      },
       "mode": {
         "name": "Operating Mode"
+      },
       "airing_coef": {
         "name": "Airing Coef"
       },


### PR DESCRIPTION
## Summary
- fix missing braces and commas in English translations

## Testing
- `pytest tests/test_translations.py` *(fails: IndentationError in device_scanner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a2215a0ec083269ade963338abe690