### PR TITLE
refactor: rely on base device info

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -62,7 +65,6 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
     ) -> None:
         """Initialize the binary sensor."""
         super().__init__(coordinator, register_name)
-        self._attr_device_info = coordinator.get_device_info()
 
         self._register_name = register_name
         self._sensor_def = sensor_definition

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -76,7 +76,6 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
     def __init__(self, coordinator: ThesslaGreenModbusCoordinator) -> None:
         """Initialize the climate entity."""
         super().__init__(coordinator, "climate")
-        self._attr_device_info = coordinator.get_device_info()
         self._attr_translation_key = "thessla_green_climate"
         self._attr_has_entity_name = True
 

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -50,7 +50,6 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
         definition: dict[str, Any],
     ) -> None:
         super().__init__(coordinator, register_name)
-        self._attr_device_info = coordinator.get_device_info()
         self._register_name = register_name
 
         self._attr_translation_key = definition["translation_key"]

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -9,9 +9,17 @@ import logging
 from pathlib import Path
 from typing import Any, Dict
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfVolumeFlowRate
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfTemperature,
+    UnitOfVolumeFlowRate,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -136,7 +144,6 @@ class ThesslaGreenSensor(ThesslaGreenEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, register_name)
-        self._attr_device_info = coordinator.get_device_info()
 
         self._register_name = register_name
         self._sensor_def = sensor_definition


### PR DESCRIPTION
## Summary
- remove redundant device info assignments in sensor, climate, binary sensor and select entities
- rely on `ThesslaGreenEntity` for device information

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/sensor.py custom_components/thessla_green_modbus/climate.py custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/select.py`
- `pytest` *(fails: IndentationError in _read_holding on line 975)*

------
https://chatgpt.com/codex/tasks/task_e_68a24170bb508326856f2def476993e2