### PR TITLE
Add Polish error messages in Thessla Green Modbus config

### DIFF
--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -2,7 +2,20 @@
   "auto_detected_note_success": "Automatyczne wykrywanie zakończone sukcesem!",
   "auto_detected_note_limited": "Ograniczone automatyczne wykrywanie - niektóre rejestry mogą być pominięte.",
   "config": {
+    "abort": {
+      "already_configured": "Urządzenie z tym adresem IP i ID urządzenia jest już skonfigurowane."
+    },
+    "error": {
+      "cannot_connect": "Nie można połączyć się z urządzeniem. Sprawdź adres IP, port i połączenie sieciowe.",
+      "invalid_auth": "Błąd uwierzytelniania. Sprawdź ustawienia ID urządzenia.",
+      "invalid_input": "Podano nieprawidłową konfigurację. Sprawdź wartości i spróbuj ponownie.",
+      "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
+    },
     "step": {
+      "confirm": {
+        "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia: {slave_id}. Wersja oprogramowania: {firmware_version}. Znalezione rejestry: {register_count}. Skuteczność skanowania: {scan_success_rate}. Możliwości ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Kontynuować z tą konfiguracją?",
+        "title": "Potwierdź konfigurację"
+      },
       "user": {
         "title": "Konfiguracja ThesslaGreen Modbus",
         "data": {
@@ -110,9 +123,6 @@
       "serial_number_6": {
         "name": "Numer seryjny 6"
       },
-        "antifreeze_mode": {
-          "name": "Tryb przeciwzamrożeniowy"
-        },
       "mode": {
         "name": "Tryb pracy"
       },


### PR DESCRIPTION
## Summary
- add Polish translations for configuration abort and error messages
- translate confirmation step description and title
- remove duplicate antifreeze mode key

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/pl.json`
- `SKIP=generate-registers pre-commit run --files custom_components/thessla_green_modbus/translations/pl.json`


------
https://chatgpt.com/codex/tasks/task_e_68a241605b788326b3d9676ddf312ac2