### PR TITLE
Format code with Black

### DIFF
--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -1,4 +1,5 @@
 """Number platform for the ThesslaGreen Modbus integration."""
+
 from __future__ import annotations
 
 import logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,10 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     cv = types.ModuleType("homeassistant.helpers.config_validation")
     selector = types.ModuleType("homeassistant.helpers.selector")
     translation = types.ModuleType("homeassistant.helpers.translation")
+
     async def async_get_translations(*args, **kwargs):  # pragma: no cover - stub
         return {}
+
     translation.async_get_translations = async_get_translations
     pymodbus = types.ModuleType("pymodbus")
     pymodbus_client = types.ModuleType("pymodbus.client")

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -105,9 +105,7 @@ def test_binary_sensor_icon_fallback(mock_coordinator):
     mock_coordinator.data["bypass"] = 1
     sensor_def = BINARY_SENSOR_DEFINITIONS["bypass"].copy()
     sensor_def.pop("icon", None)
-    sensor_without_icon = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", sensor_def
-    )
+    sensor_without_icon = ThesslaGreenBinarySensor(mock_coordinator, "bypass", sensor_def)
     assert sensor_without_icon.icon == "mdi:fan-off"  # nosec B101
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -117,7 +117,11 @@ async def test_duplicate_entry_aborts():
     flow = ConfigFlow()
     flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
 
-    validation_result = {"title": "ThesslaGreen 192.168.1.100", "device_info": {}, "scan_result": {}}
+    validation_result = {
+        "title": "ThesslaGreen 192.168.1.100",
+        "device_info": {},
+        "scan_result": {},
+    }
 
     with (
         patch(
@@ -225,6 +229,8 @@ async def test_duplicate_configuration_aborts():
     """Test configuring same host/port/slave twice aborts the flow."""
     flow = ConfigFlow()
     flow.hass = None
+
+
 async def test_confirm_step_aborts_on_existing_entry():
     """Ensure confirming a second flow aborts if unique ID already configured."""
 
@@ -260,14 +266,12 @@ async def test_confirm_step_aborts_on_existing_entry():
         if getattr(self, "_unique_id", None) in entries:
             raise AbortFlow("already_configured")
 
-
     with (
         patch(
             "custom_components.thessla_green_modbus.config_flow.validate_input",
             return_value=validation_result,
         ),
         patch(
-
             "custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id",
         ),
         patch(
@@ -296,9 +300,7 @@ async def test_confirm_step_aborts_on_existing_entry():
             new=AsyncMock(return_value={}),
         ),
         patch.object(ConfigFlow, "async_set_unique_id", async_set_unique_id),
-        patch.object(
-            ConfigFlow, "_abort_if_unique_id_configured", abort_if_unique_id_configured
-        ),
+        patch.object(ConfigFlow, "_abort_if_unique_id_configured", abort_if_unique_id_configured),
     ):
         flow1 = ConfigFlow()
         flow1.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
@@ -315,7 +317,6 @@ async def test_confirm_step_aborts_on_existing_entry():
         with pytest.raises(AbortFlow) as err:
             await flow2.async_step_confirm({})
         assert err.value.reason == "already_configured"
-
 
 
 async def test_form_user_cannot_connect():
@@ -619,9 +620,7 @@ async def test_validate_input_fallback_to_scan_without_close():
         "capabilities": {},
     }
 
-    scanner_instance = SimpleNamespace(
-        scan=AsyncMock(return_value=scan_result)
-    )
+    scanner_instance = SimpleNamespace(scan=AsyncMock(return_value=scan_result))
 
     with patch(
         "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,5 @@
 """Tests for ThesslaGreenModbusCoordinator - HA 2025.7.1+ & pymodbus 3.5+ Compatible."""
 
-
-
 import asyncio
 
 import logging

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -779,14 +779,12 @@ async def test_is_valid_register_value():
     assert scanner._is_valid_register_value("test_register", 100) is True
     assert scanner._is_valid_register_value("test_register", 0) is True
 
-
     # Temperature sensor marked unavailable should still be considered valid
     assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is True
 
     # SENSOR_UNAVAILABLE should be treated as unavailable for temperature and airflow sensors
     assert scanner._is_valid_register_value("outside_temperature", SENSOR_UNAVAILABLE) is False
     assert scanner._is_valid_register_value("supply_air_flow", SENSOR_UNAVAILABLE) is False
-
 
     # Invalid air flow value
     assert scanner._is_valid_register_value("supply_air_flow", 65535) is False
@@ -941,7 +939,6 @@ async def test_temperature_unavailable_no_warning(caplog):
     assert "outside_temperature" not in caplog.text
 
 
-
 async def test_capabilities_detect_schedule_keywords():
     """Ensure capability detection considers scheduling related registers."""
     scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
@@ -1012,7 +1009,6 @@ async def test_load_registers_duplicate_names(tmp_path):
     assert scanner._registers["04"] == {1: "reg_a_1", 2: "reg_a_2"}
 
 
-
 async def test_read_input_fallback_detects_temperature(caplog):
     """Fallback to holding registers should discover temperature inputs."""
     empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
@@ -1064,11 +1060,7 @@ async def test_read_input_fallback_detects_temperature(caplog):
             result = await scanner.scan_device()
 
     assert "outside_temperature" in result["available_registers"]["input_registers"]
-    assert any(
-        "Falling back to holding registers" in record.message
-        for record in caplog.records
-    )
-
+    assert any("Falling back to holding registers" in record.message for record in caplog.records)
 
 
 async def test_load_registers_missing_range_warning(tmp_path, caplog):
@@ -1153,7 +1145,6 @@ async def test_load_registers_parses_range_formats(tmp_path, min_raw, max_raw, c
             "custom_components.thessla_green_modbus.device_scanner.DISCRETE_INPUT_REGISTERS",
             {},
         ),
-
         patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class,
     ):
         scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
@@ -1183,9 +1174,7 @@ async def test_load_registers_parses_range_formats(tmp_path, min_raw, max_raw, c
 
 async def test_load_registers_complete_range_no_warning(tmp_path, caplog):
     """No warning when both Min and Max are provided."""
-    csv_content = (
-        "Function_Code,Address_DEC,Register_Name,Min,Max\n" "04,1,reg_a,1,10\n"
-    )
+    csv_content = "Function_Code,Address_DEC,Register_Name,Min,Max\n" "04,1,reg_a,1,10\n"
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "modbus_registers.csv").write_text(csv_content)
@@ -1202,7 +1191,6 @@ async def test_load_registers_complete_range_no_warning(tmp_path, caplog):
             "custom_components.thessla_green_modbus.device_scanner.DISCRETE_INPUT_REGISTERS",
             {},
         ),
-
         caplog.at_level(logging.WARNING),
     ):
         scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
@@ -1261,7 +1249,6 @@ async def test_load_registers_missing_required_register(tmp_path):
     ):
         with pytest.raises(ValueError, match="reg_a"):
             await ThesslaGreenDeviceScanner.create("host", 502, 10)
-
 
 
 async def test_analyze_capabilities():

--- a/tests/test_input_range_fallback.py
+++ b/tests/test_input_range_fallback.py
@@ -6,6 +6,7 @@ from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDe
 
 pytestmark = pytest.mark.asyncio
 
+
 async def test_input_range_read_after_block_failure():
     empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
     with patch.object(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 """Test integration setup for ThesslaGreen Modbus integration."""
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,7 +16,7 @@ async def test_async_setup_entry_success():
     hass = MagicMock()
     hass.data = {}
     hass.config_entries.async_forward_entry_setups = AsyncMock()
-    
+
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry"
     entry.data = {
@@ -26,7 +27,7 @@ async def test_async_setup_entry_success():
     entry.options = {}
     entry.add_update_listener = MagicMock()
     entry.async_on_unload = MagicMock()
-    
+
     with patch(
         "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator"
     ) as mock_coordinator_class:
@@ -34,9 +35,9 @@ async def test_async_setup_entry_success():
         mock_coordinator.async_config_entry_first_refresh = AsyncMock()
         mock_coordinator.async_setup = AsyncMock(return_value=True)
         mock_coordinator_class.return_value = mock_coordinator
-        
+
         result = await async_setup_entry(hass, entry)
-        
+
         assert result is True
         assert DOMAIN in hass.data
         assert entry.entry_id in hass.data[DOMAIN]
@@ -47,7 +48,7 @@ async def test_async_setup_entry_failure():
     """Test setup entry with coordinator failure."""
     hass = MagicMock()
     hass.data = {}
-    
+
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry"
     entry.data = {
@@ -56,7 +57,7 @@ async def test_async_setup_entry_failure():
         "slave_id": 10,
     }
     entry.options = {}
-    
+
     with patch(
         "custom_components.thessla_green_modbus.coordinator.ThesslaGreenModbusCoordinator"
     ) as mock_coordinator_class:
@@ -65,7 +66,7 @@ async def test_async_setup_entry_failure():
             side_effect=Exception("Connection failed")
         )
         mock_coordinator_class.return_value = mock_coordinator
-        
+
         with pytest.raises(ConfigEntryNotReady):
             await async_setup_entry(hass, entry)
 
@@ -108,17 +109,17 @@ async def test_async_unload_entry_success():
     hass = MagicMock()
     hass.data = {DOMAIN: {"test_entry": MagicMock()}}
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
-    
+
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry"
-    
+
     # Mock coordinator with shutdown method
     mock_coordinator = MagicMock()
     mock_coordinator.async_shutdown = AsyncMock()
     hass.data[DOMAIN]["test_entry"] = mock_coordinator
-    
+
     result = await async_unload_entry(hass, entry)
-    
+
     assert result is True
     hass.config_entries.async_unload_platforms.assert_called_once()
     mock_coordinator.async_shutdown.assert_called_once()
@@ -129,12 +130,12 @@ async def test_async_unload_entry_failure():
     hass = MagicMock()
     hass.data = {DOMAIN: {"test_entry": MagicMock()}}
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
-    
+
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry"
-    
+
     result = await async_unload_entry(hass, entry)
-    
+
     assert result is False
     hass.config_entries.async_unload_platforms.assert_called_once()
 
@@ -149,7 +150,7 @@ async def test_default_values():
         DEFAULT_TIMEOUT,
         DEFAULT_RETRY,
     )
-    
+
     assert DEFAULT_NAME == "ThesslaGreen"
     assert DEFAULT_PORT == 502
     assert DEFAULT_SLAVE_ID == 10
@@ -168,13 +169,13 @@ async def test_register_constants():
         INPUT_REGISTERS,
         HOLDING_REGISTERS,
     )
-    
+
     # Test that key registers are defined
     assert "power_supply_fans" in COIL_REGISTERS
     assert "outside_temperature" in INPUT_REGISTERS
     assert "mode" in HOLDING_REGISTERS
     assert "expansion" in DISCRETE_INPUT_REGISTERS
-    
+
     # Test address ranges
     assert COIL_REGISTERS["power_supply_fans"] == 0x000B
     assert INPUT_REGISTERS["outside_temperature"] == 0x0010

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,4 +1,5 @@
 """Test config entry migrations."""
+
 import pytest
 from unittest.mock import MagicMock
 
@@ -66,7 +67,4 @@ async def test_migrate_entry_updates_unique_id():
     result = await async_migrate_entry(hass, config_entry)
 
     assert result is True
-    assert (
-        hass.config_entries.async_update_entry.call_args.kwargs["unique_id"]
-        == "fe80--1:1234:5"
-    )
+    assert hass.config_entries.async_update_entry.call_args.kwargs["unique_id"] == "fe80--1:1234:5"

--- a/tests/test_platform_setup_cancellation.py
+++ b/tests/test_platform_setup_cancellation.py
@@ -1,4 +1,3 @@
-
 """Tests for cancellation during platform setup."""
 
 import asyncio

--- a/tests/test_read_cancellation.py
+++ b/tests/test_read_cancellation.py
@@ -11,6 +11,7 @@ from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOExc
 
 pytestmark = pytest.mark.asyncio
 
+
 @pytest.mark.parametrize(
     "method",
     ["_read_input", "_read_holding", "_read_coil", "_read_discrete"],
@@ -33,4 +34,3 @@ async def test_read_cancellation_during_sleep(method, caplog):
             await func(mock_client, 0x0001, 1)
 
     assert not any(record.levelno >= logging.ERROR for record in caplog.records)
-

--- a/tests/test_unused_translations.py
+++ b/tests/test_unused_translations.py
@@ -14,11 +14,7 @@ from tests.test_translations import (
     SWITCH_KEYS as SWITCH_ENTITY_KEYS,
 )
 
-SWITCH_KEYS = (
-    SWITCH_ENTITY_KEYS
-    + ["on_off_panel_mode"]
-    + list(SPECIAL_FUNCTION_MAP.keys())
-)
+SWITCH_KEYS = SWITCH_ENTITY_KEYS + ["on_off_panel_mode"] + list(SPECIAL_FUNCTION_MAP.keys())
 
 
 def _assert_no_extra_keys(trans, entity_type, valid_keys) -> None:


### PR DESCRIPTION
## Summary
- run `black .` to apply consistent formatting

## Testing
- `black --check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml'; TypeError: type 'DataUpdateCoordinator' is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c67ac6908326a7b78a490cde9696