### PR TITLE
Add vulture to development dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,5 @@ pre-commit>=3.0.0
 # Documentation
 sphinx>=4.0.0
 sphinx-rtd-theme>=1.0.0
+
+vulture


### PR DESCRIPTION
## Summary
- add vulture dev dependency

## Testing
- `pip install -r requirements-dev.txt`
- `vulture .`


------
https://chatgpt.com/codex/tasks/task_e_68a2c68361d88326af19bd391154a2f2