### PR TITLE
Add PyYAML to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ pytest>=7.0.0
 pytest-asyncio>=0.21.0
 voluptuous>=0.13.1
 pytest-homeassistant-custom-component>=0.13.0
+PyYAML>=6.0
 
 # Code quality tools
 black>=22.0.0


### PR DESCRIPTION
## Summary
- add PyYAML to `requirements-dev.txt`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ImportError in tests/test_backoff.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c6859e5c8326814f1110470490cc