### PR TITLE
Move read helpers into scanner class

### DIFF
--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -39,6 +39,12 @@ async def test_device_scanner_initialization():
     assert scanner.backoff == 0
 
 
+async def test_scanner_has_read_coil_method():
+    """Ensure scanner exposes coil reading helper."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+    assert hasattr(scanner, "_read_coil")
+
+
 async def test_read_holding_skips_after_failure():
     """Holding registers are cached after a failed read."""
     scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=2)


### PR DESCRIPTION
## Summary
- turn `_read_coil`, `_read_holding` and `_read_discrete` into methods of `ThesslaGreenDeviceScanner`
- drop module-level patches and update tests
- add regression test for `_read_coil` method

## Testing
- `pytest tests/test_backoff.py::test_backoff_delay -q`
- `pytest tests/test_backoff.py::test_backoff_zero_no_delay -q`
- `pytest tests/test_device_scanner.py::test_scanner_has_read_coil_method -q`
- `pytest tests/test_device_scanner.py::test_read_coil_retries_on_failure -q`
- `pytest tests/test_read_cancellation.py::test_read_cancellation_during_sleep -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant.components')*
- `pytest tests/test_input_range_fallback.py::test_input_range_read_after_block_failure -q` *(fails: assert (0x000E, 16) in call_log)*

------
https://chatgpt.com/codex/tasks/task_e_68a35d91b8308326b0ff0d5f14f5bca1