### PR TITLE
Remove scan fallback in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -62,10 +62,7 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
     )
 
     try:
-        if hasattr(scanner, "scan_device"):
-            scan_result = await scanner.scan_device()
-        else:
-            scan_result = await scanner.scan()
+        scan_result = await scanner.scan_device()
 
         if not scan_result:
             raise CannotConnect("Device scan failed - no data received")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -638,34 +638,3 @@ async def test_validate_input_uses_scan_device_and_closes():
     assert result["scan_result"] == scan_result
     scanner_instance.scan_device.assert_awaited_once()
     scanner_instance.close.assert_awaited_once()
-
-
-async def test_validate_input_fallback_to_scan_without_close():
-    """Test validate_input falls back to scan() when scan_device is unavailable."""
-    from custom_components.thessla_green_modbus.config_flow import (
-        validate_input,
-    )
-
-    data = {
-        CONF_HOST: "192.168.1.100",
-        CONF_PORT: 502,
-        "slave_id": 10,
-        CONF_NAME: "Test",
-    }
-
-    scan_result = {
-        "device_info": {"device_name": "Device"},
-        "available_registers": {},
-        "capabilities": {},
-    }
-
-    scanner_instance = SimpleNamespace(scan=AsyncMock(return_value=scan_result))
-
-    with patch(
-        "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",
-        AsyncMock(return_value=scanner_instance),
-    ):
-        result = await validate_input(None, data)
-
-    assert result["scan_result"] == scan_result
-    scanner_instance.scan.assert_awaited_once()


### PR DESCRIPTION
## Summary
- always invoke `scan_device` in config flow
- drop tests covering legacy `scan` fallback

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py tests/test_config_flow.py` *(fails: mypy errors, generate-registers modified file)*
- `pytest tests/test_config_flow.py tests/test_device_scanner.py` *(fails: multiple assertion and attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a35d94042c8326be3ad1a8b3fcbc1f