### PR TITLE
Log stack traces and surface missing scanner methods in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -362,3 +362,4 @@ HOLDING_REGISTERS: dict[str, int] = {
     "e_251": 8443,
     "e_252": 8444,
 }
+

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -9,6 +9,7 @@
       "cannot_connect": "Cannot connect to device. Check IP address, port, and network connection.",
       "invalid_auth": "Authentication error. Check Device ID settings.",
       "invalid_input": "Invalid configuration provided. Check values and try again.",
+      "missing_method": "Scanner is missing required method. See logs for details.",
       "unknown": "Unexpected error. Check logs for details."
     },
     "step": {

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -9,6 +9,7 @@
       "cannot_connect": "Cannot connect to device. Check IP address, port, and network connection.",
       "invalid_auth": "Authentication error. Check Device ID settings.",
       "invalid_input": "Invalid configuration provided. Check values and try again.",
+      "missing_method": "Scanner is missing required method. See logs for details.",
       "unknown": "Unexpected error. Check logs for details."
     },
     "step": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -9,6 +9,7 @@
       "cannot_connect": "Nie można połączyć się z urządzeniem. Sprawdź adres IP, port i połączenie sieciowe.",
       "invalid_auth": "Błąd uwierzytelniania. Sprawdź ustawienia ID urządzenia.",
       "invalid_input": "Podano nieprawidłową konfigurację. Sprawdź wartości i spróbuj ponownie.",
+      "missing_method": "Brak wymaganej metody w skanerze. Sprawdź logi po szczegóły.",
       "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
     },
     "step": {
@@ -31,42 +32,6 @@
           "slave_id": "Modbus device ID (default 10)"
         },
         "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP. The integration automatically detects device functions and registers."
-      },
-      "confirm": {
-        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID: {slave_id}. Firmware version: {firmware_version}. Registers found: {register_count}. Scan success rate: {scan_success_rate}. Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Continue with this configuration?",
-        "title": "Confirm Configuration"
-      }
-    },
-
-    "abort": {
-      "already_configured": "Device with this IP address and Device ID is already configured."
-    },
-    "error": {
-      "cannot_connect": "Cannot connect to device. Check IP address, port, and network connection.",
-      "invalid_auth": "Authentication error. Check Device ID settings.",
-      "invalid_input": "Invalid configuration provided. Check values and try again.",
-      "unknown": "Unexpected error. Check logs for details."
-    },
-    "step": {
-      "confirm": {
-        "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID: {slave_id}. Firmware version: {firmware_version}. Registers found: {register_count}. Scan success rate: {scan_success_rate}. Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Continue with this configuration?",
-        "title": "Confirm Configuration"
-      },
-      "user": {
-        "data": {
-          "host": "Adres IP",
-          "name": "Nazwa",
-          "port": "Port",
-          "slave_id": "ID Urządzenia"
-        },
-        "data_description": {
-          "host": "IP address of the AirPack device on your local network",
-          "name": "Device name in Home Assistant",
-          "port": "Modbus TCP port (default 502)",
-          "slave_id": "Modbus device ID (default 10)"
-        },
-        "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP. The integration automatically detects device functions and registers.",
-        "title": "Konfiguracja ThesslaGreen Modbus"
       }
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -387,7 +387,7 @@ async def test_form_user_connection_exception():
 
 
 async def test_form_user_attribute_error_scanner():
-    """AttributeError during scanning should return cannot_connect."""
+    """AttributeError during scanning should return missing_method error."""
     flow = ConfigFlow()
     flow.hass = None
 
@@ -409,7 +409,7 @@ async def test_form_user_attribute_error_scanner():
         )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == {"base": "missing_method"}
 
 
 async def test_form_user_invalid_auth():


### PR DESCRIPTION
## Summary
- Log full stack traces when connection, Modbus, or unexpected errors occur during configuration
- Raise a dedicated `missing_method` error when scanner methods are absent and surface it to the user
- Translate new error message and adjust tests accordingly

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/strings.json custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json tests/test_config_flow.py`
- `pytest tests/test_config_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68a35d9675e08326bb3021271462fde2