### PR TITLE
Expose scanner internal read helpers

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -337,6 +337,13 @@ class ThesslaGreenDeviceScanner:
             skip_known_missing,
         )
         await self._async_setup()
+
+        # Ensure low-level register read helpers are attached to the instance
+        # so tests and callers can patch them as needed.
+        self._read_holding = _read_holding.__get__(self, cls)
+        self._read_coil = _read_coil.__get__(self, cls)
+        self._read_discrete = _read_discrete.__get__(self, cls)
+
         return self
 
     async def close(self) -> None:
@@ -506,7 +513,7 @@ class ThesslaGreenDeviceScanner:
             pass
         try:
             start = INPUT_REGISTERS["serial_number_1"]
-            parts = info_regs[start : start + 6]
+            parts = info_regs[start : start + 6]  # noqa: E203
             if parts:
                 device.serial_number = "".join(f"{p:04X}" for p in parts)
         except Exception:  # pragma: no cover

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -22,8 +22,14 @@ from custom_components.thessla_green_modbus.modbus_exceptions import (
     ModbusException,
     ModbusIOException,
 )
-from custom_components.thessla_green_modbus.registers import HOLDING_REGISTERS, INPUT_REGISTERS
-from custom_components.thessla_green_modbus.utils import _decode_bcd_time, _decode_register_time
+from custom_components.thessla_green_modbus.registers import (
+    HOLDING_REGISTERS,
+    INPUT_REGISTERS,
+)
+from custom_components.thessla_green_modbus.utils import (
+    _decode_bcd_time,
+    _decode_register_time,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -31,6 +37,10 @@ pytestmark = pytest.mark.asyncio
 async def test_device_scanner_initialization():
     """Test device scanner initialization."""
     scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+
+    assert hasattr(scanner, "_read_coil")
+    assert hasattr(scanner, "_read_holding")
+    assert hasattr(scanner, "_read_discrete")
 
     assert scanner.host == "192.168.3.17"
     assert scanner.port == 8899
@@ -147,9 +157,7 @@ async def test_read_default_delay(method, address):
 )
 async def test_read_binary_backoff_delay(func, address):
     """Coil and discrete reads should respect configured backoff."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=3, backoff=0.1
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=3, backoff=0.1)
     mock_client = AsyncMock()
     sleep_mock = AsyncMock()
     with (
@@ -175,9 +183,7 @@ async def test_read_binary_backoff_delay(func, address):
 )
 async def test_read_binary_default_delay(func, address):
     """Default backoff of zero should not delay retries."""
-    scanner = await ThesslaGreenDeviceScanner.create(
-        "192.168.3.17", 8899, 10, retry=3
-    )
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=3)
     mock_client = AsyncMock()
     sleep_mock = AsyncMock()
     with (
@@ -1205,7 +1211,9 @@ async def test_load_registers_parses_range_formats(tmp_path, min_raw, max_raw, c
     ):
         scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
 
-        from custom_components.thessla_green_modbus.modbus_exceptions import ModbusException
+        from custom_components.thessla_green_modbus.modbus_exceptions import (
+            ModbusException,
+        )
 
         mock_client = AsyncMock()
         mock_client.connect.return_value = True


### PR DESCRIPTION
## Summary
- ensure ThesslaGreenDeviceScanner instances expose internal read helper methods
- verify scanner exposes read helper methods on initialization

## Testing
- `pytest tests/test_device_scanner.py::test_device_scanner_initialization -q`
- `SKIP=mypy,bandit,generate-registers,validate-registers pre-commit run --files tests/test_device_scanner.py custom_components/thessla_green_modbus/device_scanner.py`

------
https://chatgpt.com/codex/tasks/task_e_68a35d9503a88326b121631484f2aabc