### PR TITLE
Fix scanner method binding

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -340,9 +340,9 @@ class ThesslaGreenDeviceScanner:
 
         # Ensure low-level register read helpers are attached to the instance
         # so tests and callers can patch them as needed.
-        self._read_holding = _read_holding.__get__(self, cls)
-        self._read_coil = _read_coil.__get__(self, cls)
-        self._read_discrete = _read_discrete.__get__(self, cls)
+        self._read_holding = cls._read_holding.__get__(self, cls)
+        self._read_coil = cls._read_coil.__get__(self, cls)
+        self._read_discrete = cls._read_discrete.__get__(self, cls)
 
         return self
 


### PR DESCRIPTION
## Summary
- bind read helper methods on instance using class attributes

## Testing
- `python - <<'PY' ...` (config flow create/confirm)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_device_scanner.py::test_device_scanner_initialization`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_backoff.py`


------
https://chatgpt.com/codex/tasks/task_e_68a37428a860832693db7f1becc882b5