### PR TITLE
test: ensure read helper methods bound

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -340,9 +340,9 @@ class ThesslaGreenDeviceScanner:
 
         # Ensure low-level register read helpers are attached to the instance
         # so tests and callers can patch them as needed.
-        self._read_holding = _read_holding.__get__(self, cls)
-        self._read_coil = _read_coil.__get__(self, cls)
-        self._read_discrete = _read_discrete.__get__(self, cls)
+        self._read_holding = cls._read_holding.__get__(self, cls)
+        self._read_coil = cls._read_coil.__get__(self, cls)
+        self._read_discrete = cls._read_discrete.__get__(self, cls)
 
         return self
 

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -49,6 +49,14 @@ async def test_device_scanner_initialization():
     assert scanner.backoff == 0
 
 
+async def test_create_binds_read_helpers():
+    """Scanner.create binds read helper methods to the instance."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+    assert hasattr(scanner, "_read_holding")
+    assert hasattr(scanner, "_read_coil")
+    assert hasattr(scanner, "_read_discrete")
+
+
 async def test_scanner_has_read_coil_method():
     """Ensure scanner exposes coil reading helper."""
     scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)


### PR DESCRIPTION
## Summary
- add regression test confirming `ThesslaGreenDeviceScanner.create` binds read helper methods
- fix scanner factory to bind `_read_holding`, `_read_coil`, `_read_discrete` via class

## Testing
- `pytest tests/test_device_scanner.py::test_create_binds_read_helpers -q`
- `pytest tests/test_device_scanner.py::test_device_scanner_initialization -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3742994588326ba664d5803f0b439