### PR TITLE
Short-circuit unsupported register retries and aggregate skip logging

### DIFF
--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.mark.parametrize(
     "func, expected",
     [
-        (ThesslaGreenDeviceScanner._read_input, [0.5, 0.5]),
+        (ThesslaGreenDeviceScanner._read_input, [0.1, 0.2]),
         (ThesslaGreenDeviceScanner._read_holding, [0.1, 0.2]),
         (ThesslaGreenDeviceScanner._read_coil, [0.1, 0.2]),
         (ThesslaGreenDeviceScanner._read_discrete, [0.1, 0.2]),
@@ -38,7 +38,8 @@ async def test_backoff_delay(func, expected):
 @pytest.mark.parametrize(
     "func, expected",
     [
-        (ThesslaGreenDeviceScanner._read_holding, [1, 2]),
+        (ThesslaGreenDeviceScanner._read_input, [0, 0]),
+        (ThesslaGreenDeviceScanner._read_holding, [0, 0]),
         (ThesslaGreenDeviceScanner._read_coil, [0, 0]),
         (ThesslaGreenDeviceScanner._read_discrete, [0, 0]),
     ],


### PR DESCRIPTION
## Summary
- avoid repeated reads for registers returning Modbus exception codes
- make retry delays configurable and default to no backoff
- summarize skipped register ranges in one log message

## Testing
- `pytest tests/test_backoff.py tests/test_device_scanner.py::test_read_input_skips_range_on_exception_response tests/test_device_scanner.py::test_read_holding_skips_range_on_exception_response tests/test_device_scanner.py::test_read_holding_exponential_backoff`
- `pytest` *(fails: service and translation test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a3809abdc483269ea93f73b18fa93b