### PR TITLE
Handle CancelledError during entity addition

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Dict
 
@@ -46,7 +47,14 @@ async def async_setup_entry(
             _LOGGER.debug("Created binary sensor: %s", sensor_def["translation_key"])
 
     if entities:
-        async_add_entities(entities, True)
+        try:
+            async_add_entities(entities, True)
+        except asyncio.CancelledError:
+            _LOGGER.warning(
+                "Cancelled while adding binary sensor entities, retrying without initial state"
+            )
+            async_add_entities(entities, False)
+            return
         _LOGGER.info(
             "Created %d binary sensor entities for %s", len(entities), coordinator.device_name
         )

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -64,7 +65,12 @@ async def async_setup_entry(
     # Only create climate entity if basic control is available
     if coordinator.capabilities.basic_control:
         entities = [ThesslaGreenClimate(coordinator)]
-        async_add_entities(entities, True)
+        try:
+            async_add_entities(entities, True)
+        except asyncio.CancelledError:
+            _LOGGER.warning("Cancelled while adding climate entity, retrying without initial state")
+            async_add_entities(entities, False)
+            return
         _LOGGER.info("Climate entity created for %s", coordinator.device_name)
     else:
         _LOGGER.warning("Basic control not available, climate entity not created")

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -51,7 +52,13 @@ async def async_setup_entry(
         )  # Only check writable registers
 
     if has_fan_registers:
-        async_add_entities([ThesslaGreenFan(coordinator)])
+        entities = [ThesslaGreenFan(coordinator)]
+        try:
+            async_add_entities(entities, True)
+        except asyncio.CancelledError:
+            _LOGGER.warning("Cancelled while adding fan entity, retrying without initial state")
+            async_add_entities(entities, False)
+            return
         _LOGGER.info("Added fan entity")
     else:
         _LOGGER.debug("No fan control registers available - skipping fan entity")

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -74,7 +75,14 @@ async def async_setup_entry(
             _LOGGER.debug("Created number entity: %s", register_name)
 
     if entities:
-        async_add_entities(entities, True)
+        try:
+            async_add_entities(entities, True)
+        except asyncio.CancelledError:
+            _LOGGER.warning(
+                "Cancelled while adding number entities, retrying without initial state"
+            )
+            async_add_entities(entities, False)
+            return
         _LOGGER.info("Added %d number entities", len(entities))
     else:
         _LOGGER.debug("No number entities were created")

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -36,7 +37,14 @@ async def async_setup_entry(
             entities.append(ThesslaGreenSelect(coordinator, register_name, select_def))
 
     if entities:
-        async_add_entities(entities, True)
+        try:
+            async_add_entities(entities, True)
+        except asyncio.CancelledError:
+            _LOGGER.warning(
+                "Cancelled while adding select entities, retrying without initial state"
+            )
+            async_add_entities(entities, False)
+            return
         _LOGGER.info("Created %d select entities", len(entities))
 
 

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -62,7 +63,14 @@ async def async_setup_entry(
     if entities:
         # Coordinator already holds initial data from setup, so update entities before add
         # to populate their state without triggering another refresh
-        async_add_entities(entities, True)
+        try:
+            async_add_entities(entities, True)
+        except asyncio.CancelledError:
+            _LOGGER.warning(
+                "Cancelled while adding switch entities, retrying without initial state"
+            )
+            async_add_entities(entities, False)
+            return
         _LOGGER.info("Added %d switch entities", len(entities))
     else:
         _LOGGER.debug("No switch entities were created")


### PR DESCRIPTION
## Summary
- handle entity setup cancellations by retrying without initial state fetch
- add cancellation logging across platforms

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/number.py custom_components/thessla_green_modbus/select.py custom_components/thessla_green_modbus/switch.py custom_components/thessla_green_modbus/climate.py custom_components/thessla_green_modbus/fan.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.components')*


------
https://chatgpt.com/codex/tasks/task_e_68a3809bca0883269c12d189b93ec4fd