### PR TITLE
feat: add airflow unit option and migration tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributing guidelines
 - Constant Flow register names (`cf_version`, `supply_air_flow`, `exhaust_air_flow`) for Series 4 units
 - Capability detection for Constant Flow and HEWR water removal
+- Airflow unit option allowing `%` or `m³/h` reporting
+- Migration script for clearing legacy airflow statistics
 
 ### Changed
 - Bumped minimum Home Assistant version to 2025.7.1
 - Regenerated Modbus register definitions from CSV and updated coverage test
+- Assigned new unique IDs for m³/h airflow sensors
 
 ### Removed
 - Custom Modbus client in favor of native AsyncModbusTcpClient

--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Backoff**: 0-5s opóźnienia między próbami (domyślnie 0, wykładniczy)
 - **Pełna lista rejestrów**: Pomiń skanowanie (może powodować błędy)
 - **Ustawienia UART**: Skanuj opcjonalne rejestry konfiguracji portu (0x1168-0x116B)
+- **Airflow unit**: wybierz `m³/h` (domyślnie) lub `percentage`
 
 Adresy rejestrów, które wielokrotnie nie odpowiadają, są automatycznie pomijane w kolejnych skanach.
+
+Szczegóły migracji z czujników procentowych opisano w pliku [docs/airflow_migration.md](docs/airflow_migration.md).
 
 ### Proces autoskanu
 Podczas dodawania integracji moduł `device_scanner` wykonuje funkcję

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -22,6 +22,10 @@ from .const import (
     CONF_SKIP_MISSING_REGISTERS,
     CONF_SLAVE_ID,
     CONF_TIMEOUT,
+    CONF_AIRFLOW_UNIT,
+    AIRFLOW_UNIT_M3H,
+    AIRFLOW_UNIT_PERCENTAGE,
+    DEFAULT_AIRFLOW_UNIT,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_RETRY,
@@ -271,6 +275,9 @@ class OptionsFlow(config_entries.OptionsFlow):
         current_skip_missing = self.config_entry.options.get(
             CONF_SKIP_MISSING_REGISTERS, DEFAULT_SKIP_MISSING_REGISTERS
         )
+        current_airflow_unit = self.config_entry.options.get(
+            CONF_AIRFLOW_UNIT, DEFAULT_AIRFLOW_UNIT
+        )
 
         data_schema = vol.Schema(
             {
@@ -298,6 +305,10 @@ class OptionsFlow(config_entries.OptionsFlow):
                     CONF_SKIP_MISSING_REGISTERS,
                     default=current_skip_missing,
                 ): bool,
+                vol.Optional(
+                    CONF_AIRFLOW_UNIT,
+                    default=current_airflow_unit,
+                ): vol.In([AIRFLOW_UNIT_M3H, AIRFLOW_UNIT_PERCENTAGE]),
             }
         )
 
@@ -311,5 +322,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                 "force_full_enabled": "Yes" if force_full else "No",
                 "scan_uart_enabled": "Yes" if current_scan_uart else "No",
                 "skip_missing_enabled": "Yes" if current_skip_missing else "No",
+                "current_airflow_unit": current_airflow_unit,
             },
         )

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -77,6 +77,14 @@ CONF_RETRY = "retry"
 CONF_FORCE_FULL_REGISTER_LIST = "force_full_register_list"
 CONF_SCAN_UART_SETTINGS = "scan_uart_settings"
 CONF_SKIP_MISSING_REGISTERS = "skip_missing_registers"
+CONF_AIRFLOW_UNIT = "airflow_unit"
+
+AIRFLOW_UNIT_M3H = "m3h"
+AIRFLOW_UNIT_PERCENTAGE = "percentage"
+DEFAULT_AIRFLOW_UNIT = AIRFLOW_UNIT_M3H
+
+# Registers reporting airflow that changed units from percentage to m³/h
+AIRFLOW_RATE_REGISTERS = {"supply_flow_rate", "exhaust_flow_rate"}
 
 DEFAULT_SCAN_UART_SETTINGS = False
 DEFAULT_SKIP_MISSING_REGISTERS = False

--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    CONF_AIRFLOW_UNIT,
+    DEFAULT_AIRFLOW_UNIT,
+    AIRFLOW_UNIT_M3H,
+    AIRFLOW_RATE_REGISTERS,
+)
 from .coordinator import ThesslaGreenModbusCoordinator
 
 
@@ -23,7 +29,14 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
         host = self.coordinator.host.replace(":", "-")
-        return f"{DOMAIN}_{host}_{self.coordinator.port}_{self.coordinator.slave_id}_{self._key}"
+        base = f"{DOMAIN}_{host}_{self.coordinator.port}_{self.coordinator.slave_id}_{self._key}"
+        airflow_unit = (
+            getattr(getattr(self.coordinator, "entry", None), "options", {})
+            .get(CONF_AIRFLOW_UNIT, DEFAULT_AIRFLOW_UNIT)
+        )
+        if self._key in AIRFLOW_RATE_REGISTERS and airflow_unit == AIRFLOW_UNIT_M3H:
+            return f"{base}_m3h"
+        return base
 
     @property
     def available(self) -> bool:

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -9,12 +9,27 @@ from typing import Any, Dict
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import (
-    UnitOfElectricPotential,
-    UnitOfTemperature,
-    UnitOfTime,
-    UnitOfVolumeFlowRate,
-)
+try:  # pragma: no cover - use HA constants when available
+    from homeassistant.const import (
+        UnitOfElectricPotential,
+        UnitOfTemperature,
+        UnitOfTime,
+        UnitOfVolumeFlowRate,
+    )
+except Exception:  # pragma: no cover - executed only in tests
+    class UnitOfElectricPotential:  # type: ignore[misc]
+        VOLT = "V"
+
+    class UnitOfTemperature:  # type: ignore[misc]
+        CELSIUS = "°C"
+
+    class UnitOfTime:  # type: ignore[misc]
+        HOURS = "h"
+        DAYS = "d"
+        SECONDS = "s"
+
+    class UnitOfVolumeFlowRate:  # type: ignore[misc]
+        CUBIC_METERS_PER_HOUR = "m³/h"
 
 try:  # pragma: no cover - fallback for tests without full HA constants
     from homeassistant.const import PERCENTAGE  # type: ignore
@@ -221,14 +236,14 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
     },
     # Air flow sensors
     "supply_flow_rate": {
-        "translation_key": "supply_flow_rate",
+        "translation_key": "supply_flow_rate_m3h",
         "icon": "mdi:fan-plus",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         "register_type": "input_registers",
     },
     "exhaust_flow_rate": {
-        "translation_key": "exhaust_flow_rate",
+        "translation_key": "exhaust_flow_rate_m3h",
         "icon": "mdi:fan-minus",
         "state_class": SensorStateClass.MEASUREMENT,
         "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1105,7 +1105,7 @@
       "exhaust_air_flow": {
         "name": "Exhaust Air Flow"
       },
-      "exhaust_flow_rate": {
+      "exhaust_flow_rate_m3h": {
         "name": "Exhaust Flow Rate"
       },
       "exhaust_percentage": {
@@ -1233,7 +1233,7 @@
       "supply_air_temperature_temporary_2": {
         "name": "Supply Air Temperature Temporary 2"
       },
-      "supply_flow_rate": {
+      "supply_flow_rate_m3h": {
         "name": "Supply Flow Rate"
       },
       "supply_percentage": {

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1105,8 +1105,8 @@
       "exhaust_air_flow": {
         "name": "Exhaust Air Flow"
       },
-      "exhaust_flow_rate": {
-        "name": "Exhaust Flow Rate"
+      "exhaust_flow_rate_m3h": {
+        "name": "Exhaust Flow Rate (m³/h)"
       },
       "exhaust_percentage": {
         "name": "Exhaust Percentage"
@@ -1233,8 +1233,8 @@
       "supply_air_temperature_temporary_2": {
         "name": "Supply Air Temperature Temporary 2"
       },
-      "supply_flow_rate": {
-        "name": "Supply Flow Rate"
+      "supply_flow_rate_m3h": {
+        "name": "Supply Flow Rate (m³/h)"
       },
       "supply_percentage": {
         "name": "Supply Percentage"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1105,8 +1105,8 @@
       "exhaust_air_flow": {
         "name": "Strumień powietrza wywiewnego"
       },
-      "exhaust_flow_rate": {
-        "name": "Przepływ wywiewu"
+      "exhaust_flow_rate_m3h": {
+        "name": "Przepływ wywiewu (m³/h)"
       },
       "exhaust_percentage": {
         "name": "Procentowo wywiew"
@@ -1233,8 +1233,8 @@
       "supply_air_temperature_temporary_2": {
         "name": "Tymczasowa temperatura nawiewu 2"
       },
-      "supply_flow_rate": {
-        "name": "Przepływ nawiewu"
+      "supply_flow_rate_m3h": {
+        "name": "Przepływ nawiewu (m³/h)"
       },
       "supply_percentage": {
         "name": "Procentowo nawiew"

--- a/docs/airflow_migration.md
+++ b/docs/airflow_migration.md
@@ -1,0 +1,25 @@
+# Airflow Sensor Migration
+
+Recent versions of the integration report supply and exhaust airflow in
+**m³/h** instead of percentages. Legacy entities used percentage values and
+may have statistics stored in Home Assistant's database.
+
+## Clearing old statistics
+
+1. Stop Home Assistant.
+2. Run:
+   ```bash
+   python3 tools/clear_airflow_stats.py /path/to/config
+   ```
+   This removes statistics for the old `sensor.supply_flow_rate` and
+   `sensor.exhaust_flow_rate` entities.
+3. Start Home Assistant – new entities will be created with fresh statistics.
+
+Alternatively, open **Developer Tools → Statistics** in Home Assistant and
+manually clear the statistics for these sensors.
+
+## Choosing airflow units
+
+A new option **Airflow unit** is available in the integration options. Select
+`m³/h` (default) or `percentage` to have the sensors report airflow in the
+preferred unit.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,31 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     cv = types.ModuleType("homeassistant.helpers.config_validation")
     selector = types.ModuleType("homeassistant.helpers.selector")
     translation = types.ModuleType("homeassistant.helpers.translation")
+    entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+    class AddEntitiesCallback:  # pragma: no cover - simple stub
+        pass
+    entity_platform.AddEntitiesCallback = AddEntitiesCallback
+
+    const.PERCENTAGE = "%"
+
+    class UnitOfTemperature:  # pragma: no cover - enum stub
+        CELSIUS = "°C"
+
+    class UnitOfTime:  # pragma: no cover - enum stub
+        HOURS = "h"
+        DAYS = "d"
+        SECONDS = "s"
+
+    class UnitOfVolumeFlowRate:  # pragma: no cover - enum stub
+        CUBIC_METERS_PER_HOUR = "m³/h"
+
+    class UnitOfElectricPotential:  # pragma: no cover - enum stub
+        VOLT = "V"
+
+    const.UnitOfTemperature = UnitOfTemperature
+    const.UnitOfTime = UnitOfTime
+    const.UnitOfVolumeFlowRate = UnitOfVolumeFlowRate
+    const.UnitOfElectricPotential = UnitOfElectricPotential
 
     async def async_get_translations(*args, **kwargs):  # pragma: no cover - stub
         return {}
@@ -43,6 +68,36 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     pymodbus_exceptions = types.ModuleType("pymodbus.exceptions")
     pymodbus_pdu = types.ModuleType("pymodbus.pdu")
     hacc_common = types.ModuleType("pytest_homeassistant_custom_component.common")
+
+    components_pkg = types.ModuleType("homeassistant.components")
+    sensor_comp = types.ModuleType("homeassistant.components.sensor")
+    binary_sensor_comp = types.ModuleType("homeassistant.components.binary_sensor")
+    class SensorDeviceClass:  # pragma: no cover - enum stub
+        TEMPERATURE = "temperature"
+        VOLTAGE = "voltage"
+    class SensorStateClass:  # pragma: no cover - enum stub
+        MEASUREMENT = "measurement"
+    class SensorEntity:  # pragma: no cover - simple stub
+        pass
+    sensor_comp.SensorDeviceClass = SensorDeviceClass
+    sensor_comp.SensorStateClass = SensorStateClass
+    sensor_comp.SensorEntity = SensorEntity
+    class _BinaryMeta(type):  # pragma: no cover - generic fallback
+        def __getattr__(cls, item):
+            return item.lower()
+
+    class BinarySensorDeviceClass(metaclass=_BinaryMeta):  # pragma: no cover - enum stub
+        PROBLEM = "problem"
+        RUNNING = "running"
+        OPENING = "opening"
+        CLOSING = "closing"
+    binary_sensor_comp.BinarySensorDeviceClass = BinarySensorDeviceClass
+    components_pkg.sensor = sensor_comp
+    components_pkg.binary_sensor = binary_sensor_comp
+    sys.modules["homeassistant.components"] = components_pkg
+    sys.modules["homeassistant.components.sensor"] = sensor_comp
+    sys.modules["homeassistant.components.binary_sensor"] = binary_sensor_comp
+    ha.const = const
 
     class MockConfigEntry:  # pragma: no cover - simplified stub
         def __init__(self, *, domain, data, options=None):
@@ -95,6 +150,10 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
 
         async def async_shutdown(self) -> None:  # pragma: no cover - stub
             return None
+
+        @classmethod
+        def __class_getitem__(cls, item):  # pragma: no cover - allow subscripting
+            return cls
 
     class UpdateFailed(Exception):
         pass
@@ -255,6 +314,7 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     sys.modules["homeassistant.helpers.config_validation"] = cv
     sys.modules["homeassistant.helpers.selector"] = selector
     sys.modules["homeassistant.helpers.translation"] = translation
+    sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
     helpers_pkg.translation = translation
     sys.modules["pymodbus"] = pymodbus
     sys.modules["pymodbus.client"] = pymodbus_client

--- a/tests/test_airflow_unit.py
+++ b/tests/test_airflow_unit.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.thessla_green_modbus.const import (
+    DOMAIN,
+    CONF_AIRFLOW_UNIT,
+    AIRFLOW_UNIT_M3H,
+    AIRFLOW_UNIT_PERCENTAGE,
+)
+from custom_components.thessla_green_modbus.entity import ThesslaGreenEntity
+from custom_components.thessla_green_modbus.entity_mappings import SENSOR_ENTITY_MAPPINGS
+from custom_components.thessla_green_modbus.sensor import ThesslaGreenSensor
+from homeassistant.const import PERCENTAGE, UnitOfVolumeFlowRate
+
+
+def _make_coordinator(unit):
+    coord = MagicMock()
+    coord.host = "1.2.3.4"
+    coord.port = 502
+    coord.slave_id = 10
+    coord.get_device_info.return_value = {}
+    coord.entry = MagicMock()
+    coord.entry.options = {CONF_AIRFLOW_UNIT: unit}
+    coord.data = {}
+    return coord
+
+
+def test_unique_id_suffix_m3h():
+    coord = _make_coordinator(AIRFLOW_UNIT_M3H)
+    entity = ThesslaGreenEntity(coord, "supply_flow_rate")
+    assert entity.unique_id.endswith("supply_flow_rate_m3h")  # nosec
+
+
+def test_unique_id_suffix_percentage():
+    coord = _make_coordinator(AIRFLOW_UNIT_PERCENTAGE)
+    entity = ThesslaGreenEntity(coord, "supply_flow_rate")
+    assert entity.unique_id.endswith("supply_flow_rate")  # nosec
+
+
+def test_sensor_converts_to_percentage():
+    coord = _make_coordinator(AIRFLOW_UNIT_PERCENTAGE)
+    coord.data.update({"supply_flow_rate": 150, "nominal_supply_air_flow": 300})
+    sensor_def = SENSOR_ENTITY_MAPPINGS["supply_flow_rate"]
+    sensor = ThesslaGreenSensor(coord, "supply_flow_rate", sensor_def)
+    assert sensor.native_unit_of_measurement == PERCENTAGE
+    assert sensor.native_value == 50
+
+
+def test_sensor_reports_m3h_by_default():
+    coord = _make_coordinator(AIRFLOW_UNIT_M3H)
+    coord.data.update({"supply_flow_rate": 150})
+    sensor_def = SENSOR_ENTITY_MAPPINGS["supply_flow_rate"]
+    sensor = ThesslaGreenSensor(coord, "supply_flow_rate", sensor_def)
+    assert sensor.native_unit_of_measurement == UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR
+    assert sensor.native_value == 150

--- a/tools/clear_airflow_stats.py
+++ b/tools/clear_airflow_stats.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Clear legacy airflow statistics after unit change.
+
+Removes statistics entries for the legacy percentage based airflow sensors.
+
+Usage:
+    python3 clear_airflow_stats.py [CONFIG_DIR]
+
+If CONFIG_DIR is not provided the script will attempt common locations such as
+``~/.homeassistant`` or ``/config``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+import sys
+
+LEGACY_SENSORS = [
+    "sensor.supply_flow_rate",
+    "sensor.exhaust_flow_rate",
+]
+
+COMMON_CONFIG_DIRS = [
+    Path.home() / ".homeassistant",
+    Path.home() / "homeassistant",
+    Path("/config"),
+]
+
+
+def find_db(custom: Path | None) -> Path | None:
+    if custom:
+        db_path = custom / "home-assistant_v2.db"
+        return db_path if db_path.exists() else None
+    for base in COMMON_CONFIG_DIRS:
+        db_path = base / "home-assistant_v2.db"
+        if db_path.exists():
+            return db_path
+    return None
+
+
+def clear_stats(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    for sensor in LEGACY_SENSORS:
+        cur.execute(
+            "DELETE FROM statistics WHERE metadata_id=(SELECT id FROM statistics_meta WHERE statistic_id=?)",
+            (sensor,),
+        )
+        cur.execute(
+            "DELETE FROM statistics_short_term WHERE metadata_id=(SELECT id FROM statistics_meta WHERE statistic_id=?)",
+            (sensor,),
+        )
+        cur.execute(
+            "DELETE FROM statistics_meta WHERE statistic_id=?",
+            (sensor,),
+        )
+        print(f"Cleared statistics for {sensor}")
+    conn.commit()
+    conn.close()
+
+
+def main() -> None:
+    config_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+    db_path = find_db(config_dir)
+    if not db_path:
+        print("Home Assistant database not found")
+        return
+    clear_stats(db_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support selectable airflow units (m³/h or %)
- provide migration docs and script for clearing old airflow statistics
- assign new unique IDs for m³/h airflow sensors

## Testing
- `pytest` *(fails: async def functions are not supported in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a380937b748326a9545d3dbc91e7ad