### PR TITLE
Remove airflow unit suffix from unique IDs

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -4,13 +4,7 @@ from __future__ import annotations
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DOMAIN,
-    CONF_AIRFLOW_UNIT,
-    DEFAULT_AIRFLOW_UNIT,
-    AIRFLOW_UNIT_M3H,
-    AIRFLOW_RATE_REGISTERS,
-)
+from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 
 
@@ -29,14 +23,7 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
         host = self.coordinator.host.replace(":", "-")
-        base = f"{DOMAIN}_{host}_{self.coordinator.port}_{self.coordinator.slave_id}_{self._key}"
-        airflow_unit = (
-            getattr(getattr(self.coordinator, "entry", None), "options", {})
-            .get(CONF_AIRFLOW_UNIT, DEFAULT_AIRFLOW_UNIT)
-        )
-        if self._key in AIRFLOW_RATE_REGISTERS and airflow_unit == AIRFLOW_UNIT_M3H:
-            return f"{base}_m3h"
-        return base
+        return f"{DOMAIN}_{host}_{self.coordinator.port}_{self.coordinator.slave_id}_{self._key}"
 
     @property
     def available(self) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,9 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     device_registry = types.ModuleType("homeassistant.helpers.device_registry")
     service_helper = types.ModuleType("homeassistant.helpers.service")
     entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    def _async_entries_for_config_entry(*args, **kwargs):
+        return []
+    entity_registry.async_entries_for_config_entry = _async_entries_for_config_entry
     script_helper = types.ModuleType("homeassistant.helpers.script")
     script_helper._schedule_stop_scripts_after_shutdown = lambda *args, **kwargs: None
     exceptions = types.ModuleType("homeassistant.exceptions")
@@ -78,7 +81,9 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     class SensorStateClass:  # pragma: no cover - enum stub
         MEASUREMENT = "measurement"
     class SensorEntity:  # pragma: no cover - simple stub
-        pass
+        @property
+        def native_unit_of_measurement(self):
+            return getattr(self, "_attr_native_unit_of_measurement", None)
     sensor_comp.SensorDeviceClass = SensorDeviceClass
     sensor_comp.SensorStateClass = SensorStateClass
     sensor_comp.SensorEntity = SensorEntity
@@ -109,6 +114,12 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
 
         def add_to_hass(self, _hass):
             return None
+
+        def add_update_listener(self, listener):
+             return listener
+
+        def async_on_unload(self, func):
+            return func
 
     hacc_common.MockConfigEntry = MockConfigEntry
 

--- a/tests/test_airflow_unit.py
+++ b/tests/test_airflow_unit.py
@@ -25,16 +25,16 @@ def _make_coordinator(unit):
     return coord
 
 
-def test_unique_id_suffix_m3h():
-    coord = _make_coordinator(AIRFLOW_UNIT_M3H)
-    entity = ThesslaGreenEntity(coord, "supply_flow_rate")
-    assert entity.unique_id.endswith("supply_flow_rate_m3h")  # nosec
-
-
-def test_unique_id_suffix_percentage():
+def test_unique_id_same_for_all_units():
     coord = _make_coordinator(AIRFLOW_UNIT_PERCENTAGE)
     entity = ThesslaGreenEntity(coord, "supply_flow_rate")
-    assert entity.unique_id.endswith("supply_flow_rate")  # nosec
+    uid_percentage = entity.unique_id
+
+    coord.entry.options[CONF_AIRFLOW_UNIT] = AIRFLOW_UNIT_M3H
+    entity = ThesslaGreenEntity(coord, "supply_flow_rate")
+    uid_m3h = entity.unique_id
+
+    assert uid_percentage == uid_m3h  # nosec
 
 
 def test_sensor_converts_to_percentage():


### PR DESCRIPTION
## Summary
- generate entity unique IDs solely from host, port, slave_id and key
- ensure airflow unit option doesn't alter unique IDs
- update tests and stubs accordingly

## Testing
- `pytest tests/test_entity_unique_id.py tests/test_airflow_unit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3850f5df0832692e3f41b3aaa7c02