### PR TITLE
chore: add hassfest and vulture hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,18 @@ repos:
       - id: check-merge-conflict
       - id: check-json
         files: ^custom_components/.*/translations/.*\.json$
+  - repo: https://github.com/home-assistant/actions
+    rev: 1.0.0
+    hooks:
+      - id: hassfest
+        args: ["--config=."]
+        pass_filenames: false
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: v2.9.1
+    hooks:
+      - id: vulture
+        args: ["custom_components/thessla_green_modbus", "--min-confidence=80"]
+        pass_filenames: false
   - repo: local
     hooks:
       - id: generate-registers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,9 @@ Run `pre-commit install` once to activate these checks. Before committing, the f
 - **bandit** - Security scanning
 - **yamllint** - YAML validation
 - **check-merge-conflict** - Prevents committing unresolved merge conflicts
- - **check-json** - Validates translation files
+- **check-json** - Validates translation files
+- **hassfest** - Validates integration metadata against Home Assistant rules
+- **vulture** - Detects unused code in `custom_components/thessla_green_modbus`
 
 ### Manual Quality Checks
 
@@ -262,6 +264,12 @@ mypy custom_components/thessla_green_modbus/
 
 # Security scan
 bandit -r custom_components/
+
+# Validate integration metadata
+hassfest --config=.
+
+# Dead code detection
+vulture custom_components/thessla_green_modbus --min-confidence=80
 ```
 
 ## Submitting Changes


### PR DESCRIPTION
## Summary
- add hassfest and vulture pre-commit hooks
- document new quality checks

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo0ratumvb/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a385116e208326a50c49751a4574ef