### PR TITLE
chore: set 2025.1 as minimum HA version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migration script for clearing legacy airflow statistics
 
 ### Changed
-- Bumped minimum Home Assistant version to 2025.7.1
+- Bumped minimum Home Assistant version to 2025.1.0
 - Regenerated Modbus register definitions from CSV and updated coverage test
 - Assigned new unique IDs for m³/h airflow sensors
 

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -7,7 +7,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.7.1",
+  "homeassistant": "2025.1.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",


### PR DESCRIPTION
## Summary
- set minimum supported Home Assistant version to 2025.1.0
- note the new Home Assistant requirement in changelog

## Testing
- `python -m hassfest` *(fails: No module named hassfest)*
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json CHANGELOG.md` *(fails: environment setup interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a38514a5c883269fb90a9fe16d8984