### PR TITLE
Skip none registers during scanning

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -728,6 +728,8 @@ class ThesslaGreenDeviceScanner:
                         if not isinstance(name_raw, str) or not name_raw.strip():
                             continue
                         name = _to_snake_case(name_raw)
+                        if name == "none" or re.fullmatch(r"none(_\d+)?$", name):
+                            continue
                         try:
                             addr = int(row.get("Address_DEC", 0))
                         except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- skip Modbus register definitions named `none` or matching `^none(_\d+)?$`
- add test ensuring such registers are ignored by the device scanner

## Testing
- `pytest tests/test_device_scanner.py::test_load_registers_skips_none_named_registers -q`


------
https://chatgpt.com/codex/tasks/task_e_68a386a8ccdc832693feaaee8abf7a0e