### PR TITLE
Fix translation keys and add missing service translations

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1661,6 +1661,20 @@
       },
       "name": "Set Heating Curve"
     },
+    "set_device_name": {
+      "description": "Set device name using only printable ASCII characters (max 16).",
+      "fields": {
+        "device_name": {
+          "description": "Device name (1–16 printable ASCII chars).",
+          "name": "Device Name"
+        }
+      },
+      "name": "Set Device Name"
+    },
+    "refresh_device_data": {
+      "description": "Force immediate data refresh.",
+      "name": "Refresh Device Data"
+    },
     "start_pressure_test": {
       "description": "Starts automatic filter/pressure control test",
       "name": "Start Pressure Test"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -52,9 +52,6 @@
       "bypass": {
         "name": "Bypass"
       },
-      "constant_flow_active": {
-        "name": "Constant Flow Active"
-      },
       "contamination_sensor": {
         "name": "Contamination Sensor"
       },
@@ -988,30 +985,6 @@
       }
     },
     "select": {
-      "bypass_off": {
-        "name": "Bypass Off"
-      },
-      "delta_t_gwc": {
-        "name": "Delta T GWC"
-      },
-      "gwc_regen_period": {
-        "name": "GWC Regeneration Period"
-      },
-      "max_exhaust_air_flow_rate": {
-        "name": "Maximum Exhaust Air Flow Rate"
-      },
-      "max_exhaust_air_flow_rate_gwc": {
-        "name": "Maximum Exhaust Air Flow Rate GWC"
-      },
-      "max_gwc_air_temperature": {
-        "name": "Maximum GWC Air Temperature"
-      },
-      "max_supply_air_flow_rate_gwc": {
-        "name": "Maximum Supply Air Flow Rate GWC"
-      },
-      "min_gwc_air_temperature": {
-        "name": "Minimum GWC Air Temperature"
-      },
       "mode": {
         "name": "Mode",
         "state": {
@@ -1020,17 +993,37 @@
           "temporary": "Temporary"
         }
       },
-      "nominal_exhaust_air_flow": {
-        "name": "Nominal Exhaust Air Flow"
+      "bypass_mode": {
+        "name": "Bypass Mode",
+        "state": {
+          "auto": "Automatic",
+          "open": "Open",
+          "closed": "Closed"
+        }
       },
-      "nominal_exhaust_air_flow_gwc": {
-        "name": "Nominal Exhaust Air Flow GWC"
+      "gwc_mode": {
+        "name": "GWC Mode",
+        "state": {
+          "auto": "Automatic",
+          "forced": "Forced",
+          "off": "Off"
+        }
       },
-      "nominal_supply_air_flow": {
-        "name": "Nominal Supply Air Flow"
+      "season_mode": {
+        "name": "Season Mode",
+        "state": {
+          "winter": "Winter",
+          "summer": "Summer"
+        }
       },
-      "nominal_supply_air_flow_gwc": {
-        "name": "Nominal Supply Air Flow GWC"
+      "filter_change": {
+        "name": "Filter Type",
+        "state": {
+          "presostat": "Pressure switch",
+          "flat_filters": "Flat Filters",
+          "cleanpad": "CleanPad",
+          "cleanpad_pure": "CleanPad Pure"
+        }
       }
     },
     "sensor": {
@@ -1265,25 +1258,8 @@
       "eco": {
         "name": "Eco"
       },
-      "filter_change": {
-        "name": "Filter Type",
-        "state": {
-          "cleanpad": "CleanPad",
-          "cleanpad_pure": "CleanPad Pure",
-          "flat_filters": "Flat Filters",
-          "presostat": "Pressure switch"
-        }
-      },
       "fireplace": {
         "name": "Fireplace"
-      },
-      "gwc_mode": {
-        "name": "GWC Mode",
-        "state": {
-          "auto": "Automatic",
-          "forced": "Forced",
-          "off": "Off"
-        }
       },
       "hood": {
         "name": "Hood"
@@ -1296,13 +1272,6 @@
       },
       "party": {
         "name": "Party"
-      },
-      "season_mode": {
-        "name": "Season Mode",
-        "state": {
-          "summer": "Summer",
-          "winter": "Winter"
-        }
       },
       "sleep": {
         "name": "Sleep"
@@ -1359,6 +1328,12 @@
     "s_7": "Device status S 7",
     "s_8": "Device status S 8",
     "s_9": "Device status S 9"
+  },
+  "issues": {
+    "modbus_write_failed": {
+      "title": "Modbus write failed",
+      "description": "Unable to write value via Modbus. Check connection and permissions."
+    }
   },
   "options": {
     "step": {
@@ -1660,6 +1635,20 @@
         }
       },
       "name": "Set Heating Curve"
+    },
+    "set_device_name": {
+      "description": "Set device name using only printable ASCII characters (max 16).",
+      "fields": {
+        "device_name": {
+          "description": "Device name (1–16 printable ASCII chars).",
+          "name": "Device Name"
+        }
+      },
+      "name": "Set Device Name"
+    },
+    "refresh_device_data": {
+      "description": "Force immediate data refresh.",
+      "name": "Refresh Device Data"
     },
     "start_pressure_test": {
       "description": "Starts automatic filter/pressure control test",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -52,9 +52,6 @@
       "bypass": {
         "name": "Bypass"
       },
-      "constant_flow_active": {
-        "name": "Aktywny stały przepływ"
-      },
       "contamination_sensor": {
         "name": "Czujnik zanieczyszczeń"
       },
@@ -988,30 +985,6 @@
       }
     },
     "select": {
-      "bypass_off": {
-        "name": "Wyłączenie bypass"
-      },
-      "delta_t_gwc": {
-        "name": "Delta T GWC"
-      },
-      "gwc_regen_period": {
-        "name": "Okres regeneracji GWC"
-      },
-      "max_exhaust_air_flow_rate": {
-        "name": "Maximum Exhaust Air Flow Rate"
-      },
-      "max_exhaust_air_flow_rate_gwc": {
-        "name": "Maksymalny przepływ wywiewu GWC"
-      },
-      "max_gwc_air_temperature": {
-        "name": "Maksymalna temperatura powietrza GWC"
-      },
-      "max_supply_air_flow_rate_gwc": {
-        "name": "Maksymalny przepływ nawiewu GWC"
-      },
-      "min_gwc_air_temperature": {
-        "name": "Minimalna temperatura powietrza GWC"
-      },
       "mode": {
         "name": "Tryb pracy",
         "state": {
@@ -1020,17 +993,37 @@
           "temporary": "Tymczasowy"
         }
       },
-      "nominal_exhaust_air_flow": {
-        "name": "Nominalny przepływ wywiewu"
+      "bypass_mode": {
+        "name": "Tryb bypassu",
+        "state": {
+          "auto": "Automatyczny",
+          "open": "Otwarty",
+          "closed": "Zamknięty"
+        }
       },
-      "nominal_exhaust_air_flow_gwc": {
-        "name": "Nominalny przepływ wywiewu GWC"
+      "gwc_mode": {
+        "name": "Tryb GWC",
+        "state": {
+          "auto": "Automatyczny",
+          "forced": "Wymuszony",
+          "off": "Wyłączony"
+        }
       },
-      "nominal_supply_air_flow": {
-        "name": "Nominalny przepływ nawiewu"
+      "season_mode": {
+        "name": "Tryb sezonowy",
+        "state": {
+          "winter": "Zima",
+          "summer": "Lato"
+        }
       },
-      "nominal_supply_air_flow_gwc": {
-        "name": "Nominalny przepływ nawiewu GWC"
+      "filter_change": {
+        "name": "Typ filtra",
+        "state": {
+          "presostat": "Presostat",
+          "flat_filters": "Filtry płaskie",
+          "cleanpad": "CleanPad",
+          "cleanpad_pure": "CleanPad Pure"
+        }
       }
     },
     "sensor": {
@@ -1265,25 +1258,8 @@
       "eco": {
         "name": "Eco"
       },
-      "filter_change": {
-        "name": "Filter Type",
-        "state": {
-          "cleanpad": "CleanPad",
-          "cleanpad_pure": "CleanPad Pure",
-          "flat_filters": "Flat Filters",
-          "presostat": "Pressure switch"
-        }
-      },
       "fireplace": {
         "name": "Fireplace"
-      },
-      "gwc_mode": {
-        "name": "GWC Mode",
-        "state": {
-          "auto": "Automatic",
-          "forced": "Forced",
-          "off": "Off"
-        }
       },
       "hood": {
         "name": "Hood"
@@ -1296,13 +1272,6 @@
       },
       "party": {
         "name": "Party"
-      },
-      "season_mode": {
-        "name": "Season Mode",
-        "state": {
-          "summer": "Summer",
-          "winter": "Winter"
-        }
       },
       "sleep": {
         "name": "Sleep"
@@ -1359,6 +1328,12 @@
     "s_7": "Status urządzenia S 7",
     "s_8": "Status urządzenia S 8",
     "s_9": "Status urządzenia S 9"
+  },
+  "issues": {
+    "modbus_write_failed": {
+      "title": "Błąd zapisu Modbus",
+      "description": "Nie można zapisać wartości przez Modbus. Sprawdź połączenie i uprawnienia."
+    }
   },
   "options": {
     "step": {
@@ -1660,6 +1635,20 @@
         }
       },
       "name": "Ustaw krzywą grzewczą"
+    },
+    "set_device_name": {
+      "description": "Ustaw nazwę urządzenia używając wyłącznie drukowalnych znaków ASCII (maks. 16).",
+      "fields": {
+        "device_name": {
+          "description": "Nazwa urządzenia (1–16 drukowalnych znaków ASCII).",
+          "name": "Nazwa urządzenia"
+        }
+      },
+      "name": "Ustaw nazwę urządzenia"
+    },
+    "refresh_device_data": {
+      "description": "Wymuś natychmiastowe odświeżenie danych.",
+      "name": "Odśwież dane urządzenia"
     },
     "start_pressure_test": {
       "description": "Uruchamia automatyczny test kontroli filtrów/ciśnienia",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -117,8 +117,12 @@ from custom_components.thessla_green_modbus.sensor import (  # noqa: E402
 )
 
 SENSOR_KEYS = [v["translation_key"] for v in SENSOR_DEFINITIONS.values()]
-BINARY_KEYS = _load_translation_keys(ROOT / "binary_sensor.py", "BINARY_SENSOR_DEFINITIONS")
-SWITCH_KEYS = _load_keys(ROOT / "entity_mappings.py", "SWITCH_ENTITY_MAPPINGS")
+BINARY_KEYS = _load_translation_keys(
+    ROOT / "entity_mappings.py", "BINARY_SENSOR_ENTITY_MAPPINGS"
+)
+SWITCH_KEYS = _load_keys(ROOT / "entity_mappings.py", "SWITCH_ENTITY_MAPPINGS") + _load_keys(
+    ROOT / "const.py", "SPECIAL_FUNCTION_MAP"
+)
 SELECT_KEYS = _load_keys(ROOT / "entity_mappings.py", "SELECT_ENTITY_MAPPINGS")
 NUMBER_KEYS = _load_keys(ROOT / "entity_mappings.py", "NUMBER_ENTITY_MAPPINGS")
 REGISTER_KEYS = _load_keys(ROOT / "registers.py", "HOLDING_REGISTERS")
@@ -211,10 +215,13 @@ def test_new_translation_keys_present():
         "air_flow_rate_manual",
         "air_flow_rate_temporary_2",
     ]
-    new_binary_keys = ["constant_flow_active", "water_removal_active"]
+    new_binary_keys = ["water_removal_active"]
+    new_sensor_keys = ["constant_flow_active"]
     for trans in (EN, PL):
         for key in new_keys:
             assert key in trans["entity"]["sensor"]
             assert key in trans["entity"]["number"]
         for key in new_binary_keys:
             assert key in trans["entity"]["binary_sensor"]
+        for key in new_sensor_keys:
+            assert key in trans["entity"]["sensor"]


### PR DESCRIPTION
## Summary
- align binary sensor and select translations with entity mappings
- add missing service translations and issue message

## Testing
- `pytest tests/test_translations.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3851d9760832697b620803463426e