### PR TITLE
Add full register scan service and diagnostics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 - **⚡ Wszystkie funkcje specjalne** - OKAP, KOMINEK, WIETRZENIE, PUSTY DOM, BOOST
 - **🌿 Systemy GWC i Bypass** - kompletna kontrola systemów dodatkowych
 - **📅 Harmonogram tygodniowy** - pełna konfiguracja programów czasowych
-- **🛠️ 13 serwisów** - kompletne API do automatyzacji i kontroli
+- **🛠️ 14 serwisów** - kompletne API do automatyzacji i kontroli, w tym pełny skan rejestrów
 - **🔧 Diagnostyka i logowanie** - szczegółowe informacje o błędach i wydajności
 - **🌍 Wsparcie wielojęzyczne** - polski i angielski
 
@@ -112,6 +112,12 @@ urządzenie. Jeśli po aktualizacji firmware pojawią się nowe rejestry,
 ponownie uruchom skanowanie (np. usuń i dodaj integrację), aby
 zaktualizować listę `available_registers`.
 
+### Pełny skan rejestrów
+Dostępny jest serwis `thessla_green_modbus.scan_all_registers`, który wykonuje
+pełne skanowanie wszystkich rejestrów (`full_register_scan=True`) i zwraca
+listę nieznanych adresów. Operacja może trwać kilka minut i znacząco obciąża
+urządzenie – używaj jej tylko do diagnostyki.
+
 ### Włączanie logów debug
 W razie problemów możesz włączyć szczegółowe logi tej integracji. Dodaj poniższą konfigurację do `configuration.yaml` i zrestartuj Home Assistant:
 
@@ -147,7 +153,7 @@ Poziom `debug` pokaże m.in. surowe i przetworzone wartości rejestrów oraz ost
 - **Numbers**: Temperatury, intensywności, czasy, limity alarmów
 - **Selects**: Tryby pracy, tryb sezonowy, harmonogram, komunikacja, język
 
-## 🛠️ Serwisy (13 kompletnych serwisów)
+## 🛠️ Serwisy (14 kompletnych serwisów)
 
 ### Podstawowe sterowanie
 ```yaml

--- a/README_en.md
+++ b/README_en.md
@@ -19,7 +19,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 - **⚡ Every special function** – HOOD, FIREPLACE, VENTILATION, EMPTY HOUSE, BOOST
 - **🌿 GWC and Bypass systems** – complete control of additional systems
 - **📅 Weekly schedule** – full configuration of time programs
-- **🛠️ 13 services** – complete API for automation and control
+- **🛠️ 14 services** – complete API for automation and control, including full register scan
 - **🔧 Diagnostics and logging** – detailed error and performance information
 - **🌍 Multilingual support** – Polish and English
 
@@ -108,7 +108,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Numbers**: temperatures, intensities, times, alarm limits
 - **Selects**: work modes, season mode, schedule, communication, language
 
-## 🛠️ Services (13 complete services)
+## 🛠️ Services (14 complete services)
 
 ### Basic control
 ```yaml
@@ -235,6 +235,12 @@ indicate a configuration or firmware mismatch.
 - **Diagnostics**: detailed performance and error metrics
 - **Stability**: retry logic, fallback reads, graceful degradation, and automatic
   skipping of unsupported registers
+
+### Full register scan
+The `thessla_green_modbus.scan_all_registers` service runs a complete register
+scan (`full_register_scan=True`) and returns unknown addresses. This operation
+may take several minutes and can heavily load the unit, so it should be used
+only for diagnostic purposes.
 
 ## 🤝 Support and development
 

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -27,6 +27,10 @@ async def async_get_config_entry_diagnostics(
     # Gather comprehensive diagnostic data from the coordinator
     diagnostics = coordinator.get_diagnostic_data()
 
+    # Include unknown registers from full scan if available
+    if coordinator.device_scan_result and coordinator.device_scan_result.get("unknown_registers"):
+        diagnostics["unknown_registers"] = coordinator.device_scan_result["unknown_registers"]
+
     # Add human-readable descriptions for active error/status registers
     translations = await translation.async_get_translations(
         hass, hass.config.language, f"component.{DOMAIN}"

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -28,6 +28,7 @@ from .const import (
     SPECIAL_MODE_OPTIONS,
 )
 from .entity_mappings import map_legacy_entity_id
+from .device_scanner import ThesslaGreenDeviceScanner
 
 if TYPE_CHECKING:
     from .coordinator import ThesslaGreenModbusCoordinator
@@ -167,6 +168,12 @@ SET_DEVICE_NAME_SCHEMA = vol.Schema(
 )
 
 REFRESH_DEVICE_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_ids,
+    }
+)
+
+SCAN_ALL_REGISTERS_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_ids,
     }
@@ -560,6 +567,51 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 await coordinator.async_request_refresh()
                 _LOGGER.info("Refreshed device data for %s", entity_id)
 
+    async def scan_all_registers(call: ServiceCall) -> dict[str, Any] | None:
+        """Service to perform a full register scan."""
+        entity_ids = _extract_legacy_entity_ids(hass, call)
+        results: dict[str, Any] = {}
+
+        for entity_id in entity_ids:
+            coordinator = _get_coordinator_from_entity_id(hass, entity_id)
+            if not coordinator:
+                continue
+
+            scanner = await ThesslaGreenDeviceScanner.create(
+                host=coordinator.host,
+                port=coordinator.port,
+                slave_id=coordinator.slave_id,
+                timeout=coordinator.timeout,
+                retry=coordinator.retry,
+                scan_uart_settings=coordinator.scan_uart_settings,
+                skip_known_missing=False,
+            )
+            try:
+                scan_result = await scanner.scan_device(full_register_scan=True)
+            finally:
+                await scanner.close()
+
+            coordinator.device_scan_result = scan_result
+
+            unknown_registers = scan_result.get("unknown_registers", {})
+            summary = {
+                "register_count": scan_result.get("register_count", 0),
+                "unknown_register_count": sum(len(v) for v in unknown_registers.values()),
+            }
+
+            results[entity_id] = {
+                "unknown_registers": unknown_registers,
+                "summary": summary,
+            }
+            _LOGGER.info(
+                "Full register scan for %s completed: %s, unknown registers: %s",
+                entity_id,
+                summary,
+                unknown_registers,
+            )
+
+        return results or None
+
     # Register all services
     hass.services.async_register(
         DOMAIN, "set_special_mode", set_special_mode, SET_SPECIAL_MODE_SCHEMA
@@ -594,6 +646,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN, "refresh_device_data", refresh_device_data, REFRESH_DEVICE_DATA_SCHEMA
     )
+    hass.services.async_register(
+        DOMAIN, "scan_all_registers", scan_all_registers, SCAN_ALL_REGISTERS_SCHEMA
+    )
 
     _LOGGER.info("ThesslaGreen Modbus services registered successfully")
 
@@ -613,6 +668,7 @@ async def async_unload_services(hass: HomeAssistant) -> None:
         "set_modbus_parameters",
         "set_device_name",
         "refresh_device_data",
+        "scan_all_registers",
     ]
 
     for service in services:

--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -296,3 +296,8 @@ refresh_device_data:
   name: Refresh Device Data
   description: Force immediate data refresh.
   target: *tg_target
+
+scan_all_registers:
+  name: Scan All Registers
+  description: Perform full register scan and report unknown registers.
+  target: *tg_target


### PR DESCRIPTION
## Summary
- add `scan_all_registers` service and implementation
- include unknown registers in diagnostics
- document full register scan and potential load

## Testing
- `pytest` *(fails: IndentationError in custom_components/thessla_green_modbus/entity.py)*
- `pytest tests/test_services.py`


------
https://chatgpt.com/codex/tasks/task_e_68a43738b9848326b6766d78c9eddbbc