### PR TITLE
Split service registration for unknown and scan registers

### DIFF
--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -661,6 +661,8 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     )
     hass.services.async_register(
         DOMAIN, "get_unknown_registers", get_unknown_registers, REFRESH_DEVICE_DATA_SCHEMA
+    )
+    hass.services.async_register(
         DOMAIN, "scan_all_registers", scan_all_registers, SCAN_ALL_REGISTERS_SCHEMA
     )
 


### PR DESCRIPTION
## Summary
- split `get_unknown_registers` and `scan_all_registers` service registration calls

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/services.py`
- `pre-commit run --files custom_components/thessla_green_modbus/services.py` *(fails: InvalidManifestError)*
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a43cc676e483269f72c602662fac91