### PR TITLE
Simplify unique ID generation and handle airflow unit

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -29,25 +29,18 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
         host = self.coordinator.host.replace(":", "-")
-        return f"{DOMAIN}_{host}_{self.coordinator.port}_{self.coordinator.slave_id}_{self._key}"
-
-
         base = (
             f"{DOMAIN}_{host}_{self.coordinator.port}_"
             f"{self.coordinator.slave_id}_{self._key}"
         )
-        return base
 
+        if self._key in AIRFLOW_RATE_REGISTERS:
+            airflow_unit = getattr(
+                getattr(self.coordinator, "entry", None), "options", {}
+            ).get(CONF_AIRFLOW_UNIT, DEFAULT_AIRFLOW_UNIT)
+            if airflow_unit != AIRFLOW_UNIT_M3H:
+                base = f"{base}_{airflow_unit}"
 
-
-        base = f"{DOMAIN}_{host}_{self.coordinator.port}_{self.coordinator.slave_id}_{self._key}"
-        airflow_unit = getattr(getattr(self.coordinator, "entry", None), "options", {}).get(
-            CONF_AIRFLOW_UNIT,
-            DEFAULT_AIRFLOW_UNIT,
-        )
-        if self._key in AIRFLOW_RATE_REGISTERS and airflow_unit == AIRFLOW_UNIT_M3H:
-            # unique ID should remain consistent regardless of airflow unit
-            return base
         return base
 
     @property


### PR DESCRIPTION
## Summary
- streamline unique ID creation for entities
- adjust airflow unit handling for registers that vary by unit

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity.py` *(fails: InvalidManifestError)*
- `pytest` *(fails: SyntaxError: invalid syntax. Perhaps you forgot a comma?)*

------
https://chatgpt.com/codex/tasks/task_e_68a43ccad39c8326be7be0e734d23d0d