### PR TITLE
chore: update supported Home Assistant version

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -7,7 +7,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.1.0",
+  "homeassistant": "2024.12.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",


### PR DESCRIPTION
## Summary
- set minimum supported Home Assistant version to 2024.12.0 in manifest

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json` *(fails: InvalidManifestError: /root/.cache/pre-commit/reporhcffkbr/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: SyntaxError: invalid syntax (services.py, line 663))*

------
https://chatgpt.com/codex/tasks/task_e_68a43ccfbb6c83268850a031034bee97