### PR TITLE
Include options JSON in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,10 @@ where = ["."]
 include = ["custom_components*"]
 
 [tool.setuptools.package-data]
-"custom_components.thessla_green_modbus" = ["data/*.csv"]
+"custom_components.thessla_green_modbus" = [
+    "data/*.csv",
+    "options/*.json",
+]
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
## Summary
- include options JSON files in wheel package data

## Testing
- `pre-commit run --files pyproject.toml` *(fails: InvalidManifestError: /root/.cache/pre-commit/repowj65mh0c/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: SyntaxError in custom_components/thessla_green_modbus/services.py line 663)*
- `python -m build`
- `unzip -l dist/thessla_green_modbus-2.1.1-py3-none-any.whl | grep options`


------
https://chatgpt.com/codex/tasks/task_e_68a43cdbc8408326876491c06f7e4cb2