### PR TITLE
chore: constrain vulture version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         args: ["--config=."]
         pass_filenames: false
   - repo: https://github.com/jendrikseipp/vulture
-    rev: v2.9.1
+    rev: v2.14
     hooks:
       - id: vulture
         args: ["custom_components/thessla_green_modbus", "--min-confidence=80"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,4 +18,4 @@ pre-commit>=3.0.0
 sphinx>=4.0.0
 sphinx-rtd-theme>=1.0.0
 
-vulture
+vulture>=2.11,<3.0


### PR DESCRIPTION
## Summary
- constrain vulture in dev requirements
- update pre-commit hook to vulture v2.14

## Testing
- `python -m pre_commit run --all-files` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo5rbat8ln/.pre-commit-hooks.yaml is not a file)*
- `python -m vulture custom_components/thessla_green_modbus/__init__.py`
- `pytest` *(fails: SyntaxError in services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a43cd811f88326a2954007b8a18ec3