### PR TITLE
Guard rekuperator efficiency template

### DIFF
--- a/example_configuration.yaml
+++ b/example_configuration.yaml
@@ -32,6 +32,18 @@ template:
           {# Approximate power calculation based on voltage output #}
           {{ ((supply_voltage + exhaust_voltage) * 25) | round(0) }}
 
+      - name: "Sprawnosc rekuperatora"
+        unit_of_measurement: "%"
+        state: >
+          {% set supply  = states('sensor.thessla_supply_temperature')  | float(0) %}
+          {% set outside = states('sensor.thessla_outside_temperature') | float(0) %}
+          {% set exhaust = states('sensor.thessla_exhaust_temperature') | float(0) %}
+          {% if exhaust != outside %}
+            {{ ((supply - outside) / (exhaust - outside) * 100) | round(1) }}
+          {% else %}
+            unknown
+          {% endif %}
+
   - binary_sensor:
       - name: "ThesslaGreen Winter Mode"
         state: >


### PR DESCRIPTION
## Summary
- add defaults and zero-division guard to `sprawnosc rekuperatora` template sensor

## Testing
- `pip install -r requirements-dev.txt`
- `python tools/generate_registers.py`
- `python tools/validate_registers.py`
- `find custom_components -path '*/translations/*.json' -exec python -m json.tool {} \;`
- `pytest tests/test_register_coverage.py -ra`
- `pytest -ra --ignore=tests/test_register_coverage.py` *(fails: multiple failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_68a44cc27b7c83269f5ca9e969ebb359