### PR TITLE
Add calculated efficiency sensor mapping and documentation

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -211,7 +211,7 @@ automation:
 
 ### 2. Add to Energy Dashboard
 - Monitor power consumption estimates
-- Track ventilation efficiency
+- Track ventilation efficiency (`sensor.calculated_efficiency`)
 - Compare seasonal performance
 
 ### 3. Advanced Configuration

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Poziom `debug` pokaże m.in. surowe i przetworzone wartości rejestrów oraz ost
 - **Ciśnienia**: Nawiew, wywiew, różnicowe, alarmy
 - **Jakość powietrza**: CO2, VOC, indeks jakości, wilgotność
 - **Energie**: Zużycie, odzysk, moc szczytowa, średnia, roczna redukcja CO2 (kg)
-- **System**: Sprawność, godziny pracy, status filtrów, błędy
+- **System**: Obliczona sprawność, godziny pracy, status filtrów, błędy
 - **Diagnostyka**: Czas aktualizacji, jakość danych, statystyki
 
 ### Sensory binarne (40+ automatycznie wykrywanych)
@@ -393,7 +393,7 @@ podłączenie i wersję firmware.
 - ✅ **Systemy zaawansowane**: GWC, Bypass, Stały przepływ
 - ✅ **Diagnostyka**: Kompletne raportowanie błędów i alarmów
 - ✅ **Automatyzacja**: Pełna integracja z serwisami HA
-- ✅ **Monitoring**: Wydajność energetyczna i czas pracy
+- ✅ **Monitoring**: Wydajność energetyczna (`sensor.calculated_efficiency`) i czas pracy
 
 ### Wydajność
 - **Optymalizowane odczyty**: Grupowanie rejestrów, 60% mniej wywołań Modbus

--- a/README_en.md
+++ b/README_en.md
@@ -92,7 +92,7 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Pressures**: supply, exhaust, differential, alarms
 - **Air quality**: CO₂, VOC, air quality index, humidity
 - **Energy**: consumption, recovery, peak power, average, annual CO₂ reduction (kg)
-- **System**: efficiency, operating hours, filter status, errors
+- **System**: calculated efficiency, operating hours, filter status, errors
 - **Diagnostics**: update time, data quality, statistics
 
 ### Binary sensors (40+ auto detected)
@@ -227,7 +227,7 @@ indicate a configuration or firmware mismatch.
 - ✅ **Advanced systems**: GWC, Bypass, Constant flow
 - ✅ **Diagnostics**: complete error and alarm reporting
 - ✅ **Automation**: full integration with HA services
-- ✅ **Monitoring**: energy efficiency and runtime
+- ✅ **Monitoring**: energy efficiency (`calculated_efficiency` sensor) and runtime
 
 ### Performance
 - **Optimized reads**: register grouping, 60% fewer Modbus calls

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -557,6 +557,15 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "unit": PERCENTAGE,
         "register_type": "holding_registers",
     },
+    # Calculated metrics
+    "calculated_efficiency": {
+        "translation_key": "calculated_efficiency",
+        "icon": "mdi:percent",
+        "device_class": getattr(SensorDeviceClass, "EFFICIENCY", "efficiency"),
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": PERCENTAGE,
+        "register_type": "input_registers",
+    },
 }
 
 SELECT_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1071,6 +1071,9 @@
       "bypass_off": {
         "name": "Bypass Off"
       },
+      "calculated_efficiency": {
+        "name": "Calculated Efficiency"
+      },
       "cf_version": {
         "name": "CF Module Version"
       },

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1064,6 +1064,9 @@
       "bypass_off": {
         "name": "Bypass Off"
       },
+      "calculated_efficiency": {
+        "name": "Calculated Efficiency"
+      },
       "cf_version": {
         "name": "CF Module Version"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1064,6 +1064,9 @@
       "bypass_off": {
         "name": "Wyłączenie bypass"
       },
+      "calculated_efficiency": {
+        "name": "Obliczona sprawność"
+      },
       "cf_version": {
         "name": "Wersja modułu CF"
       },


### PR DESCRIPTION
## Summary
- add `calculated_efficiency` to sensor mappings
- provide translations and strings for the new sensor
- document the new calculated efficiency sensor

## Testing
- `pre-commit run --files QUICK_START.md README.md README_en.md custom_components/thessla_green_modbus/entity_mappings.py custom_components/thessla_green_modbus/strings.json custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json` *(failed: InvalidManifestError: /root/.cache/pre-commit/repo4cs6thrc/.pre-commit-hooks.yaml is not a file)*
- `ruff check custom_components/thessla_green_modbus/entity_mappings.py`
- `black --check custom_components/thessla_green_modbus/entity_mappings.py`
- `flake8 --max-line-length=100 custom_components/thessla_green_modbus/entity_mappings.py`
- `mypy custom_components/thessla_green_modbus/entity_mappings.py`
- `bandit -r custom_components/thessla_green_modbus/entity_mappings.py`
- `pytest` *(failed: 205 failed, 95 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a453a5196c832684dcbbecf21d5d93