### PR TITLE
Add power consumption estimation and energy tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 - **📱 Tylko aktywne encje** - tworzy tylko te encje, które są rzeczywiście dostępne
 - **🏠 Kompletna kontrola rekuperatora** - wszystkie tryby pracy, temperatury, przepływy
 - **📊 Pełny monitoring** - wszystkie czujniki, statusy, alarmy, diagnostyka
+- **🔋 Szacowanie zużycia energii** - wbudowane czujniki mocy i energii
 - **💨 Obsługa Constant Flow** - wykrywanie rejestrów `supply_air_flow`, `exhaust_air_flow` oraz procedury HEWR
 - **🌡️ Zaawansowana encja Climate** - pełna kontrola z preset modes i trybami specjalnymi
 - **⚡ Wszystkie funkcje specjalne** - OKAP, KOMINEK, WIETRZENIE, PUSTY DOM, BOOST

--- a/README_en.md
+++ b/README_en.md
@@ -15,6 +15,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 - **📱 Only active entities** – creates only entities that are really available
 - **🏠 Full control of the unit** – all work modes, temperatures and air flows
 - **📊 Complete monitoring** – all sensors, statuses, alarms and diagnostics
+- **🔋 Energy estimation** – built-in power and total energy sensors
 - **🌡️ Advanced Climate entity** – full HVAC control with preset modes and special modes
 - **⚡ Every special function** – HOOD, FIREPLACE, VENTILATION, EMPTY HOUSE, BOOST
 - **🌿 GWC and Bypass systems** – complete control of additional systems

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -507,6 +507,23 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "unit": UnitOfElectricPotential.VOLT,
         "register_type": "holding_registers",
     },
+    # Derived power sensors
+    "estimated_power": {
+        "translation_key": "estimated_power",
+        "icon": "mdi:flash",
+        "device_class": SensorDeviceClass.POWER,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": "W",
+        "register_type": "calculated",
+    },
+    "total_energy": {
+        "translation_key": "total_energy",
+        "icon": "mdi:counter",
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": "kWh",
+        "register_type": "calculated",
+    },
     # Coefficients and intensive settings
     "fan_speed_1_coef": {
         "translation_key": "fan_speed_1_coef",

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1098,6 +1098,12 @@
       "dac_supply": {
         "name": "Supply Fan Voltage"
       },
+      "estimated_power": {
+        "name": "Estimated Power"
+      },
+      "total_energy": {
+        "name": "Total Energy"
+      },
       "day_of_week": {
         "name": "Day of Week"
       },

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1029,12 +1029,6 @@
       }
     },
     "sensor": {
-      "air_flow_rate_manual": {
-        "name": "Manual Airflow Rate"
-      },
-      "air_flow_rate_temporary_2": {
-        "name": "Temporary Airflow Rate 2"
-      },
       "air_temperature_summer_free_cooling": {
         "name": "Air Temperature Summer Free Cooling"
       },
@@ -1043,12 +1037,6 @@
       },
       "ambient_temperature": {
         "name": "Ambient Temperature"
-      },
-      "antifreez_mode": {
-        "name": "Antifreeze Mode"
-      },
-      "antifreez_stage": {
-        "name": "Antifreeze Stage"
       },
       "antifreeze_mode": {
         "name": "Antifreeze Mode"
@@ -1063,9 +1051,6 @@
       },
       "bypass_off": {
         "name": "Bypass Off"
-      },
-      "cf_version": {
-        "name": "CF Module Version"
       },
       "comfort_mode": {
         "name": "Comfort Mode Status"
@@ -1090,6 +1075,12 @@
       },
       "dac_supply": {
         "name": "Supply Fan Voltage"
+      },
+      "estimated_power": {
+        "name": "Estimated Power"
+      },
+      "total_energy": {
+        "name": "Total Energy"
       },
       "day_of_week": {
         "name": "Day of Week"
@@ -1118,15 +1109,6 @@
       "fan_speed_3_coef": {
         "name": "Fan Speed 3 Coefficient"
       },
-      "filter_change": {
-        "name": "Filter Type",
-        "state": {
-          "cleanpad": "CleanPad",
-          "cleanpad_pure": "CleanPad Pure",
-          "flat_filters": "Flat Filters",
-          "presostat": "Pressure switch"
-        }
-      },
       "fpx_temperature": {
         "name": "FPX Temperature"
       },
@@ -1137,9 +1119,6 @@
           "forced": "Forced",
           "off": "Off"
         }
-      },
-      "gwc_regen_flag": {
-        "name": "GWC Regeneration Active"
       },
       "gwc_temperature": {
         "name": "GWC Temperature"
@@ -1203,12 +1182,6 @@
           "summer": "Summer",
           "winter": "Winter"
         }
-      },
-      "serial_number_1": {
-        "name": "Serial Number Part 1"
-      },
-      "serial_number_2": {
-        "name": "Serial Number Part 2"
       },
       "serial_number_5": {
         "name": "Serial Number 5"
@@ -1657,6 +1630,10 @@
     "start_pressure_test": {
       "description": "Starts automatic filter/pressure control test",
       "name": "Start Pressure Test"
+    },
+    "scan_all_registers": {
+      "description": "Perform full Modbus register scan for diagnostics",
+      "name": "Scan All Registers"
     }
   },
   "title": "ThesslaGreen Modbus"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1029,12 +1029,6 @@
       }
     },
     "sensor": {
-      "air_flow_rate_manual": {
-        "name": "Ręczny przepływ powietrza"
-      },
-      "air_flow_rate_temporary_2": {
-        "name": "Tymczasowy przepływ powietrza 2"
-      },
       "air_temperature_summer_free_cooling": {
         "name": "Temperatura lato chłodzenie free"
       },
@@ -1043,12 +1037,6 @@
       },
       "ambient_temperature": {
         "name": "Temperatura otoczenia"
-      },
-      "antifreez_mode": {
-        "name": "Antifreeze Mode"
-      },
-      "antifreez_stage": {
-        "name": "Etap antyzamrożeniowy"
       },
       "antifreeze_mode": {
         "name": "Tryb antyzamrożeniowy"
@@ -1063,9 +1051,6 @@
       },
       "bypass_off": {
         "name": "Wyłączenie bypass"
-      },
-      "cf_version": {
-        "name": "Wersja modułu CF"
       },
       "comfort_mode": {
         "name": "Tryb komfort"
@@ -1090,6 +1075,12 @@
       },
       "dac_supply": {
         "name": "Napięcie wentylatora nawiewnego"
+      },
+      "estimated_power": {
+        "name": "Szacowana moc"
+      },
+      "total_energy": {
+        "name": "Całkowita energia"
       },
       "day_of_week": {
         "name": "Dzień tygodnia"
@@ -1118,15 +1109,6 @@
       "fan_speed_3_coef": {
         "name": "Współczynnik prędkości 3"
       },
-      "filter_change": {
-        "name": "Typ filtrów",
-        "state": {
-          "cleanpad": "CleanPad",
-          "cleanpad_pure": "CleanPad Pure",
-          "flat_filters": "Filtry płaskie",
-          "presostat": "Presostat"
-        }
-      },
       "fpx_temperature": {
         "name": "Temperatura FPX"
       },
@@ -1137,9 +1119,6 @@
           "forced": "Forced",
           "off": "Off"
         }
-      },
-      "gwc_regen_flag": {
-        "name": "Regeneracja GWC aktywna"
       },
       "gwc_temperature": {
         "name": "Temperatura GWC"
@@ -1203,12 +1182,6 @@
           "summer": "Summer",
           "winter": "Winter"
         }
-      },
-      "serial_number_1": {
-        "name": "Numer seryjny część 1"
-      },
-      "serial_number_2": {
-        "name": "Serial Number Part 2"
       },
       "serial_number_5": {
         "name": "Numer seryjny 5"
@@ -1657,6 +1630,10 @@
     "start_pressure_test": {
       "description": "Uruchamia automatyczny test kontroli filtrów/ciśnienia",
       "name": "Rozpocznij test ciśnienia"
+    },
+    "scan_all_registers": {
+      "description": "Wykonaj pełny skan rejestrów Modbus do diagnostyki",
+      "name": "Skanuj wszystkie rejestry"
     }
   },
   "title": "ThesslaGreen Modbus"

--- a/example_configuration.yaml
+++ b/example_configuration.yaml
@@ -23,15 +23,6 @@ template:
           {% endif %}
         icon: mdi:chart-line
 
-      - name: "ThesslaGreen Power Consumption"
-        unit_of_measurement: "W"
-        device_class: power
-        state: >
-          {% set supply_voltage = states('sensor.thessla_dac_supply') | float(0) %}
-          {% set exhaust_voltage = states('sensor.thessla_dac_exhaust') | float(0) %}
-          {# Approximate power calculation based on voltage output #}
-          {{ ((supply_voltage + exhaust_voltage) * 25) | round(0) }}
-
       - name: "Sprawnosc rekuperatora"
         unit_of_measurement: "%"
         state: >
@@ -53,10 +44,10 @@ template:
 # Utility meter (optional - for energy tracking)
 utility_meter:
   thessla_daily_energy:
-    source: sensor.thessla_total_power_consumption
+    source: sensor.thessla_total_energy
     cycle: daily
   thessla_monthly_energy:
-    source: sensor.thessla_total_power_consumption
+    source: sensor.thessla_total_energy
     cycle: monthly
 
 # Input boolean for manual controls (optional)

--- a/info.md
+++ b/info.md
@@ -4,6 +4,7 @@ Pełna integracja Home Assistant dla rekuperatorów ThesslaGreen z komunikacją 
 
 ## Funkcje
 - 📊 **50+ czujników** – temperatury, przepływy, ciśnienia, jakość powietrza, energia i statusy systemu
+- 🔋 **Szacowanie zużycia energii** – wbudowany czujnik mocy i energii całkowitej
 - 🔍 **40+ sensory binarne** – statusy, tryby, wejścia, alarmy i zabezpieczenia
 - 🎛️ **30+ kontrolki** – Climate, Switch, Number, Select i inne do pełnej kontroli urządzenia
 - 🌡️ **Zaawansowana encja Climate** z preset modes i funkcjami specjalnymi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,9 +82,12 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     class SensorDeviceClass:  # pragma: no cover - enum stub
         TEMPERATURE = "temperature"
         VOLTAGE = "voltage"
+        POWER = "power"
+        ENERGY = "energy"
 
     class SensorStateClass:  # pragma: no cover - enum stub
         MEASUREMENT = "measurement"
+        TOTAL_INCREASING = "total_increasing"
 
     class SensorEntity:  # pragma: no cover - simple stub
         pass
@@ -424,6 +427,7 @@ def mock_coordinator():
         "holding_registers": {"mode", "on_off_panel_mode", "air_flow_rate_manual"},
         "coil_registers": {"power_supply_fans", "bypass"},
         "discrete_inputs": {"expansion", "contamination_sensor"},
+        "calculated": {"estimated_power", "total_energy"},
     }
     coordinator.async_write_register = AsyncMock(return_value=True)
     coordinator.async_request_refresh = AsyncMock()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -93,10 +93,13 @@ sensor_mod = types.ModuleType("homeassistant.components.sensor")
 class SensorDeviceClass:  # pragma: no cover - enum stub
     TEMPERATURE = "temperature"
     VOLTAGE = "voltage"
+    POWER = "power"
+    ENERGY = "energy"
 
 
 class SensorStateClass:  # pragma: no cover - enum stub
     MEASUREMENT = "measurement"
+    TOTAL_INCREASING = "total_increasing"
 
 
 sensor_mod.SensorDeviceClass = SensorDeviceClass

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -39,10 +39,13 @@ class SensorEntity:  # pragma: no cover - simple stub
 class SensorDeviceClass:  # pragma: no cover - enum stubs
     TEMPERATURE = "temperature"
     VOLTAGE = "voltage"
+    POWER = "power"
+    ENERGY = "energy"
 
 
 class SensorStateClass:  # pragma: no cover - enum stubs
     MEASUREMENT = "measurement"
+    TOTAL_INCREASING = "total_increasing"
 
 
 sensor_mod.SensorEntity = SensorEntity

--- a/tests/test_sensor_register_mapping.py
+++ b/tests/test_sensor_register_mapping.py
@@ -38,10 +38,13 @@ class SensorEntity:  # pragma: no cover - simple stub
 class SensorDeviceClass:  # pragma: no cover - enum stub
     TEMPERATURE = "temperature"
     VOLTAGE = "voltage"
+    POWER = "power"
+    ENERGY = "energy"
 
 
 class SensorStateClass:  # pragma: no cover - enum stub
     MEASUREMENT = "measurement"
+    TOTAL_INCREASING = "total_increasing"
 
 
 sensor_mod.SensorEntity = SensorEntity
@@ -77,5 +80,8 @@ def test_sensor_register_mapping() -> None:
         elif register_type == "holding_registers":
             assert register_name in registers.HOLDING_REGISTERS
             assert register_name not in registers.INPUT_REGISTERS
+        elif register_type == "calculated":
+            assert register_name not in registers.INPUT_REGISTERS
+            assert register_name not in registers.HOLDING_REGISTERS
         else:
             pytest.fail(f"Unknown register_type {register_type} for {register_name}")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -110,10 +110,13 @@ sensor_mod = types.ModuleType("homeassistant.components.sensor")
 class SensorDeviceClass:  # pragma: no cover - enum stub
     TEMPERATURE = "temperature"
     VOLTAGE = "voltage"
+    POWER = "power"
+    ENERGY = "energy"
 
 
 class SensorStateClass:  # pragma: no cover - enum stub
     MEASUREMENT = "measurement"
+    TOTAL_INCREASING = "total_increasing"
 
 
 sensor_mod.SensorDeviceClass = SensorDeviceClass

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -91,10 +91,13 @@ class SensorEntity:  # pragma: no cover - simple stub
 class SensorDeviceClass:  # pragma: no cover - enum stub
     TEMPERATURE = "temperature"
     VOLTAGE = "voltage"
+    POWER = "power"
+    ENERGY = "energy"
 
 
 class SensorStateClass:  # pragma: no cover - enum stub
     MEASUREMENT = "measurement"
+    TOTAL_INCREASING = "total_increasing"
 
 
 sensor_mod.SensorEntity = SensorEntity


### PR DESCRIPTION
## Summary
- estimate power usage from DAC voltages and accumulate total energy
- expose `estimated_power` and `total_energy` sensors
- document new sensors and update translations

## Testing
- `pre-commit run --files README.md README_en.md custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/entity_mappings.py custom_components/thessla_green_modbus/strings.json custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json example_configuration.yaml info.md tests/conftest.py tests/test_coordinator.py tests/test_select.py tests/test_sensor_platform.py tests/test_sensor_register_mapping.py tests/test_switch.py tests/test_translations.py` *(failed: InvalidManifestError)*
- `pytest` *(failed: async def functions are not natively supported)*
- `pytest tests/test_translations.py tests/test_unused_translations.py` *(failed: unused number translations)*

------
https://chatgpt.com/codex/tasks/task_e_68a453a7ec6883269fd3f95b5f1bceed