### PR TITLE
feat: allow skipping cache for holding reads

### DIFF
--- a/tests/test_input_range_fallback.py
+++ b/tests/test_input_range_fallback.py
@@ -31,7 +31,7 @@ async def test_input_range_read_after_block_failure():
             return SimpleNamespace(registers=[1], isError=lambda: False)
         return None
 
-    async def fake_read_holding(client, address, count):
+    async def fake_read_holding(client, address, count, **kwargs):
         return [0]
 
     async def fake_read_coil(client, address, count):


### PR DESCRIPTION
## Summary
- add `skip_cache` parameter to `_read_holding` to bypass cached unsupported ranges
- probe holding registers again by bypassing cache during full scans and batch fallbacks
- test that cached unsupported ranges can still be read when `skip_cache=True`

## Testing
- `pip install pyyaml`
- `pip install pytest-asyncio`
- `pytest` *(fails: async def functions are not natively supported)*
- `pytest tests/test_device_scanner.py::test_read_holding_skip_cache_reads_unsupported_range -q`


------
https://chatgpt.com/codex/tasks/task_e_68a45be9426083268572915a631cbf2d