### PR TITLE
Handle unsupported input ranges during single-register fallback

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -976,6 +976,17 @@ class ThesslaGreenDeviceScanner:
             )
             _LOGGER.warning("Skipping unsupported holding registers %s", ranges)
 
+    def _mark_input_supported(self, address: int) -> None:
+        """Remove address from cached unsupported input ranges after success."""
+        self._failed_input.discard(address)
+        for (start, end), code in list(self._unsupported_input_ranges.items()):
+            if start <= address <= end:
+                del self._unsupported_input_ranges[(start, end)]
+                if start <= address - 1:
+                    self._unsupported_input_ranges[(start, address - 1)] = code
+                if address + 1 <= end:
+                    self._unsupported_input_ranges[(address + 1, end)] = code
+
     async def _read_input(
         self,
         client: "AsyncModbusTcpClient",
@@ -994,9 +1005,10 @@ class ThesslaGreenDeviceScanner:
         start = address
         end = address + count - 1
 
-        for skip_start, skip_end in self._unsupported_input_ranges:
-            if skip_start <= start and end <= skip_end:
-                return None
+        if not skip_cache:
+            for skip_start, skip_end in self._unsupported_input_ranges:
+                if skip_start <= start and end <= skip_end:
+                    return None
         if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):
             first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)
             skip_start = skip_end = first
@@ -1024,6 +1036,8 @@ class ThesslaGreenDeviceScanner:
                         self._failed_input.update(range(start, end + 1))
                         self._unsupported_input_ranges[(start, end)] = code or 0
                         return None
+                    if skip_cache and count == 1:
+                        self._mark_input_supported(address)
                     return response.registers
                 _LOGGER.debug(
                     "Attempt %d failed to read input 0x%04X: %s",
@@ -1089,6 +1103,8 @@ class ThesslaGreenDeviceScanner:
                         self._failed_input.update(range(start, end + 1))
                         self._unsupported_input_ranges[(start, end)] = code or 0
                         return None
+                    if skip_cache and count == 1:
+                        self._mark_input_supported(address)
                     return response.registers
                 _LOGGER.debug(
                     "Fallback attempt %d failed to read holding 0x%04X: %s",

--- a/tests/test_input_range_fallback.py
+++ b/tests/test_input_range_fallback.py
@@ -9,10 +9,16 @@ pytestmark = pytest.mark.asyncio
 
 async def test_input_range_read_after_block_failure():
     empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
-    with patch.object(
-        ThesslaGreenDeviceScanner,
-        "_load_registers",
-        AsyncMock(return_value=(empty_regs, {})),
+    with (
+        patch.object(
+            ThesslaGreenDeviceScanner,
+            "_load_registers",
+            AsyncMock(return_value=(empty_regs, {})),
+        ),
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner.KNOWN_MISSING_REGISTERS",
+            {},
+        ),
     ):
         scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
 
@@ -67,3 +73,75 @@ async def test_input_range_read_after_block_failure():
     single_addresses = [addr for addr, cnt in call_log if cnt == 1]
     for addr in range(0x000E, 0x001E):
         assert addr in single_addresses
+
+
+async def test_block_exception_allows_single_register_reads():
+    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    with patch.object(
+        ThesslaGreenDeviceScanner,
+        "_load_registers",
+        AsyncMock(return_value=(empty_regs, {})),
+    ):
+        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
+
+    regs = {f"reg_{addr:04X}": addr for addr in range(0x0010, 0x0014)}
+    call_log: list[tuple[int, int]] = []
+
+    error_response = SimpleNamespace(
+        isError=lambda: True, exception_code=4
+    )
+
+    async def fake_call_modbus(func, slave_id, address, *, count):
+        call_log.append((address, count))
+        if address == 0x0000 and count == 5:
+            return SimpleNamespace(
+                registers=[4, 85, 0, 0, 0], isError=lambda: False
+            )
+        if address == 0x0018 and count == 6:
+            return SimpleNamespace(registers=[0] * 6, isError=lambda: False)
+        if address == 0x0010 and count == 4:
+            return error_response
+        if count == 1:
+            return SimpleNamespace(registers=[1], isError=lambda: False)
+        return None
+
+    async def fake_read_holding(client, address, count):
+        return [0]
+
+    async def fake_read_coil(client, address, count):
+        return [False]
+
+    async def fake_read_discrete(client, address, count):
+        return [False]
+
+    with (
+        patch("custom_components.thessla_green_modbus.device_scanner.INPUT_REGISTERS", regs),
+        patch("custom_components.thessla_green_modbus.device_scanner.HOLDING_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.device_scanner.COIL_REGISTERS", {}),
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner.DISCRETE_INPUT_REGISTERS",
+            {},
+        ),
+        patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class,
+    ):
+        mock_client = AsyncMock()
+        mock_client.connect.return_value = True
+        mock_client_class.return_value = mock_client
+
+        with (
+            patch(
+                "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+                side_effect=fake_call_modbus,
+            ),
+            patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
+            patch.object(scanner, "_read_coil", AsyncMock(side_effect=fake_read_coil)),
+            patch.object(scanner, "_read_discrete", AsyncMock(side_effect=fake_read_discrete)),
+        ):
+            result = await scanner.scan_device()
+
+    assert set(result["available_registers"]["input_registers"]) == set(regs)
+    assert (0x0010, 4) in call_log
+    single_addresses = [addr for addr, cnt in call_log if cnt == 1]
+    for addr in range(0x0010, 0x0014):
+        assert addr in single_addresses
+    assert scanner._unsupported_input_ranges == {}


### PR DESCRIPTION
## Summary
- Allow single-register fallback reads to bypass cached unsupported ranges
- Remove supported addresses from cached unsupported range after successful read
- Add regression test for block exception fallback behavior

## Testing
- `pytest tests/test_input_range_fallback.py -q`
- `pytest tests/test_device_scanner.py::test_read_input_skips_range_on_exception_response -q`

------
https://chatgpt.com/codex/tasks/task_e_68a45bd3c5908326903d94ce5cf9c1f5