### PR TITLE
chore: align Home Assistant minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokoł
 - ✅ **Firmware v3.x - v5.x** z automatyczną detekcją
 
 ### Home Assistant
-- ✅ **Wymagany Home Assistant 2025.7.1+** – minimalna wersja określona w `manifest.json` (pakiet `homeassistant` nie jest częścią `requirements.txt`)
+- ✅ **Wymagany Home Assistant 2025.7.1+** — minimalna wersja określona w `manifest.json` (pakiet `homeassistant` nie jest częścią `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** - najnowsza biblioteka Modbus
 - ✅ **Python 3.12+** - nowoczesne standardy
 - ✅ **Standardowy AsyncModbusTcpClient** – brak potrzeby własnego klienta Modbus

--- a/README_en.md
+++ b/README_en.md
@@ -33,7 +33,7 @@ The most complete integration for ThesslaGreen AirPack heat recovery units over 
 - ✅ **Firmware v3.x – v5.x** with automatic detection
 
 ### Home Assistant
-- ✅ **Requires Home Assistant 2025.7.1+** – minimum version declared in `manifest.json` (the `homeassistant` package is not part of `requirements.txt`)
+- ✅ **Requires Home Assistant 2025.7.1+** — minimum version declared in `manifest.json` (the `homeassistant` package is not part of `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** – latest Modbus library
 - ✅ **Python 3.12+** – modern standards
 - ✅ **Standard AsyncModbusTcpClient** – no custom Modbus client required

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -7,7 +7,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2024.12.0",
+  "homeassistant": "2025.7.1",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",

--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -1,5 +1,5 @@
 # Complete services for ThesslaGreen Modbus Integration
-# Compatibility: Home Assistant 2025.* + pymodbus 3.5.*+
+# Compatibility: Home Assistant 2025.7.1+ & pymodbus 3.5.*+
 # All models: ThesslaGreen AirPack Home series 4
 
 set_special_mode:


### PR DESCRIPTION
## Summary
- set manifest homeassistant requirement to 2025.7.1
- document unified Home Assistant requirement in READMEs and services comment

## Testing
- `pre-commit run --files README.md README_en.md custom_components/thessla_green_modbus/manifest.json custom_components/thessla_green_modbus/services.yaml` *(fails: InvalidManifestError: /root/.cache/pre-commit/repow_v6vvay/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 208 failed, 94 passed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a48041f2548326a0fc467aeeb73088