### PR TITLE
Add device name scanning and propagation

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -226,6 +226,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.available_registers[reg_type].difference_update(names)
 
                 self.device_info = self.device_scan_result.get("device_info", {})
+                self.device_info.setdefault("device_name", self._device_name)
                 self.capabilities = DeviceCapabilities(
                     **self.device_scan_result.get("capabilities", {})
                 )
@@ -1142,7 +1143,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     @property
     def device_name(self) -> str:
         """Return the configured or detected device name."""
-        return cast(str, self.device_info.get("device_name", self._device_name))
+        return cast(str, self.device_info.get("device_name") or self._device_name)
 
     @property
     def device_info_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- expose device name on DeviceInfo and scan device_name_1-8 registers
- retain scanned device name in coordinator and prioritize it in `device_name`
- test device scanner populates device_name

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/coordinator.py tests/test_device_scanner.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo90jd19p9/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_device_scanner.py::test_scan_populates_device_name -q`


------
https://chatgpt.com/codex/tasks/task_e_68a47faa85e48326a018d68389da9bcd