### PR TITLE
Remove unused async_ensure_client wrapper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -417,10 +417,6 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.exception("Unexpected error setting up Modbus client: %s", exc)
             return False
 
-    async def async_ensure_client(self) -> bool:
-        """Public wrapper ensuring the Modbus client is connected."""
-        return await self._async_setup_client()
-
     async def _ensure_connection(self) -> None:
         """Ensure Modbus connection is established."""
         if self.client and self.client.connected:


### PR DESCRIPTION
## Summary
- drop unused async_ensure_client wrapper from coordinator

## Testing
- ⚠️ `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` (InvalidManifestError: /root/.cache/pre-commit/repo_squdb9p/.pre-commit-hooks.yaml is not a file)
- ⚠️ `pytest` (208 failed, 94 passed, 1 warning)
- ✅ `pytest tests/test_coordinator.py::test_setup_and_refresh_no_cancelled_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68a47fc47c408326a743faa74250751f