### PR TITLE
Handle modbus write errors in services

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -175,6 +175,13 @@ class ConfigEntryNotReady(Exception):
 exceptions.ConfigEntryNotReady = ConfigEntryNotReady
 
 
+class HomeAssistantError(Exception):
+    pass
+
+
+exceptions.HomeAssistantError = HomeAssistantError
+
+
 class AsyncModbusTcpClient:
     pass
 


### PR DESCRIPTION
## Summary
- add helper to wrap Modbus register writes
- use helper across services to raise `HomeAssistantError` on Modbus issues
- adjust service tests for HomeAssistantError stub

## Testing
- `ruff check custom_components/thessla_green_modbus/services.py tests/test_services.py`
- `pytest tests/test_services.py`
- `pre-commit run --files custom_components/thessla_green_modbus/services.py tests/test_services.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoo0slwb3_/.pre-commit-hooks.yaml is not a file)*


------
https://chatgpt.com/codex/tasks/task_e_68a47fc1e6788326a18f644493538ebe