### PR TITLE
Add basic async_setup function

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -71,6 +71,11 @@ for domain in PLATFORM_DOMAINS:
             _LOGGER.warning("Skipping unsupported platform: %s", domain)
 
 
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ThesslaGreen Modbus from a config entry."""
     _LOGGER.debug("Setting up ThesslaGreen Modbus integration for %s", entry.title)


### PR DESCRIPTION
## Summary
- add simple async_setup to initialize DOMAIN

## Testing
- `ruff check custom_components/thessla_green_modbus/__init__.py`
- `flake8 --max-line-length=100 custom_components/thessla_green_modbus/__init__.py`
- `mypy custom_components/thessla_green_modbus/__init__.py`
- `bandit -r custom_components/thessla_green_modbus/__init__.py`
- `pytest` *(fails: async def functions are not correctly awaited, KeyError: 'bypass', unused translations etc.)*
- `pre-commit run --files custom_components/thessla_green_modbus/__init__.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repol2nd19bg/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a47fbb99d88326b6c24818d552c7d2