### PR TITLE
Warn when device model or firmware unknown

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -258,6 +258,14 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Load all registers if forced
             self._load_full_register_list()
 
+        model = self.device_info.get("model", "Unknown")
+        firmware = self.device_info.get("firmware", "Unknown")
+        if model == "Unknown" or firmware == "Unknown":
+            _LOGGER.warning(
+                "Device model or firmware could not be determined. "
+                "Verify Modbus connectivity or ensure your firmware is supported."
+            )
+
         # Pre-compute register groups for batch reading
         self._compute_register_groups()
 


### PR DESCRIPTION
## Summary
- log a warning when Modbus scan leaves model or firmware unknown to aid diagnostics

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repouj3j9pis/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 208 failed, 94 passed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a47fb0bf788326bb5317ddeaf6848c