### PR TITLE
Add serial number sensors and translations

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -335,6 +335,26 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "icon": "mdi:information",
         "register_type": "input_registers",
     },
+    "serial_number_1": {
+        "translation_key": "serial_number_1",
+        "icon": "mdi:barcode",
+        "register_type": "input_registers",
+    },
+    "serial_number_2": {
+        "translation_key": "serial_number_2",
+        "icon": "mdi:barcode",
+        "register_type": "input_registers",
+    },
+    "serial_number_3": {
+        "translation_key": "serial_number_3",
+        "icon": "mdi:barcode",
+        "register_type": "input_registers",
+    },
+    "serial_number_4": {
+        "translation_key": "serial_number_4",
+        "icon": "mdi:barcode",
+        "register_type": "input_registers",
+    },
     "serial_number_5": {
         "translation_key": "serial_number_5",
         "icon": "mdi:barcode",

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1226,6 +1226,12 @@
       "serial_number_2": {
         "name": "Serial Number Part 2"
       },
+      "serial_number_3": {
+        "name": "Serial Number Part 3"
+      },
+      "serial_number_4": {
+        "name": "Serial Number Part 4"
+      },
       "serial_number_5": {
         "name": "Serial Number 5"
       },

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1189,6 +1189,18 @@
           "winter": "Winter"
         }
       },
+      "serial_number_1": {
+        "name": "Serial Number Part 1"
+      },
+      "serial_number_2": {
+        "name": "Serial Number Part 2"
+      },
+      "serial_number_3": {
+        "name": "Serial Number Part 3"
+      },
+      "serial_number_4": {
+        "name": "Serial Number Part 4"
+      },
       "serial_number_5": {
         "name": "Serial Number 5"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1189,6 +1189,18 @@
           "winter": "Winter"
         }
       },
+      "serial_number_1": {
+        "name": "Numer seryjny 1"
+      },
+      "serial_number_2": {
+        "name": "Numer seryjny 2"
+      },
+      "serial_number_3": {
+        "name": "Numer seryjny 3"
+      },
+      "serial_number_4": {
+        "name": "Numer seryjny 4"
+      },
       "serial_number_5": {
         "name": "Numer seryjny 5"
       },


### PR DESCRIPTION
## Summary
- expose serial number register segments as sensors
- provide English and Polish translations for new serial number entities
- update base strings for serial number entries

## Testing
- `pytest` *(fails: Failed: async def functions are not defined; KeyError 'bypass'; many translation test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a4878a15108326b92141946eff1779