### PR TITLE
Clarify register scanning limits and entity mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ urządzenie. Jeśli po aktualizacji firmware pojawią się nowe rejestry,
 ponownie uruchom skanowanie (np. usuń i dodaj integrację), aby
 zaktualizować listę `available_registers`.
 
+> 🔎 Wiele wykrytych rejestrów to bloki konfiguracji lub wartości
+> wielorejestrowe, które nie mają bezpośredniego odwzorowania na encje
+> Home Assistant. Domyślnie integracja udostępnia tylko rejestry
+> zdefiniowane w [`entity_mappings.py`](custom_components/thessla_green_modbus/entity_mappings.py).
+> Włączenie opcji **Pełna lista rejestrów** (`force_full_register_list`)
+> tworzy encje dla każdego znalezionego rejestru, lecz może ujawnić
+> niekompletne dane lub pola konfiguracyjne – używaj jej ostrożnie.
+> [Więcej informacji](docs/register_scanning.md).
+
 ### Pełny skan rejestrów
 Dostępny jest serwis `thessla_green_modbus.scan_all_registers`, który wykonuje
 pełne skanowanie wszystkich rejestrów (`full_register_scan=True`) i zwraca

--- a/README_en.md
+++ b/README_en.md
@@ -85,6 +85,15 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 - **Retry**: 1‑5 attempts (default 3)
 - **Full register list**: Skip scanning (may cause errors)
 
+> 🔎 The scanner probes many registers, including configuration blocks or
+> multi-register values that do not map directly to Home Assistant entities.
+> By default the integration only exposes addresses defined in
+> [`entity_mappings.py`](custom_components/thessla_green_modbus/entity_mappings.py).
+> Enabling the **Full register list** option (`force_full_register_list`)
+> creates entities for every discovered register, but some may contain
+> partial values or internal configuration. Use this option with care.
+> [More details](docs/register_scanning.md).
+
 ## 📊 Available entities
 
 ### Sensors (50+ auto detected)

--- a/docs/register_scanning.md
+++ b/docs/register_scanning.md
@@ -1,0 +1,13 @@
+# Register scanning and entity mapping
+
+During the initial device scan the integration probes many Modbus register ranges. Some of
+the detected addresses represent configuration blocks or multi-register values rather than
+single data points. These registers do not map directly to Home Assistant entities.
+
+Only addresses defined in [entity_mappings.py](../custom_components/thessla_green_modbus/entity_mappings.py)
+are exposed as entities by default. The list covers all supported sensors and controls.
+
+Enabling the **force_full_register_list** option creates entities for every discovered
+register. This can reveal additional data but may also surface partial values or internal
+configuration fields that have no dedicated entity class. Use this option with care and
+primarily for debugging or development purposes.


### PR DESCRIPTION
## Summary
- clarify that many detected registers are config blocks or multi-register values not exposed as entities
- note that only entity_mappings.py registers are created by default
- document force_full_register_list option caveats

## Testing
- `pre-commit run --files README.md README_en.md docs/register_scanning.md` *(failed: InvalidManifestError)*
- `pytest` *(failed: async def functions are not supported, KeyError 'bypass', unused translation keys)*

------
https://chatgpt.com/codex/tasks/task_e_68a48786ec1483268fdc8e05c639a60c