### PR TITLE
Fix DeviceInfo dataclass model field

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -158,9 +158,8 @@ class DeviceInfo:
         serial_number: Unique hardware identifier for the unit.
     """
 
-    model: str = MODEL
     device_name: str = "Unknown"
-    model: str = "Unknown AirPack"
+    model: str = MODEL
     firmware: str = "Unknown"
     serial_number: str = "Unknown"
     firmware_available: bool = True


### PR DESCRIPTION
## Summary
- remove duplicate `model` field from `DeviceInfo`
- reorder `DeviceInfo` attributes to `device_name`, `model`, `firmware`, `serial_number`, `firmware_available`, `capabilities`

## Testing
- `pytest tests/test_device_scanner.py` *(fails: 20 failed, 56 passed)*
- `pytest` *(fails: 99 failed, 205 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a48780bdec832692d2411c95a585b5