### PR TITLE
docs: clarify register grouping vs entity creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ urządzenie. Jeśli po aktualizacji firmware pojawią się nowe rejestry,
 ponownie uruchom skanowanie (np. usuń i dodaj integrację), aby
 zaktualizować listę `available_registers`.
 
+Podczas skanowania rejestry są grupowane według funkcji i tylko część z nich
+przekłada się na utworzone encje. Niektóre służą jedynie do diagnostyki lub
+ustawień i nie mają bezpośredniego odzwierciedlenia w Home Assistant.
+Integracja może wykryć 200+ rejestrów, ale utworzyć ~100 encji.
+
 ### Pełny skan rejestrów
 Dostępny jest serwis `thessla_green_modbus.scan_all_registers`, który wykonuje
 pełne skanowanie wszystkich rejestrów (`full_register_scan=True`) i zwraca


### PR DESCRIPTION
## Summary
- clarify that auto-scan groups registers and may not create entities for each one
- add example with 200+ registers yielding ~100 entities

## Testing
- `pre-commit run --files README.md` *(fails: InvalidManifestError)*
- `pytest` *(fails: async tests require plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a48772bac083268aa8917ba98778b8