### PR TITLE
Fix duplicate model field in DeviceInfo dataclass

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -158,9 +158,8 @@ class DeviceInfo:
         serial_number: Unique hardware identifier for the unit.
     """
 
-    model: str = MODEL
     device_name: str = "Unknown"
-    model: str = "Unknown AirPack"
+    model: str = MODEL
     firmware: str = "Unknown"
     serial_number: str = "Unknown"
     firmware_available: bool = True


### PR DESCRIPTION
## Summary
- Remove duplicate `model` field from `DeviceInfo`
- Ensure `model` defaults to `MODEL` constant and fields ordered logically

## Testing
- `pytest` *(fails: TypeError/KeyError in services tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4897e6ea88326be8b2d39858f2815