### PR TITLE
Remove no-cover annotation from firmware fallback

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -546,7 +546,7 @@ class ThesslaGreenDeviceScanner:
 
         if None not in (major, minor, patch):
             device.firmware = f"{major}.{minor}.{patch}"
-        else:  # pragma: no cover - best effort
+        else:
             _LOGGER.error("Failed to read firmware version registers")
             device.firmware_available = False
         try:


### PR DESCRIPTION
## Summary
- remove coverage pragma from firmware version fallback to allow coverage tracking

## Testing
- `pytest tests/test_device_scanner.py --cov=custom_components.thessla_green_modbus.device_scanner --cov-report=term-missing -q` *(fails: 20 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a48939a6fc8326996cee270da33692