### PR TITLE
feat: load register metadata from csv

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -106,46 +106,47 @@ def _load_number_mappings() -> dict[str, dict[str, Any]]:
     This function reads register configurations and dynamically creates
     number entity mappings with proper min/max/step values.
     """
-    from .data.modbus_registers import get_register_info
+    from .data.modbus_registers import get_register_info, get_register_infos
 
     number_configs: dict[str, dict[str, Any]] = {}
 
     # Define registers that should be number entities
     number_registers: dict[str, dict[str, str | None]] = {
         # Temperature control
-        "required_temperature": {"unit": "°C", "icon": "mdi:thermometer"},
-        "supply_air_temperature_manual": {"unit": "°C", "icon": "mdi:thermometer-plus"},
-        "supply_air_temperature_temporary_1": {"unit": "°C", "icon": "mdi:thermometer-plus"},
-        "supply_air_temperature_temporary_2": {"unit": "°C", "icon": "mdi:thermometer-plus"},
-        "min_bypass_temperature": {"unit": "°C", "icon": "mdi:thermometer-low"},
-        "air_temperature_summer_free_heating": {"unit": "°C", "icon": "mdi:thermometer"},
-        "air_temperature_summer_free_cooling": {"unit": "°C", "icon": "mdi:thermometer"},
-        "bypass_off": {"unit": "°C", "icon": "mdi:thermometer-off"},
+        "required_temperature": {"unit": None, "icon": "mdi:thermometer"},
+        "supply_air_temperature_manual": {"unit": None, "icon": "mdi:thermometer-plus"},
+        "supply_air_temperature_temporary_1": {"unit": None, "icon": "mdi:thermometer-plus"},
+        "supply_air_temperature_temporary_2": {"unit": None, "icon": "mdi:thermometer-plus"},
+        "min_bypass_temperature": {"unit": None, "icon": "mdi:thermometer-low"},
+        "air_temperature_summer_free_heating": {"unit": None, "icon": "mdi:thermometer"},
+        "air_temperature_summer_free_cooling": {"unit": None, "icon": "mdi:thermometer"},
+        "bypass_off": {"unit": None, "icon": "mdi:thermometer-off"},
         # Air flow control
-        "air_flow_rate_manual": {"unit": "m³/h", "icon": "mdi:fan"},
-        "max_supply_air_flow_rate": {"unit": "m³/h", "icon": "mdi:fan-plus"},
-        "max_exhaust_air_flow_rate": {"unit": "m³/h", "icon": "mdi:fan-minus"},
-        "nominal_supply_air_flow": {"unit": "m³/h", "icon": "mdi:fan-clock"},
-        "nominal_exhaust_air_flow": {"unit": "m³/h", "icon": "mdi:fan-clock"},
-        "max_supply_air_flow_rate_gwc": {"unit": "m³/h", "icon": "mdi:fan-plus"},
-        "max_exhaust_air_flow_rate_gwc": {"unit": "m³/h", "icon": "mdi:fan-minus"},
-        "nominal_supply_air_flow_gwc": {"unit": "m³/h", "icon": "mdi:fan-clock"},
-        "nominal_exhaust_air_flow_gwc": {"unit": "m³/h", "icon": "mdi:fan-clock"},
+        "air_flow_rate_manual": {"unit": None, "icon": "mdi:fan"},
+        "max_supply_air_flow_rate": {"unit": None, "icon": "mdi:fan-plus"},
+        "max_exhaust_air_flow_rate": {"unit": None, "icon": "mdi:fan-minus"},
+        "nominal_supply_air_flow": {"unit": None, "icon": "mdi:fan-clock"},
+        "nominal_exhaust_air_flow": {"unit": None, "icon": "mdi:fan-clock"},
+        "max_supply_air_flow_rate_gwc": {"unit": None, "icon": "mdi:fan-plus"},
+        "max_exhaust_air_flow_rate_gwc": {"unit": None, "icon": "mdi:fan-minus"},
+        "nominal_supply_air_flow_gwc": {"unit": None, "icon": "mdi:fan-clock"},
+        "nominal_exhaust_air_flow_gwc": {"unit": None, "icon": "mdi:fan-clock"},
         # Access and timing
         "access_level": {"unit": None, "icon": "mdi:account-key"},
         # GWC parameters
-        "min_gwc_air_temperature": {"unit": "°C", "icon": "mdi:thermometer-low"},
-        "max_gwc_air_temperature": {"unit": "°C", "icon": "mdi:thermometer-high"},
-        "gwc_regen_period": {"unit": "h", "icon": "mdi:timer"},
-        "delta_t_gwc": {"unit": "°C", "icon": "mdi:thermometer-lines"},
+        "min_gwc_air_temperature": {"unit": None, "icon": "mdi:thermometer-low"},
+        "max_gwc_air_temperature": {"unit": None, "icon": "mdi:thermometer-high"},
+        "gwc_regen_period": {"unit": None, "icon": "mdi:timer"},
+        "delta_t_gwc": {"unit": None, "icon": "mdi:thermometer-lines"},
     }
 
     for register, config in number_registers.items():
         try:
             reg_info = get_register_info(register)
             if reg_info:
+                unit = config["unit"] if config["unit"] is not None else reg_info.get("unit")
                 number_configs[register] = {
-                    "unit": config["unit"],
+                    "unit": unit,
                     "icon": config["icon"],
                     "min": reg_info.get("min", 0),
                     "max": reg_info.get("max", 100),
@@ -161,6 +162,18 @@ def _load_number_mappings() -> dict[str, dict[str, Any]]:
                 "max": 100,
                 "step": 1,
             }
+
+    # Date/time registers span multiple addresses with shared name in CSV
+    date_time_infos = get_register_infos("date_time")
+    for idx, info in enumerate(date_time_infos, start=1):
+        number_configs[f"date_time_{idx}"] = {
+            "unit": info.get("unit"),
+            "icon": "mdi:calendar-clock",
+            "min": info.get("min", 0),
+            "max": info.get("max", 100),
+            "step": info.get("step", 1),
+            "scale": info.get("scale", 1),
+        }
 
     return number_configs
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -27,6 +27,8 @@ class UnitOfTemperature:  # pragma: no cover - simple stub
 class UnitOfTime:  # pragma: no cover - simple stub
     MINUTES = "min"
     HOURS = "h"
+    DAYS = "d"
+    SECONDS = "s"
 
 
 class UnitOfVolumeFlowRate:  # pragma: no cover - simple stub
@@ -233,3 +235,32 @@ async def test_async_setup_creates_new_numbers(mock_coordinator, mock_config_ent
     entities = add_entities.call_args[0][0]
     names = {entity.register_name for entity in entities}
     assert {"max_supply_air_flow_rate", "bypass_off"} <= names
+
+
+def test_air_flow_rate_manual_from_csv(mock_coordinator):
+    """Verify air_flow_rate_manual uses CSV-defined unit and range."""
+    mock_coordinator.data["air_flow_rate_manual"] = 30
+    entity_config = ENTITY_MAPPINGS["number"]["air_flow_rate_manual"]
+    number = ThesslaGreenNumber(
+        mock_coordinator, "air_flow_rate_manual", entity_config, "holding_registers"
+    )
+    assert number._attr_native_unit_of_measurement == "%"
+    assert number._attr_native_min_value == 10
+    assert number._attr_native_max_value == 100
+    assert number._attr_native_step == 1
+
+
+def test_date_time_number_from_csv(mock_coordinator):
+    """Verify date_time_1 mapping is loaded from CSV."""
+    mock_coordinator.available_registers.setdefault("holding_registers", set()).add(
+        "date_time_1"
+    )
+    mock_coordinator.data["date_time_1"] = 23
+    entity_config = ENTITY_MAPPINGS["number"]["date_time_1"]
+    number = ThesslaGreenNumber(
+        mock_coordinator, "date_time_1", entity_config, "holding_registers"
+    )
+    assert number._attr_native_unit_of_measurement == "RRMM"
+    assert number._attr_native_min_value == 0
+    assert number._attr_native_max_value == 99
+    assert number._attr_native_step == 1


### PR DESCRIPTION
## Summary
- derive entity ranges and units from bundled CSV data
- add number mappings for date_time registers
- test CSV-based entity mappings

## Testing
- `pytest tests/test_number.py::test_air_flow_rate_manual_from_csv tests/test_number.py::test_date_time_number_from_csv -q`
- `pre-commit run --files custom_components/thessla_green_modbus/data/modbus_registers.py custom_components/thessla_green_modbus/entity_mappings.py tests/test_number.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoh8qlqi3k/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a48cfd53d4832684e37d285fd1675a