### PR TITLE
Fix indentation for missing device info logging

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -262,35 +262,35 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         firmware = self.device_info.get("firmware", "Unknown")
         # Warn when any key identification fields are missing
         if model == UNKNOWN_MODEL or firmware == "Unknown":
-        missing: list[str] = []
-        if model == "Unknown":
-            missing.append("model")
-            _LOGGER.debug(
-                "Device model missing for %s:%s%s",
-                self.host,
-                self.port,
-                f" (slave {self.slave_id})" if self.slave_id is not None else "",
-            )
-        if firmware == "Unknown":
-            missing.append("firmware")
-            _LOGGER.debug(
-                "Device firmware missing for %s:%s%s",
-                self.host,
-                self.port,
-                f" (slave {self.slave_id})" if self.slave_id is not None else "",
-            )
-        if missing:
-            device_details = f"{self.host}:{self.port}"
-            if self.slave_id is not None:
-                device_details += f", slave {self.slave_id}"
-            missing_str = " and ".join(missing)
-            _LOGGER.warning(
-                "Device %s missing %s (%s). "
-                "Verify Modbus connectivity or ensure your firmware is supported.",
-                self._device_name,
-                missing_str,
-                device_details,
-            )
+            missing: list[str] = []
+            if model == "Unknown":
+                missing.append("model")
+                _LOGGER.debug(
+                    "Device model missing for %s:%s%s",
+                    self.host,
+                    self.port,
+                    f" (slave {self.slave_id})" if self.slave_id is not None else "",
+                )
+            if firmware == "Unknown":
+                missing.append("firmware")
+                _LOGGER.debug(
+                    "Device firmware missing for %s:%s%s",
+                    self.host,
+                    self.port,
+                    f" (slave {self.slave_id})" if self.slave_id is not None else "",
+                )
+            if missing:
+                device_details = f"{self.host}:{self.port}"
+                if self.slave_id is not None:
+                    device_details += f", slave {self.slave_id}"
+                missing_str = " and ".join(missing)
+                _LOGGER.warning(
+                    "Device %s missing %s (%s). "
+                    "Verify Modbus connectivity or ensure your firmware is supported.",
+                    self._device_name,
+                    missing_str,
+                    device_details,
+                )
 
         # Pre-compute register groups for batch reading
         self._compute_register_groups()


### PR DESCRIPTION
## Summary
- fix indentation for missing device info logging

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/coordinator.py`
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc0e789c83269f87567981cc2b70