### PR TITLE
Restrict multi register size definitions to starting registers

### DIFF
--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -40,11 +40,6 @@ DISCRETE_INPUT_REGISTERS: dict[str, int] = {
 MULTI_REGISTER_SIZES: dict[str, int] = {
     "date_time_1": 4,
     "lock_date_1": 3,
-    "date_time_2": 4,
-    "date_time_3": 4,
-    "date_time_4": 4,
-    "lock_date_2": 3,
-    "lock_date_3": 3,
 }
 
 INPUT_REGISTERS: dict[str, int] = {

--- a/tools/generate_registers.py
+++ b/tools/generate_registers.py
@@ -13,11 +13,6 @@ OUTPUT_PATH = ROOT / "custom_components" / "thessla_green_modbus" / "registers.p
 MULTI_REGISTER_SIZES: dict[str, int] = {
     "date_time_1": 4,
     "lock_date_1": 3,
-    "date_time_2": 4,
-    "date_time_3": 4,
-    "date_time_4": 4,
-    "lock_date_2": 3,
-    "lock_date_3": 3,
 }
 
 


### PR DESCRIPTION
## Summary
- drop non-starting entries from `MULTI_REGISTER_SIZES`
- regenerate `registers.py` with updated block size map

## Testing
- `black --check --line-length=100 tools/generate_registers.py custom_components/thessla_green_modbus/registers.py`
- `isort --profile=black --line-length=79 --check-only tools/generate_registers.py custom_components/thessla_green_modbus/registers.py`
- `ruff check --line-length=79 tools/generate_registers.py custom_components/thessla_green_modbus/registers.py`
- `flake8 --max-line-length=100 tools/generate_registers.py custom_components/thessla_green_modbus/registers.py`
- `mypy custom_components/thessla_green_modbus/registers.py --ignore-missing-imports --follow-imports=skip`
- `mypy tools/generate_registers.py --ignore-missing-imports --follow-imports=skip`
- `bandit -r custom_components/thessla_green_modbus`
- `python tools/validate_registers.py`
- `pytest` *(fails: UnboundLocalError: cannot access local variable 'HOLDING_REGISTERS' in entity_mappings.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cfd171ac8326a7bf303d42913ae8