### PR TITLE
Map cf_version register and ensure entity coverage

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -467,6 +467,11 @@ SENSOR_ENTITY_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "icon": "mdi:barcode",
         "register_type": "input_registers",
     },
+    "cf_version": {
+        "translation_key": "cf_version",
+        "icon": "mdi:information",
+        "register_type": "holding_registers",
+    },
     # Mode and status sensors
     "antifreeze_mode": {
         "translation_key": "antifreeze_mode",

--- a/tests/test_entity_mappings_completeness.py
+++ b/tests/test_entity_mappings_completeness.py
@@ -65,3 +65,5 @@ def test_entity_mappings_cover_all_registers() -> None:
     mapping_names = _entity_mapping_keys()
     missing = mapping_names - csv_names - WHITELIST
     assert not missing, f"Unknown registers in ENTITY_MAPPINGS: {sorted(missing)}"
+    unmapped = csv_names - mapping_names
+    assert not unmapped, f"Registers missing entity mapping: {sorted(unmapped)}"


### PR DESCRIPTION
## Summary
- map `cf_version` holding register to a sensor entity
- extend entity mapping test to require coverage for every CSV register

## Testing
- ⚠️ `pytest` *(fails: async def functions are not allowed to be called directly, key errors)*
- ✅ `pytest tests/test_entity_mappings_completeness.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d85105948326bbd6d95cdad256b0