### PR TITLE
Ensure error registers are binary sensors

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -997,6 +997,22 @@ def _extend_entity_mappings_from_csv() -> None:
         scale = info.get("scale", 1)
         step = info.get("step", scale)
 
+        if (
+            register in {"alarm", "error"}
+            or register.startswith("s_")
+            or register.startswith("e_")
+        ):
+            BINARY_SENSOR_ENTITY_MAPPINGS.setdefault(
+                register,
+                {
+                    "translation_key": register,
+                    "icon": "mdi:alert-circle",
+                    "register_type": "holding_registers",
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+            )
+            continue
+
         if min_val is not None and max_val is not None:
             if max_val <= 1:
                 if "W" in access:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -120,6 +120,17 @@ def test_dynamic_problem_registers_present() -> None:
         assert key in BINARY_SENSOR_DEFINITIONS  # nosec B101
 
 
+def test_problem_registers_range_mapped() -> None:
+    """Registers 0x2000-0x20FB should map to binary sensors."""
+    expected = {
+        name
+        for name, addr in HOLDING_REGISTERS.items()
+        if 0x2000 <= addr <= 0x20FB
+    }
+    for key in expected:
+        assert key in BINARY_SENSOR_DEFINITIONS  # nosec B101
+
+
 @pytest.mark.asyncio
 async def test_async_setup_creates_all_binary_sensors(
     mock_coordinator: MagicMock, mock_config_entry: MagicMock


### PR DESCRIPTION
## Summary
- Map alarm/error and S_/E_ registers to binary sensors even when marked writable
- Add coverage test for binary sensors from registers 0x2000–0x20FB

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity_mappings.py tests/test_binary_sensor.py` *(fails: InvalidManifestError)*
- `pytest tests/test_binary_sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4d8530c6c8326a29726112c9adc0f