### PR TITLE
Expose diagnostic holding registers on scan failure

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -707,6 +707,12 @@ class ThesslaGreenDeviceScanner:
                         if self._is_valid_register_value(name, value):
                             self.available_registers["holding_registers"].add(name)
 
+            # Always expose diagnostic registers so error entities exist even
+            # when the device does not implement them.
+            for name in HOLDING_REGISTERS:
+                if name.startswith(("e_", "s_")) or name in {"alarm", "error"}:
+                    self.available_registers["holding_registers"].add(name)
+
             # Scan Coil Registers in batches
             coil_addr_to_name: dict[int, str] = {}
             coil_addresses: list[int] = []


### PR DESCRIPTION
## Summary
- always mark diagnostic holding registers (alarm/error and e_/s_ codes) as available even when reads fail
- document reasoning with a code comment
- test that E/S registers remain available after Modbus errors

## Testing
- `pytest tests/test_device_scanner.py::test_scan_reports_diagnostic_registers_on_error -q`
- `pytest tests/test_device_scanner.py::test_scan_populates_device_name -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e2d35d188326b19e4155acb6c546