### PR TITLE
Log failed Modbus addresses

### DIFF
--- a/docs/register_scanning.md
+++ b/docs/register_scanning.md
@@ -4,6 +4,11 @@ During the initial device scan the integration probes many Modbus register range
 the detected addresses represent configuration blocks or multi-register values rather than
 single data points. These registers do not map directly to Home Assistant entities.
 
+If a register cannot be read because the device returns a Modbus exception or if the value
+fails basic validation, the affected addresses are now recorded and exposed in the
+diagnostics. This makes it easier to troubleshoot missing features or firmware
+incompatibilities.
+
 Only addresses defined in [entity_mappings.py](../custom_components/thessla_green_modbus/entity_mappings.py)
 are exposed as entities by default. The list covers all supported sensors and controls.
 


### PR DESCRIPTION
## Summary
- track Modbus and validation failures during device scan
- surface failed register addresses in diagnostics and scan results
- document how skipped addresses are reported

## Testing
- `pytest tests/test_device_scanner.py::test_failed_addresses_recorded_on_exception -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e2d9a9fc83268e20f1375fb7c0d8