### PR TITLE
Warn when Modbus registers missing during scan

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -313,7 +313,9 @@ class ThesslaGreenDeviceScanner:
 
     async def _async_setup(self) -> None:
         """Asynchronously load register definitions."""
-        self._registers, self._register_ranges, self._register_versions = await self._load_registers()
+        self._registers, self._register_ranges, self._register_versions = (
+            await self._load_registers()
+        )
 
     @classmethod
     async def create(
@@ -540,9 +542,7 @@ class ThesslaGreenDeviceScanner:
             ):
                 if value is None and name in INPUT_REGISTERS:
                     addr = INPUT_REGISTERS[name]
-                    single = await self._read_input(
-                        client, addr, 1, skip_cache=True
-                    )
+                    single = await self._read_input(client, addr, 1, skip_cache=True)
                     if single:
                         if name == "version_major":
                             major = single[0]
@@ -608,7 +608,9 @@ class ThesslaGreenDeviceScanner:
                 input_data = await self._read_input(client, addr, 1, skip_cache=True)
                 if not input_data:
                     continue
-                if (reg_name := self._registers.get("04", {}).get(addr)) and self._is_valid_register_value(reg_name, input_data[0]):
+                if (
+                    reg_name := self._registers.get("04", {}).get(addr)
+                ) and self._is_valid_register_value(reg_name, input_data[0]):
                     self.available_registers["input_registers"].add(reg_name)
                 else:
                     unknown_registers["input_registers"][addr] = input_data[0]
@@ -618,7 +620,9 @@ class ThesslaGreenDeviceScanner:
                 holding_data = await self._read_holding(client, addr, 1, skip_cache=True)
                 if not holding_data:
                     continue
-                if (reg_name := self._registers.get("03", {}).get(addr)) and self._is_valid_register_value(reg_name, holding_data[0]):
+                if (
+                    reg_name := self._registers.get("03", {}).get(addr)
+                ) and self._is_valid_register_value(reg_name, holding_data[0]):
                     self.available_registers["holding_registers"].add(reg_name)
                 else:
                     unknown_registers["holding_registers"][addr] = holding_data[0]
@@ -829,6 +833,36 @@ class ThesslaGreenDeviceScanner:
                 for offset, value in enumerate(data):
                     raw_registers[start + offset] = value
 
+        # Determine expected registers that were not successfully read
+        register_maps = {
+            "input_registers": INPUT_REGISTERS,
+            "holding_registers": HOLDING_REGISTERS,
+            "coil_registers": COIL_REGISTERS,
+            "discrete_inputs": DISCRETE_INPUT_REGISTERS,
+        }
+        missing_registers: dict[str, dict[str, int]] = {}
+        for reg_type, mapping in register_maps.items():
+            missing: dict[str, int] = {}
+            for name, addr in mapping.items():
+                if self.skip_known_missing and name in KNOWN_MISSING_REGISTERS[reg_type]:
+                    continue
+                if name not in self.available_registers[reg_type]:
+                    missing[name] = addr
+            if missing:
+                missing_registers[reg_type] = missing
+
+        if missing_registers:
+            details = []
+            for reg_type, regs in missing_registers.items():
+                formatted = ", ".join(
+                    f"{name}=0x{addr:04X}"
+                    for name, addr in sorted(regs.items(), key=lambda item: item[1])
+                )
+                details.append(f"{reg_type}: {formatted}")
+            _LOGGER.warning(
+                "The following registers were not found during scan: %s", "; ".join(details)
+            )
+
         result = {
             "available_registers": self.available_registers,
             "device_info": device.as_dict(),
@@ -837,6 +871,7 @@ class ThesslaGreenDeviceScanner:
             "scan_blocks": scan_blocks,
             "unknown_registers": unknown_registers,
             "scanned_registers": scanned_registers,
+            "missing_registers": missing_registers,
         }
         if self.deep_scan:
             result["raw_registers"] = raw_registers
@@ -1046,9 +1081,7 @@ class ThesslaGreenDeviceScanner:
 
     def _mark_holding_unsupported(self, start: int, end: int, code: int) -> None:
         """Track unsupported holding register range without overlaps."""
-        for (exist_start, exist_end), exist_code in list(
-            self._unsupported_holding_ranges.items()
-        ):
+        for (exist_start, exist_end), exist_code in list(self._unsupported_holding_ranges.items()):
             if exist_end < start or exist_start > end:
                 continue
             del self._unsupported_holding_ranges[(exist_start, exist_end)]
@@ -1057,6 +1090,7 @@ class ThesslaGreenDeviceScanner:
             if end < exist_end:
                 self._unsupported_holding_ranges[(end + 1, exist_end)] = exist_code
         self._unsupported_holding_ranges[(start, end)] = code
+
     def _mark_input_unsupported(self, start: int, end: int, code: int | None) -> None:
         """Cache unsupported input register range, merging overlaps."""
 

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -342,9 +342,7 @@ async def test_read_holding_skip_cache_reads_unsupported_range():
         "custom_components.thessla_green_modbus.device_scanner._call_modbus",
         AsyncMock(return_value=response),
     ) as call_mock:
-        result = await scanner._read_holding(
-            mock_client, 0x0200, 1, skip_cache=True
-        )
+        result = await scanner._read_holding(mock_client, 0x0200, 1, skip_cache=True)
 
     assert result == [123]
     call_mock.assert_awaited_once()
@@ -372,10 +370,7 @@ async def test_single_read_clears_failed_holding_cache():
     assert 0x0301 not in scanner._failed_holding
     assert (0x0300, 0x0300) in scanner._unsupported_holding_ranges
     assert (0x0302, 0x0302) in scanner._unsupported_holding_ranges
-    assert all(
-        not (start <= 0x0301 <= end)
-        for start, end in scanner._unsupported_holding_ranges
-    )
+    assert all(not (start <= 0x0301 <= end) for start, end in scanner._unsupported_holding_ranges)
 
 
 async def test_log_skipped_ranges_no_overlap(caplog):
@@ -1289,10 +1284,7 @@ async def test_load_registers_duplicate_names(tmp_path):
 async def test_load_registers_skips_none_named_registers(tmp_path):
     """Registers named 'none' or 'none_<num>' should be ignored."""
     csv_content = (
-        "Function_Code,Register_Name,Address_DEC\n"
-        "04,none,1\n"
-        "04,valid_reg,2\n"
-        "04,none_3,3\n"
+        "Function_Code,Register_Name,Address_DEC\n" "04,none,1\n" "04,valid_reg,2\n" "04,none_3,3\n"
     )
     data_dir = tmp_path / "data"
     data_dir.mkdir()
@@ -1820,3 +1812,53 @@ async def test_deep_scan_collects_raw_registers():
     expected = 0x012C - 0x000E + 1
     assert len(result["raw_registers"]) == expected
     assert result["total_addresses_scanned"] == expected
+
+
+async def test_scan_logs_missing_expected_registers(caplog):
+    """Scanner warns when expected registers are not found."""
+
+    input_regs = {
+        "version_major": 0,
+        "version_minor": 1,
+        "version_patch": 2,
+        "serial_number_1": 3,
+        "reg_a": 4,
+    }
+
+    async def fake_read_input(client, address, count, **kwargs):
+        data = [0] * count
+        if address <= 4 < address + count:
+            data[4 - address] = SENSOR_UNAVAILABLE
+        return data
+
+    with (
+        patch("custom_components.thessla_green_modbus.device_scanner.INPUT_REGISTERS", input_regs),
+        patch("custom_components.thessla_green_modbus.device_scanner.HOLDING_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.device_scanner.COIL_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.device_scanner.DISCRETE_INPUT_REGISTERS", {}),
+        patch(
+            "custom_components.thessla_green_modbus.device_scanner.KNOWN_MISSING_REGISTERS",
+            {
+                "input_registers": set(),
+                "holding_registers": set(),
+                "coil_registers": set(),
+                "discrete_inputs": set(),
+            },
+        ),
+    ):
+        scanner = ThesslaGreenDeviceScanner("host", 502)
+        scanner._client = object()
+        with (
+            patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)),
+            patch.object(scanner, "_read_holding", AsyncMock(return_value=None)),
+            patch.object(scanner, "_read_coil", AsyncMock(return_value=None)),
+            patch.object(scanner, "_read_discrete", AsyncMock(return_value=None)),
+            patch.object(scanner, "_analyze_capabilities", return_value=DeviceCapabilities()),
+            patch.object(
+                scanner, "_is_valid_register_value", side_effect=lambda n, v: n != "reg_a"
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            await scanner.scan()
+
+    assert "reg_a=0x0004" in caplog.text


### PR DESCRIPTION
## Summary
- track expected Modbus registers skipped during device scan and log their names/addresses
- add regression test for missing register warning

## Testing
- `black --check custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/registers.py tests/test_device_scanner.py`
- `ruff check custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/registers.py tests/test_device_scanner.py`
- `pytest -c tests/pytest.ini tests/test_device_scanner.py::test_scan_logs_missing_expected_registers`
- `pytest -c tests/pytest.ini tests/test_device_scanner.py::test_device_scanner_initialization`
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py custom_components/thessla_green_modbus/registers.py tests/test_device_scanner.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repog1i3i3r7/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e2d211b88326a4cf7d867821080c