### PR TITLE
Include register in generated switch configs

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -243,6 +243,7 @@ def _load_discrete_mappings() -> tuple[
         cfg: dict[str, Any] = {"translation_key": reg, "register_type": "holding_registers"}
         if len(states) == 2 and set(states.values()) == {0, 1}:
             if "W" in access:
+                cfg["register"] = reg
                 switch_configs[reg] = cfg
             else:
                 binary_configs[reg] = cfg


### PR DESCRIPTION
## Summary
- ensure switch mappings populated from register metadata include their register field

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity_mappings.py` *(fails: InvalidManifestError)*
- `pytest` *(fails: IndentationError in device_scanner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ed6558408326bfb034697794e9cd