### PR TITLE
Remove redundant register validity checks

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -622,9 +622,6 @@ class ThesslaGreenDeviceScanner:
                 input_data = await self._read_input(client, addr, 1, skip_cache=True)
                 if not input_data:
                     continue
-                if (
-                    reg_name := self._registers.get("04", {}).get(addr)
-                ) and self._is_valid_register_value(reg_name, input_data[0]):
                 reg_name = self._registers.get("04", {}).get(addr)
                 if reg_name and self._is_valid_register_value(reg_name, input_data[0]):
                     self.available_registers["input_registers"].add(reg_name)
@@ -639,9 +636,6 @@ class ThesslaGreenDeviceScanner:
                 holding_data = await self._read_holding(client, addr, 1, skip_cache=True)
                 if not holding_data:
                     continue
-                if (
-                    reg_name := self._registers.get("03", {}).get(addr)
-                ) and self._is_valid_register_value(reg_name, holding_data[0]):
                 reg_name = self._registers.get("03", {}).get(addr)
                 if reg_name and self._is_valid_register_value(reg_name, holding_data[0]):
                     self.available_registers["holding_registers"].add(reg_name)


### PR DESCRIPTION
## Summary
- fix register scan to assign register names once and validate values directly

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repowf4dq7xi/.pre-commit-hooks.yaml is not a file)*
- `ruff check custom_components/thessla_green_modbus/device_scanner.py`
- `python -m py_compile custom_components/thessla_green_modbus/device_scanner.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed68954c8326b6a99fc44b1fd0fc