### PR TITLE
Fix device scanner indentation error

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -622,9 +622,6 @@ class ThesslaGreenDeviceScanner:
                 input_data = await self._read_input(client, addr, 1, skip_cache=True)
                 if not input_data:
                     continue
-                if (
-                    reg_name := self._registers.get("04", {}).get(addr)
-                ) and self._is_valid_register_value(reg_name, input_data[0]):
                 reg_name = self._registers.get("04", {}).get(addr)
                 if reg_name and self._is_valid_register_value(reg_name, input_data[0]):
                     self.available_registers["input_registers"].add(reg_name)
@@ -639,9 +636,6 @@ class ThesslaGreenDeviceScanner:
                 holding_data = await self._read_holding(client, addr, 1, skip_cache=True)
                 if not holding_data:
                     continue
-                if (
-                    reg_name := self._registers.get("03", {}).get(addr)
-                ) and self._is_valid_register_value(reg_name, holding_data[0]):
                 reg_name = self._registers.get("03", {}).get(addr)
                 if reg_name and self._is_valid_register_value(reg_name, holding_data[0]):
                     self.available_registers["holding_registers"].add(reg_name)


### PR DESCRIPTION
## Summary
- avoid indentation error when scanning for input and holding registers

## Testing
- `pytest` *(fails: 219 failed, 100 passed, 1 warning)*
- `pytest tests/test_device_scanner.py` *(fails: 21 failed, 61 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68a4eda0915c83268e5824426a42057d