### PR TITLE
Refactor device scanner into modular components

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -38,7 +38,7 @@ from .const import (
     DEFAULT_DEEP_SCAN,
     DOMAIN,
 )
-from .device_scanner import ThesslaGreenDeviceScanner
+from .scanner_core import ThesslaGreenDeviceScanner
 from .modbus_exceptions import ConnectionException, ModbusException
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -69,7 +69,7 @@ from .const import (
     SENSOR_UNAVAILABLE,
     UNKNOWN_MODEL,
 )
-from .device_scanner import DeviceCapabilities, ThesslaGreenDeviceScanner
+from .scanner_core import DeviceCapabilities, ThesslaGreenDeviceScanner
 from .modbus_client import ThesslaGreenModbusClient
 from .modbus_helpers import _call_modbus
 from .multipliers import REGISTER_MULTIPLIERS

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -12,7 +12,6 @@ from importlib.resources import files
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Dict,
     List,
     Optional,
@@ -39,112 +38,18 @@ from .modbus_exceptions import (
 )
 from .modbus_helpers import _call_modbus
 from .registers import HOLDING_REGISTERS, INPUT_REGISTERS, MULTI_REGISTER_SIZES
-from .utils import (
-    BCD_TIME_PREFIXES,
-    TIME_REGISTER_PREFIXES,
-    _decode_bcd_time,
-    _decode_register_time,
-    _to_snake_case,
+from .utils import BCD_TIME_PREFIXES, TIME_REGISTER_PREFIXES, _to_snake_case
+from .scanner_helpers import (
+    REGISTER_ALLOWED_VALUES,
+    _format_register_value,
+    MAX_BATCH_REGISTERS,
+    UART_OPTIONAL_REGS,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
     from pymodbus.client import AsyncModbusTcpClient
 
 _LOGGER = logging.getLogger(__name__)
-
-# Specific registers may only accept discrete values
-REGISTER_ALLOWED_VALUES: dict[str, set[int]] = {
-    "mode": {0, 1, 2},
-    "season_mode": {0, 1},
-    "special_mode": set(range(0, 12)),
-    "antifreeze_mode": {0, 1},
-}
-
-
-# Registers storing combined airflow and temperature settings
-SETTING_PREFIX = "setting_"
-
-
-def _decode_setting_value(value: int) -> tuple[int, float] | None:
-    """Decode a register storing airflow and temperature as ``0xAATT``.
-
-    ``AA`` is the airflow in percent and ``TT`` is twice the desired supply
-    temperature in degrees Celsius. ``None`` is returned if the value cannot be
-    decoded or falls outside expected ranges.
-    """
-
-    if value < 0:
-        return None
-
-    airflow = (value >> 8) & 0xFF
-    temp_double = value & 0xFF
-
-    if airflow > 100 or temp_double > 200:
-        return None
-
-    return airflow, temp_double / 2
-
-
-def _format_register_value(name: str, value: int) -> int | str:
-    """Return a human-readable representation of a register value."""
-
-    if name == "manual_airing_time_to_start":
-        raw_value = value
-        value = ((value & 0xFF) << 8) | ((value >> 8) & 0xFF)
-        decoded = _decode_register_time(value)
-        if decoded is None:
-            return f"0x{raw_value:04X} (invalid)"
-        return f"{decoded // 60:02d}:{decoded % 60:02d}"
-
-    if name.startswith(BCD_TIME_PREFIXES):
-        decoded = _decode_bcd_time(value)
-        if decoded is None:
-            return f"0x{value:04X} (invalid)"
-        return f"{decoded // 60:02d}:{decoded % 60:02d}"
-
-    if name.startswith(TIME_REGISTER_PREFIXES):
-        decoded = _decode_register_time(value)
-        if decoded is None:
-            return f"0x{value:04X} (invalid)"
-        return f"{decoded // 60:02d}:{decoded % 60:02d}"
-
-    if name.startswith(SETTING_PREFIX):
-        decoded = _decode_setting_value(value)
-        if decoded is None:
-            return value
-        airflow, temp = decoded
-        temp_str = f"{temp:g}"
-        return f"{airflow}% @ {temp_str}°C"
-
-    return value
-
-
-def _decode_season_mode(value: int) -> Optional[int]:
-    """Decode season mode register which may place value in high byte."""
-    if value in (0xFF00, 0xFFFF):
-        return None
-    high = (value >> 8) & 0xFF
-    low = value & 0xFF
-    if high and low:
-        return None
-    return high or low
-
-
-SPECIAL_VALUE_DECODERS: Dict[str, Callable[[int], Optional[int]]] = {
-    "season_mode": _decode_season_mode,
-}
-
-
-# Maximum registers per batch read (Modbus limit)
-MAX_BATCH_REGISTERS = 16
-
-# Optional UART configuration registers (Air-B and Air++ ports)
-# According to the Series 4 Modbus documentation, both the Air-B
-# (0x1164-0x1167) and Air++ (0x1168-0x116B) register blocks are
-# optional and may be absent on devices without the corresponding
-# hardware. They are skipped by default unless UART scanning is
-# explicitly enabled.
-UART_OPTIONAL_REGS = range(0x1164, 0x116C)
 
 
 @dataclass

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -29,7 +29,7 @@ from .const import (
     SPECIAL_MODE_OPTIONS,
 )
 from .entity_mappings import map_legacy_entity_id
-from .device_scanner import ThesslaGreenDeviceScanner
+from .scanner_core import ThesslaGreenDeviceScanner
 from .modbus_exceptions import ConnectionException, ModbusException
 
 if TYPE_CHECKING:

--- a/tests/run_optimization_tests.py
+++ b/tests/run_optimization_tests.py
@@ -67,7 +67,7 @@ async def validate_optimization_metrics():
 
         # Test 2: Device Scanner Efficiency
         print("🔍 Testing device scanner optimization...")
-        from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+        from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 
         scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.modbus_exceptions import (
     ModbusIOException,
 )
@@ -25,7 +25,7 @@ async def test_backoff_delay(func, expected):
     sleep_mock = AsyncMock()
     with (
         patch(
-            "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+            "custom_components.thessla_green_modbus.scanner_core._call_modbus",
             AsyncMock(side_effect=ModbusIOException("boom")),
         ),
         patch("asyncio.sleep", sleep_mock),
@@ -50,7 +50,7 @@ async def test_backoff_zero_no_delay(func, expected):
     sleep_mock = AsyncMock()
     with (
         patch(
-            "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+            "custom_components.thessla_green_modbus.scanner_core._call_modbus",
             AsyncMock(side_effect=ModbusIOException("boom")),
         ),
         patch("asyncio.sleep", sleep_mock),

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -590,7 +590,7 @@ async def test_validate_input_no_data():
     }
 
     with patch(
-        "custom_components.thessla_green_modbus.device_scanner."
+        "custom_components.thessla_green_modbus.scanner_core."
         "ThesslaGreenDeviceScanner.scan_device",
         return_value=None,
     ):
@@ -613,7 +613,7 @@ async def test_validate_input_modbus_exception():
     }
 
     with patch(
-        "custom_components.thessla_green_modbus.device_scanner."
+        "custom_components.thessla_green_modbus.scanner_core."
         "ThesslaGreenDeviceScanner.scan_device",
         side_effect=ModbusException("error"),
     ):

--- a/tests/test_input_range_fallback.py
+++ b/tests/test_input_range_fallback.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, patch
 from types import SimpleNamespace
 
-from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 
 pytestmark = pytest.mark.asyncio
 
@@ -16,7 +16,7 @@ async def test_input_range_read_after_block_failure():
             AsyncMock(return_value=(empty_regs, {})),
         ),
         patch(
-            "custom_components.thessla_green_modbus.device_scanner.KNOWN_MISSING_REGISTERS",
+            "custom_components.thessla_green_modbus.scanner_core.KNOWN_MISSING_REGISTERS",
             {},
         ),
     ):
@@ -47,10 +47,10 @@ async def test_input_range_read_after_block_failure():
         return [False]
 
     with (
-        patch("custom_components.thessla_green_modbus.device_scanner.INPUT_REGISTERS", regs),
-        patch("custom_components.thessla_green_modbus.device_scanner.HOLDING_REGISTERS", {}),
-        patch("custom_components.thessla_green_modbus.device_scanner.COIL_REGISTERS", {}),
-        patch("custom_components.thessla_green_modbus.device_scanner.DISCRETE_INPUT_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.scanner_core.INPUT_REGISTERS", regs),
+        patch("custom_components.thessla_green_modbus.scanner_core.HOLDING_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.scanner_core.COIL_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.scanner_core.DISCRETE_INPUT_REGISTERS", {}),
         patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class,
     ):
         mock_client = AsyncMock()
@@ -59,7 +59,7 @@ async def test_input_range_read_after_block_failure():
 
         with (
             patch(
-                "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+                "custom_components.thessla_green_modbus.scanner_core._call_modbus",
                 side_effect=fake_call_modbus,
             ),
             patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
@@ -115,11 +115,11 @@ async def test_block_exception_allows_single_register_reads():
         return [False]
 
     with (
-        patch("custom_components.thessla_green_modbus.device_scanner.INPUT_REGISTERS", regs),
-        patch("custom_components.thessla_green_modbus.device_scanner.HOLDING_REGISTERS", {}),
-        patch("custom_components.thessla_green_modbus.device_scanner.COIL_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.scanner_core.INPUT_REGISTERS", regs),
+        patch("custom_components.thessla_green_modbus.scanner_core.HOLDING_REGISTERS", {}),
+        patch("custom_components.thessla_green_modbus.scanner_core.COIL_REGISTERS", {}),
         patch(
-            "custom_components.thessla_green_modbus.device_scanner.DISCRETE_INPUT_REGISTERS",
+            "custom_components.thessla_green_modbus.scanner_core.DISCRETE_INPUT_REGISTERS",
             {},
         ),
         patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class,
@@ -130,7 +130,7 @@ async def test_block_exception_allows_single_register_reads():
 
         with (
             patch(
-                "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+                "custom_components.thessla_green_modbus.scanner_core._call_modbus",
                 side_effect=fake_call_modbus,
             ),
             patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -347,7 +347,7 @@ class TestThesslaGreenConfigFlow:
         }
 
         with patch(
-            "custom_components.thessla_green_modbus.device_scanner."
+            "custom_components.thessla_green_modbus.scanner_core."
             "ThesslaGreenDeviceScanner.scan_device",
             return_value=scanner_result,
         ):
@@ -445,9 +445,9 @@ class TestThesslaGreenDeviceScanner:
         return client
 
     @pytest.mark.asyncio
-    async def test_device_scanner_success(self, mock_modbus_client):
+    async def test_scanner_core_success(self, mock_modbus_client):
         """Test successful device scanning."""
-        from custom_components.thessla_green_modbus.device_scanner import (
+        from custom_components.thessla_green_modbus.scanner_core import (
             ThesslaGreenDeviceScanner,
         )
 
@@ -462,9 +462,9 @@ class TestThesslaGreenDeviceScanner:
             assert result["device_info"]["firmware"] == "4.85.2"
 
     @pytest.mark.asyncio
-    async def test_device_scanner_connection_failure(self):
+    async def test_scanner_core_connection_failure(self):
         """Test scanner behavior on connection failure."""
-        from custom_components.thessla_green_modbus.device_scanner import (
+        from custom_components.thessla_green_modbus.scanner_core import (
             ThesslaGreenDeviceScanner,
         )
 
@@ -479,7 +479,7 @@ class TestThesslaGreenDeviceScanner:
 
     def test_register_value_validation(self):
         """Test register value validation logic."""
-        from custom_components.thessla_green_modbus.device_scanner import (
+        from custom_components.thessla_green_modbus.scanner_core import (
             ThesslaGreenDeviceScanner,
         )
 
@@ -518,7 +518,7 @@ class TestThesslaGreenDeviceScanner:
 
     def test_capability_analysis(self):
         """Test capability analysis logic."""
-        from custom_components.thessla_green_modbus.device_scanner import (
+        from custom_components.thessla_green_modbus.scanner_core import (
             ThesslaGreenDeviceScanner,
         )
 
@@ -733,7 +733,7 @@ class TestPerformanceOptimizations:
     @pytest.mark.asyncio
     async def test_scan_optimization_stats(self):
         """Test that device scanner provides optimization statistics."""
-        from custom_components.thessla_green_modbus.device_scanner import (
+        from custom_components.thessla_green_modbus.scanner_core import (
             ThesslaGreenDeviceScanner,
         )
 

--- a/tests/test_read_cancellation.py
+++ b/tests/test_read_cancellation.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
 
 pytestmark = pytest.mark.asyncio
@@ -23,7 +23,7 @@ async def test_read_cancellation_during_sleep(method, caplog):
 
     with (
         patch(
-            "custom_components.thessla_green_modbus.device_scanner._call_modbus",
+            "custom_components.thessla_green_modbus.scanner_core._call_modbus",
             AsyncMock(side_effect=ModbusIOException("boom")),
         ),
         patch("asyncio.sleep", AsyncMock(side_effect=asyncio.CancelledError)),

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -1,6 +1,6 @@
 import pytest
 
-from custom_components.thessla_green_modbus.device_scanner import _decode_setting_value
+from custom_components.thessla_green_modbus.scanner_helpers import _decode_setting_value
 from custom_components.thessla_green_modbus.utils import _decode_bcd_time, _decode_register_time
 
 

--- a/tests/test_register_grouping.py
+++ b/tests/test_register_grouping.py
@@ -1,6 +1,6 @@
 import pytest
 
-from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.registers import INPUT_REGISTERS
 
 

--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
-from custom_components.thessla_green_modbus.device_scanner import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.modbus_exceptions import (
     ConnectionException,
     ModbusException,

--- a/tests/test_unsupported_input_ranges.py
+++ b/tests/test_unsupported_input_ranges.py
@@ -1,6 +1,6 @@
 import logging
 
-from custom_components.thessla_green_modbus.device_scanner import (
+from custom_components.thessla_green_modbus.scanner_core import (
     ThesslaGreenDeviceScanner,
 )
 


### PR DESCRIPTION
## Summary
- Split monolithic device scanner into `scanner_core` and `scanner_helpers`
- Update integration modules and tests to use new scanner modules

## Testing
- `pytest tests/test_device_scanner.py::test_scanner_core_initialization -q`
- `pytest tests/test_device_scanner.py tests/test_scanner_close.py tests/test_read_cancellation.py tests/test_register_grouping.py tests/test_backoff.py tests/test_input_range_fallback.py tests/test_unsupported_input_ranges.py -q` *(fails: ModuleNotFoundError: No module named 'custom_components.thessla_green_modbus')*
- `pytest` *(fails: TypeError: ServiceCall() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f64f6fb48326915394e66962fe11