### PR TITLE
ci: add py_compile syntax check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,3 +67,9 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: py-compile
+        name: Validate Python syntax
+        entry: python tools/py_compile_all.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,9 @@ python run_optimization_tests.py
 # Run unit tests
 python -m pytest tests/ -v
 
+# Verify module syntax
+python tools/py_compile_all.py
+
 # Check code quality
 pre-commit run --all-files
 ```
@@ -286,6 +289,7 @@ vulture custom_components/thessla_green_modbus --min-confidence=80
 
 2. **Run all checks:**
    ```bash
+   python tools/py_compile_all.py
    pre-commit run --all-files
    python -m pytest tests/
    python run_optimization_tests.py

--- a/tools/py_compile_all.py
+++ b/tools/py_compile_all.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Compile all modules to detect syntax errors."""
+from __future__ import annotations
+
+import pathlib
+import py_compile
+import sys
+
+
+def main() -> int:
+    base_dir = pathlib.Path(__file__).resolve().parents[1] / "custom_components" / "thessla_green_modbus"
+    errors: list[str] = []
+    for module in base_dir.rglob("*.py"):
+        try:
+            py_compile.compile(module, doraise=True)
+        except py_compile.PyCompileError as err:
+            errors.append(str(err))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validate.yaml
+++ b/validate.yaml
@@ -22,6 +22,8 @@ jobs:
         run: python tools/generate_registers.py
       - name: Validate register definitions
         run: python tools/validate_registers.py
+      - name: Validate Python syntax
+        run: python tools/py_compile_all.py
       - name: Validate translations
         run: |
           find custom_components -path '*/translations/*.json' -exec python -m json.tool {} \;


### PR DESCRIPTION
## Summary
- add utility script to run `py_compile` across all integration modules
- run syntax compilation in pre-commit and validate workflow
- document the syntax check in CONTRIBUTING

## Testing
- `pre-commit run --files .pre-commit-config.yaml validate.yaml tools/py_compile_all.py CONTRIBUTING.md` *(fails: InvalidManifestError: /root/.cache/pre-commit/reponi89vgr5/.pre-commit-hooks.yaml is not a file)*
- `python tools/py_compile_all.py`
- `pytest -q` *(fails: multiple tests failed: ServiceCall() takes no arguments, KeyError, and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f651917083269cb3237080b02e34