### PR TITLE
Ensure register name block is nested in full scan loop

### DIFF
--- a/custom_components/thessla_green_modbus/device_scanner.py
+++ b/custom_components/thessla_green_modbus/device_scanner.py
@@ -622,6 +622,7 @@ class ThesslaGreenDeviceScanner:
                 input_data = await self._read_input(client, addr, 1, skip_cache=True)
                 if not input_data:
                     continue
+
                 reg_name = self._registers.get("04", {}).get(addr)
                 if reg_name and self._is_valid_register_value(reg_name, input_data[0]):
                     self.available_registers["input_registers"].add(reg_name)


### PR DESCRIPTION
## Summary
- keep `reg_name` block indented within full register scan loop

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/device_scanner.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repos803cmzv/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_device_scanner.py` *(fails: AssertionError: assert 1 == 3)*


------
https://chatgpt.com/codex/tasks/task_e_68a4f65532988326b250d180c8f61499