### PR TITLE
Skip diagnostic registers in number mappings

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -163,6 +163,8 @@ def _load_number_mappings() -> dict[str, dict[str, Any]]:
         info = _get_register_info(register)
         if not info:
             continue
+        if register.startswith(("s_", "e_", "alarm", "error")):
+            continue
         if _parse_states(info.get("unit")):
             continue
         if info.get("min") is None and info.get("max") is None:

--- a/tests/test_entity_mappings_completeness.py
+++ b/tests/test_entity_mappings_completeness.py
@@ -1,7 +1,11 @@
 import csv
 from pathlib import Path
 
-from custom_components.thessla_green_modbus.entity_mappings import ENTITY_MAPPINGS
+from custom_components.thessla_green_modbus.entity_mappings import (
+    ENTITY_MAPPINGS,
+    BINARY_SENSOR_ENTITY_MAPPINGS,
+    NUMBER_ENTITY_MAPPINGS,
+)
 from custom_components.thessla_green_modbus.utils import _to_snake_case
 
 CSV_PATH = (
@@ -67,3 +71,8 @@ def test_entity_mappings_cover_all_registers() -> None:
     assert not missing, f"Unknown registers in ENTITY_MAPPINGS: {sorted(missing)}"
     unmapped = csv_names - mapping_names
     assert not unmapped, f"Registers missing entity mapping: {sorted(unmapped)}"
+
+
+def test_s_13_is_binary_only() -> None:
+    assert "s_13" not in NUMBER_ENTITY_MAPPINGS
+    assert "s_13" in BINARY_SENSOR_ENTITY_MAPPINGS


### PR DESCRIPTION
## Summary
- avoid creating number entities for diagnostic registers (`s_`, `e_`, `alarm`, `error`)
- add test ensuring `s_13` is only exposed as a binary sensor

## Testing
- `pytest tests/test_entity_mappings_completeness.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a585c00eec83268accefcfd53aab5a