### PR TITLE
Ensure numbers created only for discovered registers

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -174,7 +174,8 @@ def _load_number_mappings() -> dict[str, dict[str, Any]]:
             "step": info.get("step", 1),
             "scale": info.get("scale", 1),
         }
-    number_configs.update(NUMBER_OVERRIDES)
+    for register, override in NUMBER_OVERRIDES.items():
+        number_configs.setdefault(register, {}).update(override)
     return number_configs
 
 # Manual overrides for number entities (icons, custom units, etc.)
@@ -205,6 +206,13 @@ NUMBER_OVERRIDES: dict[str, dict[str, Any]] = {
     "max_gwc_air_temperature": {"icon": "mdi:thermometer-high"},
     "gwc_regen_period": {"icon": "mdi:timer"},
     "delta_t_gwc": {"icon": "mdi:thermometer-lines"},
+    # Date/time registers
+    "date_time_1": {
+        "unit": "RRMM",
+        "min": 0,
+        "max": 99,
+        "step": 1,
+    },
 }
 
 

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -53,23 +53,16 @@ async def async_setup_entry(
         _LOGGER.debug("No number entity mappings found; skipping setup")
         return
 
-    # Create number entities for writable registers discovered by
+    # Create number entities only for registers discovered by
     # ThesslaGreenDeviceScanner.scan_device()
     for register_name, entity_config in number_mappings.items():
-        register_type = None
-
         if register_name in coordinator.available_registers.get("holding_registers", set()):
-            register_type = "holding_registers"
-        elif register_name in HOLDING_REGISTERS:
-            register_type = "holding_registers"
-
-        if register_type is not None:
             entities.append(
                 ThesslaGreenNumber(
                     coordinator=coordinator,
                     register_name=register_name,
                     entity_config=entity_config,
-                    register_type=register_type,
+                    register_type="holding_registers",
                 )
             )
             _LOGGER.debug("Created number entity: %s", register_name)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -237,6 +237,18 @@ async def test_async_setup_creates_new_numbers(mock_coordinator, mock_config_ent
     assert {"max_supply_air_flow_rate", "bypass_off"} <= names
 
 
+@pytest.mark.asyncio
+async def test_async_setup_skips_missing_numbers(mock_coordinator, mock_config_entry):
+    """Ensure no number entities are created when registers aren't detected."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {mock_config_entry.entry_id: mock_coordinator}}
+    mock_coordinator.available_registers = {"holding_registers": set()}
+
+    add_entities = MagicMock()
+    await async_setup_entry(hass, mock_config_entry, add_entities)
+    add_entities.assert_not_called()
+
+
 def test_air_flow_rate_manual_from_csv(mock_coordinator):
     """Verify air_flow_rate_manual uses CSV-defined unit and range."""
     mock_coordinator.data["air_flow_rate_manual"] = 30


### PR DESCRIPTION
## Summary
- create number entities only when their registers are reported by the coordinator
- preserve CSV metadata when applying overrides and add explicit `date_time_1` mapping
- test that missing registers skip number entity creation

## Testing
- `pytest tests/test_number.py`


------
https://chatgpt.com/codex/tasks/task_e_68a585c7958c83269fd30fec1419d9dd