### PR TITLE
Provide default icon for autogenerated switches

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -254,6 +254,7 @@ def _load_discrete_mappings() -> tuple[
         if len(states) == 2 and set(states.values()) == {0, 1}:
             if "W" in access:
                 cfg["register"] = reg
+                cfg.setdefault("icon", "mdi:toggle-switch")
                 switch_configs[reg] = cfg
             else:
                 binary_configs[reg] = cfg

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -94,7 +94,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
 
         # Entity configuration
         self._attr_translation_key = entity_config["translation_key"]
-        self._attr_icon = entity_config["icon"]
+        self._attr_icon = entity_config.get("icon", "mdi:toggle-switch")
 
         # Set entity category if specified
         if entity_config.get("category"):


### PR DESCRIPTION
## Summary
- set default toggle switch icon for autogenerated switch configs
- use default toggle icon when no icon provided for switch entity

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/switch.py custom_components/thessla_green_modbus/entity_mappings.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoxtui8awq/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 218 failed, 103 passed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a58cd95e988326ac35b7b600c78cd1