### PR TITLE
Fix switch icon default and test missing icon

### DIFF
--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -94,7 +94,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
 
         # Entity configuration
         self._attr_translation_key = entity_config["translation_key"]
-        self._attr_icon = entity_config["icon"]
+        self._attr_icon = entity_config.get("icon", "mdi:toggle-switch")
 
         # Set entity category if specified
         if entity_config.get("category"):


### PR DESCRIPTION
## Summary
- default icon to `mdi:toggle-switch` when switch mapping omits one
- test that switch setup works without an explicit icon

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/switch.py tests/test_switch.py` *(fails: InvalidManifestError)*
- `pytest tests/test_switch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58ce9b96c8326860095c091eddae7