### PR TITLE
feat: add aggregated error codes sensor

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -1,4 +1,7 @@
-"""Diagnostics platform for the ThesslaGreen Modbus integration."""
+"""Diagnostics platform for the ThesslaGreen Modbus integration.
+
+Includes the same translated error codes as exposed by the ``error_codes`` sensor.
+"""
 
 from __future__ import annotations
 

--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -1,6 +1,7 @@
 # Complete services for ThesslaGreen Modbus Integration
 # Compatibility: Home Assistant 2025.7.1+ & pymodbus 3.5.*+
 # All models: ThesslaGreen AirPack Home series 4
+# Active device faults are exposed via the ``sensor.error_codes`` entity
 
 set_special_mode:
   name: Set Special Mode

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1056,6 +1056,9 @@
       "cf_version": {
         "name": "CF Module Version"
       },
+      "error_codes": {
+        "name": "Error codes"
+      },
       "comfort_mode": {
         "name": "Comfort Mode Status"
       },

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1037,6 +1037,9 @@
       "cf_version": {
         "name": "CF Module Version"
       },
+      "error_codes": {
+        "name": "Error codes"
+      },
       "comfort_mode": {
         "name": "Comfort Mode Status"
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1037,6 +1037,9 @@
       "cf_version": {
         "name": "Wersja modułu CF"
       },
+      "error_codes": {
+        "name": "Kody błędów"
+      },
       "comfort_mode": {
         "name": "Tryb komfort"
       },

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -3,7 +3,7 @@
 import asyncio
 import sys
 import types
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
 # Minimal Home Assistant stubs
@@ -87,6 +87,10 @@ class DataUpdateCoordinator:  # pragma: no cover - minimal stub
     async def async_shutdown(self):  # pragma: no cover - stub
         return None
 
+    @classmethod
+    def __class_getitem__(cls, item):  # pragma: no cover - allow subscripting
+        return cls
+
 
 class UpdateFailed(Exception):  # pragma: no cover - simple stub
     pass
@@ -115,6 +119,7 @@ from custom_components.thessla_green_modbus.select import (  # noqa: E402
 )
 from custom_components.thessla_green_modbus.sensor import (  # noqa: E402
     SENSOR_DEFINITIONS,
+    ThesslaGreenErrorCodesSensor,
     ThesslaGreenSensor,
     async_setup_entry,
 )
@@ -144,7 +149,10 @@ def test_async_setup_creates_all_sensors(mock_coordinator, mock_config_entry):
         await async_setup_entry(hass, mock_config_entry, add_entities)
 
         entities = add_entities.call_args[0][0]
-        assert len(entities) == len(SENSOR_DEFINITIONS)  # nosec B101
+        assert any(
+            isinstance(e, ThesslaGreenErrorCodesSensor) for e in entities
+        )  # nosec B101
+        assert len(entities) == len(SENSOR_DEFINITIONS) + 1  # nosec B101
 
     asyncio.run(run_test())
 
@@ -169,10 +177,38 @@ def test_sensors_have_native_units(mock_coordinator, mock_config_entry):
 
         entities = add_entities.call_args[0][0]
         for entity in entities:
+            if getattr(entity, "_register_name", None) == "error_codes":
+                continue
             expected = SENSOR_DEFINITIONS[entity._register_name].get("unit")
             assert (
                 getattr(entity, "_attr_native_unit_of_measurement", None) == expected
             )  # nosec B101
+
+    asyncio.run(run_test())
+
+
+def test_error_codes_sensor_translates_active_registers(
+    mock_coordinator, mock_config_entry
+):
+    """Error sensor returns translated active codes."""
+
+    async def run_test() -> None:
+        hass = MagicMock()
+        hass.config.language = "en"
+        hass.data = {DOMAIN: {mock_config_entry.entry_id: mock_coordinator}}
+        mock_coordinator.data["e_100"] = 1
+        mock_coordinator.available_registers.setdefault("holding_registers", set()).add(
+            "e_100"
+        )
+        add_entities = MagicMock()
+        with patch(
+            "custom_components.thessla_green_modbus.sensor.translation.async_get_translations",
+            return_value={"errors.e_100": "Device error E 100"},
+        ):
+            await async_setup_entry(hass, mock_config_entry, add_entities)
+        entities = add_entities.call_args[0][0]
+        sensor = next(e for e in entities if isinstance(e, ThesslaGreenErrorCodesSensor))
+        assert sensor.native_value == "Device error E 100"  # nosec B101
 
     asyncio.run(run_test())
 
@@ -208,8 +244,9 @@ def test_sensor_value_map(mock_coordinator, mock_config_entry):
 
         add_entities = MagicMock()
         await async_setup_entry(hass, mock_config_entry, add_entities)
-
-        sensor = add_entities.call_args[0][0][0]
+        sensor = next(
+            e for e in add_entities.call_args[0][0] if getattr(e, "_register_name", "") == "mode"
+        )
         assert sensor.native_value == "auto"
 
         mock_coordinator.data["mode"] = 2

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -119,7 +119,9 @@ from custom_components.thessla_green_modbus.sensor import (  # noqa: E402
     SENSOR_DEFINITIONS,
 )
 
-SENSOR_KEYS = [v["translation_key"] for v in SENSOR_DEFINITIONS.values()]
+SENSOR_KEYS = [v["translation_key"] for v in SENSOR_DEFINITIONS.values()] + [
+    "error_codes"
+]
 BINARY_KEYS = _load_translation_keys(
     ROOT / "entity_mappings.py", "BINARY_SENSOR_ENTITY_MAPPINGS"
 )


### PR DESCRIPTION
## Summary
- add `error_codes` sensor aggregating `e_*` registers
- document `sensor.error_codes` in diagnostics and services docs
- test translation of active error codes

## Testing
- `pytest tests/test_sensor_platform.py::test_error_codes_sensor_translates_active_registers -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58ce8b9bc832698ad559457dbd60d