### PR TITLE
Handle encoded register ranges

### DIFF
--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -1,5 +1,7 @@
+import asyncio
 import pytest
 
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.scanner_helpers import _decode_setting_value
 from custom_components.thessla_green_modbus.utils import _decode_bcd_time, _decode_register_time
 
@@ -49,3 +51,12 @@ def test_decode_setting_value_valid():
 def test_decode_setting_value_invalid(value):
     """Values outside expected ranges should return None."""
     assert _decode_setting_value(value) is None
+
+
+def test_schedule_and_setting_defaults_valid():
+    """Default schedule and setting values should pass range validation."""
+    scanner = ThesslaGreenDeviceScanner("127.0.0.1", 502)
+    _, ranges, _ = asyncio.run(scanner._load_registers())
+    scanner._register_ranges = ranges
+    assert scanner._is_valid_register_value("schedule_winter_sun_3", 0x1000)
+    assert scanner._is_valid_register_value("setting_summer_mon_1", 0x4100)


### PR DESCRIPTION
## Summary
- Convert BCD time and AATT setting ranges from CSV into raw encodings before validation
- Validate BCD times and accept default schedule/setting values
- Add tests ensuring encoded schedule and setting registers pass range checks

## Testing
- `pytest tests/test_register_decoders.py -q`
- `pre-commit run --files custom_components/thessla_green_modbus/scanner_core.py tests/test_register_decoders.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo5ahtw7g9/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a59e47cda08326bef74c403cd7bcf4