### PR TITLE
Fix switch block indentation

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -282,14 +282,13 @@ def _load_discrete_mappings() -> tuple[
         cfg: dict[str, Any] = {"translation_key": reg, "register_type": "holding_registers"}
         if len(states) == 2 and set(states.values()) == {0, 1}:
             if "W" in access:
-
                 if reg in switch_keys:
-                cfg["register"] = reg
-                cfg.setdefault("icon", "mdi:toggle-switch")
-                switch_configs[reg] = cfg
-            else:
-                if reg in binary_keys:
-                    binary_configs[reg] = cfg
+                    cfg["register"] = reg
+                    cfg.setdefault("icon", "mdi:toggle-switch")
+                    switch_configs[reg] = cfg
+                else:
+                    if reg in binary_keys:
+                        binary_configs[reg] = cfg
         else:
             if reg in select_keys:
                 cfg["states"] = states


### PR DESCRIPTION
## Summary
- remove stray blank line and fix switch indentation in entity mappings

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity_mappings.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repofurau9iz/.pre-commit-hooks.yaml is not a file)*
- `python -m py_compile custom_components/thessla_green_modbus/entity_mappings.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59e53659483269d84fc14a77f95b2