### PR TITLE
Fix switch condition indentation

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -282,11 +282,10 @@ def _load_discrete_mappings() -> tuple[
         cfg: dict[str, Any] = {"translation_key": reg, "register_type": "holding_registers"}
         if len(states) == 2 and set(states.values()) == {0, 1}:
             if "W" in access:
-
                 if reg in switch_keys:
-                cfg["register"] = reg
-                cfg.setdefault("icon", "mdi:toggle-switch")
-                switch_configs[reg] = cfg
+                    cfg["register"] = reg
+                    cfg.setdefault("icon", "mdi:toggle-switch")
+                    switch_configs[reg] = cfg
             else:
                 if reg in binary_keys:
                     binary_configs[reg] = cfg


### PR DESCRIPTION
## Summary
- fix indentation for switch configuration in `entity_mappings`

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity_mappings.py` *(fails: InvalidManifestError)*
- `python -m py_compile custom_components/thessla_green_modbus/entity_mappings.py`
- `python - <<'PY'
import custom_components.thessla_green_modbus.entity_mappings as m
print('module loaded', bool(m))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a59e5680ec83268bbddd0a1e4512e2