### PR TITLE
Expand error code sensors to include status registers

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -1,6 +1,6 @@
 """Diagnostics platform for the ThesslaGreen Modbus integration.
 
-Includes the same translated error codes as exposed by the ``error_codes`` sensor.
+Includes the same translated error and status codes as exposed by the ``error_codes`` sensor.
 """
 
 from __future__ import annotations
@@ -46,7 +46,7 @@ async def async_get_config_entry_diagnostics(
     if coordinator.data:
         for key, value in coordinator.data.items():
             if value and (key.startswith("e_") or key.startswith("s_")):
-                active_errors[key] = translations.get(f"errors.{key}", key)
+                active_errors[key] = translations.get(f"codes.{key}", key)
     if active_errors:
         diagnostics["active_errors"] = active_errors
 

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1057,7 +1057,7 @@
         "name": "CF Module Version"
       },
       "error_codes": {
-        "name": "Error codes"
+        "name": "Error and status codes"
       },
       "comfort_mode": {
         "name": "Comfort Mode Status"
@@ -1314,7 +1314,7 @@
       }
     }
   },
-  "errors": {
+  "codes": {
     "e_100": "Device error E 100",
     "e_101": "Device error E 101",
     "e_102": "Device error E 102",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1038,7 +1038,7 @@
         "name": "CF Module Version"
       },
       "error_codes": {
-        "name": "Error codes"
+        "name": "Error and status codes"
       },
       "comfort_mode": {
         "name": "Comfort Mode Status"
@@ -1259,7 +1259,7 @@
       }
     }
   },
-  "errors": {
+  "codes": {
     "e_100": "Device error E 100",
     "e_101": "Device error E 101",
     "e_102": "Device error E 102",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1038,7 +1038,7 @@
         "name": "Wersja modułu CF"
       },
       "error_codes": {
-        "name": "Kody błędów"
+        "name": "Kody błędów i statusów"
       },
       "comfort_mode": {
         "name": "Tryb komfort"
@@ -1259,7 +1259,7 @@
       }
     }
   },
-  "errors": {
+  "codes": {
     "e_100": "Błąd urządzenia E 100",
     "e_101": "Błąd urządzenia E 101",
     "e_102": "Błąd urządzenia E 102",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -140,8 +140,8 @@ BINARY_KEYS = sorted(
         if k in {"alarm", "error"} or k.startswith("s_") or k.startswith("e_")
     }
 )
-# Error codes translations are not currently enforced
-ERROR_KEYS: list[str] = []
+# Error/status code translations are not currently enforced
+CODE_KEYS: list[str] = []
 ISSUE_KEYS = ["modbus_write_failed"]
 
 
@@ -169,12 +169,12 @@ def _assert_keys(trans, entity_type, keys):
     assert not extra, f"Extra {entity_type} translations: {extra}"  # nosec B101
 
 
-def _assert_error_keys(trans, keys):
-    section = trans.get("errors")
+def _assert_code_keys(trans, keys):
+    section = trans.get("codes")
     if not section:
         return
     missing = [k for k in keys if k not in section]
-    assert not missing, f"Missing error translations: {missing}"  # nosec B101
+    assert not missing, f"Missing code translations: {missing}"  # nosec B101
 
 
 def _assert_issue_keys(trans, keys):
@@ -197,8 +197,8 @@ def test_translation_keys_present():
         _assert_keys(trans, "select", SELECT_KEYS)
         if NUMBER_KEYS:
             _assert_keys(trans, "number", NUMBER_KEYS)
-        if "errors" in trans:
-            _assert_error_keys(trans, ERROR_KEYS)
+        if "codes" in trans:
+            _assert_code_keys(trans, CODE_KEYS)
         _assert_issue_keys(trans, ISSUE_KEYS)
         missing_services = [s for s in SERVICES if s not in trans["services"]]
         assert (

--- a/tests/test_unused_translations.py
+++ b/tests/test_unused_translations.py
@@ -4,7 +4,7 @@ from custom_components.thessla_green_modbus.const import SPECIAL_FUNCTION_MAP
 from tests.test_translations import (
     BINARY_KEYS,
     EN,
-    ERROR_KEYS,
+    CODE_KEYS,
     ISSUE_KEYS,
     NUMBER_KEYS,
     PL,
@@ -31,8 +31,8 @@ def test_no_unused_translation_keys() -> None:
         _assert_no_extra_keys(trans, "select", SELECT_KEYS)
         _assert_no_extra_keys(trans, "number", NUMBER_KEYS)
 
-        extra_errors = [k for k in trans.get("errors", {}) if k not in ERROR_KEYS]
-        assert not extra_errors, f"Unused error translations: {extra_errors}"  # nosec B101
+        extra_codes = [k for k in trans.get("codes", {}) if k not in CODE_KEYS]
+        assert not extra_codes, f"Unused code translations: {extra_codes}"  # nosec B101
 
         extra_issues = [k for k in trans.get("issues", {}) if k not in ISSUE_KEYS]
         assert not extra_issues, f"Unused issue translations: {extra_issues}"  # nosec B101


### PR DESCRIPTION
## Summary
- expand error code sensor to handle both E and S register prefixes
- rename error translation mapping to generic `codes`
- update diagnostics and tests for new code mapping

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/diagnostics.py custom_components/thessla_green_modbus/sensor.py custom_components/thessla_green_modbus/strings.json custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json tests/test_translations.py tests/test_unused_translations.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repocdkh8t_e/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 218 failed, async plugin required)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d89f73648326b2670d868f634b2b