### PR TITLE
docs: update error code sensor name

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ automation:
 ```
 
 ### Monitoring błędów
+Czujnik `sensor.thessla_error_codes` agreguje zarówno kody błędów (`E*`), jak i kody statusowe (`S*`).
 ```yaml
 automation:
   - alias: "Alarm przy błędach"
@@ -306,7 +307,7 @@ automation:
           title: "🚨 ThesslaGreen Error"
           message: >
             Wykryto błąd systemu wentylacji!
-            Kod błędu: {{ states('sensor.thessla_error_code') }}
+            Kod błędu: {{ states('sensor.thessla_error_codes') }}
       - service: light.turn_on
         target:
           entity_id: light.salon_led

--- a/README_en.md
+++ b/README_en.md
@@ -142,6 +142,7 @@ data:
 ```
 
 ### Error monitoring
+The `sensor.thessla_error_codes` sensor aggregates both error codes (`E*`) and status codes (`S*`).
 ```yaml
 automation:
   - alias: "Alarm on errors"
@@ -155,7 +156,7 @@ automation:
           title: "🚨 ThesslaGreen Error"
           message: >
             Ventilation system error detected!
-            Error code: {{ states('sensor.thessla_error_code') }}
+            Error code: {{ states('sensor.thessla_error_codes') }}
       - service: light.turn_on
         target:
           entity_id: light.living_room_led


### PR DESCRIPTION
## Summary
- document that `sensor.thessla_error_codes` aggregates both error and status codes
- rename references from `sensor.thessla_error_code` to `sensor.thessla_error_codes`

## Testing
- `python -m pre_commit run --files README_en.md README.md` *(fails: InvalidManifestError)*
- `pytest` *(fails: SyntaxError in sensor.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dd2ed9648326a450cf99b3a8f3bc