### PR TITLE
refactor error sensor attributes

### DIFF
--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -235,7 +235,6 @@ class ThesslaGreenErrorCodesSensor(ThesslaGreenEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """List active error/status register keys."""
         active = [
-            key for key, value in self.coordinator.data.items() if key.startswith("e_") and value
             key
             for key, value in self.coordinator.data.items()
             if (key.startswith("e_") or key.startswith("s_")) and value
@@ -276,9 +275,6 @@ class ThesslaGreenActiveErrorsSensor(ThesslaGreenEntity, SensorEntity):
         """Return list of raw active error/status codes for debugging."""
         codes = [
             code
-        """Return mapping of codes to translated descriptions."""
-        errors = {
-            code: self._translations.get(f"codes.{code}", code)
             for code, value in self.coordinator.data.items()
             if value and (code.startswith("e_") or code.startswith("s_"))
         ]


### PR DESCRIPTION
## Summary
- fix duplicated error/status comprehension
- simplify active errors sensor attributes

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/sensor.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repow3721qyw/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: tests/test_sensor_platform.py::test_sensor_value_map - RuntimeError: coroutine raised StopIteration, tests/test_sensor_platform.py::test_select_and_sensor_share_register - assert False, tests/test_sensor_register_mapping.py::test_sensor_register_mapping - AssertionError: assert 'supply_air_flow' in {'am..., ...`

------
https://chatgpt.com/codex/tasks/task_e_68a5dd1940fc8326a8a8d29cbb77bc1c