### PR TITLE
Expose translated active error codes

### DIFF
--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -225,7 +225,7 @@ class ThesslaGreenErrorCodesSensor(ThesslaGreenEntity, SensorEntity):
     def native_value(self) -> str | None:
         """Return comma-separated translated active error/status codes."""
         errors = [
-            self._translations.get(f"codes.{key}", key)
+            self._translations.get(f"errors.{key}", key)
             for key, value in self.coordinator.data.items()
             if (key.startswith("e_") or key.startswith("s_")) and value
         ]
@@ -235,7 +235,6 @@ class ThesslaGreenErrorCodesSensor(ThesslaGreenEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """List active error/status register keys."""
         active = [
-            key for key, value in self.coordinator.data.items() if key.startswith("e_") and value
             key
             for key, value in self.coordinator.data.items()
             if (key.startswith("e_") or key.startswith("s_")) and value
@@ -273,13 +272,14 @@ class ThesslaGreenActiveErrorsSensor(ThesslaGreenEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return list of raw active error/status codes for debugging."""
-        codes = [
+        """Return mapping of active error/status codes to descriptions."""
+        codes = sorted(
             code
-        """Return mapping of codes to translated descriptions."""
-        errors = {
-            code: self._translations.get(f"codes.{code}", code)
             for code, value in self.coordinator.data.items()
             if value and (code.startswith("e_") or code.startswith("s_"))
-        ]
-        return {"errors": sorted(codes)} if codes else {}
+        )
+        if not codes:
+            return {}
+
+        errors = {code: self._translations.get(f"errors.{code}", code) for code in codes}
+        return {"errors": errors, "codes": codes}

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -340,6 +340,9 @@ def test_active_errors_sensor(mock_coordinator, mock_config_entry):
             sensor.hass = hass
             await sensor.async_added_to_hass()
             assert sensor.native_value == "Outside temp sensor missing"
-            assert sensor.extra_state_attributes["errors"] == ["e_100"]
+            assert sensor.extra_state_attributes["errors"] == {
+                "e_100": "Outside temp sensor missing"
+            }
+            assert sensor.extra_state_attributes["codes"] == ["e_100"]
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Map active error and status codes to translated descriptions
- Fix error code sensor to use `errors.*` translation keys
- Test active error sensor attributes

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/sensor.py tests/test_sensor_platform.py` *(fails: InvalidManifestError: .../.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_sensor_platform.py::test_error_codes_sensor_translates_active_registers tests/test_sensor_platform.py::test_active_errors_sensor -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5dd1d92cc832691c7e11aca54fb3c