### PR TITLE
Ensure diagnostic registers mapped before register info lookup

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -1041,18 +1041,6 @@ def _extend_entity_mappings_from_csv() -> None:
         if register in SELECT_ENTITY_MAPPINGS:
             continue
 
-        info = get_register_info(register)
-        if not info:
-            continue
-
-        access = info.get("access", "") or ""
-        min_val = info.get("min")
-        max_val = info.get("max")
-        unit = info.get("unit")
-        info_text = info.get("information") or ""
-        scale = info.get("scale", 1)
-        step = info.get("step", scale)
-
         if (
             register in {"alarm", "error"}
             or register.startswith("s_")
@@ -1068,6 +1056,18 @@ def _extend_entity_mappings_from_csv() -> None:
                 },
             )
             continue
+
+        info = get_register_info(register)
+        if not info:
+            continue
+
+        access = info.get("access", "") or ""
+        min_val = info.get("min")
+        max_val = info.get("max")
+        unit = info.get("unit")
+        info_text = info.get("information") or ""
+        scale = info.get("scale", 1)
+        step = info.get("step", scale)
 
         if min_val is not None and max_val is not None:
             if max_val <= 1:


### PR DESCRIPTION
## Summary
- map alarm/error and S_/E_ registers before querying register metadata
- ensure diagnostic registers are always added as binary sensors

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity_mappings.py` *(fails: InvalidManifestError)*
- `pytest tests/test_binary_sensor.py::test_dynamic_problem_registers_present tests/test_binary_sensor.py::test_dynamic_register_entity_creation tests/test_sensor_platform.py::test_active_errors_sensor -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5e2e7c4cc8326b6255e62a43ee0eb