### PR TITLE
Use codes namespace for error translations

### DIFF
--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -225,7 +225,7 @@ class ThesslaGreenErrorCodesSensor(ThesslaGreenEntity, SensorEntity):
     def native_value(self) -> str | None:
         """Return comma-separated translated active error/status codes."""
         errors = [
-            self._translations.get(f"errors.{key}", key)
+            self._translations.get(f"codes.{key}", key)
             for key, value in self.coordinator.data.items()
             if (key.startswith("e_") or key.startswith("s_")) and value
         ]
@@ -267,7 +267,7 @@ class ThesslaGreenActiveErrorsSensor(ThesslaGreenEntity, SensorEntity):
             for key, value in self.coordinator.data.items()
             if value and (key.startswith("e_") or key.startswith("s_"))
         ]
-        labels = [self._translations.get(f"errors.{code}", code) for code in codes]
+        labels = [self._translations.get(f"codes.{code}", code) for code in codes]
         return ", ".join(sorted(labels)) if labels else None
 
     @property
@@ -281,5 +281,5 @@ class ThesslaGreenActiveErrorsSensor(ThesslaGreenEntity, SensorEntity):
         if not codes:
             return {}
 
-        errors = {code: self._translations.get(f"errors.{code}", code) for code in codes}
+        errors = {code: self._translations.get(f"codes.{code}", code) for code in codes}
         return {"errors": errors, "codes": codes}


### PR DESCRIPTION
## Summary
- switch error translation lookups from `errors.*` to `codes.*` in ThesslaGreen sensors

## Testing
- `pytest` *(fails: KeyError: 'translation_flatten_cache' and other assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e2e70130832696f2d5dd27433903