### PR TITLE
feat: add json register spec and warn on csv

### DIFF
--- a/custom_components/thessla_green_modbus/data/modbus_registers.py
+++ b/custom_components/thessla_green_modbus/data/modbus_registers.py
@@ -1,8 +1,10 @@
-"""Helpers for accessing Modbus register metadata from CSV."""
+"""Helpers for accessing Modbus register metadata from bundled specification."""
 
 from __future__ import annotations
 
 import csv
+import json
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
@@ -11,13 +13,17 @@ from ..utils import _to_snake_case
 __all__ = ["get_register_info", "get_register_infos"]
 
 _REGISTER_CACHE: Dict[str, Dict[str, Any]] | None = None
+_JSON_CACHE: list[Dict[str, Any]] | None = None
+_CSV_WARNING_LOGGED = False
+
+_LOGGER = logging.getLogger(__name__)
 
 
-def _parse_number(value: str | None) -> float | None:
-    """Convert a CSV field to a float if possible."""
+def _parse_number(value: Any) -> float | None:
+    """Convert a value to a float if possible."""
     if value is None:
         return None
-    value = value.strip()
+    value = str(value).strip()
     if not value:
         return None
     try:
@@ -30,12 +36,68 @@ def _parse_number(value: str | None) -> float | None:
             return None
 
 
+def _warn_csv_usage() -> None:
+    """Log a warning if the deprecated CSV is used."""
+    global _CSV_WARNING_LOGGED
+    if not _CSV_WARNING_LOGGED:
+        _LOGGER.warning("Loading register metadata from deprecated CSV file")
+        _CSV_WARNING_LOGGED = True
+
+
+def _load_json_registers() -> list[Dict[str, Any]] | None:
+    """Load registers from the bundled JSON specification."""
+    global _JSON_CACHE
+    if _JSON_CACHE is not None:
+        return _JSON_CACHE
+    json_path = (
+        Path(__file__).resolve().parent.parent
+        / "registers"
+        / "thessla_green_registers_full.json"
+    )
+    if not json_path.exists():
+        return None
+    with json_path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    _JSON_CACHE = data.get("registers", [])
+    return _JSON_CACHE
+
+
 def _load_registers() -> Dict[str, Dict[str, Any]]:
-    """Load register metadata from the bundled CSV file."""
+    """Load register metadata from the bundled JSON or CSV file."""
     global _REGISTER_CACHE
     if _REGISTER_CACHE is not None:
         return _REGISTER_CACHE
 
+    json_regs = _load_json_registers()
+    if json_regs is not None:
+        registers: Dict[str, Dict[str, Any]] = {}
+        for reg in json_regs:
+            name = _to_snake_case(reg.get("name", ""))
+            scale = (
+                _parse_number(reg.get("multiplier"))
+                or _parse_number(reg.get("scale"))
+                or 1
+            )
+            registers[name] = {
+                "function_code": reg.get("function"),
+                "address_hex": reg.get("address_hex"),
+                "address_dec": _parse_number(reg.get("address_dec")),
+                "access": reg.get("access"),
+                "description": reg.get("description"),
+                "min": _parse_number(reg.get("min")),
+                "max": _parse_number(reg.get("max")),
+                "default": _parse_number(reg.get("default")),
+                "scale": scale,
+                "step": scale,
+                "unit": reg.get("unit"),
+                "information": reg.get("information"),
+                "software_version": reg.get("software_version"),
+                "notes": reg.get("notes"),
+            }
+        _REGISTER_CACHE = registers
+        return registers
+
+    _warn_csv_usage()
     csv_path = Path(__file__).with_name("modbus_registers.csv")
     registers: Dict[str, Dict[str, Any]] = {}
     with csv_path.open(encoding="utf-8", newline="") as csvfile:
@@ -70,23 +132,49 @@ def get_register_info(register_name: str) -> Dict[str, Any] | None:
 
     The ``register_name`` should be provided in snake_case form. The returned
     dictionary includes fields like ``min``, ``max``, ``step`` and ``scale``.
-    Returns ``None`` if the register is not found in the CSV.
+    Returns ``None`` if the register is not found.
     """
     registers = _load_registers()
     return registers.get(register_name)
 
 
 def get_register_infos(register_name: str) -> list[Dict[str, Any]]:
-    """Return metadata for all registers matching a name.
+    """Return metadata for all registers matching a name."""
 
-    Some registers such as ``date_time`` span multiple consecutive Modbus
-    addresses but share the same name in the CSV specification.  This helper
-    returns metadata for each matching row preserving their order so callers
-    can create individual mappings (e.g. ``date_time_1`` ... ``date_time_4``).
-    """
-
-    csv_path = Path(__file__).with_name("modbus_registers.csv")
+    json_regs = _load_json_registers()
     results: list[Dict[str, Any]] = []
+    if json_regs is not None:
+        for reg in json_regs:
+            name = _to_snake_case(reg.get("name", ""))
+            if name != register_name:
+                continue
+            scale = (
+                _parse_number(reg.get("multiplier"))
+                or _parse_number(reg.get("scale"))
+                or 1
+            )
+            results.append(
+                {
+                    "function_code": reg.get("function"),
+                    "address_hex": reg.get("address_hex"),
+                    "address_dec": _parse_number(reg.get("address_dec")),
+                    "access": reg.get("access"),
+                    "description": reg.get("description"),
+                    "min": _parse_number(reg.get("min")),
+                    "max": _parse_number(reg.get("max")),
+                    "default": _parse_number(reg.get("default")),
+                    "scale": scale,
+                    "step": scale,
+                    "unit": reg.get("unit"),
+                    "information": reg.get("information"),
+                    "software_version": reg.get("software_version"),
+                    "notes": reg.get("notes"),
+                }
+            )
+        return results
+
+    _warn_csv_usage()
+    csv_path = Path(__file__).with_name("modbus_registers.csv")
     with csv_path.open(encoding="utf-8", newline="") as csvfile:
         reader = csv.DictReader(
             row for row in csvfile if row.strip() and not row.lstrip().startswith("#")

--- a/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
+++ b/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
@@ -1,0 +1,3992 @@
+{
+  "schema_version": "1.0.0",
+  "generated_at": "2025-08-22T08:23:18.108999Z",
+  "source_pdf": "MODBUS_USER_AirPack_Home_08.2021.01.pdf",
+  "publisher": "Thessla Green",
+  "device_family": "AirPack Home (Energy/Energy+)",
+  "registers": [
+    {
+      "function": "01",
+      "address_hex": "0x0005",
+      "address_dec": 5,
+      "name": "duct_warter_heater_pump",
+      "description": "Stan wyjścia przekaźnika pompy obiegowej nagrzewnicy",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "01",
+      "address_hex": "0x0009",
+      "address_dec": 9,
+      "name": "bypass",
+      "description": "Stan wyjścia siłownika przepustnicy bypass",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "01",
+      "address_hex": "0x000A",
+      "address_dec": 10,
+      "name": "info",
+      "description": "Stan wyjścia sygnału potwierdzenia pracy centrali (O1)",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "01",
+      "address_hex": "0x000B",
+      "address_dec": 11,
+      "name": "power_supply_fans",
+      "description": "Stan wyjścia przekaźnika zasilania wentylatorów",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "01",
+      "address_hex": "0x000C",
+      "address_dec": 12,
+      "name": "heating_cable",
+      "description": "Stan wyjścia przekaźnika zasilania kabla grzejnego",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "01",
+      "address_hex": "0x000D",
+      "address_dec": 13,
+      "name": "workt_permit",
+      "description": "Stan wyjścia przekaźnika potwierdzenia pracy (Expansion)",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "01",
+      "address_hex": "0x000E",
+      "address_dec": 14,
+      "name": "gwc",
+      "description": "Stan wyjścia przekaźnika GWC",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "01",
+      "address_hex": "0x000F",
+      "address_dec": 15,
+      "name": "hood",
+      "description": "Stan wyjścia zasilającego przepustnicę okapu",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0000",
+      "address_dec": 0,
+      "name": "duct_heater_protection",
+      "description": "Stan wejścia zabezpieczenia termicznego elektrycznej nagrzewnicy kanałowej",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0001",
+      "address_dec": 1,
+      "name": "expansion",
+      "description": "Komunikacja z modułem Expansion",
+      "access": "R",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0003",
+      "address_dec": 3,
+      "name": "dp_duct_filter_overflow",
+      "description": "Stan wejścia presostatu filtra kanałowego",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0004",
+      "address_dec": 4,
+      "name": "hood",
+      "description": "Stan wejścia włącznika funkcji OKAP",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0005",
+      "address_dec": 5,
+      "name": "contamination_sensor",
+      "description": "Stan wejścia dwustanowego czujnika jakości powietrza",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0006",
+      "address_dec": 6,
+      "name": "airing_sensor",
+      "description": "Stan wejścia dwustanowego czujnika wilgotności",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0007",
+      "address_dec": 7,
+      "name": "airing_switch",
+      "description": "Stan wejścia włącznika funkcji WIETRZENIE",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x000A",
+      "address_dec": 10,
+      "name": "airing_mini",
+      "description": "Stan wejścia przełącznika AirS w pozycji \"Wietrzenie\"",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x000B",
+      "address_dec": 11,
+      "name": "fan_speed_3",
+      "description": "Stan wejścia przełącznika AirS w pozycji \"3 bieg\"",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x000C",
+      "address_dec": 12,
+      "name": "fan_speed_2",
+      "description": "Stan wejścia przełącznika AirS w pozycji \"2 bieg\"",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x000D",
+      "address_dec": 13,
+      "name": "fan_speed_1",
+      "description": "Stan wejścia przełącznika AirS w pozycji \"1 bieg\"",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x000E",
+      "address_dec": 14,
+      "name": "fireplace",
+      "description": "Stan wejścia włącznika funkcji KOMINEK",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x000F",
+      "address_dec": 15,
+      "name": "ppoz",
+      "description": "Stan wejścia sygnału alarmu pożarowego (P.POZ.)",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0012",
+      "address_dec": 18,
+      "name": "dp_ahu_filter_overflow",
+      "description": "Stan wejścia presostatu filtrów w rekuperatorze (DP1)",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0013",
+      "address_dec": 19,
+      "name": "ahu_filter_protection",
+      "description": "Stan wejścia zabezpieczenia termicznego nagrzewnicy systemu FPX",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "02",
+      "address_hex": "0x0015",
+      "address_dec": 21,
+      "name": "empty_house",
+      "description": "Stan wejścia sygnału załączenia funkcji PUSTY DOM",
+      "access": "R",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0000",
+      "address_dec": 0,
+      "name": "VERSION_MAJOR",
+      "description": "Wersja oprogramowania sterownika - liczba 1 [MM]",
+      "access": "R",
+      "notes": "Format: <MM>.<mm>.<pp>; przykład 4.84.2 dla 0x0004,0x0054,0x0002."
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0001",
+      "address_dec": 1,
+      "name": "VERSION_MINOR",
+      "description": "Wersja oprogramowania sterownika - liczba 2 [mm]",
+      "access": "R"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0002",
+      "address_dec": 2,
+      "name": "day_of_week",
+      "description": "Bieżący dzień tygodnia dla trybu automatycznego",
+      "access": "R",
+      "min": 0,
+      "max": 6,
+      "enum": {
+        "0": "Poniedziałek",
+        "1": "Wtorek",
+        "2": "Środa",
+        "3": "Czwartek",
+        "4": "Piątek",
+        "5": "Sobota",
+        "6": "Niedziela"
+      }
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0003",
+      "address_dec": 3,
+      "name": "period",
+      "description": "Bieżący odcinek czasowy dla trybu automatycznego",
+      "access": "R",
+      "min": 0,
+      "max": 3,
+      "enum": {
+        "0": "Odcinek 1",
+        "1": "Odcinek 2",
+        "2": "Odcinek 3",
+        "3": "Odcinek 4"
+      }
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0004",
+      "address_dec": 4,
+      "name": "VERSION_PATCH",
+      "description": "Wersja oprogramowania sterownika - liczba 3 [pp]",
+      "access": "R"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x000E",
+      "address_dec": 14,
+      "name": "compilation_days",
+      "description": "Data kompilacji oprogramowania Basic (liczba dni od 01.01.2000)",
+      "access": "R",
+      "unit": "d"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x000F",
+      "address_dec": 15,
+      "name": "compilation_seconds",
+      "description": "Godzina kompilacji oprogramowania Basic (liczba sekund od 00:00:00)",
+      "access": "R",
+      "unit": "s"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0010",
+      "address_dec": 16,
+      "name": "outside_temperature",
+      "description": "Temperatura powietrza zewnętrznego (TZ1)",
+      "access": "R",
+      "unit": "°C",
+      "min": -999,
+      "max": 999,
+      "multiplier": 0.1,
+      "notes": "0x8000/32768 oznacza brak odczytu"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0011",
+      "address_dec": 17,
+      "name": "supply_temperature",
+      "description": "Temperatura powietrza nawiewanego (TN1)",
+      "access": "R",
+      "unit": "°C",
+      "min": -999,
+      "max": 999,
+      "multiplier": 0.1,
+      "notes": "0x8000/32768 oznacza brak odczytu"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0012",
+      "address_dec": 18,
+      "name": "exhaust_temperature",
+      "description": "Temperatura powietrza usuwanego z pomieszczenia (TP)",
+      "access": "R",
+      "unit": "°C",
+      "min": -999,
+      "max": 999,
+      "multiplier": 0.1,
+      "notes": "0x8000/32768 oznacza brak odczytu"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0013",
+      "address_dec": 19,
+      "name": "fpx_temperature",
+      "description": "Temperatura powietrza za nagrzewnicą FPX (TZ2)",
+      "access": "R",
+      "unit": "°C",
+      "min": -999,
+      "max": 999,
+      "multiplier": 0.1,
+      "notes": "0x8000/32768 oznacza brak odczytu"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0014",
+      "address_dec": 20,
+      "name": "duct_supply_temperature",
+      "description": "Temperatura za nagrzewnicą/chłodnicą kanałową (TN2)",
+      "access": "R",
+      "unit": "°C",
+      "min": -999,
+      "max": 999,
+      "multiplier": 0.1,
+      "notes": "0x8000/32768 oznacza brak odczytu"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0015",
+      "address_dec": 21,
+      "name": "gwc_temperature",
+      "description": "Temperatura przed wymiennikiem glikolowego GWC (TZ3)",
+      "access": "R",
+      "unit": "°C",
+      "min": -999,
+      "max": 999,
+      "multiplier": 0.1,
+      "notes": "0x8000/32768 oznacza brak odczytu"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0016",
+      "address_dec": 22,
+      "name": "ambient_temperature",
+      "description": "Temperatura otoczenia (TO)",
+      "access": "R",
+      "unit": "°C",
+      "min": -999,
+      "max": 999,
+      "multiplier": 0.1,
+      "notes": "0x8000/32768 oznacza brak odczytu"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0018",
+      "address_dec": 24,
+      "name": "serial_number_1",
+      "description": "Numer seryjny sterownika - liczba 1",
+      "access": "R",
+      "notes": "S/N to 6 rejestrów 0x0018..0x001D"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0019",
+      "address_dec": 25,
+      "name": "serial_number_2",
+      "description": "Numer seryjny sterownika - liczba 2",
+      "access": "R"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x001A",
+      "address_dec": 26,
+      "name": "serial_number_3",
+      "description": "Numer seryjny sterownika - liczba 3",
+      "access": "R"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x001B",
+      "address_dec": 27,
+      "name": "serial_number_4",
+      "description": "Numer seryjny sterownika - liczba 4",
+      "access": "R"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x001C",
+      "address_dec": 28,
+      "name": "serial_number_5",
+      "description": "Numer seryjny sterownika - liczba 5",
+      "access": "R"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x001D",
+      "address_dec": 29,
+      "name": "serial_number_6",
+      "description": "Numer seryjny sterownika - liczba 6",
+      "access": "R"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x010F",
+      "address_dec": 271,
+      "name": "constant_flow_active",
+      "description": "Status aktywności systemu Constant Flow",
+      "access": "R",
+      "enum": {
+        "0": "nieaktywny",
+        "1": "aktywny"
+      }
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0110",
+      "address_dec": 272,
+      "name": "supply_percentage",
+      "description": "Zadana intensywność wentylacji (nawiew) CF",
+      "access": "R",
+      "unit": "%",
+      "min": 0,
+      "max": 150,
+      "notes": "Zakres dynamiczny ograniczony 0x0114..0x0115"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0111",
+      "address_dec": 273,
+      "name": "exhaust_percentage",
+      "description": "Zadana intensywność wentylacji (wywiew) CF",
+      "access": "R",
+      "unit": "%",
+      "min": 0,
+      "max": 150,
+      "notes": "Zakres dynamiczny ograniczony 0x0114..0x0115"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0112",
+      "address_dec": 274,
+      "name": "supply_flowrate",
+      "description": "Zadany strumień przepływu (nawiew) CF",
+      "access": "R",
+      "unit": "m3/h",
+      "min": 0,
+      "max": 4095
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0113",
+      "address_dec": 275,
+      "name": "exhaust_flowrate",
+      "description": "Zadany strumień przepływu (wywiew) CF",
+      "access": "R",
+      "unit": "m3/h",
+      "min": 0,
+      "max": 4095
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0114",
+      "address_dec": 276,
+      "name": "min_percentage",
+      "description": "Minimalna intensywność wentylacji",
+      "access": "R",
+      "unit": "%",
+      "min": 10,
+      "max": 150,
+      "default": 10,
+      "notes": "Wartość zależna od instalacji"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0115",
+      "address_dec": 277,
+      "name": "max_percentage",
+      "description": "Maksymalna intensywność wentylacji",
+      "access": "R",
+      "unit": "%",
+      "min": 10,
+      "max": 150,
+      "default": 150,
+      "notes": "Wartość zależna od instalacji"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x012A",
+      "address_dec": 298,
+      "name": "water_removal_active",
+      "description": "Status działania procedury HEWR",
+      "access": "R",
+      "enum": {
+        "0": "brak (nieaktywna)",
+        "1": "jest (trwa procedura)"
+      }
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0100",
+      "address_dec": 256,
+      "name": "supplyAirFlow",
+      "description": "Wartość chwilowa strumienia powietrza - nawiew; 65535 gdy CF nieaktywny",
+      "access": "R",
+      "unit": "m3/h",
+      "min": 0,
+      "max": 65535
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0101",
+      "address_dec": 257,
+      "name": "exhaustAirFlow",
+      "description": "Wartość chwilowa strumienia powietrza - wywiew",
+      "access": "R",
+      "unit": "m3/h",
+      "min": 0,
+      "max": 65535
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0500",
+      "address_dec": 1280,
+      "name": "dac_supply",
+      "description": "PWM napięcie sterujące wentylatorem nawiewnym",
+      "access": "R",
+      "unit": "V",
+      "min": 0,
+      "max": 4095,
+      "multiplier": 0.00244,
+      "notes": "0->0.0V, 4095->10.0V"
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0501",
+      "address_dec": 1281,
+      "name": "dac_exhaust",
+      "description": "PWM napięcie sterujące wentylatorem wywiewnym",
+      "access": "R",
+      "unit": "V",
+      "min": 0,
+      "max": 4095,
+      "multiplier": 0.00244
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0502",
+      "address_dec": 1282,
+      "name": "dac_heater",
+      "description": "PWM napięcie sterujące nagrzewnicą kanałową",
+      "access": "R",
+      "unit": "V",
+      "min": 0,
+      "max": 4095,
+      "multiplier": 0.00244
+    },
+    {
+      "function": "04",
+      "address_hex": "0x0503",
+      "address_dec": 1283,
+      "name": "dac_cooler",
+      "description": "PWM napięcie sterujące chłodnicą kanałową",
+      "access": "R",
+      "unit": "V",
+      "min": 0,
+      "max": 4095,
+      "multiplier": 0.00244
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0000",
+      "address_dec": 0,
+      "name": "date_time_rrmm",
+      "description": "Data i godzina; dziesiątki/jedności roku i miesiąc [RRMM]",
+      "access": "R/W",
+      "min": 0,
+      "max": 99,
+      "notes": "00->2000,...,99->2099; wszystkie 4 rejestry muszą być odczyt/zapis razem"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0001",
+      "address_dec": 1,
+      "name": "date_time_ddtt",
+      "description": "Data i godzina; dzień miesiąca i dzień tygodnia [DDTT]",
+      "access": "R/W",
+      "min": 1,
+      "max": 31,
+      "notes": "Dzień tygodnia 0..6 = Pon..Niedz"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0002",
+      "address_dec": 2,
+      "name": "date_time_ggmm",
+      "description": "Data i godzina; godzina i minuta [GGmm]",
+      "access": "R/W",
+      "unit": "h",
+      "min": 0,
+      "max": 23
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0003",
+      "address_dec": 3,
+      "name": "date_time_sscc",
+      "description": "Data i godzina; sekunda i setne sekundy [sscc]",
+      "access": "R/W",
+      "unit": "s",
+      "min": 0,
+      "max": 59
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0007",
+      "address_dec": 7,
+      "name": "lock_date_rr",
+      "description": "Data zablokowania - rok [00RR]",
+      "access": "R",
+      "min": 0,
+      "max": 99,
+      "notes": "0x0007..0x0009 odczytywać razem"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0008",
+      "address_dec": 8,
+      "name": "lock_date_mm",
+      "description": "Data zablokowania - miesiąc [00MM]",
+      "access": "R",
+      "min": 1,
+      "max": 12
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0009",
+      "address_dec": 9,
+      "name": "lock_date_dd",
+      "description": "Data zablokowania - dzień [00DD]",
+      "access": "R",
+      "min": 1,
+      "max": 31
+    },
+    {
+      "function": "03",
+      "address_hex": "0x000D",
+      "address_dec": 13,
+      "name": "configuration_mode",
+      "description": "Tryby specjalne pracy centrali",
+      "access": "R/W",
+      "min": 0,
+      "max": 242,
+      "notes": "0=normalna; 47=AFC presostat; 65=AFC+presostat; zapis 0 dezaktywuje tryb/procedurę"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x000F",
+      "address_dec": 15,
+      "name": "access_level",
+      "description": "Poziom dostępu (zapisz kod i odczytaj poziom)",
+      "access": "R/W",
+      "min": 0,
+      "max": 3,
+      "enum": {
+        "0": "użytkownik",
+        "1": "serwis/instalator",
+        "3": "producent"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0010",
+      "address_dec": 16,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Poniedziałek – 1 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Poniedziałek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0011",
+      "address_dec": 17,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Poniedziałek – 2 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Poniedziałek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0012",
+      "address_dec": 18,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Poniedziałek – 3 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Poniedziałek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0013",
+      "address_dec": 19,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Poniedziałek – 4 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Poniedziałek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0014",
+      "address_dec": 20,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Wtorek – 1 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Wtorek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0015",
+      "address_dec": 21,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Wtorek – 2 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Wtorek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0016",
+      "address_dec": 22,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Wtorek – 3 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Wtorek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0017",
+      "address_dec": 23,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Wtorek – 4 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Wtorek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0018",
+      "address_dec": 24,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Środa – 1 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Środa",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0019",
+      "address_dec": 25,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Środa – 2 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Środa",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x001A",
+      "address_dec": 26,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Środa – 3 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Środa",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x001B",
+      "address_dec": 27,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Środa – 4 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Środa",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x001C",
+      "address_dec": 28,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Czwartek – 1 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Czwartek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x001D",
+      "address_dec": 29,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Czwartek – 2 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Czwartek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x001E",
+      "address_dec": 30,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Czwartek – 3 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Czwartek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x001F",
+      "address_dec": 31,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Czwartek – 4 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Czwartek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0020",
+      "address_dec": 32,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Piątek – 1 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Piątek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0021",
+      "address_dec": 33,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Piątek – 2 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Piątek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0022",
+      "address_dec": 34,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Piątek – 3 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Piątek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0023",
+      "address_dec": 35,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Piątek – 4 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Piątek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0024",
+      "address_dec": 36,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Sobota – 1 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Sobota",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0025",
+      "address_dec": 37,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Sobota – 2 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Sobota",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0026",
+      "address_dec": 38,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Sobota – 3 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Sobota",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0027",
+      "address_dec": 39,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Sobota – 4 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Sobota",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0028",
+      "address_dec": 40,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Niedziela – 1 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Niedziela",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0029",
+      "address_dec": 41,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Niedziela – 2 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Niedziela",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x002A",
+      "address_dec": 42,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Niedziela – 3 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Niedziela",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x002B",
+      "address_dec": 43,
+      "name": "summer_period_start",
+      "description": "Harmonogram LATO – Niedziela – 4 [GGMM]",
+      "access": "R/W",
+      "min": 0,
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Niedziela",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x002C",
+      "address_dec": 44,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Poniedziałek – 1 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Poniedziałek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x002D",
+      "address_dec": 45,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Poniedziałek – 2 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Poniedziałek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x002E",
+      "address_dec": 46,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Poniedziałek – 3 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Poniedziałek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x002F",
+      "address_dec": 47,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Poniedziałek – 4 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Poniedziałek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0030",
+      "address_dec": 48,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Wtorek – 1 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Wtorek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0031",
+      "address_dec": 49,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Wtorek – 2 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Wtorek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0032",
+      "address_dec": 50,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Wtorek – 3 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Wtorek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0033",
+      "address_dec": 51,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Wtorek – 4 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Wtorek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0034",
+      "address_dec": 52,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Środa – 1 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Środa",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0035",
+      "address_dec": 53,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Środa – 2 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Środa",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0036",
+      "address_dec": 54,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Środa – 3 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Środa",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0037",
+      "address_dec": 55,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Środa – 4 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Środa",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0038",
+      "address_dec": 56,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Czwartek – 1 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Czwartek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0039",
+      "address_dec": 57,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Czwartek – 2 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Czwartek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x003A",
+      "address_dec": 58,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Czwartek – 3 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Czwartek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x003B",
+      "address_dec": 59,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Czwartek – 4 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Czwartek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x003C",
+      "address_dec": 60,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Piątek – 1 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Piątek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x003D",
+      "address_dec": 61,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Piątek – 2 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Piątek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x003E",
+      "address_dec": 62,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Piątek – 3 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Piątek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x003F",
+      "address_dec": 63,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Piątek – 4 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Piątek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0040",
+      "address_dec": 64,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Sobota – 1 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Sobota",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0041",
+      "address_dec": 65,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Sobota – 2 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Sobota",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0042",
+      "address_dec": 66,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Sobota – 3 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Sobota",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0043",
+      "address_dec": 67,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Sobota – 4 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Sobota",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0044",
+      "address_dec": 68,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Niedziela – 1 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Niedziela",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0045",
+      "address_dec": 69,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Niedziela – 2 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Niedziela",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0046",
+      "address_dec": 70,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Niedziela – 3 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Niedziela",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0047",
+      "address_dec": 71,
+      "name": "winter_period_start",
+      "description": "Harmonogram ZIMA – Niedziela – 4 [GGMM]",
+      "access": "R/W",
+      "notes": "Binarne BCD [GGMM]; 0xA200 dezaktywuje odcinek",
+      "day": "Niedziela",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0048",
+      "address_dec": 72,
+      "name": "summer_setpoint",
+      "description": "LATO – Poniedziałek – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Poniedziałek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0049",
+      "address_dec": 73,
+      "name": "summer_setpoint",
+      "description": "LATO – Poniedziałek – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Poniedziałek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x004A",
+      "address_dec": 74,
+      "name": "summer_setpoint",
+      "description": "LATO – Poniedziałek – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Poniedziałek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x004B",
+      "address_dec": 75,
+      "name": "summer_setpoint",
+      "description": "LATO – Poniedziałek – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Poniedziałek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x004C",
+      "address_dec": 76,
+      "name": "summer_setpoint",
+      "description": "LATO – Wtorek – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Wtorek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x004D",
+      "address_dec": 77,
+      "name": "summer_setpoint",
+      "description": "LATO – Wtorek – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Wtorek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x004E",
+      "address_dec": 78,
+      "name": "summer_setpoint",
+      "description": "LATO – Wtorek – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Wtorek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x004F",
+      "address_dec": 79,
+      "name": "summer_setpoint",
+      "description": "LATO – Wtorek – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Wtorek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0050",
+      "address_dec": 80,
+      "name": "summer_setpoint",
+      "description": "LATO – Środa – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Środa",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0051",
+      "address_dec": 81,
+      "name": "summer_setpoint",
+      "description": "LATO – Środa – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Środa",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0052",
+      "address_dec": 82,
+      "name": "summer_setpoint",
+      "description": "LATO – Środa – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Środa",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0053",
+      "address_dec": 83,
+      "name": "summer_setpoint",
+      "description": "LATO – Środa – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Środa",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0054",
+      "address_dec": 84,
+      "name": "summer_setpoint",
+      "description": "LATO – Czwartek – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Czwartek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0055",
+      "address_dec": 85,
+      "name": "summer_setpoint",
+      "description": "LATO – Czwartek – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Czwartek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0056",
+      "address_dec": 86,
+      "name": "summer_setpoint",
+      "description": "LATO – Czwartek – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Czwartek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0057",
+      "address_dec": 87,
+      "name": "summer_setpoint",
+      "description": "LATO – Czwartek – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Czwartek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0058",
+      "address_dec": 88,
+      "name": "summer_setpoint",
+      "description": "LATO – Piątek – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Piątek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0059",
+      "address_dec": 89,
+      "name": "summer_setpoint",
+      "description": "LATO – Piątek – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Piątek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x005A",
+      "address_dec": 90,
+      "name": "summer_setpoint",
+      "description": "LATO – Piątek – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Piątek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x005B",
+      "address_dec": 91,
+      "name": "summer_setpoint",
+      "description": "LATO – Piątek – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Piątek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x005C",
+      "address_dec": 92,
+      "name": "summer_setpoint",
+      "description": "LATO – Sobota – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Sobota",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x005D",
+      "address_dec": 93,
+      "name": "summer_setpoint",
+      "description": "LATO – Sobota – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Sobota",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x005E",
+      "address_dec": 94,
+      "name": "summer_setpoint",
+      "description": "LATO – Sobota – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Sobota",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x005F",
+      "address_dec": 95,
+      "name": "summer_setpoint",
+      "description": "LATO – Sobota – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Sobota",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0060",
+      "address_dec": 96,
+      "name": "summer_setpoint",
+      "description": "LATO – Niedziela – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Niedziela",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0061",
+      "address_dec": 97,
+      "name": "summer_setpoint",
+      "description": "LATO – Niedziela – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Niedziela",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0062",
+      "address_dec": 98,
+      "name": "summer_setpoint",
+      "description": "LATO – Niedziela – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Niedziela",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0063",
+      "address_dec": 99,
+      "name": "summer_setpoint",
+      "description": "LATO – Niedziela – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Niedziela",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0064",
+      "address_dec": 100,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Poniedziałek – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Poniedziałek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0065",
+      "address_dec": 101,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Poniedziałek – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Poniedziałek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0066",
+      "address_dec": 102,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Poniedziałek – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Poniedziałek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0067",
+      "address_dec": 103,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Poniedziałek – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Poniedziałek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0068",
+      "address_dec": 104,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Wtorek – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Wtorek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0069",
+      "address_dec": 105,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Wtorek – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Wtorek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x006A",
+      "address_dec": 106,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Wtorek – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Wtorek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x006B",
+      "address_dec": 107,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Wtorek – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Wtorek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x006C",
+      "address_dec": 108,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Środa – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Środa",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x006D",
+      "address_dec": 109,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Środa – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Środa",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x006E",
+      "address_dec": 110,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Środa – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Środa",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x006F",
+      "address_dec": 111,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Środa – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Środa",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0070",
+      "address_dec": 112,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Czwartek – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Czwartek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0071",
+      "address_dec": 113,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Czwartek – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Czwartek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0072",
+      "address_dec": 114,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Czwartek – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Czwartek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0073",
+      "address_dec": 115,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Czwartek – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Czwartek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0074",
+      "address_dec": 116,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Piątek – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Piątek",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0075",
+      "address_dec": 117,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Piątek – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Piątek",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0076",
+      "address_dec": 118,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Piątek – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Piątek",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0077",
+      "address_dec": 119,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Piątek – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Piątek",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0078",
+      "address_dec": 120,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Sobota – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Sobota",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0079",
+      "address_dec": 121,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Sobota – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Sobota",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x007A",
+      "address_dec": 122,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Sobota – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Sobota",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x007B",
+      "address_dec": 123,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Sobota – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Sobota",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x007C",
+      "address_dec": 124,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Niedziela – 1 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Niedziela",
+      "period": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x007D",
+      "address_dec": 125,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Niedziela – 2 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Niedziela",
+      "period": 2
+    },
+    {
+      "function": "03",
+      "address_hex": "0x007E",
+      "address_dec": 126,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Niedziela – 3 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Niedziela",
+      "period": 3
+    },
+    {
+      "function": "03",
+      "address_hex": "0x007F",
+      "address_dec": 127,
+      "name": "winter_setpoint",
+      "description": "ZIMA – Niedziela – 4 [AATT]",
+      "access": "R/W",
+      "unit": "mixed",
+      "notes": "AA=%; TT = 2×temp nawiewu (°C) zapis hex [0xAATT]",
+      "day": "Niedziela",
+      "period": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0080",
+      "address_dec": 128,
+      "name": "summer_airing_start",
+      "description": "Wietrzenie LATO – Poniedziałek [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Poniedziałek"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0084",
+      "address_dec": 132,
+      "name": "summer_airing_start",
+      "description": "Wietrzenie LATO – Wtorek [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Wtorek"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0088",
+      "address_dec": 136,
+      "name": "summer_airing_start",
+      "description": "Wietrzenie LATO – Środa [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Środa"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x008C",
+      "address_dec": 140,
+      "name": "summer_airing_start",
+      "description": "Wietrzenie LATO – Czwartek [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Czwartek"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0090",
+      "address_dec": 144,
+      "name": "summer_airing_start",
+      "description": "Wietrzenie LATO – Piątek [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Piątek"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0094",
+      "address_dec": 148,
+      "name": "summer_airing_start",
+      "description": "Wietrzenie LATO – Sobota [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Sobota"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x0098",
+      "address_dec": 152,
+      "name": "summer_airing_start",
+      "description": "Wietrzenie LATO – Niedziela [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Niedziela"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x009C",
+      "address_dec": 156,
+      "name": "winter_airing_start",
+      "description": "Wietrzenie ZIMA – Poniedziałek [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Poniedziałek"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00A0",
+      "address_dec": 160,
+      "name": "winter_airing_start",
+      "description": "Wietrzenie ZIMA – Wtorek [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Wtorek"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00A4",
+      "address_dec": 164,
+      "name": "winter_airing_start",
+      "description": "Wietrzenie ZIMA – Środa [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Środa"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00A8",
+      "address_dec": 168,
+      "name": "winter_airing_start",
+      "description": "Wietrzenie ZIMA – Czwartek [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Czwartek"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00AC",
+      "address_dec": 172,
+      "name": "winter_airing_start",
+      "description": "Wietrzenie ZIMA – Piątek [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Piątek"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00B0",
+      "address_dec": 176,
+      "name": "winter_airing_start",
+      "description": "Wietrzenie ZIMA – Sobota [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Sobota"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00B4",
+      "address_dec": 180,
+      "name": "winter_airing_start",
+      "description": "Wietrzenie ZIMA – Niedziela [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza wietrzenie",
+      "day": "Niedziela"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00C0",
+      "address_dec": 192,
+      "name": "RTC_cal",
+      "description": "Dane kalibracyjne RTC (signed -127..+127)",
+      "access": "R",
+      "min": 0,
+      "max": 255,
+      "default": 198,
+      "notes": "wartości rzeczywiste: -127..+127 mapowane na 0x0081..0x007F"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00F0",
+      "address_dec": 240,
+      "name": "CF_version",
+      "description": "Wersja oprogramowania modułu CF/TG-02 [0xMMmm -> MM.mm]",
+      "access": "R"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x00F1",
+      "address_dec": 241,
+      "name": "EXP_version",
+      "description": "Wersja oprogramowania modułu Expansion [0xMMmm -> MM.mm]",
+      "access": "R"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1015",
+      "address_dec": 4117,
+      "name": "maxSupplyAirFlowRate",
+      "description": "Maks. intensywność (nawiew)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100,
+      "notes": "z kalibracji"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1016",
+      "address_dec": 4118,
+      "name": "maxSupplyAirFlowRateGwc",
+      "description": "Maks. intensywność (nawiew) z GWC",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100,
+      "notes": "z kalibracji"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1017",
+      "address_dec": 4119,
+      "name": "maxExhaustAirFlowRate",
+      "description": "Maks. intensywność (wywiew)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100,
+      "notes": "z kalibracji"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1018",
+      "address_dec": 4120,
+      "name": "maxExhaustAirFlowRateGwc",
+      "description": "Maks. intensywność (wywiew) z GWC",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100,
+      "notes": "z kalibracji"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1060",
+      "address_dec": 4192,
+      "name": "antifreezMode",
+      "description": "Flaga uruchomienia systemu FPX",
+      "access": "R",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1066",
+      "address_dec": 4198,
+      "name": "antifreezStage",
+      "description": "Tryb działania systemu FPX",
+      "access": "R",
+      "min": 0,
+      "max": 2,
+      "enum": {
+        "0": "OFF",
+        "1": "FPX1",
+        "2": "FPX2"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1070",
+      "address_dec": 4208,
+      "name": "mode",
+      "description": "Tryb pracy AirPack",
+      "access": "R/W",
+      "enum": {
+        "0": "automatyczny",
+        "1": "manualny",
+        "2": "chwilowy"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1071",
+      "address_dec": 4209,
+      "name": "seasonMode",
+      "description": "Wybór harmonogramu (AUTOMATYCZNY)",
+      "access": "R/W",
+      "enum": {
+        "0": "LATO",
+        "1": "ZIMA"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1072",
+      "address_dec": 4210,
+      "name": "airFlowRateManual",
+      "description": "Intensywność – MANUALNY",
+      "access": "R/W",
+      "unit": "%",
+      "min": 10,
+      "max": 100,
+      "default": 30
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1073",
+      "address_dec": 4211,
+      "name": "airFlowRateTemporary",
+      "description": "Intensywność – CHWILOWY",
+      "access": "R/W",
+      "unit": "%",
+      "min": 10,
+      "max": 100
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1074",
+      "address_dec": 4212,
+      "name": "supplyAirTemperatureManual",
+      "description": "Temp. nawiewu – MANUALNY (KOMFORT)",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 20,
+      "max": 90,
+      "default": 40,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1075",
+      "address_dec": 4213,
+      "name": "supplyAirTemperatureTemporary",
+      "description": "Temp. nawiewu – CHWILOWY (KOMFORT)",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 20,
+      "max": 90,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1078",
+      "address_dec": 4216,
+      "name": "fanSpeed1Coef",
+      "description": "Intensywność – AirS '1 bieg'",
+      "access": "R/W",
+      "unit": "%",
+      "min": 10,
+      "max": 45,
+      "default": 30
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1079",
+      "address_dec": 4217,
+      "name": "fanSpeed2Coef",
+      "description": "Intensywność – AirS '2 bieg'",
+      "access": "R/W",
+      "unit": "%",
+      "min": 46,
+      "max": 75,
+      "default": 60
+    },
+    {
+      "function": "03",
+      "address_hex": "0x107A",
+      "address_dec": 4218,
+      "name": "fanSpeed3Coef",
+      "description": "Intensywność – AirS '3 bieg'",
+      "access": "R/W",
+      "unit": "%",
+      "min": 76,
+      "max": 100,
+      "default": 100
+    },
+    {
+      "function": "03",
+      "address_hex": "0x107B",
+      "address_dec": 4219,
+      "name": "manualAiringTimeToStart",
+      "description": "Godzina rozpoczęcia wietrzenia – MANUAL [GGMM]",
+      "access": "R/W",
+      "notes": "0x2400 wyłącza"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1080",
+      "address_dec": 4224,
+      "name": "specialMode",
+      "description": "Funkcje specjalne (wybór)",
+      "access": "R/W",
+      "min": 0,
+      "max": 11,
+      "enum": {
+        "0": "brak",
+        "1": "OKAP (wejście sygnałowe)",
+        "2": "KOMINEK (ręcznie/wejście)",
+        "3": "WIETRZENIE (przeł. dzwonkowy)",
+        "4": "WIETRZENIE (ON/OFF)",
+        "5": "H2O/WIETRZENIE (higrostat)",
+        "6": "JP/WIETRZENIE (czujnik jakości pow.)",
+        "7": "WIETRZENIE (ręcznie)",
+        "8": "WIETRZENIE (AUTO – harmonogram)",
+        "9": "WIETRZENIE (MANUAL – harmonogram)",
+        "10": "OTWARTE OKNA (ręcznie)",
+        "11": "PUSTY DOM (ręcznie/wejście)"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1082",
+      "address_dec": 4226,
+      "name": "hoodSupplyCoef",
+      "description": "Intensywność OKAP (nawiew)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100,
+      "notes": "typ 1/2 okapu; *wydajność zależna od kalibracji"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1083",
+      "address_dec": 4227,
+      "name": "hoodExhaustCoef",
+      "description": "Intensywność OKAP (wywiew)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100,
+      "notes": "typ 1 okapu; *wydajność zależna od kalibracji"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1084",
+      "address_dec": 4228,
+      "name": "fireplaceSupplyCoef",
+      "description": "Różnicowanie strumieni – KOMINEK",
+      "access": "R/W",
+      "unit": "%",
+      "min": 5,
+      "max": 50,
+      "default": 20
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1085",
+      "address_dec": 4229,
+      "name": "airingBathroomCoef",
+      "description": "Intensywność WIETRZENIE – łazienka (3,4,5)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1086",
+      "address_dec": 4230,
+      "name": "airingCoef",
+      "description": "Intensywność WIETRZENIE – pokoje (7,8,9)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1087",
+      "address_dec": 4231,
+      "name": "contaminationCoef",
+      "description": "Intensywność WIETRZENIE – z czujnika jakości (6)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1088",
+      "address_dec": 4232,
+      "name": "emptyHouseCoef",
+      "description": "Intensywność PUSTY DOM",
+      "access": "R/W",
+      "unit": "%",
+      "min": 10,
+      "max": 100,
+      "default": 20
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1089",
+      "address_dec": 4233,
+      "name": "airingPanelModeTime",
+      "description": "Czas WIETRZENIE – ręcznie/harmonogram (7,8,9)",
+      "access": "R/W",
+      "unit": "min",
+      "min": 1,
+      "max": 45,
+      "default": 5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x108A",
+      "address_dec": 4234,
+      "name": "airingSwitchModeTime",
+      "description": "Czas WIETRZENIE – przełącznik dzwonkowy (3)",
+      "access": "R/W",
+      "unit": "min",
+      "min": 1,
+      "max": 45,
+      "default": 5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x108B",
+      "address_dec": 4235,
+      "name": "airingSwitchModeOnDelay",
+      "description": "Opóźnienie załączenia WIETRZENIE – ON/OFF (4)",
+      "access": "R/W",
+      "unit": "min",
+      "min": 0,
+      "max": 20,
+      "default": 0
+    },
+    {
+      "function": "03",
+      "address_hex": "0x108C",
+      "address_dec": 4236,
+      "name": "airingSwitchModeOffDelay",
+      "description": "Opóźnienie wyłączenia WIETRZENIE – ON/OFF (4)",
+      "access": "R/W",
+      "unit": "min",
+      "min": 0,
+      "max": 20,
+      "default": 0
+    },
+    {
+      "function": "03",
+      "address_hex": "0x108D",
+      "address_dec": 4237,
+      "name": "fireplaceModeTime",
+      "description": "Czas działania KOMINEK",
+      "access": "R/W",
+      "unit": "min",
+      "min": 1,
+      "max": 10,
+      "default": 1
+    },
+    {
+      "function": "03",
+      "address_hex": "0x108E",
+      "address_dec": 4238,
+      "name": "airingSwitchCoef",
+      "description": "Intensywność WIETRZENIE – ON/OFF/dzwonkowy (3,4)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 100,
+      "max": 150,
+      "default": 100
+    },
+    {
+      "function": "03",
+      "address_hex": "0x108F",
+      "address_dec": 4239,
+      "name": "openWindowCoef",
+      "description": "Intensywność OTWARTE OKNA (wywiew)",
+      "access": "R/W",
+      "unit": "%",
+      "notes": "10..100 -> %; 101 -> intensywność z aktywnego trybu"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1094",
+      "address_dec": 4244,
+      "name": "presCheckDay",
+      "description": "Dzień tygodnia automatycznej kontroli filtrów",
+      "access": "R/W",
+      "min": 0,
+      "max": 6,
+      "notes": "dot. presostatu / filtra kanałowego z presostatem",
+      "enum": {
+        "0": "Poniedziałek",
+        "1": "Wtorek",
+        "2": "Środa",
+        "3": "Czwartek",
+        "4": "Piątek",
+        "5": "Sobota",
+        "6": "Niedziela"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1095",
+      "address_dec": 4245,
+      "name": "presCheckTime",
+      "description": "Godzina/min. startu procedury kontroli filtrów [GGMM]",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10A0",
+      "address_dec": 4256,
+      "name": "gwcOff",
+      "description": "Dezaktywacja działania GWC",
+      "access": "R/W",
+      "enum": {
+        "0": "aktywny",
+        "1": "nieaktywny (pasywny)"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10A1",
+      "address_dec": 4257,
+      "name": "minGwcAirTemperature",
+      "description": "Dolny próg temp. załączenia GWC (zima)",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 0,
+      "max": 20,
+      "default": 10,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10A2",
+      "address_dec": 4258,
+      "name": "maxGwcAirTemperature",
+      "description": "Górny próg temp. załączenia GWC (lato)",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 30,
+      "max": 80,
+      "default": 50,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10A6",
+      "address_dec": 4262,
+      "name": "gwcRegen",
+      "description": "Typ regeneracji złoża GWC",
+      "access": "R/W",
+      "min": 0,
+      "max": 2,
+      "enum": {
+        "0": "brak",
+        "1": "dobowa (harmonogram)",
+        "2": "temperaturowa (ΔT)"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10A7",
+      "address_dec": 4263,
+      "name": "gwcMode",
+      "description": "Aktualny status działania GWC",
+      "access": "R",
+      "enum": {
+        "0": "GWC nieaktywny",
+        "1": "tryb zima",
+        "2": "tryb lato"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10A8",
+      "address_dec": 4264,
+      "name": "gwcRegenPeriod",
+      "description": "Czas trwania regeneracji GWC (temperaturowa)",
+      "access": "R/W",
+      "unit": "h",
+      "min": 4,
+      "max": 8,
+      "default": 4
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10AA",
+      "address_dec": 4266,
+      "name": "deltaTGwc",
+      "description": "ΔT warunkująca regenerację GWC",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 0,
+      "max": 10,
+      "default": 0,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10AB",
+      "address_dec": 4267,
+      "name": "startGwcRegenWinterTime",
+      "description": "Start regeneracji zimą [GGMM] (dobowa)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10AC",
+      "address_dec": 4268,
+      "name": "stopGwcRegenWinterTime",
+      "description": "Stop regeneracji zimą [GGMM] (dobowa)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10AD",
+      "address_dec": 4269,
+      "name": "startGwcRegenSummerTime",
+      "description": "Start regeneracji latem [GGMM] (dobowa)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10AE",
+      "address_dec": 4270,
+      "name": "stopGwcRegenSummerTime",
+      "description": "Stop regeneracji latem [GGMM] (dobowa)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10AF",
+      "address_dec": 4271,
+      "name": "gwcRegenFlag",
+      "description": "Flaga aktywnego trybu regeneracji GWC",
+      "access": "R",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10D0",
+      "address_dec": 4304,
+      "name": "comfortModePanel",
+      "description": "Wybór trybu EKO/KOMFORT",
+      "access": "R/W",
+      "notes": "Tryb KOMFORT niedostępny bez wym. kanałowych",
+      "enum": {
+        "0": "EKO",
+        "1": "KOMFORT"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10D1",
+      "address_dec": 4305,
+      "name": "comfortMode",
+      "description": "Status trybu KOMFORT",
+      "access": "R",
+      "enum": {
+        "0": "nieaktywny",
+        "1": "grzanie",
+        "2": "chłodzenie"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10E0",
+      "address_dec": 4320,
+      "name": "bypassOff",
+      "description": "Dezaktywacja działania bypass",
+      "access": "R/W",
+      "enum": {
+        "0": "aktywny",
+        "1": "nieaktywny (pasywny)"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10E1",
+      "address_dec": 4321,
+      "name": "minBypassTemperature",
+      "description": "Minimalna TZ1 dla załączenia bypass",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 10,
+      "max": 40,
+      "default": 20,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10E2",
+      "address_dec": 4322,
+      "name": "airTemperatureSummerFreeHeating",
+      "description": "TP poniżej której freeheating (bypass) aktywny",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 30,
+      "max": 60,
+      "default": 38,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10E3",
+      "address_dec": 4323,
+      "name": "airTemperatureSummerFreeCooling",
+      "description": "TP powyżej której freecooling (bypass) aktywny",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 30,
+      "max": 60,
+      "default": 40,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10EA",
+      "address_dec": 4330,
+      "name": "bypassMode",
+      "description": "Status bypass",
+      "access": "R",
+      "enum": {
+        "0": "nieaktywny",
+        "1": "freeheating",
+        "2": "freecooling"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10EB",
+      "address_dec": 4331,
+      "name": "bypassUserMode",
+      "description": "Tryb/sposób realizacji bypass",
+      "access": "R/W",
+      "min": 1,
+      "max": 3,
+      "enum": {
+        "1": "tylko przepustnica",
+        "2": "przepustnica + różnicowanie",
+        "3": "przepustnica + wyłączenie wywiewu"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10EC",
+      "address_dec": 4332,
+      "name": "bypassCoef1",
+      "description": "Różnicowanie strumieni (wywiew<nawiew) – tryb 2",
+      "access": "R/W",
+      "unit": "%",
+      "min": 10,
+      "max": 100,
+      "default": 50
+    },
+    {
+      "function": "03",
+      "address_hex": "0x10ED",
+      "address_dec": 4333,
+      "name": "bypassCoef2",
+      "description": "Intensywność nawiewu – tryb 2/3",
+      "access": "R/W",
+      "unit": "%",
+      "notes": "10..150; 151 -> auto z trybu automatycznego/manualnego"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1102",
+      "address_dec": 4354,
+      "name": "nominalSupplyAirFlow",
+      "description": "Nominalny strumień nawiewu (100%)",
+      "access": "R/W",
+      "unit": "m3/h",
+      "min": 110,
+      "max": 1900,
+      "notes": "zależne od modelu i kalibracji"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1103",
+      "address_dec": 4355,
+      "name": "nominalExhaustAirFlow",
+      "description": "Nominalny strumień wywiewu (100%)",
+      "access": "R/W",
+      "unit": "m3/h",
+      "min": 110,
+      "max": 1900
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1104",
+      "address_dec": 4356,
+      "name": "nominalSupplyAirFlowGWC",
+      "description": "Nominalny nawiew (100%) z GWC powietrznym",
+      "access": "R/W",
+      "unit": "m3/h",
+      "min": 110,
+      "max": 1900
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1105",
+      "address_dec": 4357,
+      "name": "nominalExhaustAirFlowGWC",
+      "description": "Nominalny wywiew (100%) z GWC powietrznym",
+      "access": "R/W",
+      "unit": "m3/h",
+      "min": 110,
+      "max": 1900
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1120",
+      "address_dec": 4384,
+      "name": "stopAhuCode",
+      "description": "Kod alarmu zatrzymującego pracę (typ S)",
+      "access": "R",
+      "min": 0,
+      "max": 98
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1123",
+      "address_dec": 4387,
+      "name": "onOffPanelMode",
+      "description": "ON/OFF – załączanie urządzenia",
+      "access": "R/W",
+      "enum": {
+        "0": "OFF",
+        "1": "ON"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x112F",
+      "address_dec": 4399,
+      "name": "language",
+      "description": "Język panelu Air++",
+      "access": "R/W",
+      "min": 0,
+      "max": 4,
+      "enum": {
+        "0": "PL",
+        "1": "EN",
+        "2": "RU",
+        "3": "UK",
+        "4": "SK"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1130",
+      "address_dec": 4400,
+      "name": "cfgMode1",
+      "description": "Tryb pracy (grupa 1) do chwilowego + intensywność",
+      "access": "R/W",
+      "min": 0,
+      "max": 2,
+      "enum": {
+        "0": "automatyczny",
+        "1": "manualny",
+        "2": "chwilowy"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1131",
+      "address_dec": 4401,
+      "name": "airFlowRateTemporary",
+      "description": "Intensywność – CHWILOWY (grupa 1)",
+      "access": "R/W",
+      "unit": "%",
+      "min": 10,
+      "max": 100
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1132",
+      "address_dec": 4402,
+      "name": "airflowRateChangeFlag",
+      "description": "Flaga aktywacji CHWILOWEGO (intensywność)",
+      "access": "R/W",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1133",
+      "address_dec": 4403,
+      "name": "cfgMode2",
+      "description": "Tryb pracy (grupa 2) do chwilowego + temp.",
+      "access": "R/W",
+      "min": 0,
+      "max": 2,
+      "enum": {
+        "0": "automatyczny",
+        "1": "manualny",
+        "2": "chwilowy"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1134",
+      "address_dec": 4404,
+      "name": "supplyAirTemperatureTemporary",
+      "description": "Temp. nawiewu – CHWILOWY (grupa 2)",
+      "access": "R/W",
+      "unit": "°C",
+      "min": 20,
+      "max": 90,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1135",
+      "address_dec": 4405,
+      "name": "temperatureChangeFlag",
+      "description": "Flaga aktywacji CHWILOWEGO (temp.)",
+      "access": "R/W",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x113D",
+      "address_dec": 4413,
+      "name": "hard_reset_settings",
+      "description": "Reset ustawień użytkownika",
+      "access": "R/W",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x113E",
+      "address_dec": 4414,
+      "name": "hard_reset_schedule",
+      "description": "Reset ustawień trybów pracy",
+      "access": "R/W",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1150",
+      "address_dec": 4432,
+      "name": "presCheckDay",
+      "description": "Dzień tygodnia automatycznej kontroli filtrów",
+      "access": "R/W",
+      "min": 0,
+      "max": 6,
+      "enum": {
+        "0": "Poniedziałek",
+        "1": "Wtorek",
+        "2": "Środa",
+        "3": "Czwartek",
+        "4": "Piątek",
+        "5": "Sobota",
+        "6": "Niedziela"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1151",
+      "address_dec": 4433,
+      "name": "presCheckTime",
+      "description": "Godzina/min. startu procedury kontroli filtrów [GGMM]",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1164",
+      "address_dec": 4452,
+      "name": "uart0Id",
+      "description": "Modbus Air-B – ID",
+      "access": "R/W",
+      "min": 10,
+      "max": 19,
+      "default": 10,
+      "notes": "od 4.76"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1165",
+      "address_dec": 4453,
+      "name": "uart0Baud",
+      "description": "Modbus Air-B – Baud",
+      "access": "R/W",
+      "min": 0,
+      "max": 8,
+      "default": 3,
+      "enum": {
+        "0": "4800",
+        "1": "9600",
+        "2": "14400",
+        "3": "19200",
+        "4": "28800",
+        "5": "38400",
+        "6": "57600",
+        "7": "76800",
+        "8": "115200"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1166",
+      "address_dec": 4454,
+      "name": "uart0Parity",
+      "description": "Modbus Air-B – Parzystość",
+      "access": "R/W",
+      "min": 0,
+      "max": 2,
+      "enum": {
+        "0": "brak",
+        "1": "parzysty",
+        "2": "nieparzysty"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1167",
+      "address_dec": 4455,
+      "name": "uart0Stop",
+      "description": "Modbus Air-B – Bity stopu",
+      "access": "R/W",
+      "min": 0,
+      "max": 1,
+      "enum": {
+        "0": "jeden",
+        "1": "dwa"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1168",
+      "address_dec": 4456,
+      "name": "uart1Id",
+      "description": "Modbus Air++ – ID",
+      "access": "R/W",
+      "min": 10,
+      "max": 19,
+      "default": 10
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1169",
+      "address_dec": 4457,
+      "name": "uart1Baud",
+      "description": "Modbus Air++ – Baud",
+      "access": "R/W",
+      "min": 0,
+      "max": 8,
+      "default": 3,
+      "enum": {
+        "0": "4800",
+        "1": "9600",
+        "2": "14400",
+        "3": "19200",
+        "4": "28800",
+        "5": "38400",
+        "6": "57600",
+        "7": "76800",
+        "8": "115200"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x116A",
+      "address_dec": 4458,
+      "name": "uart1Parity",
+      "description": "Modbus Air++ – Parzystość",
+      "access": "R/W",
+      "min": 0,
+      "max": 2,
+      "enum": {
+        "0": "brak",
+        "1": "parzysty",
+        "2": "nieparzysty"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x116B",
+      "address_dec": 4459,
+      "name": "uart1Stop",
+      "description": "Modbus Air++ – Bity stopu",
+      "access": "R/W",
+      "min": 0,
+      "max": 1,
+      "enum": {
+        "0": "jeden",
+        "1": "dwa"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FD0",
+      "address_dec": 8144,
+      "name": "deviceName",
+      "description": "Nazwa urządzenia (ASCII, 2 znaki w rejestrze)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FD1",
+      "address_dec": 8145,
+      "name": "deviceName",
+      "description": "Nazwa urządzenia (ASCII, 2 znaki w rejestrze)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FD2",
+      "address_dec": 8146,
+      "name": "deviceName",
+      "description": "Nazwa urządzenia (ASCII, 2 znaki w rejestrze)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FD3",
+      "address_dec": 8147,
+      "name": "deviceName",
+      "description": "Nazwa urządzenia (ASCII, 2 znaki w rejestrze)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FD4",
+      "address_dec": 8148,
+      "name": "deviceName",
+      "description": "Nazwa urządzenia (ASCII, 2 znaki w rejestrze)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FD5",
+      "address_dec": 8149,
+      "name": "deviceName",
+      "description": "Nazwa urządzenia (ASCII, 2 znaki w rejestrze)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FD6",
+      "address_dec": 8150,
+      "name": "deviceName",
+      "description": "Nazwa urządzenia (ASCII, 2 znaki w rejestrze)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FD7",
+      "address_dec": 8151,
+      "name": "deviceName",
+      "description": "Nazwa urządzenia (ASCII, 2 znaki w rejestrze)",
+      "access": "R/W"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FFB",
+      "address_dec": 8187,
+      "name": "lockPass1",
+      "description": "Klucz produktu użytkownika – słowo młodsze",
+      "access": "R/W",
+      "min": 0,
+      "max": 16959,
+      "notes": "Zapisywać 0x1FFB i 0x1FFC razem; odczyt 0/1 poprawności"
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FFC",
+      "address_dec": 8188,
+      "name": "lockPass2",
+      "description": "Klucz produktu użytkownika – słowo starsze",
+      "access": "R/W",
+      "min": 0,
+      "max": 15
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FFD",
+      "address_dec": 8189,
+      "name": "lockFlag",
+      "description": "Aktywacja blokady urządzenia",
+      "access": "R/W",
+      "enum": {
+        "0": "nieaktywna",
+        "1": "aktywna"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FFE",
+      "address_dec": 8190,
+      "name": "requiredTemp",
+      "description": "Temperatura zadana trybu KOMFORT",
+      "access": "R",
+      "unit": "°C",
+      "min": 20,
+      "max": 90,
+      "default": 40,
+      "resolution": 0.5
+    },
+    {
+      "function": "03",
+      "address_hex": "0x1FFF",
+      "address_dec": 8191,
+      "name": "filterChange",
+      "description": "System kontroli filtrów / typ filtrów",
+      "access": "R/W",
+      "min": 1,
+      "max": 4,
+      "enum": {
+        "1": "presostat",
+        "2": "filtry płaskie",
+        "3": "filtry CleanPad",
+        "4": "filtry CleanPad Pure"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2000",
+      "address_dec": 8192,
+      "name": "alarm",
+      "description": "Flaga wystąpienia ostrzeżenia (E)",
+      "access": "R",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2001",
+      "address_dec": 8193,
+      "name": "error",
+      "description": "Flaga wystąpienia błędu (S)",
+      "access": "R",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2002",
+      "address_dec": 8194,
+      "name": "S2",
+      "description": "Błąd komunikacji I2C",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2006",
+      "address_dec": 8198,
+      "name": "S6",
+      "description": "Zabezpieczenie termiczne nagrzewnicy FPX zadziałało maksymalną ilość razy",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2007",
+      "address_dec": 8199,
+      "name": "S7",
+      "description": "Brak możliwości kalibracji – zbyt niska temperatura zewnętrzna",
+      "access": "R/W",
+      "notes": "Reset: SERWIS",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2008",
+      "address_dec": 8200,
+      "name": "S8",
+      "description": "Konieczność wprowadzenia klucza produktu",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2009",
+      "address_dec": 8201,
+      "name": "S9",
+      "description": "Centrala zatrzymana z panelu AirS",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x200A",
+      "address_dec": 8202,
+      "name": "S10",
+      "description": "Zadziałał czujnik PPOŻ",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x200D",
+      "address_dec": 8205,
+      "name": "S13",
+      "description": "Centrala zatrzymana z panelu Air+/AirL+/Air++/AirMobile",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x200E",
+      "address_dec": 8206,
+      "name": "S14",
+      "description": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej – zadziałało maksymalną ilość razy",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x200F",
+      "address_dec": 8207,
+      "name": "S15",
+      "description": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej – brak efektu",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2010",
+      "address_dec": 8208,
+      "name": "S16",
+      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali (FPX aktywny)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2011",
+      "address_dec": 8209,
+      "name": "S17",
+      "description": "Nie wymieniono filtrów w centrali (z presostatem)",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2013",
+      "address_dec": 8211,
+      "name": "S19",
+      "description": "Nie wymieniono filtrów w centrali (bez presostatu)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2014",
+      "address_dec": 8212,
+      "name": "S20",
+      "description": "Nie wymieniono filtra kanałowego",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2016",
+      "address_dec": 8214,
+      "name": "S22",
+      "description": "Nie zadziałało zabezpieczenie przeciwzamrożeniowe wymiennika (FPX)",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2017",
+      "address_dec": 8215,
+      "name": "S23",
+      "description": "Uszkodzony czujnik temp. na wlocie do wymiennika (warunki do FPX)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2018",
+      "address_dec": 8216,
+      "name": "S24",
+      "description": "Uszkodzony czujnik temp. za nagrzewnicą wodną (kanał)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2019",
+      "address_dec": 8217,
+      "name": "S25",
+      "description": "Uszkodzony czujnik temp. powietrza zewnętrznego",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x201A",
+      "address_dec": 8218,
+      "name": "S26",
+      "description": "Uszkodzony czujnik TZ1 oraz GWC TZ3",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x201D",
+      "address_dec": 8221,
+      "name": "S29",
+      "description": "Zbyt wysoka temperatura przed rekuperatorem",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x201E",
+      "address_dec": 8222,
+      "name": "S30",
+      "description": "Nie działa wentylator nawiewny",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x201F",
+      "address_dec": 8223,
+      "name": "S31",
+      "description": "Nie działa wentylator wywiewny",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2020",
+      "address_dec": 8224,
+      "name": "S32",
+      "description": "Brak komunikacji z modułem TG-02",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2063",
+      "address_dec": 8291,
+      "name": "E99",
+      "description": "Konieczność wprowadzenia klucza produktu AirPack",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2064",
+      "address_dec": 8292,
+      "name": "E100",
+      "description": "Brak odczytu: TZ1 (czerpnia)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2065",
+      "address_dec": 8293,
+      "name": "E101",
+      "description": "Brak odczytu: TN1 (nawiew)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2066",
+      "address_dec": 8294,
+      "name": "E102",
+      "description": "Brak odczytu: TP (wywiew)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2067",
+      "address_dec": 8295,
+      "name": "E103",
+      "description": "Brak odczytu: TZ2 (FPX)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2068",
+      "address_dec": 8296,
+      "name": "E104",
+      "description": "Brak odczytu: TO (temp. otoczenia)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2069",
+      "address_dec": 8297,
+      "name": "E105",
+      "description": "Brak odczytu: TN2 (za wym. kanałowym)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x206A",
+      "address_dec": 8298,
+      "name": "E106",
+      "description": "Brak odczytu: TZ3 (GWC glikolowy)",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x208A",
+      "address_dec": 8330,
+      "name": "E138",
+      "description": "Awaria czujnika CF wentylatora nawiewnego / brak komunikacji z przetwornikiem ciśnienia",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x208B",
+      "address_dec": 8331,
+      "name": "E139",
+      "description": "Awaria czujnika CF wentylatora wywiewnego / brak komunikacji z przetwornikiem ciśnienia",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x2098",
+      "address_dec": 8344,
+      "name": "E152",
+      "description": "Temp. powietrza usuwanego z pomieszczeń wyższa od maksymalnej",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20C6",
+      "address_dec": 8390,
+      "name": "E196",
+      "description": "Regulacja instalacji nie została wykonana",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20C6",
+      "address_dec": 8390,
+      "name": "E197",
+      "description": "Regulacja instalacji została przerwana",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20C6",
+      "address_dec": 8390,
+      "name": "E198",
+      "description": "Brak komunikacji z modułem CF2",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY / UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20C6",
+      "address_dec": 8390,
+      "name": "E199",
+      "description": "Brak komunikacji z modułem CF",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY / UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20C8",
+      "address_dec": 8392,
+      "name": "E200",
+      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20C9",
+      "address_dec": 8393,
+      "name": "E201",
+      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w kanale",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20F9",
+      "address_dec": 8441,
+      "name": "E249",
+      "description": "Brak komunikacji z modułem Expansion",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY / SERWIS",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20FA",
+      "address_dec": 8442,
+      "name": "E250",
+      "description": "Sygnalizacja wymiany filtrów – centrala bez presostatu",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20FB",
+      "address_dec": 8443,
+      "name": "E251",
+      "description": "Sygnalizacja konieczności wymiany filtra kanałowego",
+      "access": "R/W",
+      "notes": "Reset: AUTOMATYCZNY",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    },
+    {
+      "function": "03",
+      "address_hex": "0x20FC",
+      "address_dec": 8444,
+      "name": "E252",
+      "description": "Sygnalizacja wymiany filtrów – centrala z presostatem",
+      "access": "R/W",
+      "notes": "Reset: UŻYTKOWNIK",
+      "enum": {
+        "0": "brak",
+        "1": "jest"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- copy full register spec JSON into integration
- load register metadata from JSON with CSV fallback and warning

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/data/modbus_registers.py custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo9dui5m6u/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 217 failed, 109 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a82ad5735083268c03f5d16cdd22fb