### PR TITLE
feat: add schedule parsing and scaling helpers

### DIFF
--- a/custom_components/thessla_green_modbus/data/modbus_registers.py
+++ b/custom_components/thessla_green_modbus/data/modbus_registers.py
@@ -8,7 +8,15 @@ from typing import Any, Dict
 
 from ..utils import _to_snake_case
 
-__all__ = ["get_register_info", "get_register_infos"]
+__all__ = [
+    "get_register_info",
+    "get_register_infos",
+    "scale_from_raw",
+    "scale_to_raw",
+    "apply_resolution",
+    "get_enum_mapping",
+    "map_enum_value",
+]
 
 _REGISTER_CACHE: Dict[str, Dict[str, Any]] | None = None
 
@@ -115,3 +123,74 @@ def get_register_infos(register_name: str) -> list[Dict[str, Any]]:
                 }
             )
     return results
+
+
+def scale_from_raw(register_name: str, value: float | int) -> float | int:
+    """Scale a raw register value using its configured multiplier."""
+
+    info = get_register_info(register_name)
+    if not info:
+        return value
+    multiplier = info.get("scale", 1) or 1
+    return value * multiplier
+
+
+def scale_to_raw(register_name: str, value: float | int) -> int | float:
+    """Convert a user value back to raw register form using the multiplier."""
+
+    info = get_register_info(register_name)
+    if not info:
+        return value
+    multiplier = info.get("scale", 1) or 1
+    return int(round(float(value) / multiplier))
+
+
+def apply_resolution(register_name: str, value: float | int) -> float | int:
+    """Round ``value`` to the register's resolution if specified."""
+
+    info = get_register_info(register_name)
+    if not info:
+        return value
+    resolution = info.get("step") or info.get("scale") or 1
+    return round(float(value) / resolution) * resolution
+
+
+def _parse_enum(info: str | None) -> dict[str, int] | None:
+    """Parse ``"0 - off; 1 - on"`` style strings into a mapping."""
+
+    if not info or "-" not in info:
+        return None
+    mapping: dict[str, int] = {}
+    for part in info.split(";"):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            num_str, label = part.split("-", 1)
+            mapping[_to_snake_case(label.strip())] = int(num_str.strip())
+        except ValueError:
+            continue
+    return mapping or None
+
+
+def get_enum_mapping(register_name: str) -> dict[str, int] | None:
+    """Return enumeration mapping for ``register_name`` if available."""
+
+    info = get_register_info(register_name)
+    if not info:
+        return None
+    return _parse_enum(info.get("unit")) or _parse_enum(info.get("information"))
+
+
+def map_enum_value(register_name: str, value: int | str) -> int | str | None:
+    """Map between numeric enum value and its textual representation."""
+
+    mapping = get_enum_mapping(register_name)
+    if not mapping:
+        return value
+    if isinstance(value, str):
+        return mapping.get(_to_snake_case(value))
+    for label, number in mapping.items():
+        if number == value:
+            return label
+    return None

--- a/custom_components/thessla_green_modbus/utils.py
+++ b/custom_components/thessla_green_modbus/utils.py
@@ -8,6 +8,7 @@ __all__ = [
     "_to_snake_case",
     "_decode_register_time",
     "_decode_bcd_time",
+    "parse_schedule_bcd",
     "BCD_TIME_PREFIXES",
     "TIME_REGISTER_PREFIXES",
 ]
@@ -65,6 +66,20 @@ def _decode_bcd_time(value: int) -> int | None:
     if 0 <= hours_dec <= 23 and 0 <= minutes_dec <= 59:
         return hours_dec * 60 + minutes_dec
     return None
+
+
+def parse_schedule_bcd(value: int) -> int | None:
+    """Parse schedule register values encoded as BCD HHMM.
+
+    The schedule registers use the BCD time representation but also employ
+    ``0x8000`` as a sentinel indicating that the entry is not configured.  This
+    helper wraps :func:`_decode_bcd_time` and converts the sentinel to
+    ``None`` while still validating the decoded time.
+    """
+
+    if value == 0x8000:
+        return None
+    return _decode_bcd_time(value)
 
 
 # Registers storing times as BCD HHMM values

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -6,6 +6,13 @@ from custom_components.thessla_green_modbus.utils import (
     _decode_bcd_time,
     _decode_register_time,
     _to_snake_case,
+    parse_schedule_bcd,
+)
+from custom_components.thessla_green_modbus.data.modbus_registers import (
+    apply_resolution,
+    map_enum_value,
+    scale_from_raw,
+    scale_to_raw,
 )
 
 
@@ -95,6 +102,14 @@ def test_time_decoding_helpers() -> None:
     assert _decode_bcd_time(2400) is None
 
 
+def test_schedule_bcd_parser() -> None:
+    """Ensure schedule parser handles valid and sentinel values."""
+
+    assert parse_schedule_bcd(0x0630) == 390
+    assert parse_schedule_bcd(0x8000) is None
+    assert parse_schedule_bcd(0x2460) is None
+
+
 def test_all_registers_have_units() -> None:
     """Ensure every register in the CSV specifies a unit."""
     csv_path = pathlib.Path("custom_components/thessla_green_modbus/data/modbus_registers.csv")
@@ -105,3 +120,16 @@ def test_all_registers_have_units() -> None:
             if not code or code.startswith("#"):
                 continue
             assert row["Unit"].strip() != ""  # nosec B101
+
+
+def test_loader_scaling_and_enum_helpers() -> None:
+    """Verify scaling, resolution and enum mapping helpers."""
+
+    # outside_temperature has multiplier/resolution 0.1
+    assert scale_from_raw("outside_temperature", 215) == 21.5
+    assert scale_to_raw("outside_temperature", 21.5) == 215
+    assert apply_resolution("outside_temperature", 21.53) == 21.5
+
+    # bypass register provides enum mapping "0 - OFF; 1 - ON"
+    assert map_enum_value("bypass", 1) == "on"
+    assert map_enum_value("bypass", "off") == 0


### PR DESCRIPTION
## Summary
- add parse_schedule_bcd to handle empty BCD schedule entries
- add helper utilities for register scaling, resolution and enum mapping
- extend register tests for new helpers

## Testing
- `pytest tests/test_registers.py::test_schedule_bcd_parser tests/test_registers.py::test_loader_scaling_and_enum_helpers tests/test_services_scaling.py::test_airflow_schedule_service_passes_user_values -vv` *(fails: KeyError: 'schedule_monday_period1_start')*


------
https://chatgpt.com/codex/tasks/task_e_68a82adad22083268bc3a0d9fa817137