### PR TITLE
Improve register loader test coverage

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -15,7 +15,11 @@ class Register:
 
     function: str
     address: int
+    name: str | None = None
     length: int = 1
+    enum: Dict[str, str] | None = None
+    multiplier: float | None = None
+    resolution: float | None = None
 
 
 @dataclass(slots=True)
@@ -35,6 +39,8 @@ class _RegisterModel(BaseModel):
     access: str | None = None
     enum: Dict[str, str] | None = None
     length: int | None = None
+    multiplier: float | None = None
+    resolution: float | None = None
 
     class Config:
         extra = "ignore"
@@ -71,7 +77,15 @@ def _load_registers() -> list[Register]:
         model = _RegisterFileModel.parse_raw(text)
 
     _REGISTERS = [
-        Register(function=r.function, address=r.address_dec, length=r.length or 1)
+        Register(
+            function=r.function,
+            address=r.address_dec,
+            name=r.name,
+            length=r.length or 1,
+            enum=r.enum,
+            multiplier=r.multiplier,
+            resolution=r.resolution,
+        )
         for r in model.registers
     ]
     return _REGISTERS

--- a/tests/test_loader_integration.py
+++ b/tests/test_loader_integration.py
@@ -1,0 +1,15 @@
+"""Smoke test using register loader with device scanner."""
+
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
+
+
+def test_scanner_with_loader_addresses():
+    """Ensure scanner can group addresses from the loader."""
+    scanner = ThesslaGreenDeviceScanner("host", 502)
+    addresses = [r.address for r in get_registers_by_function("04")[6:11]]
+    groups = scanner._group_registers_for_batch_read(addresses)
+    assert groups == [(min(addresses), len(addresses))]
+

--- a/tests/test_register_grouping.py
+++ b/tests/test_register_grouping.py
@@ -1,11 +1,9 @@
-import pytest
-
 from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.registers import INPUT_REGISTERS
+from custom_components.thessla_green_modbus.registers.loader import group_reads
 
 
-@pytest.mark.asyncio
-async def test_group_registers_split_known_missing():
+def test_group_registers_split_known_missing():
     """Known missing input registers are split into individual groups."""
     scanner = ThesslaGreenDeviceScanner("host", 502)
     missing_addr = INPUT_REGISTERS["compilation_days"]
@@ -24,3 +22,11 @@ async def test_group_registers_split_known_missing():
         (missing_addr, 1),
         (missing_addr + 1, 2),
     ]  # nosec B101
+
+
+def test_group_reads_from_json():
+    """Group consecutive registers based on JSON definitions."""
+    plans = [p for p in group_reads(max_block_size=64) if p.function == "04"]
+    assert (plans[0].address, plans[0].length) == (0, 5)
+    assert (plans[1].address, plans[1].length) == (14, 9)
+    assert (plans[2].address, plans[2].length) == (24, 6)

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -1,24 +1,54 @@
+"""Tests for JSON register loader."""
+
+from pathlib import Path
+
 from custom_components.thessla_green_modbus.registers.loader import (
-    get_all_registers,
+    _RegisterFileModel,
     get_registers_by_function,
-    group_reads,
 )
 
 
-def test_get_all_registers():
-    regs = get_all_registers()
-    assert regs, "No registers loaded"
+def _load_model() -> _RegisterFileModel:
+    text = Path("thessla_green_registers_full.json").read_text(encoding="utf-8")
+    try:
+        return _RegisterFileModel.model_validate_json(text)
+    except AttributeError:  # pragma: no cover - pydantic v1 fallback
+        return _RegisterFileModel.parse_raw(text)
 
 
-def test_get_registers_by_function():
-    all_regs = get_all_registers()
-    fn = all_regs[0].function
-    filtered = get_registers_by_function(fn)
-    assert all(r.function == fn for r in filtered)
+def test_json_schema_valid() -> None:
+    """Validate the register file against the schema."""
+    model = _load_model()
+    assert model.schema_version
+    assert model.registers
 
 
-def test_group_reads():
-    plans = group_reads(max_block_size=10)
-    assert plans, "No read plans generated"
-    for plan in plans:
-        assert plan.length <= 10
+def test_example_register_mapping() -> None:
+    """Verify example registers map to expected addresses."""
+    def addr(fn: str, name: str) -> int:
+        regs = get_registers_by_function(fn)
+        reg = next(r for r in regs if r.name == name)
+        return reg.address
+
+    assert addr("01", "duct_warter_heater_pump") == 5
+    assert addr("02", "duct_heater_protection") == 0
+    assert addr("03", "date_time_rrmm") == 0
+    assert addr("04", "VERSION_MAJOR") == 0
+
+
+def test_enum_multiplier_resolution_handling() -> None:
+    """Ensure optional register metadata is preserved."""
+    coil = get_registers_by_function("01")[0]
+    assert coil.enum == {"0": "OFF", "1": "ON"}
+
+    outside = next(
+        r for r in get_registers_by_function("04") if r.name == "outside_temperature"
+    )
+    assert outside.multiplier == 0.1
+
+    supply_manual = next(
+        r
+        for r in get_registers_by_function("03")
+        if r.name == "supplyAirTemperatureManual"
+    )
+    assert supply_manual.resolution == 0.5


### PR DESCRIPTION
## Summary
- extend register loader to keep register name and metadata such as enum, multiplier and resolution
- add tests validating JSON schema, register mappings, and metadata handling
- cover JSON-based grouping and add a simple integration smoke test using the loader

## Testing
- `pytest tests/test_register_loader.py tests/test_register_grouping.py tests/test_loader_integration.py`
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py tests/test_register_grouping.py tests/test_loader_integration.py` *(fails: InvalidManifestError for home-assistant/actions)*

------
https://chatgpt.com/codex/tasks/task_e_68a82ade7d4083268ceb72eca204ec9a