### PR TITLE
Add register loader tests and update integration

### DIFF
--- a/custom_components/thessla_green_modbus/register_loader.py
+++ b/custom_components/thessla_green_modbus/register_loader.py
@@ -1,0 +1,100 @@
+"""Utility for loading register definitions from JSON file."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+@dataclass
+class Register:
+    """Representation of a single Modbus register."""
+
+    function: str
+    address: int
+    access: str
+    name: str
+    description: str
+    enum: Dict[str, int] | None = None
+    multiplier: float | None = None
+    resolution: float | None = None
+
+
+class RegisterLoader:
+    """Load and organize register definitions."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        if path is None:
+            path = Path(__file__).parent / "registers" / "thessla_green_registers_full.json"
+        with path.open(encoding="utf-8") as f:
+            raw = json.load(f)
+
+        self.registers: Dict[str, Register] = {}
+        self.input_registers: Dict[str, int] = {}
+        self.holding_registers: Dict[str, int] = {}
+        self.coil_registers: Dict[str, int] = {}
+        self.discrete_registers: Dict[str, int] = {}
+        self.enums: Dict[str, Dict[str, int]] = {}
+        self.multipliers: Dict[str, float] = {}
+        self.resolutions: Dict[str, float] = {}
+
+        for entry in raw:
+            reg = Register(
+                function=entry["function"],
+                address=entry["address_dec"],
+                access=entry.get("access", "ro"),
+                name=entry["name"],
+                description=entry.get("description", ""),
+                enum=entry.get("enum"),
+                multiplier=entry.get("multiplier"),
+                resolution=entry.get("resolution"),
+            )
+            self.registers[reg.name] = reg
+            if reg.function == "input":
+                self.input_registers[reg.name] = reg.address
+            elif reg.function == "holding":
+                self.holding_registers[reg.name] = reg.address
+            elif reg.function == "coil":
+                self.coil_registers[reg.name] = reg.address
+            elif reg.function == "discrete":
+                self.discrete_registers[reg.name] = reg.address
+            if reg.enum is not None:
+                self.enums[reg.name] = reg.enum
+            if reg.multiplier is not None:
+                self.multipliers[reg.name] = reg.multiplier
+            if reg.resolution is not None:
+                self.resolutions[reg.name] = reg.resolution
+
+        self.group_reads: Dict[str, List[Tuple[int, int]]] = self._compute_group_reads()
+
+    def _compute_group_reads(self) -> Dict[str, List[Tuple[int, int]]]:
+        """Compute contiguous address groups for efficient reading."""
+
+        groups: Dict[str, List[Tuple[int, int]]] = {}
+        mapping = {
+            "input": self.input_registers,
+            "holding": self.holding_registers,
+            "coil": self.coil_registers,
+            "discrete": self.discrete_registers,
+        }
+        for func, regs in mapping.items():
+            addresses = sorted(regs.values())
+            if not addresses:
+                groups[func] = []
+                continue
+            ranges: List[Tuple[int, int]] = []
+            start = prev = addresses[0]
+            count = 1
+            for addr in addresses[1:]:
+                if addr == prev + 1:
+                    count += 1
+                else:
+                    ranges.append((start, count))
+                    start = addr
+                    count = 1
+                prev = addr
+            ranges.append((start, count))
+            groups[func] = ranges
+        return groups

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,6 +183,7 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
 
     util_logging.log_exception = log_exception
     util.logging = util_logging
+    util.dt = types.SimpleNamespace(now=lambda: None, utcnow=lambda: None)
     ha.util = util
 
     sys.modules["homeassistant"] = ha
@@ -209,6 +210,7 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
 
     util_logging.log_exception = log_exception
     util.logging = util_logging
+    util.dt = types.SimpleNamespace(now=lambda: None, utcnow=lambda: None)
     ha.util = util
     sys.modules["homeassistant.util"] = util
     sys.modules["homeassistant.util.logging"] = util_logging

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 testpaths = tests
 norecursedirs = .git testing_config
 python_files = test_*.py

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -130,6 +130,12 @@ for name, module in modules.items():
 # Ensure repository root is on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from custom_components.thessla_green_modbus.register_loader import RegisterLoader
+
+LOADER = RegisterLoader()
+INPUT_REGISTERS = LOADER.input_registers
+HOLDING_REGISTERS = LOADER.holding_registers
+
 # ✅ FIXED: Import correct coordinator class name
 from custom_components.thessla_green_modbus.coordinator import (
     ThesslaGreenModbusCoordinator,
@@ -201,11 +207,6 @@ def test_device_info(coordinator):
 
 def test_reverse_lookup_maps(coordinator):
     """Ensure reverse register maps resolve addresses to names."""
-    from custom_components.thessla_green_modbus.const import (
-        INPUT_REGISTERS,
-        HOLDING_REGISTERS,
-    )
-
     addr = INPUT_REGISTERS["outside_temperature"]
     assert coordinator._input_registers_rev[addr] == "outside_temperature"
 
@@ -215,7 +216,6 @@ def test_reverse_lookup_maps(coordinator):
 
 def test_reverse_lookup_performance(coordinator):
     """Dictionary lookups should outperform linear search."""
-    from custom_components.thessla_green_modbus.const import INPUT_REGISTERS
     import time
 
     addresses = list(INPUT_REGISTERS.values())

--- a/tests/test_example_configuration.py
+++ b/tests/test_example_configuration.py
@@ -1,0 +1,11 @@
+"""Smoke test for example Home Assistant configuration."""
+
+from pathlib import Path
+
+
+def test_example_configuration_loads():
+    """Ensure the example configuration file contains expected sections."""
+    path = Path(__file__).resolve().parent.parent / "example_configuration.yaml"
+    text = path.read_text(encoding="utf-8")
+    assert "template:" in text
+    assert "automation:" in text

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -1,0 +1,56 @@
+"""Tests for the register loader utility."""
+
+import json
+from pathlib import Path
+
+from custom_components.thessla_green_modbus.register_loader import RegisterLoader
+
+
+def test_json_structure():
+    """Validate structure of the registers JSON file."""
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "custom_components"
+        / "thessla_green_modbus"
+        / "registers"
+        / "thessla_green_registers_full.json"
+    )
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    required = {"function", "address_hex", "address_dec", "access", "name", "description"}
+    for entry in data:
+        assert required <= set(entry)
+
+
+def test_register_lookup_and_properties():
+    """Verify registers are loaded and accessible for all function codes."""
+    loader = RegisterLoader()
+    assert loader.input_registers["outside_temperature"] == 16
+    assert loader.holding_registers["mode"] == 4097
+    assert loader.coil_registers["bypass"] == 9
+    assert loader.discrete_registers["expansion"] == 0
+
+
+def test_enum_multiplier_resolution():
+    """Check enum, multiplier and resolution extraction."""
+    loader = RegisterLoader()
+    assert loader.enums["special_mode"]["boost"] == 1
+    assert loader.multipliers["required_temperature"] == 0.5
+    assert loader.resolutions["required_temperature"] == 0.5
+
+
+def test_group_reads_cover_addresses():
+    """Ensure group reads cover all register addresses without gaps."""
+    loader = RegisterLoader()
+    mapping = {
+        "input": loader.input_registers,
+        "holding": loader.holding_registers,
+        "coil": loader.coil_registers,
+        "discrete": loader.discrete_registers,
+    }
+    for func, regs in mapping.items():
+        addresses = sorted(regs.values())
+        grouped: list[int] = []
+        for start, count in loader.group_reads[func]:
+            grouped.extend(range(start, start + count))
+        assert grouped == addresses

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -195,6 +195,10 @@ for name, module in modules.items():
 # Ensure repository root on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from custom_components.thessla_green_modbus.register_loader import RegisterLoader
+
+HOLDING_REGISTERS = RegisterLoader().holding_registers
+
 services_module = importlib.reload(
     importlib.import_module("custom_components.thessla_green_modbus.services")
 )
@@ -207,6 +211,8 @@ def test_air_quality_register_map():
     assert AIR_QUALITY_REGISTER_MAP["co2_medium"] == "co2_threshold_medium"
     assert AIR_QUALITY_REGISTER_MAP["co2_high"] == "co2_threshold_high"
     assert AIR_QUALITY_REGISTER_MAP["humidity_target"] == "humidity_target"
+    for register in AIR_QUALITY_REGISTER_MAP.values():
+        assert register in HOLDING_REGISTERS
 
 
 def test_get_coordinator_from_entity_id_multiple_devices():

--- a/tests/test_services_scaling.py
+++ b/tests/test_services_scaling.py
@@ -5,9 +5,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from custom_components.thessla_green_modbus.const import HOLDING_REGISTERS
+from custom_components.thessla_green_modbus.register_loader import RegisterLoader
 import custom_components.thessla_green_modbus.services as services
 from custom_components.thessla_green_modbus.services import _scale_for_register
+
+HOLDING_REGISTERS = RegisterLoader().holding_registers
 
 
 class DummyCoordinator:


### PR DESCRIPTION
## Summary
- implement a JSON-based register loader with grouping logic
- add tests for register loader, service scaling, and sample configuration
- update coordinator and service tests to use loader

## Testing
- `pytest tests/test_register_loader.py tests/test_example_configuration.py tests/test_coordinator.py tests/test_services.py tests/test_services_scaling.py tests/test_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68a83fdf7b148326b48c1b615ebbdf82