### PR TITLE
docs: describe json register migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,38 @@ logger:
 ### Changelog
 Zobacz [CHANGELOG.md](CHANGELOG.md) dla pełnej historii zmian.
 
+## Migracja z CSV na JSON
+
+Od wersji 2.0 definicje rejestrów zostały przeniesione z pliku CSV do
+formatu JSON `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`.
+
+### Format pliku
+
+Każdy wpis w pliku to obiekt z polami:
+
+```json
+{
+  "function": "holding",
+  "address_hex": "0x1001",
+  "address_dec": 4097,
+  "access": "rw",
+  "name": "mode",
+  "description": "Work mode"
+}
+```
+
+Opcjonalnie można dodać `enum`, `multiplier`, `resolution`, `min`, `max`.
+
+### Dodawanie nowych rejestrów
+
+1. Otwórz plik JSON i dopisz nowy obiekt z wymaganymi polami.
+2. Zadbaj o unikalność adresów i zachowanie porządku.
+3. Uruchom test walidacyjny:
+
+```bash
+pytest tests/test_register_loader.py
+```
+
 ## 📄 Licencja
 
 MIT License - Zobacz [LICENSE](LICENSE) dla szczegółów.

--- a/README_en.md
+++ b/README_en.md
@@ -232,6 +232,38 @@ logger:
 ### Changelog
 See [CHANGELOG.md](CHANGELOG.md) for full history.
 
+## Migrating from CSV to JSON
+
+Since version 2.0 the register definitions have been moved from a CSV file to
+a JSON file at `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`.
+
+### File format
+
+Each entry in the file is an object with fields:
+
+```json
+{
+  "function": "holding",
+  "address_hex": "0x1001",
+  "address_dec": 4097,
+  "access": "rw",
+  "name": "mode",
+  "description": "Work mode"
+}
+```
+
+Optional properties: `enum`, `multiplier`, `resolution`, `min`, `max`.
+
+### Adding new registers
+
+1. Edit the JSON file and append a new object with the required fields.
+2. Ensure addresses are unique and remain sorted.
+3. Run the validation test:
+
+```bash
+pytest tests/test_register_loader.py
+```
+
 ## 📄 License
 
 MIT License – see [LICENSE](LICENSE) for details.
@@ -245,3 +277,4 @@ MIT License – see [LICENSE](LICENSE) for details.
 ---
 
 **🎉 Enjoy smart ventilation with Home Assistant!** 🏠💨
+

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1,4 +1,7 @@
-"""Data coordinator for the ThesslaGreen Modbus integration."""
+"""Asynchronous data coordinator for the ThesslaGreen Modbus integration.
+
+Handles connection management and uses register definitions loaded from
+JSON to batch Modbus reads for Home Assistant."""
 
 from __future__ import annotations
 

--- a/custom_components/thessla_green_modbus/register_loader.py
+++ b/custom_components/thessla_green_modbus/register_loader.py
@@ -1,4 +1,7 @@
-"""Utility for loading register definitions from JSON file."""
+"""Helpers for working with JSON-based register definitions.
+
+The register list lives in ``registers/thessla_green_registers_full.json`` and
+this loader is mainly used by tests and development utilities."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document migration of register definitions from CSV to JSON
- clarify how to extend register set and run validation tests
- improve module documentation and clean loader helpers

## Testing
- `pytest -q` *(fails: module 'homeassistant' has no attribute 'util')*
- `pytest tests/test_group_reads.py tests/test_register_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8435829a4832699f867e804a00be8