### PR TITLE
Add basic tests for register schema and grouping

### DIFF
--- a/tests/test_group_reads.py
+++ b/tests/test_group_reads.py
@@ -1,13 +1,13 @@
-"""Tests for group_reads utility."""
-
-from custom_components.thessla_green_modbus.loader import group_reads
+from custom_components.thessla_green_modbus.registers import get_registers_by_function, group_reads
 
 
-def test_group_reads_merges_consecutive_addresses():
-    addresses = [0, 1, 2, 3, 10, 11, 12]
-    assert group_reads(addresses) == [(0, 4), (10, 3)]
+def _expanded_addresses(fn: str) -> list[int]:
+    plans = [p for p in group_reads(max_block_size=32) if p.function == fn]
+    return [addr for plan in plans for addr in range(plan.address, plan.address + plan.length)]
 
 
-def test_group_reads_respects_max_block_size():
-    addresses = list(range(70))
-    assert group_reads(addresses, max_block_size=64) == [(0, 64), (64, 6)]
+def test_group_reads_coalesces_per_function():
+    for fn in ("01", "02", "03", "04"):
+        regs = get_registers_by_function(fn)
+        expected = sorted(r.address for r in regs)
+        assert _expanded_addresses(fn) == expected

--- a/tests/test_loader_smoke.py
+++ b/tests/test_loader_smoke.py
@@ -1,0 +1,8 @@
+from custom_components.thessla_green_modbus.registers import get_all_registers, group_reads
+
+
+def test_loader_smoke():
+    regs = get_all_registers()
+    assert regs
+    plans = group_reads()
+    assert plans

--- a/tests/test_register_json_schema.py
+++ b/tests/test_register_json_schema.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+
+def test_register_json_schema():
+    data = json.loads(Path("thessla_green_registers_full.json").read_text(encoding="utf-8"))
+    assert "registers" in data
+    registers = data["registers"]
+    assert isinstance(registers, list) and registers
+    required = {"function", "address_dec", "name"}
+    for reg in registers:
+        assert required <= reg.keys()
+        assert isinstance(reg["function"], str)
+        assert isinstance(reg["address_dec"], int)
+        assert isinstance(reg["name"], str)
+        if "enum" in reg:
+            enum = reg["enum"]
+            assert isinstance(enum, dict) and enum
+            for key, val in enum.items():
+                assert isinstance(key, str)
+                assert isinstance(val, str)
+        if "multiplier" in reg:
+            assert isinstance(reg["multiplier"], (int, float))
+        if "resolution" in reg:
+            assert isinstance(reg["resolution"], (int, float))

--- a/tests/test_register_mapping.py
+++ b/tests/test_register_mapping.py
@@ -1,0 +1,25 @@
+import pytest
+from custom_components.thessla_green_modbus.registers import get_registers_by_function
+
+
+def _reg(fn: str, name: str):
+    regs = get_registers_by_function(fn)
+    return next(r for r in regs if r.name == name)
+
+
+def test_register_mapping_and_scaling():
+    coil = _reg("01", "duct_warter_heater_pump")
+    assert coil.decode(1) == 1
+
+    discrete = _reg("02", "duct_heater_protection")
+    assert discrete.decode(0) == 0
+
+    holding = _reg("03", "supplyAirTemperatureManual")
+    assert holding.resolution == 0.5
+    assert holding.encode(21.3) == 21
+    assert holding.decode(21) == pytest.approx(21.0)
+
+    inp = _reg("04", "outside_temperature")
+    assert inp.multiplier == 0.1
+    assert inp.decode(215) == pytest.approx(21.5)
+    assert inp.encode(21.5) == 215


### PR DESCRIPTION
## Summary
- add test validating register JSON schema fields and types
- add mapping tests covering registers across functions 01-04
- test register group-read coalescing and loader smoke check

## Testing
- `pytest tests/test_register_json_schema.py tests/test_register_mapping.py tests/test_group_reads.py tests/test_loader_smoke.py -q`
- `pre-commit run --files tests/test_register_json_schema.py tests/test_register_mapping.py tests/test_group_reads.py tests/test_loader_smoke.py` *(fails: InvalidManifestError)*


------
https://chatgpt.com/codex/tasks/task_e_68a869cb64308326bb3d13ad2c0ec642