### PR TITLE
Handle 0x8000 sentinel in register decoders

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -106,6 +106,8 @@ class Register:
     # ------------------------------------------------------------------
     def decode(self, raw: int) -> Any:
         """Decode a raw register value using register metadata."""
+        if raw == 0x8000:
+            return None
 
         if self.bcd:
             hours_bcd = (raw >> 8) & 0xFF

--- a/custom_components/thessla_green_modbus/utils.py
+++ b/custom_components/thessla_green_modbus/utils.py
@@ -38,7 +38,7 @@ def _decode_register_time(value: int) -> int | None:
     extracted hour/minute fall outside of valid ranges.
     """
 
-    if value < 0:
+    if value == 0x8000 or value < 0:
         return None
 
     hour = (value >> 8) & 0xFF
@@ -52,7 +52,7 @@ def _decode_register_time(value: int) -> int | None:
 def _decode_bcd_time(value: int) -> int | None:
     """Decode BCD or decimal HHMM values to minutes since midnight."""
 
-    if value < 0:
+    if value == 0x8000 or value < 0:
         return None
 
     nibbles = [(value >> shift) & 0xF for shift in (12, 8, 4, 0)]
@@ -86,7 +86,7 @@ def parse_schedule_bcd(value: int) -> int | None:
 def _decode_aatt(value: int) -> tuple[int, float] | None:
     """Decode airflow percentage and temperature encoded as ``0xAATT``."""
 
-    if value < 0:
+    if value == 0x8000 or value < 0:
         return None
 
     airflow = (value >> 8) & 0xFF

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -17,7 +17,7 @@ def test_decode_register_time_valid():
     assert _decode_register_time(0x0000) == 0
 
 
-@pytest.mark.parametrize("value", [0x2460, 0x0960, -1])
+@pytest.mark.parametrize("value", [0x2460, 0x0960, 0x8000, -1])
 def test_decode_register_time_invalid(value):
     """Values outside valid hour/minute ranges should return None."""
     assert _decode_register_time(value) is None
@@ -31,7 +31,7 @@ def test_decode_bcd_time_valid():
     assert _decode_bcd_time(615) == 375
 
 
-@pytest.mark.parametrize("value", [0x2460, 2400, -1, 0x1A59])
+@pytest.mark.parametrize("value", [0x2460, 2400, 0x8000, -1, 0x1A59])
 def test_decode_bcd_time_invalid(value):
     """Invalid BCD or decimal times should return None."""
     assert _decode_bcd_time(value) is None
@@ -51,7 +51,7 @@ def test_decode_aatt_value_valid():
     assert _decode_aatt(0x0000) == (0, 0.0)
 
 
-@pytest.mark.parametrize("value", [-1, 0xFF28, 0x3DFF])
+@pytest.mark.parametrize("value", [-1, 0xFF28, 0x3DFF, 0x8000])
 def test_decode_aatt_value_invalid(value):
     """Values outside expected ranges should return None."""
     assert _decode_aatt(value) is None
@@ -82,3 +82,9 @@ def test_register_decode_encode_aatt():
     )
     assert reg.decode(0x3C28) == (60, 20.0)
     assert reg.encode((60, 20)) == 0x3C28
+
+
+def test_register_decode_unavailable_value():
+    """Sentinel value 0x8000 should decode to None."""
+    reg = Register(function="input", address=0, name="temp", access="ro")
+    assert reg.decode(0x8000) is None


### PR DESCRIPTION
## Summary
- return `None` when raw value equals `0x8000`
- cover sentinel handling with new decoder tests

## Testing
- `pytest tests/test_register_decoders.py -q`
- `pytest tests/test_modbus_helpers.py -q`
- `pytest -q` *(fails: IndentationError in `coordinator.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68a869d15a208326aeefc501ca346ae8