### PR TITLE
Handle DeviceCapabilities dataclass and attribute errors

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -19,6 +19,7 @@ from typing import (
     Tuple,
     TextIO,
     cast,
+    Self,
 )
 
 from .capability_rules import CAPABILITY_PATTERNS
@@ -41,7 +42,7 @@ from .modbus_exceptions import (
 )
 from .modbus_helpers import _call_modbus
 from .registers import get_all_registers
-from .utils import _decode_bcd_time, BCD_TIME_PREFIXES, TIME_REGISTER_PREFIXES, _to_snake_case
+from .utils import _decode_bcd_time, BCD_TIME_PREFIXES, _to_snake_case
 from .scanner_helpers import (
     REGISTER_ALLOWED_VALUES,
     _format_register_value,
@@ -256,7 +257,7 @@ class ThesslaGreenDeviceScanner:
         skip_known_missing: bool = False,
         deep_scan: bool = False,
         full_register_scan: bool = False,
-    ) -> "ThesslaGreenDeviceScanner":
+    ) -> Self:
         """Factory to create an initialized scanner instance."""
         self = cls(
             host,
@@ -914,7 +915,10 @@ class ThesslaGreenDeviceScanner:
             )
             if not connected:
                 raise ConnectionException("Failed to connect")
-            return await self.scan()
+            result = await self.scan()
+            if not isinstance(result, dict):
+                raise TypeError("scan() must return a dict")
+            return result
         finally:
             await self.close()
 


### PR DESCRIPTION
## Summary
- ensure DeviceCapabilities are handled as dataclass objects throughout config flow
- type-safe scanner factory/scan with return validation
- cover attribute errors in config flow validation tests

## Testing
- `pytest tests/test_config_flow.py::test_validate_input_attribute_error tests/test_config_flow.py::test_validate_input_uses_scan_device_and_closes tests/test_config_flow.py::test_form_user_attribute_error_scanner -q`


------
https://chatgpt.com/codex/tasks/task_e_68a871fea8cc8326ab0916c201f4e3b2