### PR TITLE
Add tests for register mapping and enum handling

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -177,6 +177,13 @@ def _load_registers() -> List[Register]:
             address = int(str(item.get("address_hex")), 16)
 
         try:
+            enum_map = item.get("enum")
+            if enum_map:
+                if all(isinstance(k, (int, float)) or str(k).isdigit() for k in enum_map):
+                    enum_map = {int(k): v for k, v in enum_map.items()}
+                elif all(isinstance(v, (int, float)) or str(v).isdigit() for v in enum_map.values()):
+                    enum_map = {int(v): k for k, v in enum_map.items()}
+
             registers.append(
                 Register(
                     function=function,
@@ -190,7 +197,7 @@ def _load_registers() -> List[Register]:
                     min=item.get("min"),
                     max=item.get("max"),
                     default=item.get("default"),
-                    enum=item.get("enum"),
+                    enum=enum_map,
                     notes=item.get("notes"),
                     information=item.get("information"),
                     extra=item.get("extra"),

--- a/tests/test_register_mapping.py
+++ b/tests/test_register_mapping.py
@@ -8,16 +8,20 @@ def _reg(fn: str, name: str):
 
 
 def test_register_mapping_and_scaling():
-    coil = _reg("01", "duct_warter_heater_pump")
+    coil = _reg("01", "duct_water_heater_pump")
     assert coil.decode(1) == 1
 
-    discrete = _reg("02", "duct_heater_protection")
+    discrete = _reg("02", "fire_alarm")
     assert discrete.decode(0) == 0
 
-    holding = _reg("03", "supplyAirTemperatureManual")
+    holding = _reg("03", "required_temperature")
     assert holding.resolution == 0.5
-    assert holding.encode(21.3) == 21
-    assert holding.decode(21) == pytest.approx(21.0)
+    assert holding.encode(21.3) == 43
+    assert holding.decode(43) == pytest.approx(21.5)
+
+    enum_reg = _reg("03", "special_mode")
+    assert enum_reg.decode(8) == "fireplace"
+    assert enum_reg.encode("summer") == 512
 
     inp = _reg("04", "outside_temperature")
     assert inp.multiplier == 0.1


### PR DESCRIPTION
## Summary
- handle enum mappings stored as label-to-value or value-to-label when loading register definitions
- expand register mapping test to cover coils, discrete, holding, input registers and enum encode/decode

## Testing
- `pytest tests/test_register_json_schema.py tests/test_register_mapping.py tests/test_group_reads.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a87788c5e0832691eccc41ec24b273