### PR TITLE
Use group_reads for efficient Modbus scans and handle sentinel values

### DIFF
--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -2,6 +2,10 @@ import asyncio
 import pytest
 
 from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_helpers import (
+    _decode_season_mode,
+    _format_register_value,
+)
 from custom_components.thessla_green_modbus.utils import (
     _decode_aatt,
     _decode_bcd_time,
@@ -88,3 +92,14 @@ def test_register_decode_unavailable_value():
     """Sentinel value 0x8000 should decode to None."""
     reg = Register(function="input", address=0, name="temp", access="ro")
     assert reg.decode(0x8000) is None
+
+
+def test_decode_season_mode_special_value():
+    """Season mode decoder should treat 0x8000 as undefined."""
+    assert _decode_season_mode(0x8000) is None
+
+
+def test_format_register_value_special_values():
+    """Formatter should return None for sentinel values."""
+    assert _format_register_value("schedule_test", 0x8000) is None
+    assert _format_register_value("setting_test", 0x8000) is None

--- a/tests/test_register_grouping.py
+++ b/tests/test_register_grouping.py
@@ -30,5 +30,5 @@ def test_group_reads_from_json():
     """Group consecutive registers based on JSON definitions."""
     plans = [p for p in group_reads(max_block_size=64) if p.function == "04"]
     assert (plans[0].address, plans[0].length) == (0, 5)
-    assert (plans[1].address, plans[1].length) == (14, 9)
-    assert (plans[2].address, plans[2].length) == (24, 6)
+    assert (plans[1].address, plans[1].length) == (14, 17)
+    assert (plans[2].address, plans[2].length) == (32, 8)


### PR DESCRIPTION
## Summary
- batch input/holding register scans now use shared `group_reads` helper to minimize Modbus requests
- decoders and formatting functions interpret 0x8000 and similar sentinel values as `None`
- extend tests for sentinel handling and updated register grouping

## Testing
- `pytest tests/test_register_decoders.py tests/test_register_grouping.py -q`
- `pytest -q` *(fails: SyntaxError in climate.py & services.py, missing module yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68a8778574f8832694ee23654f52e607