### PR TITLE
Load registers via loader and select Modbus function

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -20,9 +20,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, SPECIAL_FUNCTION_MAP
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
-from .const import HOLDING_REGISTERS
+from .registers import get_registers_by_function
 
 _LOGGER = logging.getLogger(__name__)
+
+HOLDING_REGISTERS = {r.name for r in get_registers_by_function("03")}
 
 # HVAC mode mappings (from device mode register)
 HVAC_MODE_MAP = {
@@ -137,7 +139,8 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return target temperature if available."""
-        data = self.coordinator.data        for key in (
+        data = self.coordinator.data
+        for key in (
             "comfort_temperature",
             "required_temperature",
             "required_temperature_legacy",

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -15,14 +15,15 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, get_holding_registers
+from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .modbus_exceptions import ConnectionException, ModbusException
+from .registers import get_registers_by_function
 
 _LOGGER = logging.getLogger(__name__)
 
-HOLDING_REGISTERS = get_holding_registers()
+HOLDING_REGISTERS = {r.name for r in get_registers_by_function("03")}
 
 
 async def async_setup_entry(

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -17,22 +17,21 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from .const import DOMAIN, get_holding_registers
+from .const import DOMAIN
 
 try:  # Newer versions expose metadata through ENTITY_MAPPINGS
     from .const import ENTITY_MAPPINGS
 except ImportError:  # pragma: no cover - fall back when not available
     ENTITY_MAPPINGS = {}
-from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .entity_mappings import ENTITY_MAPPINGS
 from .modbus_exceptions import ConnectionException, ModbusException
-from .const import HOLDING_REGISTERS
+from .registers import get_registers_by_function
 
 _LOGGER = logging.getLogger(__name__)
 
-HOLDING_REGISTERS = get_holding_registers()
+HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
 
 # Unit mappings
 UNIT_MAPPINGS = {

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -24,16 +24,11 @@ from typing import (
 
 from .capability_rules import CAPABILITY_PATTERNS
 from .const import (
-    COIL_REGISTERS,
     DEFAULT_SLAVE_ID,
-    DISCRETE_INPUT_REGISTERS,
     KNOWN_MISSING_REGISTERS,
     SENSOR_UNAVAILABLE,
     SENSOR_UNAVAILABLE_REGISTERS,
     UNKNOWN_MODEL,
-    HOLDING_REGISTERS,
-    INPUT_REGISTERS,
-    MULTI_REGISTER_SIZES,
 )
 from .modbus_exceptions import (
     ConnectionException,
@@ -54,6 +49,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from pymodbus.client import AsyncModbusTcpClient
 
 _LOGGER = logging.getLogger(__name__)
+
+REGISTER_DEFINITIONS = {r.name: r for r in get_all_registers()}
+INPUT_REGISTERS = {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "04"}
+HOLDING_REGISTERS = {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "03"}
+COIL_REGISTERS = {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "01"}
+DISCRETE_INPUT_REGISTERS = {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "02"}
+MULTI_REGISTER_SIZES = {name: reg.length for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "03" and reg.length > 1}
 
 
 @dataclass

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -11,16 +11,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, get_coil_registers, get_holding_registers
+from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .entity_mappings import ENTITY_MAPPINGS
 from .modbus_exceptions import ConnectionException, ModbusException
+from .registers import get_registers_by_function
 
 _LOGGER = logging.getLogger(__name__)
 
-HOLDING_REGISTERS = get_holding_registers()
-COIL_REGISTERS = get_coil_registers()
+HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
+COIL_REGISTERS = {r.name: r.address for r in get_registers_by_function("01")}
 
 # Switch entities that can be controlled
 SWITCH_ENTITIES = {


### PR DESCRIPTION
## Summary
- use JSON register loader and expose grouping within register_loader
- fetch register maps from loader across coordinator and platforms
- choose Modbus operation based on register metadata

## Testing
- `pytest` *(fails: custom_components/thessla_green_modbus/services.py:368 SyntaxError: invalid syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68a87783cbe8832681642ea2944ec245