### PR TITLE
Cache register loading

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -184,6 +184,8 @@ def _load_raw() -> List[Dict[str, Any]]:
 
 _REGISTERS_PATH = Path(__file__).resolve().parents[3] / "registers" / "thessla_green_registers_full.json"
 
+
+@lru_cache(maxsize=1)
 def _load_registers() -> List[Register]:
     """Load register definitions from the JSON file."""
 


### PR DESCRIPTION
## Summary
- cache `_load_registers` so register file is read only once
- add test ensuring register file read once using `lru_cache`

## Testing
- `pytest tests/test_register_loader.py::test_registers_loaded_only_once -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87c7220908326a3897aa36203e2c9