### PR TITLE
docs: document CSV→JSON register migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ pełne skanowanie wszystkich rejestrów (`full_register_scan=True`) i zwraca
 listę nieznanych adresów. Operacja może trwać kilka minut i znacząco obciąża
 urządzenie – używaj jej tylko do diagnostyki.
 
+### Migracja z CSV na JSON
+Definicje rejestrów znajdują się teraz w pliku JSON `registers/thessla_green_registers_full.json`.
+Każdy wpis w sekcji `registers` zawiera m.in. pola:
+
+- `function` – kod funkcji Modbus (`01`–`04`)
+- `address_dec` / `address_hex` – adres rejestru
+- `name` – unikalna nazwa w formacie snake_case
+- `description` – opis z dokumentacji
+- `access` – tryb dostępu (`R`/`W`)
+
+Opcjonalnie można określić `unit`, `enum`, `multiplier`, `resolution` oraz inne
+metadane. Aby dodać nowy rejestr, dopisz obiekt do listy `registers` zachowując
+porządek adresów i uruchom `pytest`, aby zweryfikować poprawność pliku.
+
 ### Włączanie logów debug
 W razie problemów możesz włączyć szczegółowe logi tej integracji. Dodaj poniższą konfigurację do `configuration.yaml` i zrestartuj Home Assistant:
 

--- a/custom_components/thessla_green_modbus/register_loader.py
+++ b/custom_components/thessla_green_modbus/register_loader.py
@@ -1,10 +1,9 @@
 """Compatibility wrapper around the JSON register loader.
 
 Historically the project exposed a :class:`RegisterLoader` class that read
-register definitions from CSV files.  The integration now uses a JSON file as
-the single source of truth.  This module keeps a minimal subset of the old API
-so external tools and some tests can continue to work while emitting a warning
-about the deprecation.
+register definitions from CSV files. The integration now uses a JSON file as
+the single source of truth. CSV support is retained solely for backward
+compatibility and the loader logs a warning whenever it is invoked.
 """
 
 from __future__ import annotations
@@ -24,7 +23,11 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class RegisterLoader:  # pragma: no cover - thin compatibility layer
-    """Backward compatible loader returning simple register maps."""
+    """Backward compatible loader returning simple register maps.
+
+    CSV input is deprecated; instantiating this class logs a warning and uses
+    the bundled JSON definitions instead.
+    """
 
     registers: Dict[str, Register]
     input_registers: Dict[str, int]

--- a/docs/register_scanning.md
+++ b/docs/register_scanning.md
@@ -16,3 +16,18 @@ Enabling the **force_full_register_list** option creates entities for every disc
 register. This can reveal additional data but may also surface partial values or internal
 configuration fields that have no dedicated entity class. Use this option with care and
 primarily for debugging or development purposes.
+
+## Migracja z CSV na JSON
+Rejestry są obecnie definiowane w pliku JSON `registers/thessla_green_registers_full.json`.
+Każdy obiekt w tablicy `registers` zawiera pola:
+
+- `function` – kod funkcji Modbus
+- `address_dec` / `address_hex` – adres rejestru
+- `name` – unikalna nazwa
+- `description` – opis
+- `access` – tryb dostępu (`R`/`W`)
+
+Opcjonalnie można zdefiniować `unit`, `enum`, `multiplier`, `resolution` i inne
+atrybuty. Aby dodać nowy rejestr, dopisz odpowiedni obiekt do listy `registers`
+z zachowaniem kolejności adresów. Format CSV pozostaje jedynie dla kompatybilności
+wstecznej – jego użycie zapisuje ostrzeżenie w logach.


### PR DESCRIPTION
## Summary
- add CSV→JSON migration guide to README and docs
- clarify register loader docstring about deprecated CSV usage

## Testing
- `pip install pyyaml`
- `pytest` *(fails: SyntaxError in custom_components/thessla_green_modbus/services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a8820338308326b56fddfd7b08ea11