### PR TITLE
docs: drop csv references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ custom_components/thessla_green_modbus/
 
 ### Regenerating register definitions
 
-Whenever `custom_components/thessla_green_modbus/data/modbus_registers.csv` is modified, regenerate
+Whenever `registers/thessla_green_registers_full.json` is modified, regenerate
 `custom_components/thessla_green_modbus/registers.py` and validate it:
 
 ```bash
@@ -172,7 +172,7 @@ python tools/generate_registers.py
 python tools/validate_registers.py
 ```
 
-Commit the updated CSV and Python files together. The `generate-registers` and `validate-registers`
+Commit the updated JSON and Python files together. The `generate-registers` and `validate-registers`
 pre-commit hooks run these checks automatically.
 
 ## Testing
@@ -189,10 +189,8 @@ python -m pytest tests/test_coordinator.py -v
 # Run with coverage
 python -m pytest tests/ --cov=custom_components.thessla_green_modbus
 
-# Validate register mappings against CSV definitions
-python -m pytest tests/test_register_coverage.py -v
-
-# Verify CSV and registers.py are in sync
+# Validate register file
+python -m pytest tests/test_register_loader.py -v
 python tools/validate_registers.py
 
 # Validate translation files

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ pełne skanowanie wszystkich rejestrów (`full_register_scan=True`) i zwraca
 listę nieznanych adresów. Operacja może trwać kilka minut i znacząco obciąża
 urządzenie – używaj jej tylko do diagnostyki.
 
-### Migracja z CSV na JSON
-Definicje rejestrów znajdują się teraz w pliku JSON `registers/thessla_green_registers_full.json`.
-Każdy wpis w sekcji `registers` zawiera m.in. pola:
+### Rejestry w formacie JSON
+Definicje rejestrów znajdują się w pliku `registers/thessla_green_registers_full.json`,
+który stanowi jedyne źródło prawdy. Każdy wpis w sekcji `registers` zawiera m.in. pola:
 
 - `function` – kod funkcji Modbus (`01`–`04`)
 - `address_dec` / `address_hex` – adres rejestru
@@ -144,7 +144,8 @@ Każdy wpis w sekcji `registers` zawiera m.in. pola:
 
 Opcjonalnie można określić `unit`, `enum`, `multiplier`, `resolution` oraz inne
 metadane. Aby dodać nowy rejestr, dopisz obiekt do listy `registers` zachowując
-porządek adresów i uruchom `pytest`, aby zweryfikować poprawność pliku.
+porządek adresów i uruchom `pytest tests/test_register_loader.py`, aby
+zweryfikować poprawność pliku.
 
 ### Włączanie logów debug
 W razie problemów możesz włączyć szczegółowe logi tej integracji. Dodaj poniższą konfigurację do `configuration.yaml` i zrestartuj Home Assistant:
@@ -504,15 +505,11 @@ python -m json.tool custom_components/thessla_green_modbus/translations/*.json
 ### Changelog
 Zobacz [CHANGELOG.md](CHANGELOG.md) dla pełnej historii zmian.
 
-## Migracja z CSV na JSON
+## Rejestry w formacie JSON
 
-Od wersji 2.0 definicje rejestrów zostały przeniesione z pliku CSV do
-formatu JSON `registers/thessla_green_registers_full.json`. Pliki CSV są
-przestarzałe – narzędzia w katalogu `tools/` obsługują wyłącznie JSON i w
-przyszłych wersjach wsparcie dla CSV zostanie usunięte. Jeśli posiadasz
-starszy plik CSV, przekonwertuj go na JSON (np. prostym skryptem w Pythonie
-lub arkuszem kalkulacyjnym), a następnie usuń wersję CSV, aby uniknąć
-konfliktów.
+Plik `registers/thessla_green_registers_full.json` przechowuje komplet
+definicji rejestrów i stanowi jedyne źródło prawdy. Wszystkie narzędzia w
+`tools/` operują wyłącznie na tym formacie.
 
 ### Format pliku
 

--- a/README_en.md
+++ b/README_en.md
@@ -287,14 +287,11 @@ python -m json.tool custom_components/thessla_green_modbus/translations/*.json
 ### Changelog
 See [CHANGELOG.md](CHANGELOG.md) for full history.
 
-## Migrating from CSV to JSON
+## JSON register definitions
 
-Since version 2.0 the register definitions live in
-`registers/thessla_green_registers_full.json`. CSV files are deprecated – the
-tools in `tools/` only understand JSON and support for CSV will be removed in
-future releases. Convert any existing CSV definitions to the JSON format (via a
-short Python script or spreadsheet export) and remove the legacy files to avoid
-confusion.
+The file `registers/thessla_green_registers_full.json` stores the complete
+register specification and is the single source of truth. All tools in
+`tools/` operate exclusively on this JSON format.
 
 ### File format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ include = ["custom_components*"]
 
 [tool.setuptools.package-data]
 "custom_components.thessla_green_modbus" = [
-    "data/*.csv",
     "options/*.json",
 ]
 


### PR DESCRIPTION
## Summary
- document JSON register file as single source of truth
- remove CSV build info from contributor guide and pyproject

## Testing
- `pre-commit run --files README.md README_en.md CONTRIBUTING.md pyproject.toml` *(fails: InvalidManifestError)*
- `pytest tests/test_register_loader.py` *(fails: StopIteration; 3 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a2aa0694832696c7ae22ca2cfd1c