### PR TITLE
feat: warn and parse legacy csv registers

### DIFF
--- a/custom_components/thessla_green_modbus/register_loader.py
+++ b/custom_components/thessla_green_modbus/register_loader.py
@@ -8,17 +8,83 @@ compatibility and the loader logs a warning whenever it is invoked.
 
 from __future__ import annotations
 
+import csv
 from dataclasses import dataclass
 import logging
 from pathlib import Path
-from typing import Dict, List, Tuple, TYPE_CHECKING
+from typing import Dict, List, Tuple
 
-from .registers import get_all_registers, get_registers_by_function
-
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    from .registers import Register
+from .registers import Register, get_all_registers, get_registers_by_function
+from .utils import _to_snake_case
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _csv_path_from_arg(path: Path | None) -> Path | None:
+    """Return CSV file path if *path* points to a CSV definition."""
+    if path is None:
+        return None
+    if path.is_file() and path.suffix.lower() == ".csv":
+        return path
+    if path.is_dir():
+        candidate = path / "modbus_registers.csv"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _load_from_csv(csv_path: Path) -> List[Register]:
+    """Parse legacy CSV register definition file."""
+    registers: List[Register] = []
+    with csv_path.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            code = row.get("Function_Code")
+            if not code or code.startswith("#"):
+                continue
+            name_raw = row.get("Register_Name")
+            if not isinstance(name_raw, str) or not name_raw.strip():
+                continue
+            name = _to_snake_case(name_raw)
+            try:
+                address = int(row.get("Address_DEC", 0))
+            except (TypeError, ValueError):
+                continue
+
+            multiplier: float | None = None
+            if row.get("Multiplier") not in (None, ""):
+                try:
+                    multiplier = float(row["Multiplier"])
+                except ValueError:
+                    multiplier = None
+
+            enum: Dict[int, str] | None = None
+            enum_text = row.get("Unit") or row.get("Information")
+            if enum_text and "-" in enum_text:
+                enum = {}
+                for part in enum_text.split(";"):
+                    part = part.strip()
+                    if not part:
+                        continue
+                    try:
+                        num_str, label = part.split("-", 1)
+                        enum[int(num_str.strip())] = _to_snake_case(label.strip())
+                    except ValueError:
+                        continue
+
+            registers.append(
+                Register(
+                    function=str(code).zfill(2),
+                    address=address,
+                    name=name,
+                    access=str(row.get("Access", "")),
+                    description=row.get("Description"),
+                    unit=row.get("Unit"),
+                    multiplier=multiplier,
+                    enum=enum,
+                )
+            )
+    return registers
 
 
 @dataclass
@@ -40,10 +106,18 @@ class RegisterLoader:  # pragma: no cover - thin compatibility layer
     group_reads: Dict[str, List[Tuple[int, int]]]
 
     def __init__(self, path: Path | None = None) -> None:
-        if path is not None:
-            _LOGGER.warning("RegisterLoader path argument is ignored; JSON definitions are built-in")
-
-        regs = get_all_registers()
+        csv_path = _csv_path_from_arg(path)
+        if csv_path:
+            _LOGGER.warning(
+                "CSV register files are deprecated; JSON definitions are authoritative"
+            )
+            regs = _load_from_csv(csv_path)
+        else:
+            if path is not None:
+                _LOGGER.warning(
+                    "RegisterLoader path argument is ignored; JSON definitions are built-in"
+                )
+            regs = get_all_registers()
         self.registers = {r.name: r for r in regs}
         self.input_registers = {r.name: r.address for r in regs if r.function == "04"}
         self.holding_registers = {r.name: r.address for r in regs if r.function == "03"}
@@ -53,11 +127,19 @@ class RegisterLoader:  # pragma: no cover - thin compatibility layer
         self.multipliers = {r.name: r.multiplier for r in regs if r.multiplier}
         self.resolutions = {r.name: r.resolution for r in regs if r.resolution}
 
-        groups: Dict[str, List[Tuple[int, int]]] = {"input": [], "holding": [], "coil": [], "discrete": []}
+        groups: Dict[str, List[Tuple[int, int]]] = {
+            "input": [],
+            "holding": [],
+            "coil": [],
+            "discrete": [],
+        }
+        regs_by_fn: Dict[str, List[int]] = {}
+        for reg in regs:
+            regs_by_fn.setdefault(reg.function, []).extend(
+                range(reg.address, reg.address + max(1, reg.length))
+            )
         for fn, key in [("04", "input"), ("03", "holding"), ("01", "coil"), ("02", "discrete")]:
-            addresses: List[int] = []
-            for reg in get_registers_by_function(fn):
-                addresses.extend(range(reg.address, reg.address + max(1, reg.length)))
+            addresses = regs_by_fn.get(fn, [])
             if not addresses:
                 continue
             addresses.sort()

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -1,5 +1,9 @@
 """Tests for JSON register loader."""
 
+import logging
+from pathlib import Path
+
+from custom_components.thessla_green_modbus.register_loader import RegisterLoader
 from custom_components.thessla_green_modbus.registers import (
     get_registers_by_function,
 )
@@ -72,3 +76,21 @@ def test_registers_loaded_only_once(monkeypatch) -> None:
 
     # The file should be read only once thanks to caching
     assert read_calls == 1
+
+
+def test_csv_loader_emits_warning(caplog) -> None:
+    """Using a CSV file should emit a deprecation warning."""
+
+    csv_path = (
+        Path(__file__).resolve().parent.parent
+        / "custom_components"
+        / "thessla_green_modbus"
+        / "data"
+        / "modbus_registers.csv"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        loader = RegisterLoader(csv_path)
+
+    assert loader.registers
+    assert any("deprecated" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- detect when RegisterLoader is given a CSV file and warn that CSV is deprecated
- parse CSV rows into Register objects using existing structures
- test warning when legacy CSV path is passed to RegisterLoader

## Testing
- `pytest tests/test_register_loader.py::test_csv_loader_emits_warning -q`
- `pip install PyYAML`
- `pytest -q` *(fails: SyntaxError: invalid syntax in custom_components/thessla_green_modbus/services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a65f5cdc83269641946f4046cb27