### PR TITLE
Add group_reads max_block_size test and docs guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ Dostępny jest serwis `thessla_green_modbus.scan_all_registers`, który wykonuje
 pełne skanowanie wszystkich rejestrów (`full_register_scan=True`) i zwraca
 listę nieznanych adresów. Operacja może trwać kilka minut i znacząco obciąża
 urządzenie – używaj jej tylko do diagnostyki.
+### Użycie `group_reads`
+Funkcja `group_reads` dzieli listę adresów na ciągłe bloki ograniczone parametrem `max_block_size` (domyślnie 64). Własne skrypty powinny z niej korzystać, aby minimalizować liczbę zapytań i nie przekraczać zalecanego rozmiaru bloku. W razie problemów z komunikacją można zmniejszyć `max_block_size`, np. do 16, co zapewnia stabilniejszy odczyt.
+
+```python
+from custom_components.thessla_green_modbus.loader import group_reads
+
+for start, size in group_reads(range(100), max_block_size=16):
+    print(start, size)
+```
+
 
 ### Rejestry w formacie JSON
 Definicje rejestrów znajdują się w pliku `registers/thessla_green_registers_full.json`,

--- a/tests/test_group_reads_max_size.py
+++ b/tests/test_group_reads_max_size.py
@@ -1,0 +1,12 @@
+from custom_components.thessla_green_modbus.loader import group_reads
+
+
+def test_group_reads_respects_max_block_size() -> None:
+    """group_reads splits long address ranges based on ``max_block_size``."""
+
+    addresses = list(range(40))
+    assert group_reads(addresses, max_block_size=16) == [
+        (0, 16),
+        (16, 16),
+        (32, 8),
+    ]


### PR DESCRIPTION
## Summary
- test: ensure `group_reads` splits reads respecting `max_block_size`
- docs: add README guidance and example for `group_reads`

## Testing
- `pytest tests/test_group_reads_max_size.py -q`
- `pytest tests/test_register_grouping.py -q`
- `pytest -q` *(fails: SyntaxError in custom_components/thessla_green_modbus/services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a950103883268615d46f8b7ee8f6