### PR TITLE
Add example register tests for Modbus functions

### DIFF
--- a/tests/test_register_examples.py
+++ b/tests/test_register_examples.py
@@ -1,0 +1,35 @@
+import pytest
+
+from custom_components.thessla_green_modbus.registers.loader import Register
+
+
+def test_coil_and_discrete_enum():
+    """Registers for function 01 and 02 should decode enums correctly."""
+    coil = Register(function="01", address=5, name="coil", access="ro", enum={0: "OFF", 1: "ON"})
+    assert coil.decode(1) == "ON"
+    assert coil.encode("OFF") == 0
+
+    discrete = Register(function="02", address=0, name="discrete", access="ro", enum={0: "brak", 1: "jest"})
+    assert discrete.decode(0) == "brak"
+    assert discrete.encode("jest") == 1
+
+
+def test_holding_multiplier_resolution_and_bcd():
+    """Function 03 registers may use multiplier/resolution and BCD."""
+    scaling = Register(function="03", address=4096, name="temp", access="rw", multiplier=0.5, resolution=0.5)
+    assert scaling.decode(45) == 22.5
+    assert scaling.encode(22.5) == 45
+
+    schedule = Register(function="03", address=4097, name="schedule", access="rw", bcd=True)
+    assert schedule.decode(0x0815) == "08:15"
+    assert schedule.encode("08:15") == 0x0815
+
+
+def test_input_extra_aatt_and_sentinel():
+    """Function 04 registers support extra aatt and sentinel values."""
+    combined = Register(function="04", address=16, name="combined", access="ro", extra={"aatt": True})
+    assert combined.decode(0x3C28) == (60, 20.0)
+    assert combined.encode((60, 20.0)) == 0x3C28
+
+    sensor = Register(function="04", address=17, name="sensor", access="ro")
+    assert sensor.decode(0x8000) is None


### PR DESCRIPTION
## Summary
- add unit tests demonstrating enum decode/encode for coil and discrete registers
- add multiplier/resolution and BCD tests for holding registers
- add extra `aatt` and sentinel handling tests for input registers

## Testing
- `pytest tests/test_register_examples.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a94eb0ac8326a9e6e2aa6f992c93