### PR TITLE
feat: centralize Modbus read grouping helper

### DIFF
--- a/custom_components/thessla_green_modbus/loader.py
+++ b/custom_components/thessla_green_modbus/loader.py
@@ -15,6 +15,7 @@ from .registers import (
     get_all_registers,
     get_registers_by_function as _get_registers_by_function,
 )
+from .modbus_helpers import group_reads
 
 
 @lru_cache(maxsize=1)
@@ -34,26 +35,5 @@ def get_registers_by_function(function: str) -> Dict[str, int]:
     """Return mapping of register names to addresses for ``function``."""
 
     return {r.name: r.address for r in _get_registers_by_function(function)}
-
-
-def group_reads(addresses: Iterable[int], max_block_size: int = 64) -> List[Tuple[int, int]]:
-    """Group raw addresses into contiguous read blocks."""
-
-    sorted_addresses = sorted(set(addresses))
-    if not sorted_addresses:
-        return []
-
-    groups: List[Tuple[int, int]] = []
-    start = prev = sorted_addresses[0]
-    for addr in sorted_addresses[1:]:
-        if addr == prev + 1 and (addr - start + 1) <= max_block_size:
-            prev = addr
-            continue
-        groups.append((start, prev - start + 1))
-        start = prev = addr
-    groups.append((start, prev - start + 1))
-    return groups
-
-
 __all__ = ["Register", "get_register_definition", "get_registers_by_function", "group_reads"]
 

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -35,9 +35,8 @@ from .modbus_exceptions import (
     ModbusException,
     ModbusIOException,
 )
-from .modbus_helpers import _call_modbus
+from .modbus_helpers import _call_modbus, group_reads as _group_reads
 from .registers import get_all_registers
-from .loader import group_reads as _loader_group_reads
 from .utils import _decode_bcd_time, BCD_TIME_PREFIXES, _to_snake_case
 from .scanner_helpers import (
     REGISTER_ALLOWED_VALUES,
@@ -461,7 +460,7 @@ class ThesslaGreenDeviceScanner:
         # First, compute contiguous blocks using the generic ``group_reads``
         # helper.  ``max_gap`` is kept for API compatibility but is not
         # required when using ``group_reads`` which already splits on gaps.
-        groups = _loader_group_reads(addresses, max_block_size=max_batch)
+        groups = _group_reads(addresses, max_block_size=max_batch)
 
         if not self._known_missing_addresses:
             return groups

--- a/tests/test_modbus_helpers.py
+++ b/tests/test_modbus_helpers.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from custom_components.thessla_green_modbus.modbus_helpers import _call_modbus
+from custom_components.thessla_green_modbus.modbus_helpers import _call_modbus, group_reads
 
 pytestmark = pytest.mark.asyncio
 
@@ -36,3 +36,19 @@ async def test_call_modbus_supports_no_slave_or_unit():
 
     result = await _call_modbus(func, 1, 30, 4)
     assert result == (30, 4)  # nosec B101
+
+
+async def test_group_reads_merges_sequential_addresses():
+    """Sequential addresses are merged into contiguous blocks."""
+
+    assert group_reads([0, 1, 2, 4, 5]) == [(0, 3), (4, 2)]
+
+
+async def test_group_reads_honours_block_size():
+    """Groups are split when exceeding ``max_block_size``."""
+
+    assert group_reads(range(10), max_block_size=4) == [
+        (0, 4),
+        (4, 4),
+        (8, 2),
+    ]


### PR DESCRIPTION
## Summary
- add `group_reads` helper for contiguous register blocks
- switch coordinator and scanner to new helper
- add tests for address grouping behaviour

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/modbus_helpers.py custom_components/thessla_green_modbus/loader.py custom_components/thessla_green_modbus/scanner_core.py custom_components/thessla_green_modbus/coordinator.py tests/test_modbus_helpers.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repolp3d11kr/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_modbus_helpers.py tests/test_register_grouping.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8a93ccab48326815a57358177db64