### PR TITLE
docs: document JSON register workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,18 +538,18 @@ Każdy wpis w pliku to obiekt z polami:
 
 Opcjonalnie można dodać `enum`, `multiplier`, `resolution`, `min`, `max`.
 
-### Dodawanie nowych rejestrów
+### Dodawanie lub aktualizowanie rejestrów
 
-1. Otwórz `registers/thessla_green_registers_full.json` i dopisz nowy obiekt z
-   wymaganymi polami.
-2. Zadbaj o unikalność adresów i zachowanie porządku.
+1. Otwórz `registers/thessla_green_registers_full.json` i wprowadź nowe wpisy
+   lub zmodyfikuj istniejące.
+2. Zadbaj o unikalność adresów i zachowanie posortowanej kolejności.
 3. Uruchom test walidacyjny:
 
 ```bash
 pytest tests/test_register_loader.py
 ```
 
-4. Wygeneruj moduł `registers.py` i zweryfikuj spójność:
+4. Wygeneruj moduł `registers.py` i opcjonalnie zweryfikuj spójność:
 
 ```bash
 python tools/generate_registers.py
@@ -557,6 +557,19 @@ python tools/validate_registers.py
 ```
 
 5. Dołącz zmienione pliki (`registers.py` oraz JSON) do commitu.
+
+### Migracja z CSV na JSON
+
+Pliki CSV zostały oznaczone jako przestarzałe i ich obsługa będzie
+usunięta w przyszłych wersjach. Użycie pliku CSV zapisze ostrzeżenie w
+logach. Aby ręcznie przekonwertować dane:
+
+1. Otwórz dotychczasowy plik CSV z definicjami rejestrów.
+2. Dla każdego wiersza utwórz obiekt w `registers/thessla_green_registers_full.json`
+   z polami `function`, `address_dec`, `address_hex`, `name`, `description` i `access`.
+3. Zachowaj sortowanie adresów oraz format liczbowy (`0x` dla wartości hex).
+4. Usuń lub zignoruj plik CSV i uruchom walidację jak przy dodawaniu nowych
+   rejestrów.
 
 ## 📄 Licencja
 

--- a/docs/register_scanning.md
+++ b/docs/register_scanning.md
@@ -17,9 +17,30 @@ register. This can reveal additional data but may also surface partial values or
 configuration fields that have no dedicated entity class. Use this option with care and
 primarily for debugging or development purposes.
 
+## Dodawanie lub aktualizowanie rejestrów
+
+1. Edytuj plik `registers/thessla_green_registers_full.json` dodając nowe obiekty
+   lub modyfikując istniejące wpisy.
+2. Zachowaj unikalność adresów oraz posortowaną kolejność.
+3. Uruchom test walidacyjny:
+
+   ```bash
+   pytest tests/test_register_loader.py
+   ```
+
+4. Wygeneruj moduł `registers.py` i opcjonalnie sprawdź spójność:
+
+   ```bash
+   python tools/generate_registers.py
+   python tools/validate_registers.py
+   ```
+
+5. Do commitu dodaj zmodyfikowany plik JSON oraz wygenerowany `registers.py`.
+
 ## Migracja z CSV na JSON
 Rejestry są obecnie definiowane w pliku JSON `registers/thessla_green_registers_full.json`.
-Każdy obiekt w tablicy `registers` zawiera pola:
+Format CSV jest przestarzały i zostanie usunięty w przyszłych wersjach – jego
+użycie zapisuje ostrzeżenie w logach. Każdy obiekt w tablicy `registers` zawiera pola:
 
 - `function` – kod funkcji Modbus
 - `address_dec` / `address_hex` – adres rejestru
@@ -28,6 +49,13 @@ Każdy obiekt w tablicy `registers` zawiera pola:
 - `access` – tryb dostępu (`R`/`W`)
 
 Opcjonalnie można zdefiniować `unit`, `enum`, `multiplier`, `resolution` i inne
-atrybuty. Aby dodać nowy rejestr, dopisz odpowiedni obiekt do listy `registers`
-z zachowaniem kolejności adresów. Format CSV pozostaje jedynie dla kompatybilności
-wstecznej – jego użycie zapisuje ostrzeżenie w logach.
+atrybuty.
+
+Aby ręcznie przekonwertować istniejący plik CSV:
+
+1. Otwórz plik CSV i odwzoruj kolumny na odpowiednie pola JSON.
+2. Dla każdego wiersza utwórz obiekt w `registers/thessla_green_registers_full.json`.
+3. Przekonwertuj adresy na postać dziesiętną i heksadecymalną (`0x...`).
+4. Po konwersji uruchom test i narzędzia z sekcji powyżej, aby zweryfikować plik.
+
+Po migracji usuń lub zignoruj plik CSV – integracja korzysta wyłącznie z definicji JSON.


### PR DESCRIPTION
## Summary
- document JSON register file path and update steps in README
- expand docs with register update workflow
- add CSV-to-JSON migration notes with manual conversion tips

## Testing
- `pytest` *(fails: SyntaxError in custom_components/thessla_green_modbus/services.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a8ab2699d08326a16eeff7f5734fda