### PR TITLE
chore: update integration type to hub

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -19,7 +19,7 @@
     "voluptuous>=0.13.1"
   ],
   "version": "2.1.1",
-  "integration_type": "device",
+  "integration_type": "hub",
   "dhcp": [
     {
       "hostname": "airpack*",


### PR DESCRIPTION
## Summary
- set `integration_type` to `hub` in the manifest

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo4sn7u6a8/.pre-commit-hooks.yaml is not a file)*
- `python -m script.hassfest --config /workspace/thesslagreen` *(fails: ModuleNotFoundError: No module named 'script.translations')*

------
https://chatgpt.com/codex/tasks/task_e_68a8adcfe5588326bf995b0ef7ef9571