### PR TITLE
Clarify register path resolution

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -132,8 +132,10 @@ class Register:
 # Loading helpers
 # ---------------------------------------------------------------------------
 
-# Single source of truth for the bundled register definitions.  The JSON file
-# lives alongside this module inside the installed package.
+# Single source of truth for the bundled register definitions.
+# ``resources.files`` resolves the JSON relative to this module which means the
+# same path works both when running the tests directly from the source tree and
+# when the integration is installed as a package at runtime.
 _REGISTERS_PATH = resources.files(__package__).joinpath(
     "thessla_green_registers_full.json"
 )


### PR DESCRIPTION
## Summary
- document register file path logic

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoq8de3akh/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: SyntaxError: invalid syntax (services.py, line 368))*

------
https://chatgpt.com/codex/tasks/task_e_68a8c164024883268a98f4430b3518a6