### PR TITLE
Fix work_permit register name

### DIFF
--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -10,7 +10,7 @@ COIL_REGISTERS: dict[str, int] = {
     "info": 10,
     "power_supply_fans": 11,
     "heating_cable": 12,
-    "workt_permit": 13,
+    "work_permit": 13,
     "gwc": 14,
     "hood": 15,
 }

--- a/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
+++ b/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
@@ -69,7 +69,7 @@
       "function": "01",
       "address_hex": "0x000D",
       "address_dec": 13,
-      "name": "workt_permit",
+      "name": "work_permit",
       "description": "Stan wyjścia przekaźnika potwierdzenia pracy (Expansion)",
       "access": "R",
       "enum": {

--- a/registers
+++ b/registers
@@ -1,0 +1,1 @@
+custom_components/thessla_green_modbus/registers


### PR DESCRIPTION
## Summary
- fix work_permit register name in JSON
- regenerate registers mapping
- link top-level registers directory to component registers

## Testing
- `SKIP=hassfest pre-commit run --files custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json custom_components/thessla_green_modbus/registers.py` *(fails: InvalidManifestError: `/root/.cache/pre-commit/repomxv8y0oc/.pre-commit-hooks.yaml` is not a file)*
- `pytest tests/test_register_json_schema.py::test_register_json_schema tests/test_register_cache_invalidation.py::test_register_cache_invalidation -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c15f56b08326ac667eb21884e7f0