### PR TITLE
Remove deprecated CSV register handling

### DIFF
--- a/custom_components/thessla_green_modbus/register_loader.py
+++ b/custom_components/thessla_green_modbus/register_loader.py
@@ -2,97 +2,29 @@
 
 Historically the project exposed a :class:`RegisterLoader` class that read
 register definitions from CSV files. The integration now uses a JSON file as
-the single source of truth. CSV support is retained solely for backward
-compatibility and the loader logs a warning whenever it is invoked.
+the single source of truth and CSV input is no longer supported. The class is
+retained for backward compatibility but always loads the bundled JSON data and
+ignores any path argument.
 """
 
 from __future__ import annotations
 
-import csv
 from dataclasses import dataclass
 import logging
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-from .registers import Register, get_all_registers, get_registers_by_function
-from .utils import _to_snake_case
+from .registers import Register, get_all_registers
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _csv_path_from_arg(path: Path | None) -> Path | None:
-    """Return CSV file path if *path* points to a CSV definition."""
-    if path is None:
-        return None
-    if path.is_file() and path.suffix.lower() == ".csv":
-        return path
-    if path.is_dir():
-        candidate = path / "modbus_registers.csv"
-        if candidate.exists():
-            return candidate
-    return None
-
-
-def _load_from_csv(csv_path: Path) -> List[Register]:
-    """Parse legacy CSV register definition file."""
-    registers: List[Register] = []
-    with csv_path.open("r", encoding="utf-8") as fh:
-        reader = csv.DictReader(fh)
-        for row in reader:
-            code = row.get("Function_Code")
-            if not code or code.startswith("#"):
-                continue
-            name_raw = row.get("Register_Name")
-            if not isinstance(name_raw, str) or not name_raw.strip():
-                continue
-            name = _to_snake_case(name_raw)
-            try:
-                address = int(row.get("Address_DEC", 0))
-            except (TypeError, ValueError):
-                continue
-
-            multiplier: float | None = None
-            if row.get("Multiplier") not in (None, ""):
-                try:
-                    multiplier = float(row["Multiplier"])
-                except ValueError:
-                    multiplier = None
-
-            enum: Dict[int, str] | None = None
-            enum_text = row.get("Unit") or row.get("Information")
-            if enum_text and "-" in enum_text:
-                enum = {}
-                for part in enum_text.split(";"):
-                    part = part.strip()
-                    if not part:
-                        continue
-                    try:
-                        num_str, label = part.split("-", 1)
-                        enum[int(num_str.strip())] = _to_snake_case(label.strip())
-                    except ValueError:
-                        continue
-
-            registers.append(
-                Register(
-                    function=str(code).zfill(2),
-                    address=address,
-                    name=name,
-                    access=str(row.get("Access", "")),
-                    description=row.get("Description"),
-                    unit=row.get("Unit"),
-                    multiplier=multiplier,
-                    enum=enum,
-                )
-            )
-    return registers
 
 
 @dataclass
 class RegisterLoader:  # pragma: no cover - thin compatibility layer
     """Backward compatible loader returning simple register maps.
 
-    CSV input is deprecated; instantiating this class logs a warning and uses
-    the bundled JSON definitions instead.
+    The bundled JSON register definitions are always used. Any supplied path is
+    ignored.
     """
 
     registers: Dict[str, Register]
@@ -106,18 +38,11 @@ class RegisterLoader:  # pragma: no cover - thin compatibility layer
     group_reads: Dict[str, List[Tuple[int, int]]]
 
     def __init__(self, path: Path | None = None) -> None:
-        csv_path = _csv_path_from_arg(path)
-        if csv_path:
-            _LOGGER.warning(
-                "CSV register files are deprecated; JSON definitions are authoritative"
+        if path is not None:
+            _LOGGER.info(
+                "RegisterLoader path argument is ignored; JSON definitions are built-in",
             )
-            regs = _load_from_csv(csv_path)
-        else:
-            if path is not None:
-                _LOGGER.warning(
-                    "RegisterLoader path argument is ignored; JSON definitions are built-in"
-                )
-            regs = get_all_registers()
+        regs = get_all_registers()
         self.registers = {r.name: r for r in regs}
         self.input_registers = {r.name: r.address for r in regs if r.function == "04"}
         self.holding_registers = {r.name: r.address for r in regs if r.function == "03"}

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -64,7 +64,7 @@ def test_decode_aatt_value_invalid(value):
 def test_schedule_and_setting_defaults_valid():
     """Default schedule and setting values should pass range validation."""
     scanner = ThesslaGreenDeviceScanner("127.0.0.1", 502)
-    _, ranges, _ = asyncio.run(scanner._load_registers())
+    _, ranges = asyncio.run(scanner._load_registers())
     scanner._register_ranges = ranges
     assert scanner._is_valid_register_value("schedule_winter_sun_3", 0x1000)
     assert scanner._is_valid_register_value("setting_summer_mon_1", 0x4100)

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -80,8 +80,8 @@ def test_registers_loaded_only_once(monkeypatch) -> None:
     assert read_calls == 1
 
 
-def test_csv_loader_emits_warning(caplog) -> None:
-    """Using a CSV file should emit a deprecation warning."""
+def test_path_argument_ignored(caplog) -> None:
+    """Providing a path should not trigger any CSV handling."""
 
     csv_path = (
         Path(__file__).resolve().parent.parent / "tools" / "modbus_registers.csv"
@@ -91,4 +91,4 @@ def test_csv_loader_emits_warning(caplog) -> None:
         loader = RegisterLoader(csv_path)
 
     assert loader.registers
-    assert any("deprecated" in rec.message for rec in caplog.records)
+    assert not caplog.records


### PR DESCRIPTION
## Summary
- remove obsolete CSV-loading code from scanner core
- simplify register loader to always use bundled JSON definitions
- adjust tests to verify runtime has no CSV references

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/register_loader.py custom_components/thessla_green_modbus/scanner_core.py tests/test_device_scanner.py tests/test_register_decoders.py tests/test_register_loader.py` *(failed: InvalidManifestError)*
- `pytest` *(failed: SyntaxError: invalid syntax in services.py)*
- `pytest -c tests/pytest.ini tests/test_register_loader.py::test_path_argument_ignored tests/test_register_decoders.py::test_schedule_and_setting_defaults_valid tests/test_device_scanner.py::test_is_valid_register_value`


------
https://chatgpt.com/codex/tasks/task_e_68a8c80fc8288326a79ff04412466c52