### PR TITLE
Fix register name typos and validate against translations

### DIFF
--- a/custom_components/thessla_green_modbus/registers.py
+++ b/custom_components/thessla_green_modbus/registers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 # Generated from thessla_green_registers_full.json
 
 COIL_REGISTERS: dict[str, int] = {
-    "duct_warter_heater_pump": 5,
+    "duct_water_heater_pump": 5,
     "bypass": 9,
     "info": 10,
     "power_supply_fans": 11,

--- a/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
+++ b/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
@@ -9,7 +9,7 @@
       "function": "01",
       "address_hex": "0x0005",
       "address_dec": 5,
-      "name": "duct_warter_heater_pump",
+      "name": "duct_water_heater_pump",
       "description": "Stan wyjścia przekaźnika pompy obiegowej nagrzewnicy",
       "access": "R",
       "enum": {


### PR DESCRIPTION
## Summary
- correct `duct_water_heater_pump` and ensure `work_permit` register names are consistent
- regenerate register map and add test checking register names against translation keys

## Testing
- `pytest tests/test_translations.py::test_register_names_match_translations -q`
- `pre-commit run --files registers/thessla_green_registers_full.json custom_components/thessla_green_modbus/registers.py tests/test_translations.py tools/generate_registers.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo6j1zwy74/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c806f4588326857624574ba1b036