### PR TITLE
docs: document hub integration type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ## ✨ Kompletna integracja ThesslaGreen AirPack z Home Assistant
 
 Najkompletniejsza integracja dla rekuperatorów ThesslaGreen AirPack z protokołem Modbus TCP/RTU. Obsługuje **wszystkie 200+ rejestrów** z dokumentacji MODBUS_USER_AirPack_Home_08.2021.01 bez wyjątku.
+Integracja działa jako **hub** w Home Assistant.
 
 ### 🚀 Kluczowe funkcje v2.1+
 

--- a/README_en.md
+++ b/README_en.md
@@ -8,6 +8,7 @@
 ## ✨ Complete ThesslaGreen AirPack integration for Home Assistant
 
 The most complete integration for ThesslaGreen AirPack heat recovery units over Modbus TCP/RTU. Supports **all 200+ registers** from documentation `MODBUS_USER_AirPack_Home_08.2021.01` without exception.
+The integration works as a **hub** in Home Assistant.
 
 ### 🚀 Key features v2.1+
 


### PR DESCRIPTION
## Summary
- note integration works as a hub in README and README_en

## Testing
- `pre-commit run --files README.md README_en.md custom_components/thessla_green_modbus/manifest.json` *(failed: InvalidManifestError: /root/.cache/pre-commit/repou7y8tbaw/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(failed: SyntaxError in custom_components/thessla_green_modbus/services.py:368)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cba8b34083269212b69901c6fa12