### PR TITLE
Reload registers when JSON changes

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -322,10 +322,15 @@ _REGISTER_CACHE: List[Register] = []
 _REGISTERS_HASH: str | None = None
 
 
-def _compute_file_hash() -> str:
-    """Return the SHA256 hash of the registers file."""
+def _compute_file_hash(path: Path | None = None) -> str:
+    """Return the SHA256 hash of the given registers file.
 
-    return hashlib.sha256(_REGISTERS_PATH.read_bytes()).hexdigest()
+    ``path`` defaults to :data:`_REGISTERS_PATH` but is parameterised to make
+    testing easier by allowing callers to pass a temporary file.
+    """
+
+    target = path or _REGISTERS_PATH
+    return hashlib.sha256(target.read_bytes()).hexdigest()
 
 
 def _load_registers() -> List[Register]:

--- a/tests/test_register_loader_validation.py
+++ b/tests/test_register_loader_validation.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pytest
 
-from custom_components.thessla_green_modbus.registers.loader import _load_registers
+from custom_components.thessla_green_modbus.registers.loader import (
+    _load_registers,
+    get_registers_hash,
+)
 
 
 def test_invalid_register_schema(monkeypatch, tmp_path) -> None:
@@ -24,4 +27,36 @@ def test_invalid_register_schema(monkeypatch, tmp_path) -> None:
 
     with pytest.raises(ValueError):
         _load_registers()
+
+
+def test_register_auto_reload(monkeypatch, tmp_path) -> None:
+    """Loader should reload registers when the JSON file changes."""
+
+    data = {
+        "registers": [
+            {"function": "03", "address_dec": 1, "name": "first"}
+        ]
+    }
+    reg_file = tmp_path / "regs.json"
+    reg_file.write_text(json.dumps(data), encoding="utf-8")
+
+    # Point the loader to our temporary file and prime the cache
+    monkeypatch.setattr(
+        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
+        reg_file,
+    )
+    _load_registers.cache_clear()
+    assert len(_load_registers()) == 1
+    original_hash = get_registers_hash()
+
+    # Add a new register to the JSON definition
+    data["registers"].append({"function": "03", "address_dec": 2, "name": "second"})
+    reg_file.write_text(json.dumps(data), encoding="utf-8")
+
+    # A subsequent call should detect the change and reload definitions
+    assert len(_load_registers()) == 2
+    assert get_registers_hash() != original_hash
+
+    # Reset cache for other tests
+    _load_registers.cache_clear()
 


### PR DESCRIPTION
## Summary
- compute hash for registers file with optional path parameter
- automatically reload registers when JSON data changes and verify via tests

## Testing
- `pre-commit run --files registers/loader.py tests/test_register_loader_validation.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoqri8xufa/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_register_loader_validation.py::test_register_auto_reload -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8cbaaf5e08326b1c5ce6c5fd7fe73