### PR TITLE
refactor: remove root registers copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ for start, size in group_reads(range(100), max_block_size=16):
 
 
 ### Rejestry w formacie JSON
-Definicje rejestrów znajdują się w pliku `registers/thessla_green_registers_full.json`,
+Definicje rejestrów znajdują się w pliku `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`,
 który stanowi jedyne źródło prawdy. Każdy wpis w sekcji `registers` zawiera m.in. pola:
 
 - `function` – kod funkcji Modbus (`01`–`04`)
@@ -493,7 +493,7 @@ python3 tools/cleanup_old_entities.py \
 - 🤝 [Contributing](CONTRIBUTING.md)
 
 ### Aktualizacja `registers.py`
-Zmiany w pliku `registers/thessla_green_registers_full.json` wymagają ponownego
+Zmiany w pliku `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` wymagają ponownego
 wygenerowania modułu z definicjami rejestrów i jego walidacji:
 
 ```bash
@@ -517,7 +517,7 @@ Zobacz [CHANGELOG.md](CHANGELOG.md) dla pełnej historii zmian.
 
 ## Rejestry w formacie JSON
 
-Plik `registers/thessla_green_registers_full.json` przechowuje komplet
+Plik `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` przechowuje komplet
 definicji rejestrów i stanowi jedyne źródło prawdy. Wszystkie narzędzia w
 `tools/` operują wyłącznie na tym formacie.
 
@@ -540,7 +540,7 @@ Opcjonalnie można dodać `enum`, `multiplier`, `resolution`, `min`, `max`.
 
 ### Dodawanie lub aktualizowanie rejestrów
 
-1. Otwórz `registers/thessla_green_registers_full.json` i wprowadź nowe wpisy
+1. Otwórz `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` i wprowadź nowe wpisy
    lub zmodyfikuj istniejące.
 2. Zadbaj o unikalność adresów i zachowanie posortowanej kolejności.
 3. Uruchom test walidacyjny:
@@ -565,7 +565,7 @@ usunięta w przyszłych wersjach. Użycie pliku CSV zapisze ostrzeżenie w
 logach. Aby ręcznie przekonwertować dane:
 
 1. Otwórz dotychczasowy plik CSV z definicjami rejestrów.
-2. Dla każdego wiersza utwórz obiekt w `registers/thessla_green_registers_full.json`
+2. Dla każdego wiersza utwórz obiekt w `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`
    z polami `function`, `address_dec`, `address_hex`, `name`, `description` i `access`.
 3. Zachowaj sortowanie adresów oraz format liczbowy (`0x` dla wartości hex).
 4. Usuń lub zignoruj plik CSV i uruchom walidację jak przy dodawaniu nowych

--- a/README_en.md
+++ b/README_en.md
@@ -266,7 +266,7 @@ only for diagnostic purposes.
 - 🤝 [Contributing](CONTRIBUTING.md)
 
 ### Updating `registers.py`
-Whenever `registers/thessla_green_registers_full.json` changes, regenerate and
+Whenever `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` changes, regenerate and
 validate the Python module:
 
 ```bash
@@ -289,7 +289,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 ## JSON register definitions
 
-The file `registers/thessla_green_registers_full.json` stores the complete
+The file `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` stores the complete
 register specification and is the single source of truth. All tools in
 `tools/` operate exclusively on this JSON format.
 
@@ -312,7 +312,7 @@ Optional properties: `enum`, `multiplier`, `resolution`, `min`, `max`.
 
 ### Adding new registers
 
-1. Edit `registers/thessla_green_registers_full.json` and append a new object
+1. Edit `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` and append a new object
    with the required fields.
 2. Ensure addresses are unique and remain sorted.
 3. Run the validation test:

--- a/docs/register_scanning.md
+++ b/docs/register_scanning.md
@@ -19,7 +19,7 @@ primarily for debugging or development purposes.
 
 ## Dodawanie lub aktualizowanie rejestrów
 
-1. Edytuj plik `registers/thessla_green_registers_full.json` dodając nowe obiekty
+1. Edytuj plik `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` dodając nowe obiekty
    lub modyfikując istniejące wpisy.
 2. Zachowaj unikalność adresów oraz posortowaną kolejność.
 3. Uruchom test walidacyjny:
@@ -38,7 +38,7 @@ primarily for debugging or development purposes.
 5. Do commitu dodaj zmodyfikowany plik JSON oraz wygenerowany `registers.py`.
 
 ## Migracja z CSV na JSON
-Rejestry są obecnie definiowane w pliku JSON `registers/thessla_green_registers_full.json`.
+Rejestry są obecnie definiowane w pliku JSON `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`.
 Format CSV jest przestarzały i zostanie usunięty w przyszłych wersjach – jego
 użycie zapisuje ostrzeżenie w logach. Każdy obiekt w tablicy `registers` zawiera pola:
 
@@ -54,7 +54,7 @@ atrybuty.
 Aby ręcznie przekonwertować istniejący plik CSV:
 
 1. Otwórz plik CSV i odwzoruj kolumny na odpowiednie pola JSON.
-2. Dla każdego wiersza utwórz obiekt w `registers/thessla_green_registers_full.json`.
+2. Dla każdego wiersza utwórz obiekt w `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`.
 3. Przekonwertuj adresy na postać dziesiętną i heksadecymalną (`0x...`).
 4. Po konwersji uruchom test i narzędzia z sekcji powyżej, aby zweryfikować plik.
 

--- a/registers
+++ b/registers
@@ -1,1 +1,0 @@
-custom_components/thessla_green_modbus/registers

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from importlib import resources
 
 from custom_components.thessla_green_modbus.data import modbus_registers as mr
 from custom_components.thessla_green_modbus.data.modbus_registers import (
@@ -16,39 +16,43 @@ from custom_components.thessla_green_modbus.registers.loader import _load_regist
 def test_register_cache_invalidation() -> None:
     """Modifying the register JSON should trigger cache rebuilds."""
 
-    registers_path = (
-        Path(__file__).resolve().parent.parent
-        / "registers"
+    with resources.as_file(
+        resources.files("custom_components.thessla_green_modbus.registers")
         / "thessla_green_registers_full.json"
-    )
+    ) as registers_path:
+        original_content = registers_path.read_text()
 
-    original_content = registers_path.read_text()
+        try:
+            # Ensure caches start from a known state
+            _load_registers.cache_clear()
+            mr._REGISTER_CACHE = None
+            mr._REGISTER_HASH = None
 
-    try:
-        # Ensure caches start from a known state
-        _load_registers.cache_clear()
-        mr._REGISTER_CACHE = None
-        mr._REGISTER_HASH = None
+            # Prime caches
+            first_reg = get_all_registers()[0]
+            register_name = first_reg.name
+            assert (
+                get_register_info(register_name)["description"]
+                == first_reg.description
+            )
 
-        # Prime caches
-        first_reg = get_all_registers()[0]
-        register_name = first_reg.name
-        assert get_register_info(register_name)["description"] == first_reg.description
+            # Modify the JSON file
+            data = json.loads(original_content)
+            data["registers"][0]["description"] = "changed description"
+            registers_path.write_text(json.dumps(data))
 
-        # Modify the JSON file
-        data = json.loads(original_content)
-        data["registers"][0]["description"] = "changed description"
-        registers_path.write_text(json.dumps(data))
-
-        # Re-fetch without clearing caches; both loaders should detect the change
-        updated_reg = get_all_registers()[0]
-        assert updated_reg.name == register_name
-        assert updated_reg.description == "changed description"
-        assert get_register_info(register_name)["description"] == "changed description"
-    finally:
-        # Restore original file and clear caches for other tests
-        registers_path.write_text(original_content)
-        _load_registers.cache_clear()
-        mr._REGISTER_CACHE = None
-        mr._REGISTER_HASH = None
+            # Re-fetch without clearing caches; both loaders should detect the change
+            updated_reg = get_all_registers()[0]
+            assert updated_reg.name == register_name
+            assert updated_reg.description == "changed description"
+            assert (
+                get_register_info(register_name)["description"]
+                == "changed description"
+            )
+        finally:
+            # Restore original file and clear caches for other tests
+            registers_path.write_text(original_content)
+            _load_registers.cache_clear()
+            mr._REGISTER_CACHE = None
+            mr._REGISTER_HASH = None
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -4,6 +4,7 @@ import re
 import sys
 import types
 from pathlib import Path
+from importlib import resources
 
 import yaml
 
@@ -254,8 +255,11 @@ def _to_snake(name: str) -> str:
 def test_register_names_match_translations() -> None:
     """Ensure register names used in mappings exist and have translations."""
 
-    reg_path = Path(__file__).resolve().parent.parent / "registers" / "thessla_green_registers_full.json"
-    data = json.loads(reg_path.read_text())
+    reg_path = (
+        resources.files("custom_components.thessla_green_modbus.registers")
+        .joinpath("thessla_green_registers_full.json")
+    )
+    data = json.loads(reg_path.read_text(encoding="utf-8"))
     registers = data["registers"]
 
     fn_map = {


### PR DESCRIPTION
## Summary
- remove root-level registers symlink
- reference bundled registers JSON via `importlib.resources`
- update docs for new register path

## Testing
- `pytest` *(fails: SyntaxError: invalid syntax in services.py:368)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cbbf04948326b23a7c54c30d586b