### PR TITLE
Handle register file changes and invalid paths

### DIFF
--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -80,6 +80,25 @@ def test_registers_loaded_only_once(monkeypatch) -> None:
     assert read_calls == 1
 
 
+def test_missing_register_file(monkeypatch, tmp_path) -> None:
+    """Loader should handle missing JSON definition path."""
+
+    from custom_components.thessla_green_modbus.registers.loader import (
+        _load_registers,
+        get_registers_hash,
+    )
+
+    missing = tmp_path / "missing.json"
+    monkeypatch.setattr(
+        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
+        missing,
+    )
+    _load_registers.cache_clear()
+
+    assert _load_registers() == []
+    assert get_registers_hash() == ""
+
+
 def test_path_argument_ignored(caplog) -> None:
     """Providing a path should not trigger any CSV handling."""
 

--- a/tests/test_register_loader_validation.py
+++ b/tests/test_register_loader_validation.py
@@ -49,9 +49,14 @@ def test_register_auto_reload(monkeypatch, tmp_path) -> None:
     assert len(_load_registers()) == 1
     original_hash = get_registers_hash()
 
-    # Add a new register to the JSON definition
+    # Add a new register to the JSON definition but keep mtime the same to
+    # ensure the loader also verifies the file hash.
     data["registers"].append({"function": "03", "address_dec": 2, "name": "second"})
     reg_file.write_text(json.dumps(data), encoding="utf-8")
+    mtime = reg_file.stat().st_mtime
+    import os
+
+    os.utime(reg_file, (mtime, mtime))
 
     # A subsequent call should detect the change and reload definitions
     assert len(_load_registers()) == 2


### PR DESCRIPTION
## Summary
- detect register definition file changes using mtime and hash and reload cache
- expose register file path via `_REGISTERS_PATH` and remove duplicate definition
- add tests for missing register file and cache reload even when mtime unchanged

## Testing
- `pytest tests/test_register_loader.py tests/test_register_loader_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8cee1b6088326ac938a3b7d50ff92