### PR TITLE
chore: use hub integration type and relax pymodbus requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped minimum Home Assistant version to 2025.1.0
 - Regenerated Modbus register definitions from CSV and updated coverage test
 - Assigned new unique IDs for m³/h airflow sensors
+- Updated integration type to `hub` and relaxed `pymodbus` requirement to `>=3.5`
 
 ### Removed
 - Custom Modbus client in favor of native AsyncModbusTcpClient

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -15,7 +15,7 @@
     "registers/thessla_green_registers_full.json"
   ],
   "requirements": [
-    "pymodbus>=3.5.0,<4.0.0",
+    "pymodbus>=3.5",
     "voluptuous>=0.13.1"
   ],
   "version": "2.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.12"
 # Core dependencies
 dependencies = [
-    "pymodbus>=3.5.0,<4.0.0",
+    "pymodbus>=3.5",
     "voluptuous>=0.13.1",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # (minimum version declared in manifest.json)
 
 # Modbus communication library
-pymodbus>=3.5.0,<4.0.0
+pymodbus>=3.5
 
 # Data validation and schemas
 voluptuous>=0.13.1


### PR DESCRIPTION
## Summary
- ensure integration is marked as a hub
- drop upper bound on pymodbus dependency

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json requirements.txt pyproject.toml CHANGELOG.md` *(fails: InvalidManifestError: /root/.cache/pre-commit/repou4xvp9ik/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: NameError: name '_REGISTERS_PATH' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cee91d4083268c7ef1503ed36a9e