### PR TITLE
Use importlib resources for register path

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -20,6 +20,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import time
+from importlib import resources
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -28,17 +29,10 @@ from ..utils import _to_snake_case
 
 _LOGGER = logging.getLogger(__name__)
 
-# Path to the canonical JSON register definition bundled with the integration.
-_REGISTERS_PATH = Path(__file__).with_name("thessla_green_registers_full.json")
-
 # Path to the bundled register definition file.  Tests patch this constant to
 # supply temporary files, therefore it must be a module level variable instead
 # of being computed inside helper functions.
-_REGISTERS_PATH = Path(__file__).resolve().with_name(
-    "thessla_green_registers_full.json"
-)
-# Path to bundled register definitions
-_REGISTERS_PATH = Path(__file__).resolve().with_name("thessla_green_registers_full.json")
+_REGISTERS_PATH = resources.files(__package__) / "thessla_green_registers_full.json"
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
@@ -280,7 +274,6 @@ def _load_registers_from_file(path: Path | None = None) -> List[Register]:
     """Load register definitions from the bundled JSON file."""
 
     target = path or _REGISTERS_PATH
-    path = path or _REGISTERS_PATH
     try:
         raw = json.loads(target.read_text(encoding="utf-8"))
     except FileNotFoundError:  # pragma: no cover - sanity check
@@ -350,7 +343,6 @@ def _load_registers_from_file(path: Path | None = None) -> List[Register]:
 # Cache for loaded register definitions and the file hash used to build it
 _REGISTER_CACHE: List[Register] = []
 _REGISTERS_HASH: str | None = None
-_REGISTERS_PATH = resources.files(__package__) / "thessla_green_registers_full.json"
 
 
 def _compute_file_hash(path: Path | None = None) -> str:

--- a/tests/test_register_loader_validation.py
+++ b/tests/test_register_loader_validation.py
@@ -1,14 +1,10 @@
 """Validation tests for the register loader."""
 
 import json
-from pathlib import Path
 
 import pytest
 
-from custom_components.thessla_green_modbus.registers.loader import (
-    _load_registers,
-    get_registers_hash,
-)
+from custom_components.thessla_green_modbus.registers import loader
 
 
 def test_invalid_register_schema(monkeypatch, tmp_path) -> None:
@@ -19,14 +15,11 @@ def test_invalid_register_schema(monkeypatch, tmp_path) -> None:
     bad_file.write_text(json.dumps(bad_data), encoding="utf-8")
 
     # Point loader to our invalid file and ensure cache is cleared
-    monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
-        bad_file,
-    )
-    _load_registers.cache_clear()
+    monkeypatch.setattr(loader, "_REGISTERS_PATH", bad_file)
+    loader._load_registers.cache_clear()
 
     with pytest.raises(ValueError):
-        _load_registers()
+        loader._load_registers()
 
 
 def test_register_auto_reload(monkeypatch, tmp_path) -> None:
@@ -41,22 +34,19 @@ def test_register_auto_reload(monkeypatch, tmp_path) -> None:
     reg_file.write_text(json.dumps(data), encoding="utf-8")
 
     # Point the loader to our temporary file and prime the cache
-    monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
-        reg_file,
-    )
-    _load_registers.cache_clear()
-    assert len(_load_registers()) == 1
-    original_hash = get_registers_hash()
+    monkeypatch.setattr(loader, "_REGISTERS_PATH", reg_file)
+    loader._load_registers.cache_clear()
+    assert len(loader._load_registers()) == 1
+    original_hash = loader.get_registers_hash()
 
     # Add a new register to the JSON definition
     data["registers"].append({"function": "03", "address_dec": 2, "name": "second"})
     reg_file.write_text(json.dumps(data), encoding="utf-8")
 
     # A subsequent call should detect the change and reload definitions
-    assert len(_load_registers()) == 2
-    assert get_registers_hash() != original_hash
+    assert len(loader._load_registers()) == 2
+    assert loader.get_registers_hash() != original_hash
 
     # Reset cache for other tests
-    _load_registers.cache_clear()
+    loader._load_registers.cache_clear()
 


### PR DESCRIPTION
## Summary
- compute register definition path using `importlib.resources.files`
- update tests to patch loader register path via module

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader_validation.py` *(failed: InvalidManifestError: /root/.cache/pre-commit/repoilhdt57a/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_register_loader_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d945f8648326b8b35b89aa2c5657