### PR TITLE
Normalize register naming and tests

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from datetime import time
 from pathlib import Path
 from typing import Any, Dict, List
+import importlib.resources as resources
 
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from ..utils import _to_snake_case
@@ -306,7 +307,7 @@ def _load_registers_from_file(path: Path | None = None) -> List[Register]:
         elif function == "03" and address >= 111:
             address -= 111
 
-        name = str(item["name"])
+        name = _normalise_name(str(item["name"]))
 
         enum_map = item.get("enum")
         if name == "special_mode":

--- a/tests/test_register_mapping.py
+++ b/tests/test_register_mapping.py
@@ -1,10 +1,12 @@
 import pytest
 from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.utils import _to_snake_case
 
 
 def _reg(fn: str, name: str):
     regs = get_registers_by_function(fn)
-    return next(r for r in regs if r.name == name)
+    norm_name = _to_snake_case(name)
+    return next(r for r in regs if r.name == norm_name)
 
 
 @pytest.mark.parametrize(
@@ -45,7 +47,7 @@ def test_register_mapping_and_scaling() -> None:
     assert discrete.decode(0) == "brak"
     assert discrete.encode("jest") == 1
 
-    holding = _reg("03", "supplyAirTemperatureManual")
+    holding = _reg("03", "supply_air_temperature_manual")
     assert holding.resolution == 0.5
     assert holding.encode(21.3) == 21
     assert holding.decode(21) == pytest.approx(21.0)


### PR DESCRIPTION
## Summary
- ensure test helper normalizes register names using snake_case
- normalize loaded register names using `_normalise_name`

## Testing
- `pre-commit run --files tests/test_register_mapping.py custom_components/thessla_green_modbus/registers/loader.py` *(fails: InvalidManifestError)*
- `pytest tests/test_register_mapping.py` *(fails: JSONDecodeError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d95d85288326893413c1252788c3