### PR TITLE
Allow configurable Modbus scan block size

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_SLAVE_ID,
     CONF_TIMEOUT,
     CONF_DEEP_SCAN,
+    CONF_SCAN_MAX_BLOCK_SIZE,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_RETRY,
@@ -33,6 +34,7 @@ from .const import (
     DEFAULT_SLAVE_ID,
     DEFAULT_TIMEOUT,
     DEFAULT_DEEP_SCAN,
+    DEFAULT_SCAN_MAX_BLOCK_SIZE,
     DOMAIN,
     AIRFLOW_UNIT_M3H,
     AIRFLOW_UNIT_PERCENTAGE,
@@ -112,6 +114,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_SKIP_MISSING_REGISTERS, DEFAULT_SKIP_MISSING_REGISTERS
     )
     deep_scan = entry.options.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN)
+    scan_max_block_size = entry.options.get(
+        CONF_SCAN_MAX_BLOCK_SIZE, DEFAULT_SCAN_MAX_BLOCK_SIZE
+    )
 
     _LOGGER.info(
         "Initializing ThesslaGreen device: %s at %s:%s (slave_id=%s, scan_interval=%ds)",
@@ -138,6 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         scan_uart_settings=scan_uart_settings,
         deep_scan=deep_scan,
         skip_missing_registers=skip_missing_registers,
+        scan_max_block_size=scan_max_block_size,
         entry=entry,
     )
 

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_TIMEOUT,
     CONF_AIRFLOW_UNIT,
     CONF_DEEP_SCAN,
+    CONF_SCAN_MAX_BLOCK_SIZE,
     AIRFLOW_UNIT_M3H,
     AIRFLOW_UNIT_PERCENTAGE,
     DEFAULT_AIRFLOW_UNIT,
@@ -37,6 +38,7 @@ from .const import (
     DEFAULT_SLAVE_ID,
     DEFAULT_TIMEOUT,
     DEFAULT_DEEP_SCAN,
+    DEFAULT_SCAN_MAX_BLOCK_SIZE,
     DOMAIN,
 )
 from .scanner_core import DeviceCapabilities, ThesslaGreenDeviceScanner
@@ -338,6 +340,9 @@ class OptionsFlow(config_entries.OptionsFlow):
             CONF_AIRFLOW_UNIT, DEFAULT_AIRFLOW_UNIT
         )
         current_deep_scan = self.config_entry.options.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN)
+        current_scan_max_block_size = self.config_entry.options.get(
+            CONF_SCAN_MAX_BLOCK_SIZE, DEFAULT_SCAN_MAX_BLOCK_SIZE
+        )
 
         data_schema = vol.Schema(
             {
@@ -374,6 +379,11 @@ class OptionsFlow(config_entries.OptionsFlow):
                     default=current_deep_scan,
                     description={"advanced": True},
                 ): bool,
+                vol.Optional(
+                    CONF_SCAN_MAX_BLOCK_SIZE,
+                    default=current_scan_max_block_size,
+                    description={"advanced": True},
+                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=125)),
             }
         )
 
@@ -389,5 +399,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                 "skip_missing_enabled": "Yes" if current_skip_missing else "No",
                 "current_airflow_unit": current_airflow_unit,
                 "deep_scan_enabled": "Yes" if current_deep_scan else "No",
+                "current_scan_max_block_size": str(current_scan_max_block_size),
             },
         )

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -88,6 +88,7 @@ CONF_SCAN_UART_SETTINGS = "scan_uart_settings"
 CONF_SKIP_MISSING_REGISTERS = "skip_missing_registers"
 CONF_AIRFLOW_UNIT = "airflow_unit"
 CONF_DEEP_SCAN = "deep_scan"  # Perform exhaustive raw register scan for diagnostics
+CONF_SCAN_MAX_BLOCK_SIZE = "scan_max_block_size"
 
 AIRFLOW_UNIT_M3H = "m3h"
 AIRFLOW_UNIT_PERCENTAGE = "percentage"
@@ -99,6 +100,7 @@ AIRFLOW_RATE_REGISTERS = {"supply_flow_rate", "exhaust_flow_rate"}
 DEFAULT_SCAN_UART_SETTINGS = False
 DEFAULT_SKIP_MISSING_REGISTERS = False
 DEFAULT_DEEP_SCAN = False
+DEFAULT_SCAN_MAX_BLOCK_SIZE = 64
 
 # Registers that are known to be unavailable on some devices
 KNOWN_MISSING_REGISTERS = {

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -81,6 +81,7 @@ from .const import (
     MODEL,
     SENSOR_UNAVAILABLE,
     UNKNOWN_MODEL,
+    DEFAULT_SCAN_MAX_BLOCK_SIZE,
 )
 from .registers import get_all_registers, get_registers_by_function
 from .scanner_core import DeviceCapabilities, ThesslaGreenDeviceScanner
@@ -113,6 +114,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         force_full_register_list: bool = False,
         scan_uart_settings: bool = False,
         deep_scan: bool = False,
+        scan_max_block_size: int = DEFAULT_SCAN_MAX_BLOCK_SIZE,
         entry: ConfigEntry | None = None,
         skip_missing_registers: bool = False,
     ) -> None:
@@ -142,6 +144,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.deep_scan = deep_scan
         self.entry = entry
         self.skip_missing_registers = skip_missing_registers
+        self.scan_max_block_size = scan_max_block_size
 
         # Connection management
         self.client: ThesslaGreenModbusClient | None = None
@@ -222,6 +225,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     scan_uart_settings=self.scan_uart_settings,
                     skip_known_missing=self.skip_missing_registers,
                     deep_scan=self.deep_scan,
+                    scan_max_block_size=self.scan_max_block_size,
                 )
 
                 self.device_scan_result = await scanner.scan_device()
@@ -397,7 +401,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     length = 1
                 addresses.extend(range(addr, addr + length))
 
-            self._register_groups[key] = group_reads(addresses)
+            self._register_groups[key] = group_reads(
+                addresses, max_block_size=self.scan_max_block_size
+            )
 
         _LOGGER.debug(
             "Pre-computed register groups: %s",

--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from importlib import resources
 from dataclasses import dataclass
 from datetime import time
 from pathlib import Path

--- a/custom_components/thessla_green_modbus/scanner_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner_helpers.py
@@ -77,7 +77,7 @@ SPECIAL_VALUE_DECODERS: Dict[str, Callable[[int], Optional[int]]] = {
 }
 
 # Maximum registers per batch read (Modbus limit)
-MAX_BATCH_REGISTERS = 16
+MAX_BATCH_REGISTERS = 64
 
 # Optional UART configuration registers (Air-B and Air++ ports)
 # According to the Series 4 Modbus documentation, both the Air-B

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -828,6 +828,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 scan_uart_settings=coordinator.scan_uart_settings,
                 skip_known_missing=False,
                 full_register_scan=True,
+                scan_max_block_size=coordinator.scan_max_block_size,
             )
             try:
                 scan_result = await scanner.scan_device()

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1370,7 +1370,8 @@
           "scan_interval": "Scan Interval (seconds)",
           "skip_missing_registers": "Skip Known Missing Registers",
           "timeout": "Connection Timeout (seconds)",
-          "deep_scan": "Deep Register Scan"
+          "deep_scan": "Deep Register Scan",
+          "scan_max_block_size": "Max Register Block Size"
         },
         "data_description": {
           "force_full_register_list": "Skip scanning and load all registers (may cause errors)",
@@ -1378,9 +1379,10 @@
           "scan_interval": "How often to read data from device (10-300 seconds)",
           "skip_missing_registers": "Do not poll registers known to be unavailable",
           "timeout": "Maximum time to wait for response (5-60 seconds)",
-          "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics"
+          "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
+          "scan_max_block_size": "Maximum registers per batch read (1-125)"
         },
-        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}.",
+        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max block size: {current_scan_max_block_size}.",
         "title": "ThesslaGreen Modbus Options"
       }
     }

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1321,7 +1321,8 @@
           "scan_interval": "Scan Interval (seconds)",
           "skip_missing_registers": "Skip Known Missing Registers",
           "timeout": "Connection Timeout (seconds)",
-          "deep_scan": "Deep Register Scan"
+          "deep_scan": "Deep Register Scan",
+          "scan_max_block_size": "Max Register Block Size"
         },
         "data_description": {
           "force_full_register_list": "Skip scanning and load all registers (may cause errors)",
@@ -1329,9 +1330,10 @@
           "scan_interval": "How often to read data from device (10-300 seconds)",
           "skip_missing_registers": "Do not poll registers known to be unavailable",
           "timeout": "Maximum time to wait for response (5-60 seconds)",
-          "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics"
+          "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
+          "scan_max_block_size": "Maximum registers per batch read (1-125)"
         },
-        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}.",
+        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max block size: {current_scan_max_block_size}.",
         "title": "ThesslaGreen Modbus Options"
       }
     }

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1321,7 +1321,8 @@
           "scan_interval": "Interwał skanowania (s)",
           "skip_missing_registers": "Pomijaj znane brakujące rejestry",
           "timeout": "Limit czasu połączenia (s)",
-          "deep_scan": "Głęboki skan rejestrów"
+          "deep_scan": "Głęboki skan rejestrów",
+          "scan_max_block_size": "Maksymalny rozmiar bloku rejestrów"
         },
         "data_description": {
           "force_full_register_list": "Pomiń skanowanie i załaduj wszystkie rejestry (może powodować błędy)",
@@ -1329,9 +1330,10 @@
           "scan_interval": "Jak często odczytywać dane z urządzenia (10-300 s)",
           "skip_missing_registers": "Nie odczytuj rejestrów, które są znane jako niedostępne",
           "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)",
-          "deep_scan": "Odczyt surowych rejestrów 0x0000-0x012C do diagnostyki"
+          "deep_scan": "Odczyt surowych rejestrów 0x0000-0x012C do diagnostyki",
+          "scan_max_block_size": "Maksymalna liczba rejestrów w jednym odczycie (1-125)"
         },
-        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}.",
+        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Maksymalny rozmiar bloku: {current_scan_max_block_size}.",
         "title": "Opcje ThesslaGreen Modbus"
       }
     }

--- a/tests/test_group_reads.py
+++ b/tests/test_group_reads.py
@@ -2,15 +2,29 @@
 
 import custom_components.thessla_green_modbus.registers.loader as loader
 from custom_components.thessla_green_modbus.registers import ReadPlan, Register, group_reads
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_helpers import MAX_BATCH_REGISTERS
 
 
 def test_group_reads_merges_consecutive_addresses(monkeypatch):
-    regs = [Register("input", addr, "r") for addr in [0, 1, 2, 3, 10, 11, 12]]
+    regs = [
+        Register("input", addr, f"r{addr}", "r")
+        for addr in [0, 1, 2, 3, 10, 11, 12]
+    ]
     monkeypatch.setattr(loader, "_load_registers", lambda: regs)
     assert group_reads() == [ReadPlan("input", 0, 4), ReadPlan("input", 10, 3)]
 
 
 def test_group_reads_respects_max_block_size(monkeypatch):
-    regs = [Register("input", addr, "r") for addr in range(70)]
+    regs = [Register("input", addr, f"r{addr}", "r") for addr in range(70)]
     monkeypatch.setattr(loader, "_load_registers", lambda: regs)
     assert group_reads(max_block_size=64) == [ReadPlan("input", 0, 64), ReadPlan("input", 64, 6)]
+
+
+def test_scanner_respects_default_max_block_size():
+    scanner = ThesslaGreenDeviceScanner("host", 502)
+    addresses = list(range(MAX_BATCH_REGISTERS + 6))
+    assert scanner._group_registers_for_batch_read(addresses) == [
+        (0, MAX_BATCH_REGISTERS),
+        (MAX_BATCH_REGISTERS, 6),
+    ]

--- a/tests/test_group_reads_max_size.py
+++ b/tests/test_group_reads_max_size.py
@@ -1,11 +1,12 @@
-from custom_components.thessla_green_modbus.loader import group_reads
+from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 
 
 def test_group_reads_respects_max_block_size() -> None:
     """group_reads splits long address ranges based on ``max_block_size``."""
 
     addresses = list(range(40))
-    assert group_reads(addresses, max_block_size=16) == [
+    scanner = ThesslaGreenDeviceScanner("host", 502, scan_max_block_size=16)
+    assert scanner._group_registers_for_batch_read(addresses) == [
         (0, 16),
         (16, 16),
         (32, 8),


### PR DESCRIPTION
## Summary
- raise default MAX_BATCH_REGISTERS to 64
- support configurable scan_max_block_size integration option
- ensure scanner and tests respect configurable max block size

## Testing
- `pytest tests/test_group_reads.py tests/test_group_reads_max_size.py`
- `pytest` *(fails: IndentationError in tests/test_register_cache_invalidation.py; ModuleNotFoundError custom_components.thessla_green_modbus.register_loader)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d953b7e0832687daf88c4545d3b5