### PR TITLE
Refactor register loader to use importlib resources and hash caching

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -18,13 +18,11 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from importlib import resources
+import importlib.resources as resources
 from dataclasses import dataclass
 from datetime import time
-from importlib import resources
 from pathlib import Path
 from typing import Any, Dict, List
-import importlib.resources as resources
 
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from ..utils import _to_snake_case
@@ -34,7 +32,9 @@ _LOGGER = logging.getLogger(__name__)
 # Path to the bundled register definition file.  Tests patch this constant to
 # supply temporary files, therefore it must be a module level variable instead
 # of being computed inside helper functions.
-_REGISTERS_PATH = resources.files(__package__) / "thessla_green_registers_full.json"
+_REGISTERS_PATH = resources.files(__package__).joinpath(
+    "thessla_green_registers_full.json"
+)
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
@@ -272,17 +272,18 @@ def _normalise_name(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _load_registers_from_file(path: Path | None = None) -> List[Register]:
+def _load_registers_from_file() -> List[Register]:
     """Load register definitions from the bundled JSON file."""
 
-    target = path or _REGISTERS_PATH
     try:
-        raw = json.loads(target.read_text(encoding="utf-8"))
+        raw = json.loads(_REGISTERS_PATH.read_text(encoding="utf-8"))
     except FileNotFoundError:  # pragma: no cover - sanity check
-        _LOGGER.error("Register definition file missing: %s", target)
+        _LOGGER.error("Register definition file missing: %s", _REGISTERS_PATH)
         return []
     except Exception:  # pragma: no cover - defensive
-        _LOGGER.exception("Failed to read register definitions from %s", target)
+        _LOGGER.exception(
+            "Failed to read register definitions from %s", _REGISTERS_PATH
+        )
         return []
 
     items = raw.get("registers", raw) if isinstance(raw, dict) else raw
@@ -347,15 +348,10 @@ _REGISTER_CACHE: List[Register] = []
 _REGISTERS_HASH: str | None = None
 
 
-def _compute_file_hash(path: Path | None = None) -> str:
-    """Return the SHA256 hash of the given registers file.
+def _compute_file_hash() -> str:
+    """Return the SHA256 hash of the registers file."""
 
-    ``path`` defaults to :data:`_REGISTERS_PATH` but is parameterised to make
-    testing easier by allowing callers to pass a temporary file.
-    """
-
-    target = path or _REGISTERS_PATH
-    return hashlib.sha256(target.read_bytes()).hexdigest()
+    return hashlib.sha256(_REGISTERS_PATH.read_bytes()).hexdigest()
 
 
 def _load_registers() -> List[Register]:

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -3,147 +3,43 @@
 from __future__ import annotations
 
 import json
-from importlib import resources
-from pathlib import Path
 from pathlib import Path
 
-import pytest
-
-import custom_components.thessla_green_modbus.registers.loader as mr
-from custom_components.thessla_green_modbus.registers import get_all_registers
 from custom_components.thessla_green_modbus.registers import loader as mr
-from custom_components.thessla_green_modbus.registers.loader import _load_registers
-
-
-@pytest.mark.usefixtures("monkeypatch")
-def test_register_cache_invalidation(monkeypatch, tmp_path) -> None:
-    """Modifying the register JSON should trigger cache rebuilds."""
-
-    # Copy bundled registers to a temporary file and patch loader to use it
-    temp = tmp_path / "registers.json"
-    temp.write_text(mr._REGISTERS_PATH.read_text(), encoding="utf-8")
-    monkeypatch.setattr(mr, "_REGISTERS_PATH", temp)
-    monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
-        temp,
-    )
-
-        try:
-            # Ensure caches start from a known state
-            _load_registers.cache_clear()
-            mr._REGISTER_CACHE = None
-            mr._REGISTER_HASH = None
-
-            # Prime caches
-            first_reg = get_all_registers()[0]
-            register_name = first_reg.name
-
-            def _desc(name: str) -> str | None:
-                for reg in get_all_registers():
-                    if reg.name == name:
-                        return reg.description
-                return None
-
-            assert _desc(register_name) == first_reg.description
-
-            # Modify the JSON file
-            data = json.loads(original_content)
-            data["registers"][0]["description"] = "changed description"
-            registers_path.write_text(json.dumps(data))
-
-            # Re-fetch without clearing caches; both loaders should detect the change
-            updated_reg = get_all_registers()[0]
-            assert updated_reg.name == register_name
-            assert updated_reg.description == "changed description"
-            assert _desc(register_name) == "changed description"
-        finally:
-            # Restore original file and clear caches for other tests
-            registers_path.write_text(original_content)
-            _load_registers.cache_clear()
-            mr._REGISTER_CACHE = None
-            mr._REGISTER_HASH = None
-
-    # Ensure caches start from a known state
-    _load_registers.cache_clear()
-    mr._REGISTER_CACHE = []
-    mr._REGISTERS_HASH = None
-
-    real_read_text = Path.read_text
-
-    def spy(self: Path, *args, **kwargs):
-        assert self.suffix != ".csv"
-        return real_read_text(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "read_text", spy)
-
-    first_reg = get_all_registers()[0]
-    register_name = first_reg.name
-    assert first_reg.description
-
-    # Modify the JSON file
-    data = json.loads(temp.read_text())
-    data["registers"][0]["description"] = "changed description"
-    temp.write_text(json.dumps(data), encoding="utf-8")
-
-    # Re-fetch without clearing caches; loader should detect the change
-    updated_reg = get_all_registers()[0]
-    assert updated_reg.name == register_name
-    assert updated_reg.description == "changed description"
-from importlib import resources
-from pathlib import Path
-
-from custom_components.thessla_green_modbus.registers.loader import (
-    _cache_clear,
-    _load_registers,
-    _REGISTERS_PATH,
-)
 
 
 def test_register_cache_invalidation(tmp_path: Path, monkeypatch) -> None:
     """Modifying the register JSON should trigger cache rebuilds."""
 
-    # Work on a temporary copy of the registers file
+    # Minimal register file used for testing
     tmp_json = tmp_path / "registers.json"
-    tmp_json.write_text(_REGISTERS_PATH.read_text())
-    monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
-        tmp_json,
+    tmp_json.write_text(
+        json.dumps(
+            {
+                "registers": [
+                    {
+                        "function": "01",
+                        "address_hex": "0x0000",
+                        "address_dec": 0,
+                        "name": "test_reg",
+                        "description": "original",
+                        "access": "R",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
     )
+    monkeypatch.setattr(mr, "_REGISTERS_PATH", tmp_json)
 
-    _cache_clear()
-    first = _load_registers()[0]
-    assert first.description
+    mr._cache_clear()
 
-    # Change description in the JSON and ensure cache reload after clearing
+    first = mr.get_all_registers()[0]
+    assert first.description == "original"
+
     data = json.loads(tmp_json.read_text())
-    data["registers"][0]["description"] = "changed description"
-    tmp_json.write_text(json.dumps(data))
+    data["registers"][0]["description"] = "changed"
+    tmp_json.write_text(json.dumps(data), encoding="utf-8")
 
-    _cache_clear()
-    updated = _load_registers()[0]
-    assert updated.description == "changed description"
-
-    _cache_clear()
-def test_register_cache_invalidation() -> None:
-    """Modifying the register JSON should trigger cache rebuilds."""
-
-    with resources.as_file(
-        resources.files("custom_components.thessla_green_modbus.registers")
-        / "thessla_green_registers_full.json"
-    ) as registers_path:
-        original = registers_path.read_text()
-        try:
-            _load_registers.cache_clear()
-
-            first = get_all_registers()[0]
-            assert first.description
-
-            data = json.loads(original)
-            data["registers"][0]["description"] = "changed description"
-            registers_path.write_text(json.dumps(data))
-
-            updated = get_all_registers()[0]
-            assert updated.description == "changed description"
-        finally:
-            registers_path.write_text(original)
-            _load_registers.cache_clear()
+    updated = mr.get_all_registers()[0]
+    assert updated.description == "changed"


### PR DESCRIPTION
## Summary
- simplify register loader imports and resource handling
- compute register file hash to refresh cache
- add test for cache invalidation when register JSON changes

## Testing
- `pytest tests/test_register_cache_invalidation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8dbd0dcf88326b84921b1b8827c59