### PR TITLE
Add retry and timeout handling in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -6,7 +6,7 @@ import asyncio
 import dataclasses
 import logging
 import traceback
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -42,9 +42,52 @@ from .const import (
     DOMAIN,
 )
 from .scanner_core import DeviceCapabilities, ThesslaGreenDeviceScanner
-from .modbus_exceptions import ConnectionException, ModbusException
+from .modbus_exceptions import (
+    ConnectionException,
+    ModbusException,
+    ModbusIOException,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# Delay between retries when establishing the connection during the config flow.
+# Uses exponential backoff: ``backoff * 2 ** (attempt-1)``.
+CONFIG_FLOW_BACKOFF = 0.1
+
+
+async def _run_with_retry(
+    func: "Callable[[], Awaitable[Any]]",
+    *,
+    retries: int,
+    backoff: float,
+) -> Any:
+    """Execute ``func`` with retry and backoff.
+
+    Retries are attempted for connection and Modbus related exceptions. The
+    final exception is raised if all attempts fail.
+    """
+
+    for attempt in range(1, retries + 1):
+        try:
+            return await func()
+        except (
+            ConnectionException,
+            ModbusIOException,
+            ModbusException,
+            asyncio.TimeoutError,
+            OSError,
+        ) as exc:
+            if attempt >= retries:
+                raise
+            delay = backoff * 2 ** (attempt - 1)
+            if delay:
+                try:
+                    await asyncio.sleep(delay)
+                except asyncio.CancelledError:
+                    _LOGGER.debug("Retry sleep cancelled")
+                    raise
+    # Should never reach here
+    raise RuntimeError("Retry wrapper failed without raising")
 
 
 class CannotConnect(Exception):
@@ -65,17 +108,26 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
 
     scanner: ThesslaGreenDeviceScanner | None = None
     try:
-        scanner = await ThesslaGreenDeviceScanner.create(
-            host=host,
-            port=port,
-            slave_id=slave_id,
-            timeout=timeout,
-            retry=DEFAULT_RETRY,
-            deep_scan=data.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN),
+        scanner = await _run_with_retry(
+            lambda: ThesslaGreenDeviceScanner.create(
+                host=host,
+                port=port,
+                slave_id=slave_id,
+                timeout=timeout,
+                retry=DEFAULT_RETRY,
+                backoff=CONFIG_FLOW_BACKOFF,
+                deep_scan=data.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN),
+            ),
+            retries=DEFAULT_RETRY,
+            backoff=CONFIG_FLOW_BACKOFF,
         )
 
         # Verify connection by reading a few safe registers
-        await asyncio.wait_for(scanner.verify_connection(), timeout=timeout)
+        await _run_with_retry(
+            lambda: asyncio.wait_for(scanner.verify_connection(), timeout=timeout),
+            retries=DEFAULT_RETRY,
+            backoff=CONFIG_FLOW_BACKOFF,
+        )
 
         # Perform full device scan
         scan_result = await asyncio.wait_for(scanner.scan_device(), timeout=timeout)
@@ -115,6 +167,10 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
         _LOGGER.error("Connection error: %s", exc)
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
         raise CannotConnect("cannot_connect") from exc
+    except ModbusIOException as exc:
+        _LOGGER.error("Modbus IO error during device validation: %s", exc)
+        _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
+        raise CannotConnect("timeout") from exc
     except asyncio.TimeoutError as exc:
         _LOGGER.error("Timeout during device validation: %s", exc)
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
@@ -131,7 +187,7 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
     except OSError as exc:
         _LOGGER.error("Unexpected error during device validation: %s", exc)
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
-        raise CannotConnect from exc
+        raise CannotConnect("cannot_connect") from exc
     finally:
         if hasattr(scanner, "close"):
             await scanner.close()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,10 +1,11 @@
 """Test config flow for ThesslaGreen Modbus integration."""
 # ruff: noqa: E402
 
+import asyncio
 import sys
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, patch, call
 
 import logging
 import pytest
@@ -37,6 +38,7 @@ from custom_components.thessla_green_modbus.config_flow import (
 from custom_components.thessla_green_modbus.modbus_exceptions import (
     ConnectionException,
     ModbusException,
+    ModbusIOException,
 )
 
 CONF_NAME = "name"
@@ -794,9 +796,10 @@ async def test_validate_input_verify_connection_failure():
         "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",
         AsyncMock(return_value=scanner_instance),
     ):
-        with pytest.raises(CannotConnect):
+        with pytest.raises(CannotConnect) as err:
             await validate_input(None, data)
 
+    assert err.value.args[0] == "cannot_connect"
     scanner_instance.close.assert_awaited_once()
 
 
@@ -1005,4 +1008,82 @@ async def test_validate_input_scan_device_attribute_error():
             await validate_input(None, data)
 
     assert err.value.args[0] == "missing_method"
+    scanner_instance.close.assert_awaited_once()
+
+
+async def test_validate_input_retries_transient_failures():
+    """Transient failures during setup should be retried with backoff."""
+    from custom_components.thessla_green_modbus.config_flow import validate_input
+    from custom_components.thessla_green_modbus.scanner_core import DeviceCapabilities
+
+    data = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "Test",
+    }
+
+    scan_result = {
+        "device_info": {},
+        "available_registers": {},
+        "capabilities": DeviceCapabilities(),
+    }
+
+    scanner_instance = SimpleNamespace(
+        verify_connection=AsyncMock(side_effect=[ConnectionException("fail"), None]),
+        scan_device=AsyncMock(return_value=scan_result),
+        close=AsyncMock(),
+    )
+
+    create_mock = AsyncMock(side_effect=[ConnectionException("fail"), scanner_instance])
+    sleep_mock = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",
+            create_mock,
+        ),
+        patch("asyncio.sleep", sleep_mock),
+    ):
+        result = await validate_input(None, data)
+
+    assert result["scan_result"] == scan_result
+    assert create_mock.await_count == 2
+    assert scanner_instance.verify_connection.await_count == 2
+    assert [call.args[0] for call in sleep_mock.await_args_list] == [0.1, 0.1]
+
+
+@pytest.mark.parametrize("exc", [asyncio.TimeoutError, ModbusIOException])
+async def test_validate_input_timeout_errors(exc):
+    """Timeout-related errors should map to timeout in UI."""
+    from custom_components.thessla_green_modbus.config_flow import (
+        CannotConnect,
+        validate_input,
+    )
+    from custom_components.thessla_green_modbus.scanner_core import DeviceCapabilities
+
+    data = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "Test",
+    }
+
+    scanner_instance = SimpleNamespace(
+        verify_connection=AsyncMock(side_effect=exc),
+        scan_device=AsyncMock(return_value={"capabilities": DeviceCapabilities()}),
+        close=AsyncMock(),
+    )
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",
+            AsyncMock(return_value=scanner_instance),
+        ),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        with pytest.raises(CannotConnect) as err:
+            await validate_input(None, data)
+
+    assert err.value.args[0] == "timeout"
     scanner_instance.close.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add retry/backoff helper for config flow device creation and verification
- map Modbus and timeout errors to clearer UI messages
- test config flow retries and timeout handling

## Testing
- `pytest tests/test_config_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8dbde15808326aed1daad20789b8d