### PR TITLE
Expose detailed diagnostic metrics

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1090,6 +1090,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         statistics = self.statistics.copy()
         if statistics.get("last_successful_update"):
             statistics["last_successful_update"] = statistics["last_successful_update"].isoformat()
+        total_registers = sum(len(v) for v in self.available_registers.values())
+        error_stats = {
+            "connection_errors": statistics.get("connection_errors", 0),
+            "timeout_errors": statistics.get("timeout_errors", 0),
+        }
 
         diagnostics: dict[str, Any] = {
             "connection": connection,
@@ -1106,6 +1111,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "unknown_registers": self.unknown_registers,
             "scanned_registers": self.scanned_registers,
             "last_scan": self.last_scan.isoformat() if self.last_scan else None,
+            "firmware_version": self.device_info.get("firmware"),
+            "total_available_registers": total_registers,
+            "error_statistics": error_stats,
         }
 
         if self.device_scan_result and "raw_registers" in self.device_scan_result:

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -29,8 +29,24 @@ async def async_get_config_entry_diagnostics(
 
     # Gather comprehensive diagnostic data from the coordinator
     diagnostics = coordinator.get_diagnostic_data()
+
+    # Supplement diagnostics with coordinator statistics
+    diagnostics.setdefault(
+        "firmware_version", coordinator.device_info.get("firmware")
+    )
+    diagnostics.setdefault(
+        "total_available_registers",
+        sum(len(regs) for regs in coordinator.available_registers.values()),
+    )
     diagnostics["last_scan"] = (
         coordinator.last_scan.isoformat() if coordinator.last_scan else None
+    )
+    diagnostics.setdefault(
+        "error_statistics",
+        {
+            "connection_errors": coordinator.statistics.get("connection_errors", 0),
+            "timeout_errors": coordinator.statistics.get("timeout_errors", 0),
+        },
     )
 
     if coordinator.device_scan_result and "raw_registers" in coordinator.device_scan_result:


### PR DESCRIPTION
## Summary
- Extend diagnostics to report firmware version, available register count and error statistics
- Expose new metrics via coordinator's `get_diagnostic_data`
- Test diagnostics include firmware, registers and error counters

## Testing
- `pip install -r requirements-dev.txt`
- `pytest tests/test_diagnostics.py`
- `pytest tests/test_coordinator.py` *(fails: cannot import name 'loader')*


------
https://chatgpt.com/codex/tasks/task_e_68a8dbe02cb88326afe29b6a1b48b3ad