### PR TITLE
Add tests for multi-register decoding

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import struct
 import importlib.resources as resources
 from dataclasses import dataclass
 from datetime import time
@@ -89,6 +90,20 @@ class Register:
                 return self.enum[str(raw)]
 
         value: Any = raw
+        if self.length > 1 and self.extra and self.extra.get("type"):
+            dtype = self.extra["type"]
+            byte_len = self.length * 2
+            raw_bytes = raw.to_bytes(byte_len, "big", signed=False)
+            if dtype == "float32":
+                value = struct.unpack(">f", raw_bytes)[0]
+            elif dtype == "int32":
+                value = struct.unpack(">i", raw_bytes)[0]
+            elif dtype == "uint32":
+                value = struct.unpack(">I", raw_bytes)[0]
+            elif dtype == "int64":
+                value = struct.unpack(">q", raw_bytes)[0]
+            elif dtype == "uint64":
+                value = struct.unpack(">Q", raw_bytes)[0]
         if self.multiplier is not None:
             value = value * self.multiplier
         if self.resolution is not None:
@@ -156,6 +171,18 @@ class Register:
         if self.resolution is not None:
             step = self.resolution
             raw = int(round(float(raw) / step) * step)
+        if self.length > 1 and self.extra and self.extra.get("type"):
+            dtype = self.extra["type"]
+            if dtype == "float32":
+                return int.from_bytes(struct.pack(">f", float(raw)), "big")
+            if dtype == "int32":
+                return int.from_bytes(struct.pack(">i", int(raw)), "big")
+            if dtype == "uint32":
+                return int.from_bytes(struct.pack(">I", int(raw)), "big")
+            if dtype == "int64":
+                return int.from_bytes(struct.pack(">q", int(raw)), "big")
+            if dtype == "uint64":
+                return int.from_bytes(struct.pack(">Q", int(raw)), "big")
         return int(raw)
 
 

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -116,3 +116,98 @@ def test_register_bitmask_decode_encode():
     )
     assert reg.decode(5) == ["A", "C"]
     assert reg.encode(["A", "C"]) == 5
+
+
+@pytest.fixture
+def float32_register() -> Register:
+    """Register representing a 32-bit floating point value."""
+    return Register(
+        function="holding",
+        address=0,
+        name="float32_test",
+        access="rw",
+        length=2,
+        extra={"type": "float32"},
+    )
+
+
+@pytest.fixture
+def int32_register() -> Register:
+    """Register representing a signed 32-bit integer."""
+    return Register(
+        function="holding",
+        address=0,
+        name="int32_test",
+        access="rw",
+        length=2,
+        extra={"type": "int32"},
+    )
+
+
+@pytest.fixture
+def uint32_register() -> Register:
+    """Register representing an unsigned 32-bit integer."""
+    return Register(
+        function="holding",
+        address=0,
+        name="uint32_test",
+        access="rw",
+        length=2,
+        extra={"type": "uint32"},
+    )
+
+
+@pytest.fixture
+def int64_register() -> Register:
+    """Register representing a signed 64-bit integer."""
+    return Register(
+        function="holding",
+        address=0,
+        name="int64_test",
+        access="rw",
+        length=4,
+        extra={"type": "int64"},
+    )
+
+
+@pytest.fixture
+def uint64_register() -> Register:
+    """Register representing an unsigned 64-bit integer."""
+    return Register(
+        function="holding",
+        address=0,
+        name="uint64_test",
+        access="rw",
+        length=4,
+        extra={"type": "uint64"},
+    )
+
+
+@pytest.mark.parametrize("value", [12.5, -7.25])
+def test_register_float32_encode_decode(float32_register: Register, value: float) -> None:
+    raw = float32_register.encode(value)
+    assert float32_register.decode(raw) == pytest.approx(value)
+
+
+@pytest.mark.parametrize("value", [0, 2147483647, -1, -2147483648])
+def test_register_int32_encode_decode(int32_register: Register, value: int) -> None:
+    raw = int32_register.encode(value)
+    assert int32_register.decode(raw) == value
+
+
+@pytest.mark.parametrize("value", [0, 4294967295])
+def test_register_uint32_encode_decode(uint32_register: Register, value: int) -> None:
+    raw = uint32_register.encode(value)
+    assert uint32_register.decode(raw) == value
+
+
+@pytest.mark.parametrize("value", [1234567890123456789, -987654321098765432])
+def test_register_int64_encode_decode(int64_register: Register, value: int) -> None:
+    raw = int64_register.encode(value)
+    assert int64_register.decode(raw) == value
+
+
+@pytest.mark.parametrize("value", [0, 2**64 - 1])
+def test_register_uint64_encode_decode(uint64_register: Register, value: int) -> None:
+    raw = uint64_register.encode(value)
+    assert uint64_register.decode(raw) == value


### PR DESCRIPTION
## Summary
- extend register encode/decode with float32/int32/uint32/int64/uint64 support
- add tests for encoding/decoding 32-bit and 64-bit values including floats

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py tests/test_register_decoders.py` (failed: InvalidManifestError: /root/.cache/pre-commit/repows5qfvbj/.pre-commit-hooks.yaml is not a file)
- `pytest tests/test_register_decoders.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e0b980f8832699d8b75b316e3338