### PR TITLE
Enable dict-style iteration of capabilities dataclasses

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -331,7 +331,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
                 caps_data = DeviceCapabilities()
         else:
             caps_data = DeviceCapabilities()
-        capabilities = caps_data.as_dict()
 
         register_count = self._scan_result.get(
             "register_count",
@@ -339,7 +338,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
         )
 
         capabilities_list = [
-            k.replace("_", " ").title() for k, v in capabilities.items() if v
+            k.replace("_", " ").title() for k, v in caps_data.items() if v
         ]
 
         scan_success_rate = "100%" if register_count > 0 else "0%"

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1104,9 +1104,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "available_registers": {
                 key: sorted(list(value)) for key, value in self.available_registers.items()
             },
-            "capabilities": (
-                self.capabilities.as_dict() if hasattr(self.capabilities, "as_dict") else {}
-            ),
+            "capabilities": dict(self.capabilities),
             "scan_result": self.device_scan_result,
             "unknown_registers": self.unknown_registers,
             "scanned_registers": self.scanned_registers,

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -66,6 +66,15 @@ class DeviceInfo:
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
 
+    def items(self):
+        return asdict(self).items()
+
+    def keys(self):
+        return asdict(self).keys()
+
+    def __iter__(self):
+        return iter(self.items())
+
 
 @dataclass
 class DeviceCapabilities:
@@ -123,6 +132,15 @@ class DeviceCapabilities:
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+    def items(self):
+        return asdict(self).items()
+
+    def keys(self):
+        return asdict(self).keys()
+
+    def __iter__(self):
+        return iter(self.items())
 
 
 class ThesslaGreenDeviceScanner:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1124,3 +1124,21 @@ async def test_validate_input_timeout_errors(exc):
 
     assert err.value.args[0] == "timeout"
     scanner_instance.close.assert_awaited_once()
+
+
+def test_device_capabilities_iteration():
+    """DeviceCapabilities should support iteration like a dict."""
+    from custom_components.thessla_green_modbus.scanner_core import DeviceCapabilities
+
+    caps = DeviceCapabilities(basic_control=True, bypass_system=True)
+
+    # items() should yield key-value pairs
+    items = dict(caps.items())
+    assert items["basic_control"] is True
+    assert items["bypass_system"] is True
+
+    # direct iteration should also yield pairs
+    iterated = dict(iter(caps))
+    assert iterated["basic_control"] is True
+    # keys() should include attribute names
+    assert "bypass_system" in caps.keys()


### PR DESCRIPTION
## Summary
- Add `items`, `keys` and iterator methods to `DeviceInfo` and `DeviceCapabilities`
- Iterate directly over dataclass instances in config flow and coordinator
- Test that `DeviceCapabilities` supports iteration

## Testing
- `pytest tests/test_config_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8e03b58d88326a36e1b474051e065