### PR TITLE
Add capabilities and registers hash to diagnostics

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import translation
 
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
+from .registers import get_registers_hash
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ async def async_get_config_entry_diagnostics(
 
     # Gather comprehensive diagnostic data from the coordinator
     diagnostics = coordinator.get_diagnostic_data()
+    diagnostics.setdefault("registers_hash", get_registers_hash())
+    diagnostics.setdefault("capabilities", coordinator.capabilities.as_dict())
 
     # Supplement diagnostics with coordinator statistics
     diagnostics.setdefault(

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1,6 +1,10 @@
 {
   "auto_detected_note_limited": "Limited auto-detection - some registers may be missing.",
   "auto_detected_note_success": "Auto-detection successful!",
+  "diagnostics": {
+    "registers_hash": "Register definitions hash",
+    "capabilities": "Device capabilities"
+  },
   "config": {
     "abort": {
       "already_configured": "Device with this IP address and Device ID is already configured."

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1,6 +1,10 @@
 {
   "auto_detected_note_limited": "Limited auto-detection - some registers may be missing.",
   "auto_detected_note_success": "Auto-detection successful!",
+  "diagnostics": {
+    "registers_hash": "Register definitions hash",
+    "capabilities": "Device capabilities"
+  },
   "config": {
     "abort": {
       "already_configured": "Device with this IP address and Device ID is already configured."

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1,6 +1,10 @@
 {
   "auto_detected_note_limited": "Ograniczone automatyczne wykrywanie - niektóre rejestry mogą być pominięte.",
   "auto_detected_note_success": "Automatyczne wykrywanie zakończone sukcesem!",
+  "diagnostics": {
+    "registers_hash": "Suma kontrolna rejestrów",
+    "capabilities": "Możliwości urządzenia"
+  },
   "config": {
     "abort": {
       "already_configured": "Urządzenie z tym adresem IP i ID urządzenia jest już skonfigurowane."

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -9,7 +9,7 @@ import pytest
 # Stub registers module to avoid heavy imports during diagnostics import
 registers_stub = ModuleType("custom_components.thessla_green_modbus.registers")
 registers_stub.get_all_registers = lambda: []
-registers_stub.get_registers_hash = lambda: ""
+registers_stub.get_registers_hash = lambda: "hash"
 registers_stub.get_registers_by_function = lambda *args, **kwargs: []
 registers_stub.group_reads = lambda *args, **kwargs: []
 sys.modules["custom_components.thessla_green_modbus.registers"] = registers_stub
@@ -73,6 +73,7 @@ async def test_last_scan_in_diagnostics():
             self.device_info = {}
             self.available_registers = {}
             self.statistics = {}
+            self.capabilities = SimpleNamespace(as_dict=lambda: {})
 
         def get_diagnostic_data(self):
             return {}
@@ -107,6 +108,7 @@ async def test_additional_diagnostic_fields():
                 "holding_registers": {"c"},
             }
             self.statistics = {"connection_errors": 2, "timeout_errors": 1}
+            self.capabilities = SimpleNamespace(as_dict=lambda: {"fan": True})
 
         def get_diagnostic_data(self):
             return {}
@@ -131,3 +133,5 @@ async def test_additional_diagnostic_fields():
         "timeout_errors": 1,
     }
     assert result["last_scan"] == last_scan.isoformat()
+    assert result["registers_hash"] == "hash"
+    assert result["capabilities"] == {"fan": True}


### PR DESCRIPTION
## Summary
- include register definition hash and capabilities in diagnostics payload
- localize new diagnostics fields
- extend diagnostics tests for new fields

## Testing
- `pytest tests/test_diagnostics.py -q`
- `pre-commit run --files custom_components/thessla_green_modbus/diagnostics.py custom_components/thessla_green_modbus/strings.json custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json tests/test_diagnostics.py` *(failed: InvalidManifestError: /root/.cache/pre-commit/repoagkx3t9_/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e0389b9483269a5d417573aea72d