### PR TITLE
Improve Modbus logging and timeout handling

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -64,11 +64,23 @@ async def _call_modbus(
             kwarg = ""
         _KWARG_CACHE[func] = kwarg
 
+    _LOGGER.debug(
+        "Sending %s to slave %s: args=%s kwargs=%s",
+        getattr(func, "__name__", repr(func)),
+        slave_id,
+        positional,
+        kwargs,
+    )
+
     if kwarg == "slave":
-        return await func(*positional, slave=slave_id, **kwargs)
-    if kwarg == "unit":
-        return await func(*positional, unit=slave_id, **kwargs)
-    return await func(*positional, **kwargs)
+        response = await func(*positional, slave=slave_id, **kwargs)
+    elif kwarg == "unit":
+        response = await func(*positional, unit=slave_id, **kwargs)
+    else:
+        response = await func(*positional, **kwargs)
+
+    _LOGGER.debug("Received from %s: %s", getattr(func, "__name__", repr(func)), response)
+    return response
 
 
 def group_reads(addresses: Iterable[int], max_block_size: int = 64) -> List[Tuple[int, int]]:


### PR DESCRIPTION
## Summary
- add debug logs for Modbus frames and register values
- log timeouts as warnings and persistent errors as errors
- cover scanner timeout logging with new test

## Testing
- `pytest tests/test_device_scanner.py -k test_read_holding_timeout_logging -q`
- `pre-commit run --files custom_components/thessla_green_modbus/modbus_helpers.py custom_components/thessla_green_modbus/scanner_core.py custom_components/thessla_green_modbus/coordinator.py tests/test_device_scanner.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repof9f_wdcg/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a967354dd08326a6b91fc6c4367a84