### PR TITLE
Filter capability list to booleans

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -338,7 +338,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
         )
 
         capabilities_list = [
-            k.replace("_", " ").title() for k, v in caps_data.items() if v
+            field.name.replace("_", " ").title()
+            for field in dataclasses.fields(DeviceCapabilities)
+            if field.type in (bool, "bool") and getattr(caps_data, field.name)
         ]
 
         scan_success_rate = "100%" if register_count > 0 else "0%"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -283,6 +283,40 @@ async def test_async_step_confirm_auto_detected_note(registers, expected_note):
     assert result["description_placeholders"]["auto_detected_note"] == translations[expected_note]
 
 
+async def test_async_step_confirm_capabilities_only_bool():
+    """Ensure capabilities list includes only boolean fields."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+    flow._data = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "My Device",
+    }
+    flow._device_info = {}
+    flow._scan_result = {
+        "available_registers": {},
+        "capabilities": {
+            "temperature_sensors": {"t1"},
+            "expansion_module": True,
+            "temperature_sensors_count": 1,
+        },
+        "register_count": 1,
+    }
+
+    with patch(
+        "homeassistant.helpers.translation.async_get_translations",
+        new=AsyncMock(return_value={}),
+    ):
+        result = await flow.async_step_confirm()
+
+    placeholders = result["description_placeholders"]
+    assert "Expansion Module" in placeholders["capabilities_list"]
+    assert "Temperature Sensors" not in placeholders["capabilities_list"]
+    assert placeholders["capabilities_count"] == "1"
+
+
 async def test_unique_id_sanitized():
     """Ensure unique ID replaces colons in host with hyphens."""
     flow = ConfigFlow()


### PR DESCRIPTION
## Summary
- ensure capabilities list in config flow includes only boolean capabilities
- add test to verify non-boolean capability fields are excluded

## Testing
- `pytest tests/test_config_flow.py -k capabilities_only_bool`
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py tests/test_config_flow.py` *(fails: InvalidManifestError: .../home-assistant/actions .pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9673b53288326bb337ce7d86d62b5