### PR TITLE
Validate register function and access types

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -341,6 +341,12 @@ def _validate_item(item: Dict[str, Any]) -> None:
         raise ValueError("missing 'function'")
     if not isinstance(item["function"], (str, int)):
         raise ValueError("invalid 'function'")
+    if str(item["function"]) not in {"01", "02", "03", "04"}:
+        raise ValueError("invalid 'function'")
+    if not isinstance(item.get("access"), str):
+        raise ValueError("missing or invalid 'access'")
+    if item["access"] not in {"R/-", "R/W", "R", "W"}:
+        raise ValueError("invalid 'access'")
     if item.get("address_dec") is None and item.get("address_hex") is None:
         raise ValueError("missing address field")
     if item.get("address_dec") is not None and not isinstance(item["address_dec"], int):


### PR DESCRIPTION
## Summary
- restrict register `function` codes to 01-04 and `access` to known variants
- validate function/access values when loading register definitions
- add tests covering invalid function and access values

## Testing
- `pytest tests/test_register_loader_validation.py tests/test_register_loader.py -q`
- `pytest tests/test_register_grouping.py tests/test_register_decoders.py -q` *(fails: group read expectations and negative int handling)*

------
https://chatgpt.com/codex/tasks/task_e_68a9673889048326987dc40f37e21004