### PR TITLE
Ensure CSV artifacts are input-only and excluded from packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include custom_components/thessla_green_modbus/translations *.json
 recursive-include custom_components/thessla_green_modbus/registers *.json
 include custom_components/thessla_green_modbus/services.yaml
 prune tools
+global-exclude *.csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ include = ["custom_components*"]
     "registers/*.json",
 ]
 
+[tool.setuptools.exclude-package-data]
+"*" = ["*.csv"]
+
 [tool.ruff]
 line-length = 79
 target-version = "py312"

--- a/tests/test_no_csv_references.py
+++ b/tests/test_no_csv_references.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import tomllib
 
 
 def test_no_csv_references() -> None:
@@ -15,4 +16,27 @@ def test_no_csv_references() -> None:
     )
     csv_files = list(runtime.rglob("*.csv"))
     assert not csv_files, f"Unexpected CSV files found: {csv_files}"
+
+
+def test_modbus_registers_csv_excluded_from_package_data() -> None:
+    """Ensure tools CSV file is excluded from built packages."""
+
+    repo_root = Path(__file__).resolve().parent.parent
+    assert (repo_root / "tools" / "modbus_registers.csv").exists()
+
+    manifest_lines = (
+        repo_root / "MANIFEST.in"
+    ).read_text(encoding="utf-8").splitlines()
+    assert "global-exclude *.csv" in [line.strip() for line in manifest_lines]
+
+    pyproject_data = tomllib.loads(
+        (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    exclude_patterns = (
+        pyproject_data.get("tool", {})
+        .get("setuptools", {})
+        .get("exclude-package-data", {})
+        .get("*", [])
+    )
+    assert "*.csv" in exclude_patterns
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,3 @@
+# Tools
+
+The `modbus_registers.csv` file is provided **only** as input for `convert_registers_csv_to_json.py`. It is not packaged or used at runtime.


### PR DESCRIPTION
## Summary
- document that `modbus_registers.csv` is only an input to `convert_registers_csv_to_json.py`
- exclude all CSV files from packaging in `MANIFEST.in` and `pyproject.toml`
- test that packaging configuration ignores `tools/modbus_registers.csv`

## Testing
- `pytest tests/test_no_csv_references.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9672546dc832688f9594529ca908e