### PR TITLE
Use PERCENTAGE constant in _infer_icon

### DIFF
--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -138,7 +138,7 @@ def _infer_icon(name: str, unit: str | None) -> str:
         return "mdi:thermometer"
     if unit in {"m³/h", "m3/h"} or "flow" in name or "fan" in name:
         return "mdi:fan"
-    if unit == "%" or "percentage" in name:
+    if unit == PERCENTAGE or "percentage" in name:
         return "mdi:percent-outline"
     if unit in {"s", "min", "h", "d"} or "time" in name:
         return "mdi:timer"


### PR DESCRIPTION
## Summary
- use PERCENTAGE constant instead of literal "%" when inferring percent icons

## Testing
- `pytest tests/test_unused_translations.py tests/test_entity_unique_id.py` *(fails: ImportError: cannot import name 'loader' from 'custom_components.thessla_green_modbus')*


------
https://chatgpt.com/codex/tasks/task_e_68a9f75fd06c83268808141fd9d50939