### PR TITLE
Simplify register loader caching

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -22,9 +22,9 @@ import struct
 import importlib.resources as resources
 from dataclasses import dataclass
 from datetime import time
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Sequence
-import struct
 
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from ..utils import _to_snake_case
@@ -384,18 +384,24 @@ def _normalise_name(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _load_registers_from_file() -> List[Register]:
-    """Load register definitions from the bundled JSON file."""
+@lru_cache(maxsize=1)
+def _load_registers_from_file(
+    path: Path, *, file_hash: str
+) -> List[Register]:
+    """Load register definitions from ``path``.
+
+    ``file_hash`` is only used to invalidate the cache when the underlying file
+    content changes.  It is marked as a keyword-only argument to ensure callers
+    pass it explicitly which makes the intention clearer.
+    """
 
     try:
-        raw = json.loads(_REGISTERS_PATH.read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:  # pragma: no cover - sanity check
-        _LOGGER.error("Register definition file missing: %s", _REGISTERS_PATH)
+        _LOGGER.error("Register definition file missing: %s", path)
         return []
     except Exception:  # pragma: no cover - defensive
-        _LOGGER.exception(
-            "Failed to read register definitions from %s", _REGISTERS_PATH
-        )
+        _LOGGER.exception("Failed to read register definitions from %s", path)
         return []
 
     items = raw.get("registers", raw) if isinstance(raw, dict) else raw
@@ -455,11 +461,6 @@ def _load_registers_from_file() -> List[Register]:
     return registers
 
 
-# Cache for loaded register definitions and the file hash used to build it
-_REGISTER_CACHE: List[Register] = []
-_REGISTERS_HASH: str | None = None
-
-
 def _compute_file_hash() -> str:
     """Return the SHA256 hash of the registers file."""
 
@@ -469,22 +470,14 @@ def _compute_file_hash() -> str:
 def _load_registers() -> List[Register]:
     """Return cached register definitions, reloading if the file changed."""
 
-    global _REGISTERS_HASH
-    current_hash = _compute_file_hash()
-    if not _REGISTER_CACHE or _REGISTERS_HASH != current_hash:
-        _REGISTER_CACHE.clear()
-        _REGISTER_CACHE.extend(_load_registers_from_file())
-        _REGISTERS_HASH = current_hash
-    return _REGISTER_CACHE
+    file_hash = _compute_file_hash()
+    return _load_registers_from_file(_REGISTERS_PATH, file_hash=file_hash)
 
 
-def _cache_clear() -> None:
-    global _REGISTERS_HASH
-    _REGISTER_CACHE.clear()
-    _REGISTERS_HASH = None
+def clear_cache() -> None:
+    """Clear the register definition cache."""
 
-
-_load_registers.cache_clear = _cache_clear  # type: ignore[attr-defined]
+    _load_registers_from_file.cache_clear()
 
 
 # Load register definitions once at import time
@@ -509,8 +502,10 @@ def get_registers_by_function(fn: str) -> List[Register]:
 
 def get_registers_hash() -> str:
     """Return the hash of the currently loaded register file."""
-
-    return _REGISTERS_HASH or ""
+    try:
+        return _compute_file_hash()
+    except Exception:  # pragma: no cover - defensive
+        return ""
 
 
 @dataclass(slots=True)

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -1,9 +1,8 @@
 import json
 from pathlib import Path
-from importlib import resources
 
 from custom_components.thessla_green_modbus.registers.loader import (
-    _cache_clear,
+    clear_cache,
     _load_registers,
     _REGISTERS_PATH,
 )
@@ -19,7 +18,7 @@ def test_register_cache_invalidation(tmp_path: Path, monkeypatch) -> None:
         tmp_json,
     )
 
-    _cache_clear()
+    clear_cache()
     first = _load_registers()[0]
     assert first.description
 
@@ -27,8 +26,8 @@ def test_register_cache_invalidation(tmp_path: Path, monkeypatch) -> None:
     data["registers"][0]["description"] = "changed description"
     tmp_json.write_text(json.dumps(data), encoding="utf-8")
 
-    _cache_clear()
+    clear_cache()
     updated = _load_registers()[0]
     assert updated.description == "changed description"
 
-    _cache_clear()
+    clear_cache()


### PR DESCRIPTION
## Summary
- replace manual register caching with `functools.lru_cache`
- add `clear_cache()` helper for tests
- update cache invalidation test to use `clear_cache`

## Testing
- `python -m pytest tests/test_register_cache_invalidation.py -q`
- `python -m pytest -q` *(fails: cannot import name 'loader' from 'custom_components.thessla_green_modbus'; cannot import name 'ReadPlan')*


------
https://chatgpt.com/codex/tasks/task_e_68a9f75d25b4832695887b1914ba35bb