### PR TITLE
Specify UTF-8 when loading option JSON

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -10,14 +10,14 @@ from .registers import get_registers_by_function
 
 def _build_map(fn: str) -> dict[str, int]:
     return {r.name: r.address for r in get_registers_by_function(fn) if r.name}
+
+
 COIL_REGISTERS = _build_map("coil")
 DISCRETE_INPUT_REGISTERS = _build_map("discrete")
 HOLDING_REGISTERS = _build_map("holding")
 INPUT_REGISTERS = _build_map("input")
 MULTI_REGISTER_SIZES = {
-    r.name: r.length
-    for r in get_registers_by_function("holding")
-    if r.name and r.length > 1
+    r.name: r.length for r in get_registers_by_function("holding") if r.name and r.length > 1
 }
 
 OPTIONS_PATH = Path(__file__).parent / "options"
@@ -206,6 +206,7 @@ def get_discrete_input_registers() -> Dict[str, int]:
     """Return mapping of discrete input registers loaded from JSON definitions."""
     return _build_map("discrete")
 
+
 # ============================================================================
 # Complete register mapping from MODBUS_USER_AirPack_Home_08.2021.01 PDF
 # ============================================================================
@@ -219,7 +220,10 @@ def _load_json_option(filename: str) -> list[Any]:
     """
 
     try:
-        return cast(list[Any], json.loads((OPTIONS_PATH / filename).read_text()))
+        return cast(
+            list[Any],
+            json.loads((OPTIONS_PATH / filename).read_text(encoding="utf-8")),
+        )
     except (FileNotFoundError, json.JSONDecodeError) as err:
         _LOGGER.warning("Failed to load %s: %s", filename, err)
         return []

--- a/tests/test_options_loading.py
+++ b/tests/test_options_loading.py
@@ -11,7 +11,7 @@ def test_deep_scan_defaults():
 
 
 def test_missing_options_file(monkeypatch, caplog):
-    def missing(_self: Path) -> str:  # pragma: no cover - simple stub
+    def missing(_self: Path, **kwargs) -> str:  # pragma: no cover - simple stub
         raise FileNotFoundError
 
     monkeypatch.setattr(Path, "read_text", missing)
@@ -24,7 +24,7 @@ def test_missing_options_file(monkeypatch, caplog):
 
 
 def test_malformed_options_file(monkeypatch, caplog):
-    def malformed(_self: Path) -> str:  # pragma: no cover - simple stub
+    def malformed(_self: Path, **kwargs) -> str:  # pragma: no cover - simple stub
         return "{"
 
     monkeypatch.setattr(Path, "read_text", malformed)


### PR DESCRIPTION
## Summary
- Ensure option JSON files are read with UTF-8 encoding
- Adapt option-loading tests to handle encoding parameter

## Testing
- `ruff check custom_components/thessla_green_modbus/const.py`
- `flake8 --max-line-length=100 custom_components/thessla_green_modbus/const.py`
- `bandit custom_components/thessla_green_modbus/const.py`
- `pytest tests/test_options_loading.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9f75d92dc8326be7003113ddfe52c