### PR TITLE
Remove duplicate struct import

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 from datetime import time
 from pathlib import Path
 from typing import Any, Dict, List, Sequence
-import struct
 
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from ..utils import _to_snake_case


### PR DESCRIPTION
## Summary
- deduplicate `struct` import in Modbus register loader

## Testing
- `ruff check custom_components/thessla_green_modbus/registers/loader.py`
- `flake8 --max-line-length=100 --extend-ignore=E302,E303 custom_components/thessla_green_modbus/registers/loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9f761311c83268996ba9ff0480dc8