### PR TITLE
Remove duplicate struct import

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -25,8 +25,6 @@ from datetime import time
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Sequence, Set, Tuple
-import struct
-from typing import Any, Dict, List, Sequence
 
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from ..utils import _to_snake_case


### PR DESCRIPTION
## Summary
- remove duplicated `struct` import from register loader
- deduplicate typing import

## Testing
- `pytest` *(fails: ImportError: cannot import name 'loader' from 'custom_components.thessla_green_modbus'; ImportError: cannot import name 'ReadPlan'; ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a9f95e5a888326a4f4ab7d9bd484a8