### PR TITLE
Wrap scan_device with retry

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -147,7 +147,11 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
         )
 
         # Perform full device scan
-        scan_result = await asyncio.wait_for(scanner.scan_device(), timeout=timeout)
+        scan_result = await _run_with_retry(
+            lambda: asyncio.wait_for(scanner.scan_device(), timeout=timeout),
+            retries=DEFAULT_RETRY,
+            backoff=CONFIG_FLOW_BACKOFF,
+        )
 
         caps_obj = scan_result.get("capabilities")
         if caps_obj is None:


### PR DESCRIPTION
## Summary
- retry scan_device during config flow using _run_with_retry with default retry/backoff
- expand config flow tests to cover scan_device retry behavior

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py tests/test_config_flow.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo0_81itjl/.pre-commit-hooks.yaml is not a file)*
- `pytest -c tests/pytest.ini tests/test_config_flow.py::test_validate_input_retries_transient_failures -vv`

------
https://chatgpt.com/codex/tasks/task_e_68a9fa916ec88326be694e53afc90b46