### PR TITLE
Handle translation errors in diagnostics

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -72,9 +72,13 @@ async def async_get_config_entry_diagnostics(
     diagnostics.setdefault("failed_addresses", failed_addrs)
 
     # Add human-readable descriptions for active error/status registers
-    translations = await translation.async_get_translations(
-        hass, hass.config.language, f"component.{DOMAIN}"
-    )
+    translations: dict[str, str] = {}
+    try:
+        translations = await translation.async_get_translations(
+            hass, hass.config.language, f"component.{DOMAIN}"
+        )
+    except Exception as err:  # pragma: no cover - defensive
+        _LOGGER.debug("Translation load failed: %s", err)
     active_errors: dict[str, str] = {}
     if coordinator.data:
         for key, value in coordinator.data.items():


### PR DESCRIPTION
## Summary
- Handle translation failures in diagnostics, logging a debug message and continuing with empty translations
- Add unit test to cover translation error handling

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/diagnostics.py tests/test_diagnostics.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoa9vxrarb/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_diagnostics.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9fa92d7e483269f0343a8d444b999