### PR TITLE
docs: clarify scanner module path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ custom_components/thessla_green_modbus/
 ├── config_flow.py           # Configuration UI
 ├── const.py                 # Constants and register definitions
 ├── coordinator.py           # Data coordinator (optimized)
-├── device_scanner.py        # Device capability scanner
+├── scanner_core.py          # Device capability scanner
 ├── climate.py               # Climate entity (enhanced)
 ├── sensor.py                # Sensor entities
 ├── binary_sensor.py         # Binary sensor entities (enhanced)

--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ pomijane w kolejnych skanach.
 Szczegóły migracji z czujników procentowych opisano w pliku [docs/airflow_migration.md](docs/airflow_migration.md).
 
 ### Proces autoskanu
-Podczas dodawania integracji moduł `ThesslaGreenDeviceScanner` (plik
-`scanner_core.py`) wywołuje metodę `ThesslaGreenDeviceScanner.scan_device()`,
-która otwiera połączenie Modbus, wykrywa dostępne rejestry oraz
-możliwości urządzenia, a następnie zamyka klienta. Wynik skanowania
+Podczas dodawania integracji moduł `ThesslaGreenDeviceScanner` z pliku
+`custom_components/thessla_green_modbus/scanner_core.py` wywołuje metodę
+`scan_device()`. Funkcja ta otwiera połączenie Modbus, skanuje dostępne
+rejestry i możliwości urządzenia, a następnie zamyka klienta. Wynik
 trafia do struktury `available_registers`, z której koordynator tworzy
-jedynie encje obsługiwane przez dane urządzenie. Jeśli po aktualizacji
-firmware pojawią się nowe rejestry, ponownie uruchom skanowanie (np.
-usuń i dodaj integrację), aby zaktualizować listę `available_registers`.
+jedynie encje obsługiwane przez dane urządzenie. Po aktualizacji
+firmware uruchom ponownie skanowanie (np. usuń i dodaj integrację), aby
+zaktualizować listę `available_registers`.
 
 Podczas skanowania rejestry są grupowane według funkcji i tylko część z nich
 przekłada się na utworzone encje. Niektóre służą jedynie do diagnostyki lub

--- a/README_en.md
+++ b/README_en.md
@@ -96,13 +96,14 @@ cp -r thessla-green-modbus-ha/custom_components/thessla_green_modbus custom_comp
 > [More details](docs/register_scanning.md).
 
 ### Auto-scan process
-During setup the `ThesslaGreenDeviceScanner` module (`scanner_core.py`)
-invokes `ThesslaGreenDeviceScanner.scan_device()` which opens a Modbus
-connection, detects available registers and device capabilities, then
-closes the client. The results populate `available_registers` from which
-the coordinator creates only entities supported by the device. After
-firmware updates run the scan again (e.g. remove and re-add the
-integration) to refresh `available_registers`.
+During setup the `ThesslaGreenDeviceScanner` module from
+`custom_components/thessla_green_modbus/scanner_core.py` invokes
+`scan_device()`. This method opens a Modbus connection, scans available
+registers and device capabilities, then closes the client. The results
+populate `available_registers`, from which the coordinator creates only
+entities supported by the device. After firmware updates run the scan
+again (e.g. remove and re-add the integration) to refresh
+`available_registers`.
 
 ## 📊 Available entities
 


### PR DESCRIPTION
## Summary
- document that the ThesslaGreenDeviceScanner lives in `custom_components/thessla_green_modbus/scanner_core.py`
- explain that `scan_device()` opens a Modbus connection, scans registers and closes the client
- update contributing file structure to reference `scanner_core.py`

## Testing
- `pre-commit run --files README.md README_en.md CONTRIBUTING.md` *(fails: InvalidManifestError from home-assistant/actions)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a9fc0a847c8326ac35b6f2ebee1b79