### PR TITLE
Use DeviceCapabilities.as_dict in diagnostics

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1190,7 +1190,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "available_registers": {
                 key: sorted(list(value)) for key, value in self.available_registers.items()
             },
-            "capabilities": dict(self.capabilities),
+            "capabilities": self.capabilities.as_dict(),
             "scan_result": self.device_scan_result,
             "unknown_registers": self.unknown_registers,
             "scanned_registers": self.scanned_registers,


### PR DESCRIPTION
## Summary
- ensure diagnostics use `DeviceCapabilities.as_dict()`

## Testing
- `pytest tests/test_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9fc0f047c8326907d59cab28cccb9