### PR TITLE
chore: remove redundant typing imports

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -28,7 +28,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Sequence, Set, Tuple, Literal
 
 import pydantic
-from typing import Any, Dict, List, Sequence, Set, Tuple
 
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from ..utils import _to_snake_case


### PR DESCRIPTION
## Summary
- remove redundant typing import block from register loader

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py` *(fails: InvalidManifestError)*
- `pytest` *(fails: 265 failed, 142 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ffa755d88326ba620f6f050f1435