### PR TITLE
Clarify modbus CSV usage and enforce tool-only consumption

### DIFF
--- a/tools/convert_registers_csv_to_json.py
+++ b/tools/convert_registers_csv_to_json.py
@@ -37,7 +37,9 @@ def convert(csv_path: Path = CSV_PATH, json_path: Path = JSON_PATH) -> None:
     seen_pairs: set[tuple[str, int]] = set()
 
     with csv_path.open("r", encoding="utf-8") as fh:
-        reader = csv.DictReader(fh)
+        reader = csv.DictReader(
+            line for line in fh if not line.lstrip().startswith("#")
+        )
         for row in reader:
             name = row.get("Register_Name")
             if not name:

--- a/tools/modbus_registers.csv
+++ b/tools/modbus_registers.csv
@@ -1,3 +1,4 @@
+# This file is developer input only; used by tools/convert_registers_csv_to_json.py to generate JSON and not used at runtime.
 Function_Code,Address_HEX,Address_DEC,Access,Register_Name,Description,Min,Max,Default_Value,Multiplier,Unit,Information,Software_Version,Notes
 # 01 - READ COILS
 01,0x0005,5,R/-,duct_water_heater_pump,Stan wyjścia przekaźnika pompy obiegowej nagrzewnicy,0,1,,,0 - OFF; 1 - ON,,,


### PR DESCRIPTION
## Summary
- mark `tools/modbus_registers.csv` as developer input only
- skip commented lines when converting CSV to JSON
- guard against CSV file path references outside `tools/`

## Testing
- `pre-commit run --files tools/modbus_registers.csv tools/convert_registers_csv_to_json.py tests/test_no_csv_references.py` *(fails: InvalidManifestError, repo https://github.com/home-assistant/actions missing .pre-commit-hooks.yaml)*
- `pytest` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ffb3f4708326b484c0946810e189