### PR TITLE
Remove duplicate typing imports in loader

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -28,7 +28,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Sequence, Set, Tuple, Literal
 
 import pydantic
-from typing import Any, Dict, List, Sequence, Set, Tuple
 
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from ..utils import _to_snake_case


### PR DESCRIPTION
## Summary
- remove duplicate `typing` import in register loader

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a9ffc82bc8832689066c3a7c8cc119