### PR TITLE
feat: expose English register descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Każdy wpis w sekcji `registers` zawiera m.in. pola:
 - `function` – kod funkcji Modbus (`01`–`04`)
 - `address_dec` / `address_hex` – adres rejestru
 - `name` – unikalna nazwa w formacie snake_case
-- `description` – opis z dokumentacji
+- `description` – opis z dokumentacji (język polski)
+- `description_en` – opis w języku angielskim
 - `access` – tryb dostępu (`R`/`W`)
 
 Opcjonalnie można określić `unit`, `enum`, `multiplier`, `resolution` oraz inne
@@ -535,7 +536,8 @@ Każdy wpis w pliku to obiekt z polami:
   "address_dec": 4097,
   "access": "rw",
   "name": "mode",
-  "description": "Work mode"
+  "description": "Tryb pracy",
+  "description_en": "Work mode"
 }
 ```
 
@@ -568,7 +570,7 @@ logach. Aby ręcznie przekonwertować dane:
 
 1. Otwórz dotychczasowy plik CSV z definicjami rejestrów.
 2. Dla każdego wiersza utwórz obiekt w `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`
-   z polami `function`, `address_dec`, `address_hex`, `name`, `description` i `access`.
+   z polami `function`, `address_dec`, `address_hex`, `name`, `description`, `description_en` i `access`.
 3. Zachowaj sortowanie według `function` i `address_dec` oraz format liczbowy (`0x` dla wartości hex).
 4. Usuń lub zignoruj plik CSV i uruchom walidację jak przy dodawaniu nowych
    rejestrów.

--- a/README_en.md
+++ b/README_en.md
@@ -315,7 +315,8 @@ Each entry in the file is an object with fields:
   "address_dec": 4097,
   "access": "rw",
   "name": "mode",
-  "description": "Work mode"
+  "description": "Tryb pracy",
+  "description_en": "Work mode"
 }
 ```
 
@@ -324,7 +325,7 @@ Optional properties: `enum`, `multiplier`, `resolution`, `min`, `max`.
 ### Adding new registers
 
 1. Edit `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` and append a new object
-   with the required fields.
+   with the required fields (`function`, `address_dec`, `address_hex`, `name`, `description`, `description_en`, `access`).
 2. Ensure addresses are unique and remain sorted.
 3. Run the validation test:
 

--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -54,6 +54,7 @@ class Register:
     name: str
     access: str
     description: str | None = None
+    description_en: str | None = None
     unit: str | None = None
     multiplier: float | None = None
     resolution: float | None = None
@@ -340,6 +341,7 @@ class RegisterDefinition(pydantic.BaseModel):
     multiplier: float | None = None
     resolution: float | None = None
     description: str | None = None
+    description_en: str | None = None
     min: float | None = None
     max: float | None = None
     default: float | None = None
@@ -455,6 +457,7 @@ def _load_registers_from_file(
                 name=name,
                 access=str(parsed.access),
                 description=parsed.description,
+                description_en=parsed.description_en,
                 unit=parsed.unit,
                 multiplier=multiplier,
                 resolution=resolution,

--- a/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
+++ b/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
@@ -13,7 +13,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wyjścia przekaźnika pompy obiegowej nagrzewnicy"
+      "description": "Stan wyjścia przekaźnika pompy obiegowej nagrzewnicy",
+      "description_en": "Stan wyjścia przekaźnika pompy obiegowej nagrzewnicy"
     },
     {
       "function": "01",
@@ -28,7 +29,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wyjścia siłownika przepustnicy bypass"
+      "description": "Stan wyjścia siłownika przepustnicy bypass",
+      "description_en": "Stan wyjścia siłownika przepustnicy bypass"
     },
     {
       "function": "01",
@@ -43,7 +45,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wyjścia sygnału potwierdzenia pracy centrali (O1)"
+      "description": "Stan wyjścia sygnału potwierdzenia pracy centrali (O1)",
+      "description_en": "Stan wyjścia sygnału potwierdzenia pracy centrali (O1)"
     },
     {
       "function": "01",
@@ -58,7 +61,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wyjścia przekaźnika zasilania wentylatorów"
+      "description": "Stan wyjścia przekaźnika zasilania wentylatorów",
+      "description_en": "Stan wyjścia przekaźnika zasilania wentylatorów"
     },
     {
       "function": "01",
@@ -73,7 +77,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wyjścia przekaźnika zasilania kabla grzejnego"
+      "description": "Stan wyjścia przekaźnika zasilania kabla grzejnego",
+      "description_en": "Stan wyjścia przekaźnika zasilania kabla grzejnego"
     },
     {
       "function": "01",
@@ -88,7 +93,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wyjścia przekaźnika potwierdzenia pracy (Expansion)"
+      "description": "Stan wyjścia przekaźnika potwierdzenia pracy (Expansion)",
+      "description_en": "Stan wyjścia przekaźnika potwierdzenia pracy (Expansion)"
     },
     {
       "function": "01",
@@ -103,7 +109,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wyjścia przekaźnika GWC"
+      "description": "Stan wyjścia przekaźnika GWC",
+      "description_en": "Stan wyjścia przekaźnika GWC"
     },
     {
       "function": "01",
@@ -118,7 +125,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wyjścia zasilającego przepustnicę okapu"
+      "description": "Stan wyjścia zasilającego przepustnicę okapu",
+      "description_en": "Stan wyjścia zasilającego przepustnicę okapu"
     },
     {
       "function": "02",
@@ -133,7 +141,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia zabezpieczenia termicznego elektrycznej nagrzewnicy kanałowej"
+      "description": "Stan wejścia zabezpieczenia termicznego elektrycznej nagrzewnicy kanałowej",
+      "description_en": "Stan wejścia zabezpieczenia termicznego elektrycznej nagrzewnicy kanałowej"
     },
     {
       "function": "02",
@@ -148,7 +157,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Komunikacja z modułem Expansion"
+      "description": "Komunikacja z modułem Expansion",
+      "description_en": "Komunikacja z modułem Expansion"
     },
     {
       "function": "02",
@@ -163,7 +173,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia presostatu filtra kanałowego"
+      "description": "Stan wejścia presostatu filtra kanałowego",
+      "description_en": "Stan wejścia presostatu filtra kanałowego"
     },
     {
       "function": "02",
@@ -178,7 +189,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia włącznika funkcji OKAP"
+      "description": "Stan wejścia włącznika funkcji OKAP",
+      "description_en": "Stan wejścia włącznika funkcji OKAP"
     },
     {
       "function": "02",
@@ -193,7 +205,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia dwustanowego czujnika jakości powietrza"
+      "description": "Stan wejścia dwustanowego czujnika jakości powietrza",
+      "description_en": "Stan wejścia dwustanowego czujnika jakości powietrza"
     },
     {
       "function": "02",
@@ -208,7 +221,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia dwustanowego czujnika wilgotności"
+      "description": "Stan wejścia dwustanowego czujnika wilgotności",
+      "description_en": "Stan wejścia dwustanowego czujnika wilgotności"
     },
     {
       "function": "02",
@@ -223,7 +237,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia włącznika funkcji WIETRZENIE"
+      "description": "Stan wejścia włącznika funkcji WIETRZENIE",
+      "description_en": "Stan wejścia włącznika funkcji WIETRZENIE"
     },
     {
       "function": "02",
@@ -238,7 +253,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia przełącznika AirS w pozycji \"Wietrzenie\""
+      "description": "Stan wejścia przełącznika AirS w pozycji \"Wietrzenie\"",
+      "description_en": "Stan wejścia przełącznika AirS w pozycji \"Wietrzenie\""
     },
     {
       "function": "02",
@@ -253,7 +269,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia przełącznika AirS w pozycji \"3 bieg\""
+      "description": "Stan wejścia przełącznika AirS w pozycji \"3 bieg\"",
+      "description_en": "Stan wejścia przełącznika AirS w pozycji \"3 bieg\""
     },
     {
       "function": "02",
@@ -268,7 +285,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia przełącznika AirS w pozycji \"2 bieg\""
+      "description": "Stan wejścia przełącznika AirS w pozycji \"2 bieg\"",
+      "description_en": "Stan wejścia przełącznika AirS w pozycji \"2 bieg\""
     },
     {
       "function": "02",
@@ -283,7 +301,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia przełącznika AirS w pozycji \"1 bieg\""
+      "description": "Stan wejścia przełącznika AirS w pozycji \"1 bieg\"",
+      "description_en": "Stan wejścia przełącznika AirS w pozycji \"1 bieg\""
     },
     {
       "function": "02",
@@ -298,7 +317,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia włącznika funkcji KOMINEK"
+      "description": "Stan wejścia włącznika funkcji KOMINEK",
+      "description_en": "Stan wejścia włącznika funkcji KOMINEK"
     },
     {
       "function": "02",
@@ -313,7 +333,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia sygnału alarmu pożarowego (P.POZ.)"
+      "description": "Stan wejścia sygnału alarmu pożarowego (P.POZ.)",
+      "description_en": "Stan wejścia sygnału alarmu pożarowego (P.POZ.)"
     },
     {
       "function": "02",
@@ -328,7 +349,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia presostatu filtrów w rekuperatorze (DP1)"
+      "description": "Stan wejścia presostatu filtrów w rekuperatorze (DP1)",
+      "description_en": "Stan wejścia presostatu filtrów w rekuperatorze (DP1)"
     },
     {
       "function": "02",
@@ -343,7 +365,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia zabezpieczenia termicznego nagrzewnicy systemu przeciwzamrożeniowego FPX"
+      "description": "Stan wejścia zabezpieczenia termicznego nagrzewnicy systemu przeciwzamrożeniowego FPX",
+      "description_en": "Stan wejścia zabezpieczenia termicznego nagrzewnicy systemu przeciwzamrożeniowego FPX"
     },
     {
       "function": "02",
@@ -358,7 +381,8 @@
       },
       "multiplier": null,
       "resolution": null,
-      "description": "Stan wejścia sygnału załączenia funkcji PUSTY DOM"
+      "description": "Stan wejścia sygnału załączenia funkcji PUSTY DOM",
+      "description_en": "Stan wejścia sygnału załączenia funkcji PUSTY DOM"
     },
     {
       "function": "03",
@@ -370,7 +394,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Data i godzina - liczba dziesiątek / jedności roku i miesiąc [RRMM]"
+      "description": "Data i godzina - liczba dziesiątek / jedności roku i miesiąc [RRMM]",
+      "description_en": "Data i godzina - liczba dziesiątek / jedności roku i miesiąc [RRMM]"
     },
     {
       "function": "03",
@@ -382,7 +407,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Data i godzina - dzień miesiąca i dzień tygodnia [DDTT]"
+      "description": "Data i godzina - dzień miesiąca i dzień tygodnia [DDTT]",
+      "description_en": "Data i godzina - dzień miesiąca i dzień tygodnia [DDTT]"
     },
     {
       "function": "03",
@@ -394,7 +420,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Data i godzina - godzina i minuta [GGmm]"
+      "description": "Data i godzina - godzina i minuta [GGmm]",
+      "description_en": "Data i godzina - godzina i minuta [GGmm]"
     },
     {
       "function": "03",
@@ -406,7 +433,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Data i godzina - sekunda i setne części sekundy [sscc]"
+      "description": "Data i godzina - sekunda i setne części sekundy [sscc]",
+      "description_en": "Data i godzina - sekunda i setne części sekundy [sscc]"
     },
     {
       "function": "03",
@@ -418,7 +446,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Data zablokowania centrali kluczem produktu - liczba dziesiątek / jedności roku [00RR]"
+      "description": "Data zablokowania centrali kluczem produktu - liczba dziesiątek / jedności roku [00RR]",
+      "description_en": "Data zablokowania centrali kluczem produktu - liczba dziesiątek / jedności roku [00RR]"
     },
     {
       "function": "03",
@@ -430,7 +459,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Data zablokowania centrali kluczem produktu - miesiąc [00MM]"
+      "description": "Data zablokowania centrali kluczem produktu - miesiąc [00MM]",
+      "description_en": "Data zablokowania centrali kluczem produktu - miesiąc [00MM]"
     },
     {
       "function": "03",
@@ -442,7 +472,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Data zablokowania centrali kluczem produktu - dzień [00DD]"
+      "description": "Data zablokowania centrali kluczem produktu - dzień [00DD]",
+      "description_en": "Data zablokowania centrali kluczem produktu - dzień [00DD]"
     },
     {
       "function": "03",
@@ -458,7 +489,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Tryby specjalne pracy centrali"
+      "description": "Tryby specjalne pracy centrali",
+      "description_en": "Tryby specjalne pracy centrali"
     },
     {
       "function": "03",
@@ -474,7 +506,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Poziom dostępu"
+      "description": "Poziom dostępu",
+      "description_en": "Poziom dostępu"
     },
     {
       "function": "03",
@@ -486,7 +519,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - 1"
+      "description": "LATO - Poniedziałek - 1",
+      "description_en": "LATO - Poniedziałek - 1"
     },
     {
       "function": "03",
@@ -498,7 +532,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - 2"
+      "description": "LATO - Poniedziałek - 2",
+      "description_en": "LATO - Poniedziałek - 2"
     },
     {
       "function": "03",
@@ -510,7 +545,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - 3"
+      "description": "LATO - Poniedziałek - 3",
+      "description_en": "LATO - Poniedziałek - 3"
     },
     {
       "function": "03",
@@ -522,7 +558,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - 4"
+      "description": "LATO - Poniedziałek - 4",
+      "description_en": "LATO - Poniedziałek - 4"
     },
     {
       "function": "03",
@@ -534,7 +571,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - 1"
+      "description": "LATO - Wtorek - 1",
+      "description_en": "LATO - Wtorek - 1"
     },
     {
       "function": "03",
@@ -546,7 +584,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - 2"
+      "description": "LATO - Wtorek - 2",
+      "description_en": "LATO - Wtorek - 2"
     },
     {
       "function": "03",
@@ -558,7 +597,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - 3"
+      "description": "LATO - Wtorek - 3",
+      "description_en": "LATO - Wtorek - 3"
     },
     {
       "function": "03",
@@ -570,7 +610,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - 4"
+      "description": "LATO - Wtorek - 4",
+      "description_en": "LATO - Wtorek - 4"
     },
     {
       "function": "03",
@@ -582,7 +623,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - 1"
+      "description": "LATO - Środa - 1",
+      "description_en": "LATO - Środa - 1"
     },
     {
       "function": "03",
@@ -594,7 +636,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - 2"
+      "description": "LATO - Środa - 2",
+      "description_en": "LATO - Środa - 2"
     },
     {
       "function": "03",
@@ -606,7 +649,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - 3"
+      "description": "LATO - Środa - 3",
+      "description_en": "LATO - Środa - 3"
     },
     {
       "function": "03",
@@ -618,7 +662,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - 4"
+      "description": "LATO - Środa - 4",
+      "description_en": "LATO - Środa - 4"
     },
     {
       "function": "03",
@@ -630,7 +675,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - 1"
+      "description": "LATO - Czwartek - 1",
+      "description_en": "LATO - Czwartek - 1"
     },
     {
       "function": "03",
@@ -642,7 +688,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - 2"
+      "description": "LATO - Czwartek - 2",
+      "description_en": "LATO - Czwartek - 2"
     },
     {
       "function": "03",
@@ -654,7 +701,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - 3"
+      "description": "LATO - Czwartek - 3",
+      "description_en": "LATO - Czwartek - 3"
     },
     {
       "function": "03",
@@ -666,7 +714,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - 4"
+      "description": "LATO - Czwartek - 4",
+      "description_en": "LATO - Czwartek - 4"
     },
     {
       "function": "03",
@@ -678,7 +727,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - 1"
+      "description": "LATO - Piątek - 1",
+      "description_en": "LATO - Piątek - 1"
     },
     {
       "function": "03",
@@ -690,7 +740,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - 2"
+      "description": "LATO - Piątek - 2",
+      "description_en": "LATO - Piątek - 2"
     },
     {
       "function": "03",
@@ -702,7 +753,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - 3"
+      "description": "LATO - Piątek - 3",
+      "description_en": "LATO - Piątek - 3"
     },
     {
       "function": "03",
@@ -714,7 +766,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - 4"
+      "description": "LATO - Piątek - 4",
+      "description_en": "LATO - Piątek - 4"
     },
     {
       "function": "03",
@@ -726,7 +779,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - 1"
+      "description": "LATO - Sobota - 1",
+      "description_en": "LATO - Sobota - 1"
     },
     {
       "function": "03",
@@ -738,7 +792,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - 2"
+      "description": "LATO - Sobota - 2",
+      "description_en": "LATO - Sobota - 2"
     },
     {
       "function": "03",
@@ -750,7 +805,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - 3"
+      "description": "LATO - Sobota - 3",
+      "description_en": "LATO - Sobota - 3"
     },
     {
       "function": "03",
@@ -762,7 +818,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - 4"
+      "description": "LATO - Sobota - 4",
+      "description_en": "LATO - Sobota - 4"
     },
     {
       "function": "03",
@@ -774,7 +831,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - 1"
+      "description": "LATO - Niedziela - 1",
+      "description_en": "LATO - Niedziela - 1"
     },
     {
       "function": "03",
@@ -786,7 +844,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - 2"
+      "description": "LATO - Niedziela - 2",
+      "description_en": "LATO - Niedziela - 2"
     },
     {
       "function": "03",
@@ -798,7 +857,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - 3"
+      "description": "LATO - Niedziela - 3",
+      "description_en": "LATO - Niedziela - 3"
     },
     {
       "function": "03",
@@ -810,7 +870,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - 4"
+      "description": "LATO - Niedziela - 4",
+      "description_en": "LATO - Niedziela - 4"
     },
     {
       "function": "03",
@@ -822,7 +883,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - 1"
+      "description": "ZIMA - Poniedziałek - 1",
+      "description_en": "ZIMA - Poniedziałek - 1"
     },
     {
       "function": "03",
@@ -834,7 +896,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - 2"
+      "description": "ZIMA - Poniedziałek - 2",
+      "description_en": "ZIMA - Poniedziałek - 2"
     },
     {
       "function": "03",
@@ -846,7 +909,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - 3"
+      "description": "ZIMA - Poniedziałek - 3",
+      "description_en": "ZIMA - Poniedziałek - 3"
     },
     {
       "function": "03",
@@ -858,7 +922,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - 4"
+      "description": "ZIMA - Poniedziałek - 4",
+      "description_en": "ZIMA - Poniedziałek - 4"
     },
     {
       "function": "03",
@@ -870,7 +935,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - 1"
+      "description": "ZIMA - Wtorek - 1",
+      "description_en": "ZIMA - Wtorek - 1"
     },
     {
       "function": "03",
@@ -882,7 +948,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - 2"
+      "description": "ZIMA - Wtorek - 2",
+      "description_en": "ZIMA - Wtorek - 2"
     },
     {
       "function": "03",
@@ -894,7 +961,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - 3"
+      "description": "ZIMA - Wtorek - 3",
+      "description_en": "ZIMA - Wtorek - 3"
     },
     {
       "function": "03",
@@ -906,7 +974,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - 4"
+      "description": "ZIMA - Wtorek - 4",
+      "description_en": "ZIMA - Wtorek - 4"
     },
     {
       "function": "03",
@@ -918,7 +987,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - 1"
+      "description": "ZIMA - Środa - 1",
+      "description_en": "ZIMA - Środa - 1"
     },
     {
       "function": "03",
@@ -930,7 +1000,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - 2"
+      "description": "ZIMA - Środa - 2",
+      "description_en": "ZIMA - Środa - 2"
     },
     {
       "function": "03",
@@ -942,7 +1013,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - 3"
+      "description": "ZIMA - Środa - 3",
+      "description_en": "ZIMA - Środa - 3"
     },
     {
       "function": "03",
@@ -954,7 +1026,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - 4"
+      "description": "ZIMA - Środa - 4",
+      "description_en": "ZIMA - Środa - 4"
     },
     {
       "function": "03",
@@ -966,7 +1039,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - 1"
+      "description": "ZIMA - Czwartek - 1",
+      "description_en": "ZIMA - Czwartek - 1"
     },
     {
       "function": "03",
@@ -978,7 +1052,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - 2"
+      "description": "ZIMA - Czwartek - 2",
+      "description_en": "ZIMA - Czwartek - 2"
     },
     {
       "function": "03",
@@ -990,7 +1065,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - 3"
+      "description": "ZIMA - Czwartek - 3",
+      "description_en": "ZIMA - Czwartek - 3"
     },
     {
       "function": "03",
@@ -1002,7 +1078,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - 4"
+      "description": "ZIMA - Czwartek - 4",
+      "description_en": "ZIMA - Czwartek - 4"
     },
     {
       "function": "03",
@@ -1014,7 +1091,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - 1"
+      "description": "ZIMA - Piątek - 1",
+      "description_en": "ZIMA - Piątek - 1"
     },
     {
       "function": "03",
@@ -1026,7 +1104,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - 2"
+      "description": "ZIMA - Piątek - 2",
+      "description_en": "ZIMA - Piątek - 2"
     },
     {
       "function": "03",
@@ -1038,7 +1117,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - 3"
+      "description": "ZIMA - Piątek - 3",
+      "description_en": "ZIMA - Piątek - 3"
     },
     {
       "function": "03",
@@ -1050,7 +1130,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - 4"
+      "description": "ZIMA - Piątek - 4",
+      "description_en": "ZIMA - Piątek - 4"
     },
     {
       "function": "03",
@@ -1062,7 +1143,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - 1"
+      "description": "ZIMA - Sobota - 1",
+      "description_en": "ZIMA - Sobota - 1"
     },
     {
       "function": "03",
@@ -1074,7 +1156,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - 2"
+      "description": "ZIMA - Sobota - 2",
+      "description_en": "ZIMA - Sobota - 2"
     },
     {
       "function": "03",
@@ -1086,7 +1169,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - 3"
+      "description": "ZIMA - Sobota - 3",
+      "description_en": "ZIMA - Sobota - 3"
     },
     {
       "function": "03",
@@ -1098,7 +1182,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - 4"
+      "description": "ZIMA - Sobota - 4",
+      "description_en": "ZIMA - Sobota - 4"
     },
     {
       "function": "03",
@@ -1110,7 +1195,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - 1"
+      "description": "ZIMA - Niedziela - 1",
+      "description_en": "ZIMA - Niedziela - 1"
     },
     {
       "function": "03",
@@ -1122,7 +1208,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - 2"
+      "description": "ZIMA - Niedziela - 2",
+      "description_en": "ZIMA - Niedziela - 2"
     },
     {
       "function": "03",
@@ -1134,7 +1221,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - 3"
+      "description": "ZIMA - Niedziela - 3",
+      "description_en": "ZIMA - Niedziela - 3"
     },
     {
       "function": "03",
@@ -1146,7 +1234,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - 4"
+      "description": "ZIMA - Niedziela - 4",
+      "description_en": "ZIMA - Niedziela - 4"
     },
     {
       "function": "03",
@@ -1158,7 +1247,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - 1 [AATT]"
+      "description": "LATO - Poniedziałek - 1 [AATT]",
+      "description_en": "LATO - Poniedziałek - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1170,7 +1260,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - 2 [AATT]"
+      "description": "LATO - Poniedziałek - 2 [AATT]",
+      "description_en": "LATO - Poniedziałek - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1182,7 +1273,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - 3 [AATT]"
+      "description": "LATO - Poniedziałek - 3 [AATT]",
+      "description_en": "LATO - Poniedziałek - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1194,7 +1286,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - 4 [AATT]"
+      "description": "LATO - Poniedziałek - 4 [AATT]",
+      "description_en": "LATO - Poniedziałek - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1206,7 +1299,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - 1 [AATT]"
+      "description": "LATO - Wtorek - 1 [AATT]",
+      "description_en": "LATO - Wtorek - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1218,7 +1312,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - 2 [AATT]"
+      "description": "LATO - Wtorek - 2 [AATT]",
+      "description_en": "LATO - Wtorek - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1230,7 +1325,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - 3 [AATT]"
+      "description": "LATO - Wtorek - 3 [AATT]",
+      "description_en": "LATO - Wtorek - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1242,7 +1338,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - 4 [AATT]"
+      "description": "LATO - Wtorek - 4 [AATT]",
+      "description_en": "LATO - Wtorek - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1254,7 +1351,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - 1 [AATT]"
+      "description": "LATO - Środa - 1 [AATT]",
+      "description_en": "LATO - Środa - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1266,7 +1364,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - 2 [AATT]"
+      "description": "LATO - Środa - 2 [AATT]",
+      "description_en": "LATO - Środa - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1278,7 +1377,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - 3 [AATT]"
+      "description": "LATO - Środa - 3 [AATT]",
+      "description_en": "LATO - Środa - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1290,7 +1390,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - 4 [AATT]"
+      "description": "LATO - Środa - 4 [AATT]",
+      "description_en": "LATO - Środa - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1302,7 +1403,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - 1 [AATT]"
+      "description": "LATO - Czwartek - 1 [AATT]",
+      "description_en": "LATO - Czwartek - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1314,7 +1416,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - 2 [AATT]"
+      "description": "LATO - Czwartek - 2 [AATT]",
+      "description_en": "LATO - Czwartek - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1326,7 +1429,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - 3 [AATT]"
+      "description": "LATO - Czwartek - 3 [AATT]",
+      "description_en": "LATO - Czwartek - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1338,7 +1442,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - 4 [AATT]"
+      "description": "LATO - Czwartek - 4 [AATT]",
+      "description_en": "LATO - Czwartek - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1350,7 +1455,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - 1 [AATT]"
+      "description": "LATO - Piątek - 1 [AATT]",
+      "description_en": "LATO - Piątek - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1362,7 +1468,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - 2 [AATT]"
+      "description": "LATO - Piątek - 2 [AATT]",
+      "description_en": "LATO - Piątek - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1374,7 +1481,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - 3 [AATT]"
+      "description": "LATO - Piątek - 3 [AATT]",
+      "description_en": "LATO - Piątek - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1386,7 +1494,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - 4 [AATT]"
+      "description": "LATO - Piątek - 4 [AATT]",
+      "description_en": "LATO - Piątek - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1398,7 +1507,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - 1 [AATT]"
+      "description": "LATO - Sobota - 1 [AATT]",
+      "description_en": "LATO - Sobota - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1410,7 +1520,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - 2 [AATT]"
+      "description": "LATO - Sobota - 2 [AATT]",
+      "description_en": "LATO - Sobota - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1422,7 +1533,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - 3 [AATT]"
+      "description": "LATO - Sobota - 3 [AATT]",
+      "description_en": "LATO - Sobota - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1434,7 +1546,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - 4 [AATT]"
+      "description": "LATO - Sobota - 4 [AATT]",
+      "description_en": "LATO - Sobota - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1446,7 +1559,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - 1 [AATT]"
+      "description": "LATO - Niedziela - 1 [AATT]",
+      "description_en": "LATO - Niedziela - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1458,7 +1572,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - 2 [AATT]"
+      "description": "LATO - Niedziela - 2 [AATT]",
+      "description_en": "LATO - Niedziela - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1470,7 +1585,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - 3 [AATT]"
+      "description": "LATO - Niedziela - 3 [AATT]",
+      "description_en": "LATO - Niedziela - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1482,7 +1598,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - 4 [AATT]"
+      "description": "LATO - Niedziela - 4 [AATT]",
+      "description_en": "LATO - Niedziela - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1494,7 +1611,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - 1 [AATT]"
+      "description": "ZIMA - Poniedziałek - 1 [AATT]",
+      "description_en": "ZIMA - Poniedziałek - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1506,7 +1624,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - 2 [AATT]"
+      "description": "ZIMA - Poniedziałek - 2 [AATT]",
+      "description_en": "ZIMA - Poniedziałek - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1518,7 +1637,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - 3 [AATT]"
+      "description": "ZIMA - Poniedziałek - 3 [AATT]",
+      "description_en": "ZIMA - Poniedziałek - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1530,7 +1650,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - 4 [AATT]"
+      "description": "ZIMA - Poniedziałek - 4 [AATT]",
+      "description_en": "ZIMA - Poniedziałek - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1542,7 +1663,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - 1 [AATT]"
+      "description": "ZIMA - Wtorek - 1 [AATT]",
+      "description_en": "ZIMA - Wtorek - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1554,7 +1676,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - 2 [AATT]"
+      "description": "ZIMA - Wtorek - 2 [AATT]",
+      "description_en": "ZIMA - Wtorek - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1566,7 +1689,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - 3 [AATT]"
+      "description": "ZIMA - Wtorek - 3 [AATT]",
+      "description_en": "ZIMA - Wtorek - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1578,7 +1702,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - 4 [AATT]"
+      "description": "ZIMA - Wtorek - 4 [AATT]",
+      "description_en": "ZIMA - Wtorek - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1590,7 +1715,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - 1 [AATT]"
+      "description": "ZIMA - Środa - 1 [AATT]",
+      "description_en": "ZIMA - Środa - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1602,7 +1728,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - 2 [AATT]"
+      "description": "ZIMA - Środa - 2 [AATT]",
+      "description_en": "ZIMA - Środa - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1614,7 +1741,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - 3 [AATT]"
+      "description": "ZIMA - Środa - 3 [AATT]",
+      "description_en": "ZIMA - Środa - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1626,7 +1754,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - 4 [AATT]"
+      "description": "ZIMA - Środa - 4 [AATT]",
+      "description_en": "ZIMA - Środa - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1638,7 +1767,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - 1 [AATT]"
+      "description": "ZIMA - Czwartek - 1 [AATT]",
+      "description_en": "ZIMA - Czwartek - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1650,7 +1780,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - 2 [AATT]"
+      "description": "ZIMA - Czwartek - 2 [AATT]",
+      "description_en": "ZIMA - Czwartek - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1662,7 +1793,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - 3 [AATT]"
+      "description": "ZIMA - Czwartek - 3 [AATT]",
+      "description_en": "ZIMA - Czwartek - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1674,7 +1806,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - 4 [AATT]"
+      "description": "ZIMA - Czwartek - 4 [AATT]",
+      "description_en": "ZIMA - Czwartek - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1686,7 +1819,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - 1 [AATT]"
+      "description": "ZIMA - Piątek - 1 [AATT]",
+      "description_en": "ZIMA - Piątek - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1698,7 +1832,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - 2 [AATT]"
+      "description": "ZIMA - Piątek - 2 [AATT]",
+      "description_en": "ZIMA - Piątek - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1710,7 +1845,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - 3 [AATT]"
+      "description": "ZIMA - Piątek - 3 [AATT]",
+      "description_en": "ZIMA - Piątek - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1722,7 +1858,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - 4 [AATT]"
+      "description": "ZIMA - Piątek - 4 [AATT]",
+      "description_en": "ZIMA - Piątek - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1734,7 +1871,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - 1 [AATT]"
+      "description": "ZIMA - Sobota - 1 [AATT]",
+      "description_en": "ZIMA - Sobota - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1746,7 +1884,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - 2 [AATT]"
+      "description": "ZIMA - Sobota - 2 [AATT]",
+      "description_en": "ZIMA - Sobota - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1758,7 +1897,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - 3 [AATT]"
+      "description": "ZIMA - Sobota - 3 [AATT]",
+      "description_en": "ZIMA - Sobota - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1770,7 +1910,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - 4 [AATT]"
+      "description": "ZIMA - Sobota - 4 [AATT]",
+      "description_en": "ZIMA - Sobota - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1782,7 +1923,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - 1 [AATT]"
+      "description": "ZIMA - Niedziela - 1 [AATT]",
+      "description_en": "ZIMA - Niedziela - 1 [AATT]"
     },
     {
       "function": "03",
@@ -1794,7 +1936,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - 2 [AATT]"
+      "description": "ZIMA - Niedziela - 2 [AATT]",
+      "description_en": "ZIMA - Niedziela - 2 [AATT]"
     },
     {
       "function": "03",
@@ -1806,7 +1949,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - 3 [AATT]"
+      "description": "ZIMA - Niedziela - 3 [AATT]",
+      "description_en": "ZIMA - Niedziela - 3 [AATT]"
     },
     {
       "function": "03",
@@ -1818,7 +1962,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - 4 [AATT]"
+      "description": "ZIMA - Niedziela - 4 [AATT]",
+      "description_en": "ZIMA - Niedziela - 4 [AATT]"
     },
     {
       "function": "03",
@@ -1830,7 +1975,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Poniedziałek - Wietrzenie [GGMM]"
+      "description": "LATO - Poniedziałek - Wietrzenie [GGMM]",
+      "description_en": "LATO - Poniedziałek - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1842,7 +1988,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Wtorek - Wietrzenie [GGMM]"
+      "description": "LATO - Wtorek - Wietrzenie [GGMM]",
+      "description_en": "LATO - Wtorek - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1854,7 +2001,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Środa - Wietrzenie [GGMM]"
+      "description": "LATO - Środa - Wietrzenie [GGMM]",
+      "description_en": "LATO - Środa - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1866,7 +2014,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Czwartek - Wietrzenie [GGMM]"
+      "description": "LATO - Czwartek - Wietrzenie [GGMM]",
+      "description_en": "LATO - Czwartek - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1878,7 +2027,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Piątek - Wietrzenie [GGMM]"
+      "description": "LATO - Piątek - Wietrzenie [GGMM]",
+      "description_en": "LATO - Piątek - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1890,7 +2040,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Sobota - Wietrzenie [GGMM]"
+      "description": "LATO - Sobota - Wietrzenie [GGMM]",
+      "description_en": "LATO - Sobota - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1902,7 +2053,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "LATO - Niedziela - Wietrzenie [GGMM]"
+      "description": "LATO - Niedziela - Wietrzenie [GGMM]",
+      "description_en": "LATO - Niedziela - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1914,7 +2066,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Poniedziałek - Wietrzenie [GGMM]"
+      "description": "ZIMA - Poniedziałek - Wietrzenie [GGMM]",
+      "description_en": "ZIMA - Poniedziałek - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1926,7 +2079,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Wtorek - Wietrzenie [GGMM]"
+      "description": "ZIMA - Wtorek - Wietrzenie [GGMM]",
+      "description_en": "ZIMA - Wtorek - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1938,7 +2092,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Środa - Wietrzenie [GGMM]"
+      "description": "ZIMA - Środa - Wietrzenie [GGMM]",
+      "description_en": "ZIMA - Środa - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1950,7 +2105,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Czwartek - Wietrzenie [GGMM]"
+      "description": "ZIMA - Czwartek - Wietrzenie [GGMM]",
+      "description_en": "ZIMA - Czwartek - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1962,7 +2118,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Piątek - Wietrzenie [GGMM]"
+      "description": "ZIMA - Piątek - Wietrzenie [GGMM]",
+      "description_en": "ZIMA - Piątek - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1974,7 +2131,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Sobota - Wietrzenie [GGMM]"
+      "description": "ZIMA - Sobota - Wietrzenie [GGMM]",
+      "description_en": "ZIMA - Sobota - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1986,7 +2144,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ZIMA - Niedziela - Wietrzenie [GGMM]"
+      "description": "ZIMA - Niedziela - Wietrzenie [GGMM]",
+      "description_en": "ZIMA - Niedziela - Wietrzenie [GGMM]"
     },
     {
       "function": "03",
@@ -1998,7 +2157,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Dane kalibracyjne zegara czasu rzeczywistego"
+      "description": "Dane kalibracyjne zegara czasu rzeczywistego",
+      "description_en": "Dane kalibracyjne zegara czasu rzeczywistego"
     },
     {
       "function": "03",
@@ -2010,7 +2170,8 @@
       "enum": null,
       "multiplier": null,
       "resolution": null,
-      "description": "Wersja oprogramowania modułu CF lub (od 4.75) TG-02"
+      "description": "Wersja oprogramowania modułu CF lub (od 4.75) TG-02",
+      "description_en": "Wersja oprogramowania modułu CF lub (od 4.75) TG-02"
     },
     {
       "function": "03",
@@ -2022,7 +2183,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Wartość chwilowa strumienia powietrza - nawiew"
+      "description": "Wartość chwilowa strumienia powietrza - nawiew",
+      "description_en": "Wartość chwilowa strumienia powietrza - nawiew"
     },
     {
       "function": "03",
@@ -2034,7 +2196,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Wartość chwilowa strumienia powietrza - wywiew"
+      "description": "Wartość chwilowa strumienia powietrza - wywiew",
+      "description_en": "Wartość chwilowa strumienia powietrza - wywiew"
     },
     {
       "function": "03",
@@ -2046,7 +2209,8 @@
       "enum": null,
       "multiplier": 0.00244,
       "resolution": 0.00244,
-      "description": "Napięcie sterujące wentylatorem nawiewnym (PWM)"
+      "description": "Napięcie sterujące wentylatorem nawiewnym (PWM)",
+      "description_en": "Napięcie sterujące wentylatorem nawiewnym (PWM)"
     },
     {
       "function": "03",
@@ -2058,7 +2222,8 @@
       "enum": null,
       "multiplier": 0.00244,
       "resolution": 0.00244,
-      "description": "Napięcie sterujące wentylatorem wywiewnym (PWM)"
+      "description": "Napięcie sterujące wentylatorem wywiewnym (PWM)",
+      "description_en": "Napięcie sterujące wentylatorem wywiewnym (PWM)"
     },
     {
       "function": "03",
@@ -2070,7 +2235,8 @@
       "enum": null,
       "multiplier": 0.00244,
       "resolution": 0.00244,
-      "description": "Napięcie sterujące nagrzewnicą kanałową (PWM)"
+      "description": "Napięcie sterujące nagrzewnicą kanałową (PWM)",
+      "description_en": "Napięcie sterujące nagrzewnicą kanałową (PWM)"
     },
     {
       "function": "03",
@@ -2082,7 +2248,8 @@
       "enum": null,
       "multiplier": 0.00244,
       "resolution": 0.00244,
-      "description": "Napięcie sterujące chłodnicą kanałową (PWM)"
+      "description": "Napięcie sterujące chłodnicą kanałową (PWM)",
+      "description_en": "Napięcie sterujące chłodnicą kanałową (PWM)"
     },
     {
       "function": "03",
@@ -2094,7 +2261,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji (nawiew)"
+      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji (nawiew)",
+      "description_en": "Maksymalna możliwa do ustawienia intensywność wentylacji (nawiew)"
     },
     {
       "function": "03",
@@ -2106,7 +2274,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji dla instalacji z GWC (nawiew)"
+      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji dla instalacji z GWC (nawiew)",
+      "description_en": "Maksymalna możliwa do ustawienia intensywność wentylacji dla instalacji z GWC (nawiew)"
     },
     {
       "function": "03",
@@ -2118,7 +2287,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji (wywiew)"
+      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji (wywiew)",
+      "description_en": "Maksymalna możliwa do ustawienia intensywność wentylacji (wywiew)"
     },
     {
       "function": "03",
@@ -2130,7 +2300,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji dla instalacji z GWC (wywiew)"
+      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji dla instalacji z GWC (wywiew)",
+      "description_en": "Maksymalna możliwa do ustawienia intensywność wentylacji dla instalacji z GWC (wywiew)"
     },
     {
       "function": "03",
@@ -2145,7 +2316,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Flaga uruchomienia systemu FPX"
+      "description": "Flaga uruchomienia systemu FPX",
+      "description_en": "Flaga uruchomienia systemu FPX"
     },
     {
       "function": "03",
@@ -2161,7 +2333,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Tryb działania systemu FPX"
+      "description": "Tryb działania systemu FPX",
+      "description_en": "Tryb działania systemu FPX"
     },
     {
       "function": "03",
@@ -2177,7 +2350,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Tryb pracy AirPack"
+      "description": "Tryb pracy AirPack",
+      "description_en": "Tryb pracy AirPack"
     },
     {
       "function": "03",
@@ -2192,7 +2366,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Wybór harmonogramu - tryb AUTOMATYCZNY"
+      "description": "Wybór harmonogramu - tryb AUTOMATYCZNY",
+      "description_en": "Wybór harmonogramu - tryb AUTOMATYCZNY"
     },
     {
       "function": "03",
@@ -2204,7 +2379,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji - tryb MANUALNY"
+      "description": "Intensywność wentylacji - tryb MANUALNY",
+      "description_en": "Intensywność wentylacji - tryb MANUALNY"
     },
     {
       "function": "03",
@@ -2216,7 +2392,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji - tryb CHWILOWY"
+      "description": "Intensywność wentylacji - tryb CHWILOWY",
+      "description_en": "Intensywność wentylacji - tryb CHWILOWY"
     },
     {
       "function": "03",
@@ -2228,7 +2405,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Zadana temperatura nawiewu - tryb MANUALNY"
+      "description": "Zadana temperatura nawiewu - tryb MANUALNY",
+      "description_en": "Zadana temperatura nawiewu - tryb MANUALNY"
     },
     {
       "function": "03",
@@ -2240,7 +2418,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Zadana temperatura nawiewu - tryb CHWILOWY"
+      "description": "Zadana temperatura nawiewu - tryb CHWILOWY",
+      "description_en": "Zadana temperatura nawiewu - tryb CHWILOWY"
     },
     {
       "function": "03",
@@ -2252,7 +2431,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawa intensywności wentylacji - \"1 bieg\" - panel AirS"
+      "description": "Nastawa intensywności wentylacji - \"1 bieg\" - panel AirS",
+      "description_en": "Nastawa intensywności wentylacji - \"1 bieg\" - panel AirS"
     },
     {
       "function": "03",
@@ -2264,7 +2444,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawa intensywności wentylacji - \"2 bieg\" - panel AirS"
+      "description": "Nastawa intensywności wentylacji - \"2 bieg\" - panel AirS",
+      "description_en": "Nastawa intensywności wentylacji - \"2 bieg\" - panel AirS"
     },
     {
       "function": "03",
@@ -2276,7 +2457,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawa intensywności wentylacji - \"3 bieg\" - panel AirS"
+      "description": "Nastawa intensywności wentylacji - \"3 bieg\" - panel AirS",
+      "description_en": "Nastawa intensywności wentylacji - \"3 bieg\" - panel AirS"
     },
     {
       "function": "03",
@@ -2288,7 +2470,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Godzina rozpoczęcia wietrzenia w trybie MANUALNYM [GGMM]"
+      "description": "Godzina rozpoczęcia wietrzenia w trybie MANUALNYM [GGMM]",
+      "description_en": "Godzina rozpoczęcia wietrzenia w trybie MANUALNYM [GGMM]"
     },
     {
       "function": "03",
@@ -2313,7 +2496,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Funkcje specjalne"
+      "description": "Funkcje specjalne",
+      "description_en": "Funkcje specjalne"
     },
     {
       "function": "03",
@@ -2325,7 +2509,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji dla funkcji OKAP (nawiew)"
+      "description": "Intensywność wentylacji dla funkcji OKAP (nawiew)",
+      "description_en": "Intensywność wentylacji dla funkcji OKAP (nawiew)"
     },
     {
       "function": "03",
@@ -2337,7 +2522,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji dla funkcji OKAP (wywiew)"
+      "description": "Intensywność wentylacji dla funkcji OKAP (wywiew)",
+      "description_en": "Intensywność wentylacji dla funkcji OKAP (wywiew)"
     },
     {
       "function": "03",
@@ -2349,7 +2535,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Różnicowanie strumieni dla funkcji KOMINEK"
+      "description": "Różnicowanie strumieni dla funkcji KOMINEK",
+      "description_en": "Różnicowanie strumieni dla funkcji KOMINEK"
     },
     {
       "function": "03",
@@ -2361,7 +2548,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 3, 4, 5 (łazienka)"
+      "description": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 3, 4, 5 (łazienka)",
+      "description_en": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 3, 4, 5 (łazienka)"
     },
     {
       "function": "03",
@@ -2373,7 +2561,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 7, 8, 9 (pokoje)"
+      "description": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 7, 8, 9 (pokoje)",
+      "description_en": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 7, 8, 9 (pokoje)"
     },
     {
       "function": "03",
@@ -2385,7 +2574,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 6 (usuwanie zanieczyszczeń)"
+      "description": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 6 (usuwanie zanieczyszczeń)",
+      "description_en": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 6 (usuwanie zanieczyszczeń)"
     },
     {
       "function": "03",
@@ -2397,7 +2587,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji dla funkcji PUSTY DOM"
+      "description": "Intensywność wentylacji dla funkcji PUSTY DOM",
+      "description_en": "Intensywność wentylacji dla funkcji PUSTY DOM"
     },
     {
       "function": "03",
@@ -2409,7 +2600,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Czas działania funkcji WIETRZENIE - Funkcja specjalna nr: 7, 8, 9 (pokoje)"
+      "description": "Czas działania funkcji WIETRZENIE - Funkcja specjalna nr: 7, 8, 9 (pokoje)",
+      "description_en": "Czas działania funkcji WIETRZENIE - Funkcja specjalna nr: 7, 8, 9 (pokoje)"
     },
     {
       "function": "03",
@@ -2421,7 +2613,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Czas działania funkcji WIETRZENIE - Funkcja specjalna nr: 3 (łazienka)"
+      "description": "Czas działania funkcji WIETRZENIE - Funkcja specjalna nr: 3 (łazienka)",
+      "description_en": "Czas działania funkcji WIETRZENIE - Funkcja specjalna nr: 3 (łazienka)"
     },
     {
       "function": "03",
@@ -2433,7 +2626,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Opóźnienie załączenia funkcji WIETRZENIE - Funkcja specjalna nr: 4 (łazienka)"
+      "description": "Opóźnienie załączenia funkcji WIETRZENIE - Funkcja specjalna nr: 4 (łazienka)",
+      "description_en": "Opóźnienie załączenia funkcji WIETRZENIE - Funkcja specjalna nr: 4 (łazienka)"
     },
     {
       "function": "03",
@@ -2445,7 +2639,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Opóźnienie wyłączenia funkcji WIETRZENIE - Funkcja specjalna nr: 4 (łazienka)"
+      "description": "Opóźnienie wyłączenia funkcji WIETRZENIE - Funkcja specjalna nr: 4 (łazienka)",
+      "description_en": "Opóźnienie wyłączenia funkcji WIETRZENIE - Funkcja specjalna nr: 4 (łazienka)"
     },
     {
       "function": "03",
@@ -2457,7 +2652,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Czas działania funkcji KOMINEK"
+      "description": "Czas działania funkcji KOMINEK",
+      "description_en": "Czas działania funkcji KOMINEK"
     },
     {
       "function": "03",
@@ -2469,7 +2665,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 3, 4"
+      "description": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 3, 4",
+      "description_en": "Intensywność wentylacji dla funkcji WIETRZENIE - Funkcja specjalna nr: 3, 4"
     },
     {
       "function": "03",
@@ -2481,7 +2678,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji dla funkcji OTWARTE OKNA (wywiew)"
+      "description": "Intensywność wentylacji dla funkcji OTWARTE OKNA (wywiew)",
+      "description_en": "Intensywność wentylacji dla funkcji OTWARTE OKNA (wywiew)"
     },
     {
       "function": "03",
@@ -2501,7 +2699,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Dzień tygodnia, w którym przeprowadzana będzie procedura automatycznej kontroli filtrów"
+      "description": "Dzień tygodnia, w którym przeprowadzana będzie procedura automatycznej kontroli filtrów",
+      "description_en": "Dzień tygodnia, w którym przeprowadzana będzie procedura automatycznej kontroli filtrów"
     },
     {
       "function": "03",
@@ -2513,7 +2712,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Godzina i minuta rozpoczęcia automatycznej procedury kontroli filtrów [GGMM]"
+      "description": "Godzina i minuta rozpoczęcia automatycznej procedury kontroli filtrów [GGMM]",
+      "description_en": "Godzina i minuta rozpoczęcia automatycznej procedury kontroli filtrów [GGMM]"
     },
     {
       "function": "03",
@@ -2528,7 +2728,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Dezaktywacja działania GWC"
+      "description": "Dezaktywacja działania GWC",
+      "description_en": "Dezaktywacja działania GWC"
     },
     {
       "function": "03",
@@ -2540,7 +2741,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Dolny próg temperatury załączenia funkcji GWC"
+      "description": "Dolny próg temperatury załączenia funkcji GWC",
+      "description_en": "Dolny próg temperatury załączenia funkcji GWC"
     },
     {
       "function": "03",
@@ -2552,7 +2754,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Górny próg temperatury załączenia funkcji GWC"
+      "description": "Górny próg temperatury załączenia funkcji GWC",
+      "description_en": "Górny próg temperatury załączenia funkcji GWC"
     },
     {
       "function": "03",
@@ -2568,7 +2771,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Wybór typu regeneracji złoża GWC"
+      "description": "Wybór typu regeneracji złoża GWC",
+      "description_en": "Wybór typu regeneracji złoża GWC"
     },
     {
       "function": "03",
@@ -2584,7 +2788,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Aktualny status działania GWC"
+      "description": "Aktualny status działania GWC",
+      "description_en": "Aktualny status działania GWC"
     },
     {
       "function": "03",
@@ -2596,7 +2801,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Czas trwania regeneracji złoża GWC dla regeneracji temperaturowej"
+      "description": "Czas trwania regeneracji złoża GWC dla regeneracji temperaturowej",
+      "description_en": "Czas trwania regeneracji złoża GWC dla regeneracji temperaturowej"
     },
     {
       "function": "03",
@@ -2608,7 +2814,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Różnica temperatur warunkująca załączenie regeneracji temperaturowej złoża GWC"
+      "description": "Różnica temperatur warunkująca załączenie regeneracji temperaturowej złoża GWC",
+      "description_en": "Różnica temperatur warunkująca załączenie regeneracji temperaturowej złoża GWC"
     },
     {
       "function": "03",
@@ -2620,7 +2827,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Godzina i minuta rozpoczęcia regeneracji zimą [GGMM] w przypadku regeneracji dobowej (harmonogram)"
+      "description": "Godzina i minuta rozpoczęcia regeneracji zimą [GGMM] w przypadku regeneracji dobowej (harmonogram)",
+      "description_en": "Godzina i minuta rozpoczęcia regeneracji zimą [GGMM] w przypadku regeneracji dobowej (harmonogram)"
     },
     {
       "function": "03",
@@ -2632,7 +2840,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Godzina i minuta zakończenia regeneracji zimą [GGMM] w przypadku regeneracji dobowej (harmonogram)"
+      "description": "Godzina i minuta zakończenia regeneracji zimą [GGMM] w przypadku regeneracji dobowej (harmonogram)",
+      "description_en": "Godzina i minuta zakończenia regeneracji zimą [GGMM] w przypadku regeneracji dobowej (harmonogram)"
     },
     {
       "function": "03",
@@ -2644,7 +2853,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Godzina i minuta rozpoczęcia regeneracji latem [GGMM] w przypadku regeneracji dobowej (harmonogram)"
+      "description": "Godzina i minuta rozpoczęcia regeneracji latem [GGMM] w przypadku regeneracji dobowej (harmonogram)",
+      "description_en": "Godzina i minuta rozpoczęcia regeneracji latem [GGMM] w przypadku regeneracji dobowej (harmonogram)"
     },
     {
       "function": "03",
@@ -2656,7 +2866,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Godzina i minuta zakończenia regeneracji latem [GGMM] w przypadku regeneracji dobowej (harmonogram)"
+      "description": "Godzina i minuta zakończenia regeneracji latem [GGMM] w przypadku regeneracji dobowej (harmonogram)",
+      "description_en": "Godzina i minuta zakończenia regeneracji latem [GGMM] w przypadku regeneracji dobowej (harmonogram)"
     },
     {
       "function": "03",
@@ -2671,7 +2882,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Flaga informująca o aktywnym trybie regeneracji złoża GWC"
+      "description": "Flaga informująca o aktywnym trybie regeneracji złoża GWC",
+      "description_en": "Flaga informująca o aktywnym trybie regeneracji złoża GWC"
     },
     {
       "function": "03",
@@ -2686,7 +2898,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Wybór trybu pracy AirPack - EKO / KOMFORT"
+      "description": "Wybór trybu pracy AirPack - EKO / KOMFORT",
+      "description_en": "Wybór trybu pracy AirPack - EKO / KOMFORT"
     },
     {
       "function": "03",
@@ -2702,7 +2915,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Aktualny status trybu KOMFORT"
+      "description": "Aktualny status trybu KOMFORT",
+      "description_en": "Aktualny status trybu KOMFORT"
     },
     {
       "function": "03",
@@ -2717,7 +2931,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Dezaktywacja działania bypass"
+      "description": "Dezaktywacja działania bypass",
+      "description_en": "Dezaktywacja działania bypass"
     },
     {
       "function": "03",
@@ -2729,7 +2944,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Minimalna temperatura powietrza zewnętrznego warunkująca załączenie bypass"
+      "description": "Minimalna temperatura powietrza zewnętrznego warunkująca załączenie bypass",
+      "description_en": "Minimalna temperatura powietrza zewnętrznego warunkująca załączenie bypass"
     },
     {
       "function": "03",
@@ -2741,7 +2957,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Temperatura aktywacji działania bypass w funkcji grzania (freeheating)"
+      "description": "Temperatura aktywacji działania bypass w funkcji grzania (freeheating)",
+      "description_en": "Temperatura aktywacji działania bypass w funkcji grzania (freeheating)"
     },
     {
       "function": "03",
@@ -2753,7 +2970,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Temperatura aktywacji działania bypass w funkcji chłodzenia (freecooling)"
+      "description": "Temperatura aktywacji działania bypass w funkcji chłodzenia (freecooling)",
+      "description_en": "Temperatura aktywacji działania bypass w funkcji chłodzenia (freecooling)"
     },
     {
       "function": "03",
@@ -2769,7 +2987,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Aktualny status bypass"
+      "description": "Aktualny status bypass",
+      "description_en": "Aktualny status bypass"
     },
     {
       "function": "03",
@@ -2785,7 +3004,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Tryb pracy / sposób realizacji funkcji bypass"
+      "description": "Tryb pracy / sposób realizacji funkcji bypass",
+      "description_en": "Tryb pracy / sposób realizacji funkcji bypass"
     },
     {
       "function": "03",
@@ -2797,7 +3017,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Różnicowanie strumieni (wywiew < nawiew) dla bypass działającego w trybie 2"
+      "description": "Różnicowanie strumieni (wywiew < nawiew) dla bypass działającego w trybie 2",
+      "description_en": "Różnicowanie strumieni (wywiew < nawiew) dla bypass działającego w trybie 2"
     },
     {
       "function": "03",
@@ -2809,7 +3030,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadana intensywność wentylacji (nawiew) dla bypass działającego w trybie 2 lub 3"
+      "description": "Zadana intensywność wentylacji (nawiew) dla bypass działającego w trybie 2 lub 3",
+      "description_en": "Zadana intensywność wentylacji (nawiew) dla bypass działającego w trybie 2 lub 3"
     },
     {
       "function": "03",
@@ -2821,7 +3043,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nominalny strumień powietrza nawiewanego"
+      "description": "Nominalny strumień powietrza nawiewanego",
+      "description_en": "Nominalny strumień powietrza nawiewanego"
     },
     {
       "function": "03",
@@ -2833,7 +3056,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nominalny strumień powietrza wywiewanego"
+      "description": "Nominalny strumień powietrza wywiewanego",
+      "description_en": "Nominalny strumień powietrza wywiewanego"
     },
     {
       "function": "03",
@@ -2845,7 +3069,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nominalny strumień powietrza nawiewanego dla działającego GWC powietrznego (typ 1)"
+      "description": "Nominalny strumień powietrza nawiewanego dla działającego GWC powietrznego (typ 1)",
+      "description_en": "Nominalny strumień powietrza nawiewanego dla działającego GWC powietrznego (typ 1)"
     },
     {
       "function": "03",
@@ -2857,7 +3082,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nominalny strumień powietrza wywiewanego dla działającego GWC powietrznego (typ 1)"
+      "description": "Nominalny strumień powietrza wywiewanego dla działającego GWC powietrznego (typ 1)",
+      "description_en": "Nominalny strumień powietrza wywiewanego dla działającego GWC powietrznego (typ 1)"
     },
     {
       "function": "03",
@@ -2872,7 +3098,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Kod alarmu zatrzymującego pracę AirPack"
+      "description": "Kod alarmu zatrzymującego pracę AirPack",
+      "description_en": "Kod alarmu zatrzymującego pracę AirPack"
     },
     {
       "function": "03",
@@ -2887,7 +3114,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "ON / OFF - załączanie urządzenia"
+      "description": "ON / OFF - załączanie urządzenia",
+      "description_en": "ON / OFF - załączanie urządzenia"
     },
     {
       "function": "03",
@@ -2905,7 +3133,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Wybór języka panelu Air++"
+      "description": "Wybór języka panelu Air++",
+      "description_en": "Wybór języka panelu Air++"
     },
     {
       "function": "03",
@@ -2921,7 +3150,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Tryb pracy AirPack - równorzędny z 0x1133"
+      "description": "Tryb pracy AirPack - równorzędny z 0x1133",
+      "description_en": "Tryb pracy AirPack - równorzędny z 0x1133"
     },
     {
       "function": "03",
@@ -2933,7 +3163,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Intensywność wentylacji - tryb CHWILOWY"
+      "description": "Intensywność wentylacji - tryb CHWILOWY",
+      "description_en": "Intensywność wentylacji - tryb CHWILOWY"
     },
     {
       "function": "03",
@@ -2948,7 +3179,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Flaga wymuszenia / aktywacji trybu CHWILOWEGO - zmiana intensywności wentylacji"
+      "description": "Flaga wymuszenia / aktywacji trybu CHWILOWEGO - zmiana intensywności wentylacji",
+      "description_en": "Flaga wymuszenia / aktywacji trybu CHWILOWEGO - zmiana intensywności wentylacji"
     },
     {
       "function": "03",
@@ -2964,7 +3196,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Tryb pracy AirPack - równorzędny z 0x1130"
+      "description": "Tryb pracy AirPack - równorzędny z 0x1130",
+      "description_en": "Tryb pracy AirPack - równorzędny z 0x1130"
     },
     {
       "function": "03",
@@ -2976,7 +3209,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Zadana temperatura nawiewu - tryb CHWILOWY"
+      "description": "Zadana temperatura nawiewu - tryb CHWILOWY",
+      "description_en": "Zadana temperatura nawiewu - tryb CHWILOWY"
     },
     {
       "function": "03",
@@ -2991,7 +3225,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Flaga wymuszenia / aktywacji trybu CHWILOWEGO - zmiana wartości zadanej temperatury nawiewu"
+      "description": "Flaga wymuszenia / aktywacji trybu CHWILOWEGO - zmiana wartości zadanej temperatury nawiewu",
+      "description_en": "Flaga wymuszenia / aktywacji trybu CHWILOWEGO - zmiana wartości zadanej temperatury nawiewu"
     },
     {
       "function": "03",
@@ -3006,7 +3241,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Reset ustawień użytkownika"
+      "description": "Reset ustawień użytkownika",
+      "description_en": "Reset ustawień użytkownika"
     },
     {
       "function": "03",
@@ -3021,7 +3257,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Reset ustawień trybów pracy"
+      "description": "Reset ustawień trybów pracy",
+      "description_en": "Reset ustawień trybów pracy"
     },
     {
       "function": "03",
@@ -3041,7 +3278,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Dzień tygodnia, w którym przeprowadzana będzie procedura automatycznej kontroli filtrów"
+      "description": "Dzień tygodnia, w którym przeprowadzana będzie procedura automatycznej kontroli filtrów",
+      "description_en": "Dzień tygodnia, w którym przeprowadzana będzie procedura automatycznej kontroli filtrów"
     },
     {
       "function": "03",
@@ -3053,7 +3291,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Godzina i minuta rozpoczęcia automatycznej procedury kontroli filtrów [GGMM]"
+      "description": "Godzina i minuta rozpoczęcia automatycznej procedury kontroli filtrów [GGMM]",
+      "description_en": "Godzina i minuta rozpoczęcia automatycznej procedury kontroli filtrów [GGMM]"
     },
     {
       "function": "03",
@@ -3065,7 +3304,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawy komunikacji Modbus - port Air-B ID urządzenia"
+      "description": "Nastawy komunikacji Modbus - port Air-B ID urządzenia",
+      "description_en": "Nastawy komunikacji Modbus - port Air-B ID urządzenia"
     },
     {
       "function": "03",
@@ -3087,7 +3327,8 @@
       },
       "multiplier": 3.0,
       "resolution": 3.0,
-      "description": "Nastawy komunikacji Modbus - port Air-B Szybkość transmisji"
+      "description": "Nastawy komunikacji Modbus - port Air-B Szybkość transmisji",
+      "description_en": "Nastawy komunikacji Modbus - port Air-B Szybkość transmisji"
     },
     {
       "function": "03",
@@ -3103,7 +3344,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawy komunikacji Modbus - port Air-B Parzystość"
+      "description": "Nastawy komunikacji Modbus - port Air-B Parzystość",
+      "description_en": "Nastawy komunikacji Modbus - port Air-B Parzystość"
     },
     {
       "function": "03",
@@ -3118,7 +3360,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawy komunikacji Modbus - port Air-B Bity stopu"
+      "description": "Nastawy komunikacji Modbus - port Air-B Bity stopu",
+      "description_en": "Nastawy komunikacji Modbus - port Air-B Bity stopu"
     },
     {
       "function": "03",
@@ -3130,7 +3373,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawy komunikacji Modbus - port Air++ ID urządzenia"
+      "description": "Nastawy komunikacji Modbus - port Air++ ID urządzenia",
+      "description_en": "Nastawy komunikacji Modbus - port Air++ ID urządzenia"
     },
     {
       "function": "03",
@@ -3152,7 +3396,8 @@
       },
       "multiplier": 3.0,
       "resolution": 3.0,
-      "description": "Nastawy komunikacji Modbus - port Air++ Szybkość transmisji"
+      "description": "Nastawy komunikacji Modbus - port Air++ Szybkość transmisji",
+      "description_en": "Nastawy komunikacji Modbus - port Air++ Szybkość transmisji"
     },
     {
       "function": "03",
@@ -3168,7 +3413,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawy komunikacji Modbus - port Air++ Parzystość"
+      "description": "Nastawy komunikacji Modbus - port Air++ Parzystość",
+      "description_en": "Nastawy komunikacji Modbus - port Air++ Parzystość"
     },
     {
       "function": "03",
@@ -3183,7 +3429,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nastawy komunikacji Modbus - port Air++ Bity stopu"
+      "description": "Nastawy komunikacji Modbus - port Air++ Bity stopu",
+      "description_en": "Nastawy komunikacji Modbus - port Air++ Bity stopu"
     },
     {
       "function": "03",
@@ -3200,7 +3447,8 @@
       "extra": {
         "type": "string",
         "encoding": "ascii"
-      }
+      },
+      "description_en": "Nazwa urządzenia"
     },
     {
       "function": "03",
@@ -3217,7 +3465,8 @@
       "extra": {
         "type": "uint32",
         "endianness": "little"
-      }
+      },
+      "description_en": "Klucz produktu użytkownika"
     },
     {
       "function": "03",
@@ -3232,7 +3481,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Aktywacja blokady urządzenia"
+      "description": "Aktywacja blokady urządzenia",
+      "description_en": "Aktywacja blokady urządzenia"
     },
     {
       "function": "03",
@@ -3244,7 +3494,8 @@
       "enum": null,
       "multiplier": 0.5,
       "resolution": 0.5,
-      "description": "Temperatura zadana trybu KOMFORT"
+      "description": "Temperatura zadana trybu KOMFORT",
+      "description_en": "Temperatura zadana trybu KOMFORT"
     },
     {
       "function": "03",
@@ -3261,7 +3512,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "System kontroli filtrów / typ filtrów"
+      "description": "System kontroli filtrów / typ filtrów",
+      "description_en": "System kontroli filtrów / typ filtrów"
     },
     {
       "function": "03",
@@ -3276,7 +3528,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Alarmy - Flaga informująca o wystąpieniu ostrzeżenia - alarm \"E\""
+      "description": "Alarmy - Flaga informująca o wystąpieniu ostrzeżenia - alarm \"E\"",
+      "description_en": "Alarmy - Flaga informująca o wystąpieniu ostrzeżenia - alarm \"E\""
     },
     {
       "function": "03",
@@ -3291,7 +3544,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Alarmy - Flaga informująca o wystąpieniu błędu - alarm \"S\""
+      "description": "Alarmy - Flaga informująca o wystąpieniu błędu - alarm \"S\"",
+      "description_en": "Alarmy - Flaga informująca o wystąpieniu błędu - alarm \"S\""
     },
     {
       "function": "03",
@@ -3306,7 +3560,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Błąd komunikacji I2C"
+      "description": "Błąd komunikacji I2C",
+      "description_en": "Błąd komunikacji I2C"
     },
     {
       "function": "03",
@@ -3321,7 +3576,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zabezpieczenie termiczne nagrzewnicy FPX zadziałało maksymalną ilość razy w określonym czasie"
+      "description": "Zabezpieczenie termiczne nagrzewnicy FPX zadziałało maksymalną ilość razy w określonym czasie",
+      "description_en": "Zabezpieczenie termiczne nagrzewnicy FPX zadziałało maksymalną ilość razy w określonym czasie"
     },
     {
       "function": "03",
@@ -3336,7 +3592,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak możliwości kalibracji urządzenia ze względu na zbyt niską temperaturę powietrza zewnętrznego"
+      "description": "Brak możliwości kalibracji urządzenia ze względu na zbyt niską temperaturę powietrza zewnętrznego",
+      "description_en": "Brak możliwości kalibracji urządzenia ze względu na zbyt niską temperaturę powietrza zewnętrznego"
     },
     {
       "function": "03",
@@ -3351,7 +3608,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Sygnalizacja konieczności wprowadzenia klucza produktu"
+      "description": "Sygnalizacja konieczności wprowadzenia klucza produktu",
+      "description_en": "Sygnalizacja konieczności wprowadzenia klucza produktu"
     },
     {
       "function": "03",
@@ -3366,7 +3624,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Centrala zatrzymana z panelu AirS"
+      "description": "Centrala zatrzymana z panelu AirS",
+      "description_en": "Centrala zatrzymana z panelu AirS"
     },
     {
       "function": "03",
@@ -3381,7 +3640,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadziałał czujnik PPOŻ"
+      "description": "Zadziałał czujnik PPOŻ",
+      "description_en": "Zadziałał czujnik PPOŻ"
     },
     {
       "function": "03",
@@ -3393,7 +3653,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Centrala zatrzymana z panelu Air+ lub AirL+, Air++ lub AirMobile"
+      "description": "Centrala zatrzymana z panelu Air+ lub AirL+, Air++ lub AirMobile",
+      "description_en": "Centrala zatrzymana z panelu Air+ lub AirL+, Air++ lub AirMobile"
     },
     {
       "function": "03",
@@ -3408,7 +3669,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej zadziałało maksymalną ilość razy"
+      "description": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej zadziałało maksymalną ilość razy",
+      "description_en": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej zadziałało maksymalną ilość razy"
     },
     {
       "function": "03",
@@ -3423,7 +3685,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej nie przyniosło oczekiwanych rezultatów"
+      "description": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej nie przyniosło oczekiwanych rezultatów",
+      "description_en": "Zabezpieczenie przeciwzamrożeniowe nagrzewnicy wodnej nie przyniosło oczekiwanych rezultatów"
     },
     {
       "function": "03",
@@ -3438,7 +3701,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali przy aktywnym systemie FPX"
+      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali przy aktywnym systemie FPX",
+      "description_en": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali przy aktywnym systemie FPX"
     },
     {
       "function": "03",
@@ -3453,7 +3717,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nie zostały wymienione filtry w centrali (w przypadku centrali wyposażonej w presostat)"
+      "description": "Nie zostały wymienione filtry w centrali (w przypadku centrali wyposażonej w presostat)",
+      "description_en": "Nie zostały wymienione filtry w centrali (w przypadku centrali wyposażonej w presostat)"
     },
     {
       "function": "03",
@@ -3468,7 +3733,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nie zostały wymienione filtry w centrali (w przypadku centrali nie wyposażonej w presostat)"
+      "description": "Nie zostały wymienione filtry w centrali (w przypadku centrali nie wyposażonej w presostat)",
+      "description_en": "Nie zostały wymienione filtry w centrali (w przypadku centrali nie wyposażonej w presostat)"
     },
     {
       "function": "03",
@@ -3483,7 +3749,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nie został wymieniony filtr kanałowy"
+      "description": "Nie został wymieniony filtr kanałowy",
+      "description_en": "Nie został wymieniony filtr kanałowy"
     },
     {
       "function": "03",
@@ -3498,7 +3765,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nie zadziałało zabezpieczenie przeciwzamrożeniowe wymiennika rekuperacyjnego (FPX)"
+      "description": "Nie zadziałało zabezpieczenie przeciwzamrożeniowe wymiennika rekuperacyjnego (FPX)",
+      "description_en": "Nie zadziałało zabezpieczenie przeciwzamrożeniowe wymiennika rekuperacyjnego (FPX)"
     },
     {
       "function": "03",
@@ -3513,7 +3781,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Uszkodzony czujnik temperatury powietrza na wlocie do wymiennika rekuperacyjnego przy temperaturze powietrza zewnętrznego stanowiącej warunki do zadziałania systemu FPX"
+      "description": "Uszkodzony czujnik temperatury powietrza na wlocie do wymiennika rekuperacyjnego przy temperaturze powietrza zewnętrznego stanowiącej warunki do zadziałania systemu FPX",
+      "description_en": "Uszkodzony czujnik temperatury powietrza na wlocie do wymiennika rekuperacyjnego przy temperaturze powietrza zewnętrznego stanowiącej warunki do zadziałania systemu FPX"
     },
     {
       "function": "03",
@@ -3528,7 +3797,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Uszkodzony czujnik temperatury powietrza w kanale nawiewnym za nagrzewnicą wodną"
+      "description": "Uszkodzony czujnik temperatury powietrza w kanale nawiewnym za nagrzewnicą wodną",
+      "description_en": "Uszkodzony czujnik temperatury powietrza w kanale nawiewnym za nagrzewnicą wodną"
     },
     {
       "function": "03",
@@ -3543,7 +3813,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Uszkodzony czujnik temperatury powietrza zewnętrznego"
+      "description": "Uszkodzony czujnik temperatury powietrza zewnętrznego",
+      "description_en": "Uszkodzony czujnik temperatury powietrza zewnętrznego"
     },
     {
       "function": "03",
@@ -3558,7 +3829,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Uszkodzony czujnik temperatury powietrza zewnętrznego oraz czujnik temperatury powietrza dla glikolowego GWC"
+      "description": "Uszkodzony czujnik temperatury powietrza zewnętrznego oraz czujnik temperatury powietrza dla glikolowego GWC",
+      "description_en": "Uszkodzony czujnik temperatury powietrza zewnętrznego oraz czujnik temperatury powietrza dla glikolowego GWC"
     },
     {
       "function": "03",
@@ -3573,7 +3845,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zbyt wysoka temperatura przed rekuperatorem"
+      "description": "Zbyt wysoka temperatura przed rekuperatorem",
+      "description_en": "Zbyt wysoka temperatura przed rekuperatorem"
     },
     {
       "function": "03",
@@ -3588,7 +3861,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nie działa wentylator nawiewny"
+      "description": "Nie działa wentylator nawiewny",
+      "description_en": "Nie działa wentylator nawiewny"
     },
     {
       "function": "03",
@@ -3603,7 +3877,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Nie działa wentylator wywiewny"
+      "description": "Nie działa wentylator wywiewny",
+      "description_en": "Nie działa wentylator wywiewny"
     },
     {
       "function": "03",
@@ -3618,7 +3893,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak komunikacji z modułem TG-02"
+      "description": "Brak komunikacji z modułem TG-02",
+      "description_en": "Brak komunikacji z modułem TG-02"
     },
     {
       "function": "03",
@@ -3633,7 +3909,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Sygnalizacja konieczności wprowadzenia klucza produktu centrali wentylacyjnej AirPack"
+      "description": "Sygnalizacja konieczności wprowadzenia klucza produktu centrali wentylacyjnej AirPack",
+      "description_en": "Sygnalizacja konieczności wprowadzenia klucza produktu centrali wentylacyjnej AirPack"
     },
     {
       "function": "03",
@@ -3648,7 +3925,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak odczytu z czujnika temperatury powietrza zewnętrznego - CZERPNIA (TZ1)"
+      "description": "Brak odczytu z czujnika temperatury powietrza zewnętrznego - CZERPNIA (TZ1)",
+      "description_en": "Brak odczytu z czujnika temperatury powietrza zewnętrznego - CZERPNIA (TZ1)"
     },
     {
       "function": "03",
@@ -3663,7 +3941,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak odczytu z czujnika temperatury powietrza nawiewanego - NAWIEW (TN1)"
+      "description": "Brak odczytu z czujnika temperatury powietrza nawiewanego - NAWIEW (TN1)",
+      "description_en": "Brak odczytu z czujnika temperatury powietrza nawiewanego - NAWIEW (TN1)"
     },
     {
       "function": "03",
@@ -3678,7 +3957,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak odczytu z czujnika temperatury powietrza usuwanego z pomieszczeń - WYWIEW (TP)"
+      "description": "Brak odczytu z czujnika temperatury powietrza usuwanego z pomieszczeń - WYWIEW (TP)",
+      "description_en": "Brak odczytu z czujnika temperatury powietrza usuwanego z pomieszczeń - WYWIEW (TP)"
     },
     {
       "function": "03",
@@ -3693,7 +3973,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak odczytu z czujnika temperatury powietrza na wlocie do wymiennika rekuperacyjnego - FPX (TZ2)"
+      "description": "Brak odczytu z czujnika temperatury powietrza na wlocie do wymiennika rekuperacyjnego - FPX (TZ2)",
+      "description_en": "Brak odczytu z czujnika temperatury powietrza na wlocie do wymiennika rekuperacyjnego - FPX (TZ2)"
     },
     {
       "function": "03",
@@ -3708,7 +3989,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak odczytu z czujnika temperatury powietrza w pomieszczeniu, w którym jest zamontowana centrala (TO)"
+      "description": "Brak odczytu z czujnika temperatury powietrza w pomieszczeniu, w którym jest zamontowana centrala (TO)",
+      "description_en": "Brak odczytu z czujnika temperatury powietrza w pomieszczeniu, w którym jest zamontowana centrala (TO)"
     },
     {
       "function": "03",
@@ -3723,7 +4005,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak odczytu z czujnika temperatury powietrza nawiewanego za wymiennikiem kanałowym (TN2)"
+      "description": "Brak odczytu z czujnika temperatury powietrza nawiewanego za wymiennikiem kanałowym (TN2)",
+      "description_en": "Brak odczytu z czujnika temperatury powietrza nawiewanego za wymiennikiem kanałowym (TN2)"
     },
     {
       "function": "03",
@@ -3738,7 +4021,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak odczytu z czujnika temperatury powietrza zewnętrznego glikolowego GWC (TZ3)"
+      "description": "Brak odczytu z czujnika temperatury powietrza zewnętrznego glikolowego GWC (TZ3)",
+      "description_en": "Brak odczytu z czujnika temperatury powietrza zewnętrznego glikolowego GWC (TZ3)"
     },
     {
       "function": "03",
@@ -3753,7 +4037,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Awaria czujnika CF wentylatora nawiewnego - Brak komunikacji z przetwornikiem ciśnienia wentylatora"
+      "description": "Awaria czujnika CF wentylatora nawiewnego - Brak komunikacji z przetwornikiem ciśnienia wentylatora",
+      "description_en": "Awaria czujnika CF wentylatora nawiewnego - Brak komunikacji z przetwornikiem ciśnienia wentylatora"
     },
     {
       "function": "03",
@@ -3768,7 +4053,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Awaria czujnika CF wentylatora wywiewnego - Brak komunikacji z przetwornikiem ciśnienia wentylatora"
+      "description": "Awaria czujnika CF wentylatora wywiewnego - Brak komunikacji z przetwornikiem ciśnienia wentylatora",
+      "description_en": "Awaria czujnika CF wentylatora wywiewnego - Brak komunikacji z przetwornikiem ciśnienia wentylatora"
     },
     {
       "function": "03",
@@ -3783,7 +4069,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Temperatura powietrza usuwanego z pomieszczeń wyższa od maksymalnej"
+      "description": "Temperatura powietrza usuwanego z pomieszczeń wyższa od maksymalnej",
+      "description_en": "Temperatura powietrza usuwanego z pomieszczeń wyższa od maksymalnej"
     },
     {
       "function": "03",
@@ -3795,7 +4082,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Flagi błędów E196-E199"
+      "description": "Flagi błędów E196-E199",
+      "description_en": "Flagi błędów E196-E199"
     },
     {
       "function": "03",
@@ -3810,7 +4098,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali"
+      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali",
+      "description_en": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w centrali"
     },
     {
       "function": "03",
@@ -3825,7 +4114,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w kanale"
+      "description": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w kanale",
+      "description_en": "Zadziałało zabezpieczenie termiczne nagrzewnicy elektrycznej w kanale"
     },
     {
       "function": "03",
@@ -3840,7 +4130,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Brak komunikacji z modułem Expansion"
+      "description": "Brak komunikacji z modułem Expansion",
+      "description_en": "Brak komunikacji z modułem Expansion"
     },
     {
       "function": "03",
@@ -3855,7 +4146,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Sygnalizacja konieczności wymiany filtrów w centrali nie wyposażonej w presostat"
+      "description": "Sygnalizacja konieczności wymiany filtrów w centrali nie wyposażonej w presostat",
+      "description_en": "Sygnalizacja konieczności wymiany filtrów w centrali nie wyposażonej w presostat"
     },
     {
       "function": "03",
@@ -3870,7 +4162,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Sygnalizacja konieczności wymiany filtra kanałowego"
+      "description": "Sygnalizacja konieczności wymiany filtra kanałowego",
+      "description_en": "Sygnalizacja konieczności wymiany filtra kanałowego"
     },
     {
       "function": "03",
@@ -3885,7 +4178,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Sygnalizacja konieczności wymiany filtrów w centrali wyposażonej w presostat"
+      "description": "Sygnalizacja konieczności wymiany filtrów w centrali wyposażonej w presostat",
+      "description_en": "Sygnalizacja konieczności wymiany filtrów w centrali wyposażonej w presostat"
     },
     {
       "function": "04",
@@ -3897,7 +4191,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Główna wersja oprogramowania"
+      "description": "Główna wersja oprogramowania",
+      "description_en": "Główna wersja oprogramowania"
     },
     {
       "function": "04",
@@ -3909,7 +4204,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Wersja poboczna oprogramowania"
+      "description": "Wersja poboczna oprogramowania",
+      "description_en": "Wersja poboczna oprogramowania"
     },
     {
       "function": "04",
@@ -3929,7 +4225,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Bieżący dzień tygodnia dla trybu automatycznego"
+      "description": "Bieżący dzień tygodnia dla trybu automatycznego",
+      "description_en": "Bieżący dzień tygodnia dla trybu automatycznego"
     },
     {
       "function": "04",
@@ -3946,7 +4243,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Bieżący odcinek czasowy dla trybu automatycznego"
+      "description": "Bieżący odcinek czasowy dla trybu automatycznego",
+      "description_en": "Bieżący odcinek czasowy dla trybu automatycznego"
     },
     {
       "function": "04",
@@ -3958,7 +4256,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Wersja poprawki oprogramowania"
+      "description": "Wersja poprawki oprogramowania",
+      "description_en": "Wersja poprawki oprogramowania"
     },
     {
       "function": "04",
@@ -3970,7 +4269,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Data kompilacji oprogramowania Basic"
+      "description": "Data kompilacji oprogramowania Basic",
+      "description_en": "Data kompilacji oprogramowania Basic"
     },
     {
       "function": "04",
@@ -3982,7 +4282,8 @@
       "enum": null,
       "multiplier": 2.0,
       "resolution": 2.0,
-      "description": "Godzina kompilacji oprogramowania Basic"
+      "description": "Godzina kompilacji oprogramowania Basic",
+      "description_en": "Godzina kompilacji oprogramowania Basic"
     },
     {
       "function": "04",
@@ -3994,7 +4295,8 @@
       "enum": null,
       "multiplier": 0.1,
       "resolution": 0.1,
-      "description": "Temperatura powietrza zewnętrznego (TZ1)"
+      "description": "Temperatura powietrza zewnętrznego (TZ1)",
+      "description_en": "Temperatura powietrza zewnętrznego (TZ1)"
     },
     {
       "function": "04",
@@ -4006,7 +4308,8 @@
       "enum": null,
       "multiplier": 0.1,
       "resolution": 0.1,
-      "description": "Temperatura powietrza nawiewanego (TN1)"
+      "description": "Temperatura powietrza nawiewanego (TN1)",
+      "description_en": "Temperatura powietrza nawiewanego (TN1)"
     },
     {
       "function": "04",
@@ -4018,7 +4321,8 @@
       "enum": null,
       "multiplier": 0.1,
       "resolution": 0.1,
-      "description": "Temperatura powietrza usuwanego z pomieszczenia (TP)"
+      "description": "Temperatura powietrza usuwanego z pomieszczenia (TP)",
+      "description_en": "Temperatura powietrza usuwanego z pomieszczenia (TP)"
     },
     {
       "function": "04",
@@ -4030,7 +4334,8 @@
       "enum": null,
       "multiplier": 0.1,
       "resolution": 0.1,
-      "description": "Temperatura powietrza za nagrzewnicą FPX (TZ2)"
+      "description": "Temperatura powietrza za nagrzewnicą FPX (TZ2)",
+      "description_en": "Temperatura powietrza za nagrzewnicą FPX (TZ2)"
     },
     {
       "function": "04",
@@ -4042,7 +4347,8 @@
       "enum": null,
       "multiplier": 0.1,
       "resolution": 0.1,
-      "description": "Temperatura powietrza za nagrzewnicą / chłodnicą kanałową (TN2)"
+      "description": "Temperatura powietrza za nagrzewnicą / chłodnicą kanałową (TN2)",
+      "description_en": "Temperatura powietrza za nagrzewnicą / chłodnicą kanałową (TN2)"
     },
     {
       "function": "04",
@@ -4054,7 +4360,8 @@
       "enum": null,
       "multiplier": 0.1,
       "resolution": 0.1,
-      "description": "Temperatura przed wymiennikiem systemu glikolowego GWC (TZ3)"
+      "description": "Temperatura przed wymiennikiem systemu glikolowego GWC (TZ3)",
+      "description_en": "Temperatura przed wymiennikiem systemu glikolowego GWC (TZ3)"
     },
     {
       "function": "04",
@@ -4066,7 +4373,8 @@
       "enum": null,
       "multiplier": 0.1,
       "resolution": 0.1,
-      "description": "Temperatura otoczenia (TO)"
+      "description": "Temperatura otoczenia (TO)",
+      "description_en": "Temperatura otoczenia (TO)"
     },
     {
       "function": "04",
@@ -4078,7 +4386,8 @@
       "enum": null,
       "multiplier": 0.1,
       "resolution": 0.1,
-      "description": "Temperatura nagrzewnicy (TH)"
+      "description": "Temperatura nagrzewnicy (TH)",
+      "description_en": "Temperatura nagrzewnicy (TH)"
     },
     {
       "function": "04",
@@ -4095,7 +4404,8 @@
       "extra": {
         "type": "string",
         "encoding": "ascii"
-      }
+      },
+      "description_en": "Numer seryjny sterownika"
     },
     {
       "function": "04",
@@ -4110,7 +4420,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Status aktywności systemu Constant Flow"
+      "description": "Status aktywności systemu Constant Flow",
+      "description_en": "Status aktywności systemu Constant Flow"
     },
     {
       "function": "04",
@@ -4122,7 +4433,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadana intensywność wentylacji (nawiew)"
+      "description": "Zadana intensywność wentylacji (nawiew)",
+      "description_en": "Zadana intensywność wentylacji (nawiew)"
     },
     {
       "function": "04",
@@ -4134,7 +4446,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadana intensywność wentylacji (nawiew)"
+      "description": "Zadana intensywność wentylacji (nawiew)",
+      "description_en": "Zadana intensywność wentylacji (nawiew)"
     },
     {
       "function": "04",
@@ -4146,7 +4459,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadany strumień przepływu (nawiew)"
+      "description": "Zadany strumień przepływu (nawiew)",
+      "description_en": "Zadany strumień przepływu (nawiew)"
     },
     {
       "function": "04",
@@ -4158,7 +4472,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Zadany strumień przepływu (wywiew)"
+      "description": "Zadany strumień przepływu (wywiew)",
+      "description_en": "Zadany strumień przepływu (wywiew)"
     },
     {
       "function": "04",
@@ -4170,7 +4485,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Minimalna możliwa do ustawienia intensywność wentylacji"
+      "description": "Minimalna możliwa do ustawienia intensywność wentylacji",
+      "description_en": "Minimalna możliwa do ustawienia intensywność wentylacji"
     },
     {
       "function": "04",
@@ -4182,7 +4498,8 @@
       "enum": null,
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji"
+      "description": "Maksymalna możliwa do ustawienia intensywność wentylacji",
+      "description_en": "Maksymalna możliwa do ustawienia intensywność wentylacji"
     },
     {
       "function": "04",
@@ -4197,7 +4514,8 @@
       },
       "multiplier": 1.0,
       "resolution": 1.0,
-      "description": "Status działania procedury HEWR"
+      "description": "Status działania procedury HEWR",
+      "description_en": "Status działania procedury HEWR"
     }
   ]
 }

--- a/docs/register_scanning.md
+++ b/docs/register_scanning.md
@@ -69,7 +69,8 @@ użycie zapisuje ostrzeżenie w logach. Każdy obiekt w tablicy `registers` zawi
 - `function` – kod funkcji Modbus
 - `address_dec` / `address_hex` – adres rejestru
 - `name` – unikalna nazwa
-- `description` – opis
+- `description` – opis po polsku
+- `description_en` – opis po angielsku
 - `access` – tryb dostępu (`R`/`W`)
 
 Opcjonalnie można zdefiniować `unit`, `enum`, `multiplier`, `resolution` i inne

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -21,13 +21,16 @@ def test_register_cache_invalidation(tmp_path: Path, monkeypatch) -> None:
     clear_cache()
     first = _load_registers()[0]
     assert first.description
+    assert first.description_en
 
     data = json.loads(tmp_json.read_text())
     data["registers"][0]["description"] = "changed description"
+    data["registers"][0]["description_en"] = "changed description en"
     tmp_json.write_text(json.dumps(data), encoding="utf-8")
 
     clear_cache()
     updated = _load_registers()[0]
     assert updated.description == "changed description"
+    assert updated.description_en == "changed description en"
 
     clear_cache()

--- a/tools/convert_registers_csv_to_json.py
+++ b/tools/convert_registers_csv_to_json.py
@@ -103,6 +103,7 @@ def convert(csv_path: Path = CSV_PATH, json_path: Path = JSON_PATH) -> None:
                     ("multiplier", multiplier),
                     ("resolution", resolution),
                     ("description", row.get("Description")),
+                    ("description_en", row.get("Description_EN") or row.get("Description")),
                 ]
             )
 


### PR DESCRIPTION
## Summary
- add description_en support to register tooling and loader
- duplicate Polish descriptions into new English field
- document new description_en field and test cache invalidation

## Testing
- `pytest` *(fails: Missing binary_sensor translations and others)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3fea517c832695df2ecd1c27c00c