### PR TITLE
Cache DeviceCapabilities serialization

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -162,7 +162,7 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
                 field.name for field in dataclasses.fields(DeviceCapabilities)
             }
             try:
-                caps_dict = dataclasses.asdict(caps_obj)
+                caps_dict = caps_obj.as_dict()
             except AttributeError as err:  # pragma: no cover - defensive
                 _LOGGER.error("Capabilities missing required fields: %s", err)
                 raise CannotConnect("invalid_capabilities") from err

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -151,20 +151,19 @@ class DeviceCapabilities:
     temperature_sensors_count: int = 0
 
     def as_dict(self) -> dict[str, Any]:
-        data = asdict(self)
-        for key, value in data.items():
-            if isinstance(value, set):
-                data[key] = sorted(value)
-        return data
+        """Return capabilities as a dictionary with set values sorted.
 
-    def items(self):
-        return asdict(self).items()
+        The result is cached on first call to avoid repeated ``dataclasses.asdict``
+        invocations when capabilities are accessed multiple times.
+        """
 
-    def keys(self):
-        return asdict(self).keys()
-
-    def __iter__(self):
-        return iter(self.items())
+        if not hasattr(self, "_as_dict_cache"):
+            data = asdict(self)
+            for key, value in data.items():
+                if isinstance(value, set):
+                    data[key] = sorted(value)
+            self._as_dict_cache = data
+        return self._as_dict_cache
 
 
 class ThesslaGreenDeviceScanner:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1223,19 +1223,18 @@ async def test_validate_input_timeout_errors(exc):
     scanner_instance.close.assert_awaited_once()
 
 
-def test_device_capabilities_iteration():
-    """DeviceCapabilities should support iteration like a dict."""
+def test_device_capabilities_serialization():
+    """DeviceCapabilities.as_dict returns a JSON-serializable dict."""
     from custom_components.thessla_green_modbus.scanner_core import DeviceCapabilities
 
-    caps = DeviceCapabilities(basic_control=True, bypass_system=True)
+    caps = DeviceCapabilities(
+        basic_control=True,
+        bypass_system=True,
+        temperature_sensors={"t2", "t1"},
+    )
 
-    # items() should yield key-value pairs
-    items = dict(caps.items())
-    assert items["basic_control"] is True
-    assert items["bypass_system"] is True
-
-    # direct iteration should also yield pairs
-    iterated = dict(iter(caps))
-    assert iterated["basic_control"] is True
-    # keys() should include attribute names
-    assert "bypass_system" in caps.keys()
+    serialized = caps.as_dict()
+    assert serialized["basic_control"] is True
+    assert serialized["bypass_system"] is True
+    # sets should be sorted lists for JSON serialization
+    assert serialized["temperature_sensors"] == ["t1", "t2"]


### PR DESCRIPTION
## Summary
- cache DeviceCapabilities.as_dict results and drop mapping methods
- use as_dict() for capabilities in config flow
- test capabilities serialization

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/scanner_core.py custom_components/thessla_green_modbus/config_flow.py tests/test_config_flow.py` *(fails: InvalidManifestError: https://github.com/home-assistant/actions)*
- `pytest tests/test_config_flow.py -k device_capabilities_serialization -vv`
- `pytest tests/test_config_flow.py::test_validate_input_uses_scan_device_and_closes`


------
https://chatgpt.com/codex/tasks/task_e_68aa3fd31c5083269e02c0b9ad8cb51e