### PR TITLE
Generate strings.json options from register definitions

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -126,51 +126,141 @@
       "work_permit": {
         "name": "Work Permit"
       },
-      "alarm": { "name": "Warning Active" },
-      "error": { "name": "Error Active" },
-      "s_2": { "name": "I2C Communication Error" },
-      "s_6": { "name": "FPX Heater Thermal Protection" },
-      "s_7": { "name": "Calibration Not Possible - Low Outdoor Temp" },
-      "s_8": { "name": "Product Key Required" },
-      "s_9": { "name": "Unit Stopped From AirS Panel" },
-      "s_10": { "name": "Fire Sensor Triggered" },
-      "s_13": { "name": "Unit Stopped From Remote Panel" },
-      "s_14": { "name": "Water Heater Antifreeze Limit Reached" },
-      "s_15": { "name": "Water Heater Antifreeze Ineffective" },
-      "s_16": { "name": "Electric Heater Thermal Protection" },
-      "s_17": { "name": "Filters Not Replaced (With Pressure Sensor)" },
-      "s_19": { "name": "Filters Not Replaced (No Pressure Sensor)" },
-      "s_20": { "name": "Duct Filter Not Replaced" },
-      "s_22": { "name": "Heat Exchanger Antifreeze Failure" },
-      "s_23": { "name": "Heat Exchanger Inlet Sensor Fault" },
-      "s_24": { "name": "Supply Duct Sensor Fault After Water Heater" },
-      "s_25": { "name": "Outdoor Temperature Sensor Fault" },
-      "s_26": { "name": "Outdoor and GWC Sensor Fault" },
-      "s_29": { "name": "Too High Temperature Before Exchanger" },
-      "s_30": { "name": "Supply Fan Failure" },
-      "s_31": { "name": "Exhaust Fan Failure" },
-      "s_32": { "name": "No Communication With TG-02 Module" },
-      "e_99": { "name": "Product Key Required (AirPack)" },
-      "e_100": { "name": "No Reading From Outdoor Temp Sensor (TZ1)" },
-      "e_101": { "name": "No Reading From Supply Temp Sensor (TN1)" },
-      "e_102": { "name": "No Reading From Exhaust Temp Sensor (TP)" },
-      "e_103": { "name": "No Reading From Inlet Temp Sensor (TZ2)" },
-      "e_104": { "name": "No Reading From Room Temp Sensor (TO)" },
-      "e_105": { "name": "No Reading From Supply Temp Sensor After Exchanger (TN2)" },
-      "e_106": { "name": "No Reading From GWC Outdoor Temp Sensor (TZ3)" },
-      "e_138": { "name": "Supply Fan CF Sensor Failure" },
-      "e_139": { "name": "Exhaust Fan CF Sensor Failure" },
-      "e_152": { "name": "Exhaust Air Temp Above Maximum" },
-      "e_196": { "name": "Installation Balancing Not Performed" },
-      "e_197": { "name": "Installation Balancing Interrupted" },
-      "e_198": { "name": "No Communication With CF2 Module" },
-      "e_199": { "name": "No Communication With CF Module" },
-      "e_200": { "name": "Electrical Heater Thermal Protection (Unit)" },
-      "e_201": { "name": "Electrical Heater Thermal Protection (Duct)" },
-      "e_249": { "name": "No Communication With Expansion Module" },
-      "e_250": { "name": "Filter Replacement Required (No Pressure Sensor)" },
-      "e_251": { "name": "Duct Filter Replacement Required" },
-      "e_252": { "name": "Filter Replacement Required (With Pressure Sensor)" }
+      "alarm": {
+        "name": "Warning Active"
+      },
+      "error": {
+        "name": "Error Active"
+      },
+      "s_2": {
+        "name": "I2C Communication Error"
+      },
+      "s_6": {
+        "name": "FPX Heater Thermal Protection"
+      },
+      "s_7": {
+        "name": "Calibration Not Possible - Low Outdoor Temp"
+      },
+      "s_8": {
+        "name": "Product Key Required"
+      },
+      "s_9": {
+        "name": "Unit Stopped From AirS Panel"
+      },
+      "s_10": {
+        "name": "Fire Sensor Triggered"
+      },
+      "s_13": {
+        "name": "Unit Stopped From Remote Panel"
+      },
+      "s_14": {
+        "name": "Water Heater Antifreeze Limit Reached"
+      },
+      "s_15": {
+        "name": "Water Heater Antifreeze Ineffective"
+      },
+      "s_16": {
+        "name": "Electric Heater Thermal Protection"
+      },
+      "s_17": {
+        "name": "Filters Not Replaced (With Pressure Sensor)"
+      },
+      "s_19": {
+        "name": "Filters Not Replaced (No Pressure Sensor)"
+      },
+      "s_20": {
+        "name": "Duct Filter Not Replaced"
+      },
+      "s_22": {
+        "name": "Heat Exchanger Antifreeze Failure"
+      },
+      "s_23": {
+        "name": "Heat Exchanger Inlet Sensor Fault"
+      },
+      "s_24": {
+        "name": "Supply Duct Sensor Fault After Water Heater"
+      },
+      "s_25": {
+        "name": "Outdoor Temperature Sensor Fault"
+      },
+      "s_26": {
+        "name": "Outdoor and GWC Sensor Fault"
+      },
+      "s_29": {
+        "name": "Too High Temperature Before Exchanger"
+      },
+      "s_30": {
+        "name": "Supply Fan Failure"
+      },
+      "s_31": {
+        "name": "Exhaust Fan Failure"
+      },
+      "s_32": {
+        "name": "No Communication With TG-02 Module"
+      },
+      "e_99": {
+        "name": "Product Key Required (AirPack)"
+      },
+      "e_100": {
+        "name": "No Reading From Outdoor Temp Sensor (TZ1)"
+      },
+      "e_101": {
+        "name": "No Reading From Supply Temp Sensor (TN1)"
+      },
+      "e_102": {
+        "name": "No Reading From Exhaust Temp Sensor (TP)"
+      },
+      "e_103": {
+        "name": "No Reading From Inlet Temp Sensor (TZ2)"
+      },
+      "e_104": {
+        "name": "No Reading From Room Temp Sensor (TO)"
+      },
+      "e_105": {
+        "name": "No Reading From Supply Temp Sensor After Exchanger (TN2)"
+      },
+      "e_106": {
+        "name": "No Reading From GWC Outdoor Temp Sensor (TZ3)"
+      },
+      "e_138": {
+        "name": "Supply Fan CF Sensor Failure"
+      },
+      "e_139": {
+        "name": "Exhaust Fan CF Sensor Failure"
+      },
+      "e_152": {
+        "name": "Exhaust Air Temp Above Maximum"
+      },
+      "e_196": {
+        "name": "Installation Balancing Not Performed"
+      },
+      "e_197": {
+        "name": "Installation Balancing Interrupted"
+      },
+      "e_198": {
+        "name": "No Communication With CF2 Module"
+      },
+      "e_199": {
+        "name": "No Communication With CF Module"
+      },
+      "e_200": {
+        "name": "Electrical Heater Thermal Protection (Unit)"
+      },
+      "e_201": {
+        "name": "Electrical Heater Thermal Protection (Duct)"
+      },
+      "e_249": {
+        "name": "No Communication With Expansion Module"
+      },
+      "e_250": {
+        "name": "Filter Replacement Required (No Pressure Sensor)"
+      },
+      "e_251": {
+        "name": "Duct Filter Replacement Required"
+      },
+      "e_252": {
+        "name": "Filter Replacement Required (With Pressure Sensor)"
+      }
     },
     "climate": {
       "thessla_green_climate": {
@@ -1524,15 +1614,15 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.modbus_baud_rate_115200": "115200",
+                "thessla_green_modbus.modbus_baud_rate_4800": "4800",
+                "thessla_green_modbus.modbus_baud_rate_9600": "9600",
                 "thessla_green_modbus.modbus_baud_rate_14400": "14400",
                 "thessla_green_modbus.modbus_baud_rate_19200": "19200",
                 "thessla_green_modbus.modbus_baud_rate_28800": "28800",
                 "thessla_green_modbus.modbus_baud_rate_38400": "38400",
-                "thessla_green_modbus.modbus_baud_rate_4800": "4800",
                 "thessla_green_modbus.modbus_baud_rate_57600": "57600",
                 "thessla_green_modbus.modbus_baud_rate_76800": "76800",
-                "thessla_green_modbus.modbus_baud_rate_9600": "9600"
+                "thessla_green_modbus.modbus_baud_rate_115200": "115200"
               }
             }
           }
@@ -1543,8 +1633,8 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.modbus_parity_even": "Even",
                 "thessla_green_modbus.modbus_parity_none": "None",
+                "thessla_green_modbus.modbus_parity_even": "Even",
                 "thessla_green_modbus.modbus_parity_odd": "Odd"
               }
             }
@@ -1590,16 +1680,16 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.special_mode_away": "Away",
-                "thessla_green_modbus.special_mode_bathroom": "Bathroom",
+                "thessla_green_modbus.special_mode_none": "None",
                 "thessla_green_modbus.special_mode_boost": "Boost",
                 "thessla_green_modbus.special_mode_eco": "Eco",
+                "thessla_green_modbus.special_mode_away": "Away",
+                "thessla_green_modbus.special_mode_sleep": "Sleep",
                 "thessla_green_modbus.special_mode_fireplace": "Fireplace",
                 "thessla_green_modbus.special_mode_hood": "Hood",
-                "thessla_green_modbus.special_mode_kitchen": "Kitchen",
-                "thessla_green_modbus.special_mode_none": "None",
                 "thessla_green_modbus.special_mode_party": "Party",
-                "thessla_green_modbus.special_mode_sleep": "Sleep",
+                "thessla_green_modbus.special_mode_bathroom": "Bathroom",
+                "thessla_green_modbus.special_mode_kitchen": "Kitchen",
                 "thessla_green_modbus.special_mode_summer": "Summer",
                 "thessla_green_modbus.special_mode_winter": "Winter"
               }

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1436,15 +1436,15 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.modbus_baud_rate_115200": "115200",
+                "thessla_green_modbus.modbus_baud_rate_4800": "4800",
+                "thessla_green_modbus.modbus_baud_rate_9600": "9600",
                 "thessla_green_modbus.modbus_baud_rate_14400": "14400",
                 "thessla_green_modbus.modbus_baud_rate_19200": "19200",
                 "thessla_green_modbus.modbus_baud_rate_28800": "28800",
                 "thessla_green_modbus.modbus_baud_rate_38400": "38400",
-                "thessla_green_modbus.modbus_baud_rate_4800": "4800",
                 "thessla_green_modbus.modbus_baud_rate_57600": "57600",
                 "thessla_green_modbus.modbus_baud_rate_76800": "76800",
-                "thessla_green_modbus.modbus_baud_rate_9600": "9600"
+                "thessla_green_modbus.modbus_baud_rate_115200": "115200"
               }
             }
           }
@@ -1455,8 +1455,8 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.modbus_parity_even": "Even",
                 "thessla_green_modbus.modbus_parity_none": "None",
+                "thessla_green_modbus.modbus_parity_even": "Even",
                 "thessla_green_modbus.modbus_parity_odd": "Odd"
               }
             }
@@ -1502,16 +1502,16 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.special_mode_away": "Away",
-                "thessla_green_modbus.special_mode_bathroom": "Bathroom",
+                "thessla_green_modbus.special_mode_none": "None",
                 "thessla_green_modbus.special_mode_boost": "Boost",
                 "thessla_green_modbus.special_mode_eco": "Eco",
+                "thessla_green_modbus.special_mode_away": "Away",
+                "thessla_green_modbus.special_mode_sleep": "Sleep",
                 "thessla_green_modbus.special_mode_fireplace": "Fireplace",
                 "thessla_green_modbus.special_mode_hood": "Hood",
-                "thessla_green_modbus.special_mode_kitchen": "Kitchen",
-                "thessla_green_modbus.special_mode_none": "None",
                 "thessla_green_modbus.special_mode_party": "Party",
-                "thessla_green_modbus.special_mode_sleep": "Sleep",
+                "thessla_green_modbus.special_mode_bathroom": "Bathroom",
+                "thessla_green_modbus.special_mode_kitchen": "Kitchen",
                 "thessla_green_modbus.special_mode_summer": "Summer",
                 "thessla_green_modbus.special_mode_winter": "Winter"
               }

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1436,15 +1436,15 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.modbus_baud_rate_115200": "115200",
+                "thessla_green_modbus.modbus_baud_rate_4800": "4800",
+                "thessla_green_modbus.modbus_baud_rate_9600": "9600",
                 "thessla_green_modbus.modbus_baud_rate_14400": "14400",
                 "thessla_green_modbus.modbus_baud_rate_19200": "19200",
                 "thessla_green_modbus.modbus_baud_rate_28800": "28800",
                 "thessla_green_modbus.modbus_baud_rate_38400": "38400",
-                "thessla_green_modbus.modbus_baud_rate_4800": "4800",
                 "thessla_green_modbus.modbus_baud_rate_57600": "57600",
                 "thessla_green_modbus.modbus_baud_rate_76800": "76800",
-                "thessla_green_modbus.modbus_baud_rate_9600": "9600"
+                "thessla_green_modbus.modbus_baud_rate_115200": "115200"
               }
             }
           }
@@ -1455,8 +1455,8 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.modbus_parity_even": "Parzysta",
                 "thessla_green_modbus.modbus_parity_none": "Brak",
+                "thessla_green_modbus.modbus_parity_even": "Parzysta",
                 "thessla_green_modbus.modbus_parity_odd": "Nieparzysta"
               }
             }
@@ -1502,16 +1502,16 @@
           "selector": {
             "select": {
               "options": {
-                "thessla_green_modbus.special_mode_away": "Nieobecność",
-                "thessla_green_modbus.special_mode_bathroom": "Łazienka",
+                "thessla_green_modbus.special_mode_none": "Brak",
                 "thessla_green_modbus.special_mode_boost": "Boost",
                 "thessla_green_modbus.special_mode_eco": "Eco",
+                "thessla_green_modbus.special_mode_away": "Nieobecność",
+                "thessla_green_modbus.special_mode_sleep": "Sen",
                 "thessla_green_modbus.special_mode_fireplace": "Kominek",
                 "thessla_green_modbus.special_mode_hood": "Okap",
-                "thessla_green_modbus.special_mode_kitchen": "Kuchnia",
-                "thessla_green_modbus.special_mode_none": "Brak",
                 "thessla_green_modbus.special_mode_party": "Impreza",
-                "thessla_green_modbus.special_mode_sleep": "Sen",
+                "thessla_green_modbus.special_mode_bathroom": "Łazienka",
+                "thessla_green_modbus.special_mode_kitchen": "Kuchnia",
                 "thessla_green_modbus.special_mode_summer": "Lato",
                 "thessla_green_modbus.special_mode_winter": "Zima"
               }

--- a/tests/test_strings_json_generation.py
+++ b/tests/test_strings_json_generation.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+from tools import generate_strings
+
+ROOT = Path(__file__).resolve().parents[1]
+STRINGS = ROOT / 'custom_components' / 'thessla_green_modbus' / 'strings.json'
+EN = ROOT / 'custom_components' / 'thessla_green_modbus' / 'translations' / 'en.json'
+PL = ROOT / 'custom_components' / 'thessla_green_modbus' / 'translations' / 'pl.json'
+
+
+def _load(path):
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def test_strings_in_sync():
+    opts = generate_strings.build()
+    strings = _load(STRINGS)
+    en = _load(EN)
+    pl = _load(PL)
+
+    fields = strings['services']['set_modbus_parameters']['fields']
+    assert fields['baud_rate']['selector']['select']['options'] == opts['baud_rate'][0]
+    assert fields['parity']['selector']['select']['options'] == opts['parity'][0]
+    assert fields['port']['selector']['select']['options'] == opts['port'][0]
+    assert fields['stop_bits']['selector']['select']['options'] == opts['stop_bits'][0]
+    mode_opts = strings['services']['set_special_mode']['fields']['mode']['selector']['select']['options']
+    assert mode_opts == opts['special_mode'][0]
+
+    en_fields = en['services']['set_modbus_parameters']['fields']
+    assert en_fields['baud_rate']['selector']['select']['options'] == opts['baud_rate'][0]
+    assert en_fields['parity']['selector']['select']['options'] == opts['parity'][0]
+    assert en_fields['port']['selector']['select']['options'] == opts['port'][0]
+    assert en_fields['stop_bits']['selector']['select']['options'] == opts['stop_bits'][0]
+    en_mode = en['services']['set_special_mode']['fields']['mode']['selector']['select']['options']
+    assert en_mode == opts['special_mode'][0]
+
+    pl_fields = pl['services']['set_modbus_parameters']['fields']
+    assert pl_fields['baud_rate']['selector']['select']['options'] == opts['baud_rate'][1]
+    assert pl_fields['parity']['selector']['select']['options'] == opts['parity'][1]
+    assert pl_fields['port']['selector']['select']['options'] == opts['port'][1]
+    assert pl_fields['stop_bits']['selector']['select']['options'] == opts['stop_bits'][1]
+    pl_mode = pl['services']['set_special_mode']['fields']['mode']['selector']['select']['options']
+    assert pl_mode == opts['special_mode'][1]

--- a/tools/generate_strings.py
+++ b/tools/generate_strings.py
@@ -1,0 +1,56 @@
+import json, pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+REG = ROOT / 'custom_components' / 'thessla_green_modbus' / 'registers' / 'thessla_green_registers_full.json'
+STRINGS = ROOT / 'custom_components' / 'thessla_green_modbus' / 'strings.json'
+EN = ROOT / 'custom_components' / 'thessla_green_modbus' / 'translations' / 'en.json'
+PL = ROOT / 'custom_components' / 'thessla_green_modbus' / 'translations' / 'pl.json'
+SPECIAL_PATH = ROOT / 'custom_components' / 'thessla_green_modbus' / 'options' / 'special_modes.json'
+
+
+def build():
+    regs = {r['name']: r for r in json.loads(REG.read_text(encoding='utf-8'))['registers']}
+    baud = [str(v) for v in regs['uart0_baud']['enum'].values()]
+    baud_opt = {f'thessla_green_modbus.modbus_baud_rate_{v}': v for v in baud}
+    parity_map = {'brak': ('none','None','Brak'), 'parzysty': ('even','Even','Parzysta'), 'nieparzysty': ('odd','Odd','Nieparzysta')}
+    parity_en = {f"thessla_green_modbus.modbus_parity_{parity_map[v][0]}": parity_map[v][1] for v in regs['uart0_parity']['enum'].values()}
+    parity_pl = {f"thessla_green_modbus.modbus_parity_{parity_map[v][0]}": parity_map[v][2] for v in regs['uart0_parity']['enum'].values()}
+    stop_map = {'jeden': ('1','1'), 'dwa': ('2','2')}
+    stop_opt = {f"thessla_green_modbus.modbus_stop_bits_{stop_map[v][0]}": stop_map[v][1] for v in regs['uart0_stop']['enum'].values()}
+    port_opt = {'thessla_green_modbus.modbus_port_air_b':'Air-B','thessla_green_modbus.modbus_port_air_plus':'Air++'}
+    spec_keys = json.loads(SPECIAL_PATH.read_text(encoding='utf-8'))
+    spec_en = {'none':'None','boost':'Boost','eco':'Eco','away':'Away','sleep':'Sleep','fireplace':'Fireplace','hood':'Hood','party':'Party','bathroom':'Bathroom','kitchen':'Kitchen','summer':'Summer','winter':'Winter'}
+    spec_pl = {'none':'Brak','boost':'Boost','eco':'Eco','away':'Nieobecność','sleep':'Sen','fireplace':'Kominek','hood':'Okap','party':'Impreza','bathroom':'Łazienka','kitchen':'Kuchnia','summer':'Lato','winter':'Zima'}
+    spec_en_opt = {k: spec_en[k.split('.')[-1].replace('special_mode_','')] for k in spec_keys}
+    spec_pl_opt = {k: spec_pl[k.split('.')[-1].replace('special_mode_','')] for k in spec_keys}
+    return {
+        'baud_rate': (baud_opt, baud_opt),
+        'parity': (parity_en, parity_pl),
+        'stop_bits': (stop_opt, stop_opt),
+        'port': (port_opt, port_opt),
+        'special_mode': (spec_en_opt, spec_pl_opt),
+    }
+
+
+def write():
+    strings = json.loads(STRINGS.read_text(encoding='utf-8'))
+    en = json.loads(EN.read_text(encoding='utf-8'))
+    pl = json.loads(PL.read_text(encoding='utf-8'))
+    opts = build()
+    def apply(obj, lang):
+        fields = obj['services']['set_modbus_parameters']['fields']
+        fields['baud_rate']['selector']['select']['options'] = opts['baud_rate'][0]
+        fields['parity']['selector']['select']['options'] = opts['parity'][0 if lang=='en' else 1]
+        fields['port']['selector']['select']['options'] = opts['port'][0]
+        fields['stop_bits']['selector']['select']['options'] = opts['stop_bits'][0]
+        obj['services']['set_special_mode']['fields']['mode']['selector']['select']['options'] = opts['special_mode'][0 if lang=='en' else 1]
+    apply(strings,'en')
+    apply(en,'en')
+    apply(pl,'pl')
+    STRINGS.write_text(json.dumps(strings, indent=2, ensure_ascii=False)+'\n',encoding='utf-8')
+    EN.write_text(json.dumps(en, indent=2, ensure_ascii=False)+'\n',encoding='utf-8')
+    PL.write_text(json.dumps(pl, indent=2, ensure_ascii=False)+'\n',encoding='utf-8')
+
+
+if __name__ == '__main__':
+    write()


### PR DESCRIPTION
## Summary
- add tool to build service option strings from register enums
- generate strings.json and translations from register data
- verify translations stay in sync with register definitions

## Testing
- `pytest tests/test_strings_json_generation.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa3ff0d32483269c075265821059d7