### PR TITLE
Use Home Assistant version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ New Features
 
-#### Enhanced Climate Entity (HA 2025.7.1+ Compatible)
+#### Enhanced Climate Entity (HA 2025.7.0+ Compatible)
 - **Preset Modes**: Eco, Comfort, Boost, Sleep, Away
 - **Custom ThesslaGreen Presets**: OKAP, KOMINEK, WIETRZENIE, GOTOWANIE, PRANIE, ŁAZIENKA
 - **Advanced Temperature Control**: Manual/temporary/comfort temperature settings
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Comprehensive Device Scanner** - Intelligent capability detection with 60+ capabilities
 - **Enhanced Error Handling** - Smart retry logic and graceful error recovery
 
-#### Complete Entity Coverage (HA 2025.7.1+)
+#### Complete Entity Coverage (HA 2025.7.0+)
 - **Temperature Sensors** (11): All temperature measurement points
 - **Flow Sensors** (8): Complete air flow monitoring including Constant Flow
 - **Performance Sensors** (7): Efficiency and performance indicators
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Technical Improvements
 
-#### Optimized Coordinator (HA 2025.7.1+)
+#### Optimized Coordinator (HA 2025.7.0+)
 - **Pre-computed Register Groups** - Efficient batch reading with intelligent grouping
 - **Enhanced Error Handling** - Smart retry logic with exponential backoff
 - **Memory Optimization** - Reduced memory usage through efficient data structures
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Numbers**: Smart validation with range checking and recommendations
 - **Select**: Enhanced mode selection with context information
 
-#### Services Integration (HA 2025.7.1+)
+#### Services Integration (HA 2025.7.0+)
 - **Basic Control**: Set mode, intensity, special functions
 - **Advanced Functions**: Boost mode, comfort temperature, quick ventilation
 - **System Management**: Emergency stop, alarm reset, device rescan
@@ -103,8 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Coil Registers | 25+ | Output controls and system switches |
 | Discrete Inputs | 35+ | Input status and sensor health |
 
-### 🏠 Home Assistant Compatibility (HA 2025.7.1+)
-- **HA 2025.7.1+** - Latest Home Assistant compatibility
+### 🏠 Home Assistant Compatibility (HA 2025.7.0+)
+- **HA 2025.7.0+** - Latest Home Assistant compatibility
 - **Modern Standards** - Follows latest HA development guidelines
 - **Device Registry** - Proper device registration with enhanced info
 - **Entity Categories** - Proper categorization for better UI organization

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub release](https://img.shields.io/github/release/thesslagreen/thessla-green-modbus-ha.svg)](https://github.com/thesslagreen/thessla-green-modbus-ha/releases)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7.1%2B-blue.svg)](https://home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7.0%2B-blue.svg)](https://home-assistant.io/)
 [![Python](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://python.org/)
 
 ## ✨ Kompletna integracja ThesslaGreen AirPack z Home Assistant
@@ -35,7 +35,7 @@ Integracja działa jako **hub** w Home Assistant.
 - ✅ **Firmware v3.x - v5.x** z automatyczną detekcją
 
 ### Home Assistant
-- ✅ **Wymagany Home Assistant 2025.7.1+** — minimalna wersja określona w `manifest.json` (pakiet `homeassistant` nie jest częścią `requirements.txt`)
+- ✅ **Wymagany Home Assistant 2025.7.0+** — minimalna wersja określona w `manifest.json` (pakiet `homeassistant` nie jest częścią `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** - najnowsza biblioteka Modbus
 - ✅ **Python 3.12+** - nowoczesne standardy
 - ✅ **Standardowy AsyncModbusTcpClient** – brak potrzeby własnego klienta Modbus

--- a/README_en.md
+++ b/README_en.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub release](https://img.shields.io/github/release/thesslagreen/thessla-green-modbus-ha.svg)](https://github.com/thesslagreen/thessla-green-modbus-ha/releases)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7.1%2B-blue.svg)](https://home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.7.0%2B-blue.svg)](https://home-assistant.io/)
 [![Python](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://python.org/)
 
 ## ✨ Complete ThesslaGreen AirPack integration for Home Assistant
@@ -34,7 +34,7 @@ The integration works as a **hub** in Home Assistant.
 - ✅ **Firmware v3.x – v5.x** with automatic detection
 
 ### Home Assistant
-- ✅ **Requires Home Assistant 2025.7.1+** — minimum version declared in `manifest.json` (the `homeassistant` package is not part of `requirements.txt`)
+- ✅ **Requires Home Assistant 2025.7.0+** — minimum version declared in `manifest.json` (the `homeassistant` package is not part of `requirements.txt`)
 - ✅ **pymodbus 3.5.0+** – latest Modbus library
 - ✅ **Python 3.12+** – modern standards
 - ✅ **Standard AsyncModbusTcpClient** – no custom Modbus client required

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -7,7 +7,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
-  "homeassistant": "2025.7.1",
+  "homeassistant": ">=2025.7.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",


### PR DESCRIPTION
## Summary
- relax Home Assistant requirement to a version range
- document supported Home Assistant 2025.7.0+ in README and changelog

## Testing
- `python -m pre_commit run --files custom_components/thessla_green_modbus/manifest.json README.md README_en.md CHANGELOG.md` (fails: InvalidManifestError: /root/.cache/pre-commit/reponhf0od0u/.pre-commit-hooks.yaml is not a file)
- `python -m pytest` (fails: 142 failed, 269 passed, 1 warning)


------
https://chatgpt.com/codex/tasks/task_e_68aa3fecb51c83268914584be0d145aa