### PR TITLE
Add coverage for diagnostics metrics and document fields

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,16 @@
+# Diagnostics Fields
+
+The Thessla Green Modbus integration exposes several fields via the Home Assistant diagnostics panel. These fields provide insight into device state and communication issues.
+
+- `registers_hash`: Stable hash of the register definitions packaged with the integration.
+- `capabilities`: Features supported by the connected device.
+- `firmware_version`: Firmware version reported by the device.
+- `total_available_registers`: Count of registers known to the integration.
+- `last_scan`: ISO-8601 timestamp of the most recent register scan.
+- `error_statistics`: Breakdown of recent connection and timeout errors.
+- `raw_registers`: Raw register dump returned during the last scan, when available.
+- `unknown_registers`: Registers read from the device that are not in the register map.
+- `failed_addresses`: Addresses skipped during scanning due to errors.
+- `active_errors`: Currently active error or status codes with translations when available.
+
+These diagnostics make it easier to troubleshoot setup issues and confirm device behavior.


### PR DESCRIPTION
## Summary
- test diagnostics output includes raw register dump, last scan timestamp and error statistics
- document available diagnostics fields for troubleshooting

## Testing
- `pytest tests/test_diagnostics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aabff90f808326a6e770598293e505