### PR TITLE
refactor: remove unused json import

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -1,6 +1,5 @@
 """Constants and register definitions for the ThesslaGreen Modbus integration."""
 
-import json
 from pathlib import Path
 from typing import Any, Dict, cast
 
@@ -179,6 +178,8 @@ def _load_json_option(filename: str) -> list[Any]:
     Returns an empty list if the file does not exist or cannot be parsed.
     ``filename`` should be relative to ``OPTIONS_PATH``.
     """
+
+    import json
 
     try:
         return cast(


### PR DESCRIPTION
## Summary
- remove unused json import

## Testing
- `ruff check custom_components/thessla_green_modbus/const.py`
- `flake8 custom_components/thessla_green_modbus/const.py` *(fails: E501 line too long; E303 too many blank lines)*

------
https://chatgpt.com/codex/tasks/task_e_68aabff0ecb88326ba2900c7fe892a13