### PR TITLE
refactor: remove unused multi-register map

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -15,9 +15,6 @@ COIL_REGISTERS = _build_map("coil")
 DISCRETE_INPUT_REGISTERS = _build_map("discrete")
 HOLDING_REGISTERS = _build_map("holding")
 INPUT_REGISTERS = _build_map("input")
-MULTI_REGISTER_SIZES = {
-    r.name: r.length for r in get_registers_by_function("holding") if r.name and r.length > 1
-}
 
 OPTIONS_PATH = Path(__file__).parent / "options"
 


### PR DESCRIPTION
## Summary
- remove obsolete MULTI_REGISTER_SIZES constant from const.py so only scanner_core builds the multi-register map

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/const.py` *(fails: InvalidManifestError: ...home-assistant/actions...)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.util.network')*

------
https://chatgpt.com/codex/tasks/task_e_68aabfece87083268fbba7a9045d41a9