### PR TITLE
Validate port and slave ID ranges

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -108,6 +108,12 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
     name = data.get(CONF_NAME, DEFAULT_NAME)
     timeout = data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
 
+    # Validate port and slave id ranges
+    if not 1 <= port <= 65535:
+        raise vol.Invalid("invalid_port")
+    if not 0 <= slave_id <= 247:
+        raise vol.Invalid("invalid_slave")
+
     # Validate host is either an IP address or a valid hostname
     try:
         ipaddress.ip_address(host)

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -16,6 +16,8 @@
       "invalid_domain": "Invalid hostname or domain.",
       "invalid_ipv4": "Invalid IPv4 address.",
       "invalid_ipv6": "Invalid IPv6 address.",
+      "invalid_port": "Port must be between 1 and 65535.",
+      "invalid_slave": "Device ID must be between 0 and 247.",
       "missing_method": "Scanner is missing required method. See logs for details.",
       "modbus_error": "Modbus communication error. Check wiring and settings.",
       "timeout": "Connection timed out. Verify host and port.",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -16,6 +16,8 @@
       "invalid_domain": "Nieprawidłowa nazwa hosta lub domena.",
       "invalid_ipv4": "Nieprawidłowy adres IPv4.",
       "invalid_ipv6": "Nieprawidłowy adres IPv6.",
+      "invalid_port": "Port musi być z zakresu 1–65535.",
+      "invalid_slave": "ID urządzenia musi być z zakresu 0–247.",
       "missing_method": "Brak wymaganej metody w skanerze. Sprawdź logi po szczegóły.",
       "modbus_error": "Błąd komunikacji Modbus. Sprawdź okablowanie i ustawienia.",
       "timeout": "Przekroczono czas połączenia. Sprawdź host i port.",


### PR DESCRIPTION
## Summary
- validate port and Modbus slave ID ranges in config flow
- add translation messages for invalid port and slave ID
- test invalid port and slave ID in validate_input

## Testing
- `pytest tests/test_config_flow.py::test_validate_input_invalid_port tests/test_config_flow.py::test_validate_input_invalid_slave -vv`
- `pytest tests/test_config_flow.py` *(fails: DID NOT RAISE <class 'custom_components.thessla_green_modbus.config_flow.CannotConnect'>)*

------
https://chatgpt.com/codex/tasks/task_e_68aabfe608808326a4b0bb11a18355ab