### PR TITLE
chore: update startup message

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -43,10 +43,9 @@ from .const import PLATFORMS as PLATFORM_DOMAINS
 from .modbus_exceptions import ConnectionException, ModbusException
 from .registers import loader
 
-# Migration message for start-up logs
-MIGRATION_MESSAGE = (
-    "Register definitions now use JSON format by default; CSV files are deprecated "
-    "and will be removed in a future release."
+# Informational message for start-up logs
+REGISTER_FORMAT_MESSAGE = (
+    "Register definitions now use JSON format only; CSV support has been removed."
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -86,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     This hook is invoked by Home Assistant during config entry setup even
     though it appears unused within the integration code itself.
     """
-    _LOGGER.info(MIGRATION_MESSAGE)
+    _LOGGER.info(REGISTER_FORMAT_MESSAGE)
     _LOGGER.debug("Setting up ThesslaGreen Modbus integration for %s", entry.title)
 
     # Get configuration - support both new and legacy keys


### PR DESCRIPTION
## Summary
- clarify startup log to indicate register definitions are JSON-only

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install -r requirements-dev.txt` *(fails: ResolutionImpossible: dependency conflict for pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68aabfd5f1608326af46d7d82ba97715