### PR TITLE
Remove unused import in Modbus register loader

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -29,7 +29,6 @@ from typing import Any, Literal, Sequence
 
 import pydantic
 
-from ..modbus_helpers import group_reads
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from ..utils import _to_snake_case
 from ..modbus_helpers import group_reads as _group_reads
@@ -382,9 +381,6 @@ def _normalise_name(name: str) -> str:
     }
     snake = _to_snake_case(name)
     return fixes.get(snake, snake)
-
-
-
 # ---------------------------------------------------------------------------
 # Register loading helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- drop unused `group_reads` import
- tidy spacing around register-loading helpers

## Testing
- `ruff check custom_components/thessla_green_modbus/registers/loader.py`
- `flake8 --max-line-length=100 custom_components/thessla_green_modbus/registers/loader.py`
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo41yh3i6s/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68aabfd196208326923a3f6bf9d50fb0