### PR TITLE
Add register JSON sort tool and test

### DIFF
--- a/tests/test_register_json_order.py
+++ b/tests/test_register_json_order.py
@@ -1,0 +1,25 @@
+"""Verify the canonical register JSON file is sorted."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_register_json_order() -> None:
+    """Registers should be ordered by function then decimal address."""
+
+    json_path = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "thessla_green_modbus"
+        / "registers"
+        / "thessla_green_registers_full.json"
+    )
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    registers = data["registers"]
+    sorted_regs = sorted(
+        registers,
+        key=lambda r: (int(str(r["function"])), int(r["address_dec"])),
+    )
+    assert registers == sorted_regs

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,3 +11,16 @@
 3. Commit the updated JSON file.
 
 The CSV file is excluded from packages and must not be imported or accessed at runtime. The conversion is one-way: runtime code reads only the generated JSON.
+
+## Sort register JSON file
+
+The register file should remain deterministically ordered by Modbus function code
+and decimal address. Run the helper below to enforce the ordering:
+
+```bash
+python tools/sort_registers_json.py
+```
+
+By default the script operates on
+`custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`
+but an alternate path may be supplied as an argument.

--- a/tools/sort_registers_json.py
+++ b/tools/sort_registers_json.py
@@ -1,0 +1,51 @@
+"""Sort the canonical JSON register file by function and address."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_JSON = (
+    ROOT
+    / "custom_components"
+    / "thessla_green_modbus"
+    / "registers"
+    / "thessla_green_registers_full.json"
+)
+
+
+def sort_registers_json(path: Path = DEFAULT_JSON) -> None:
+    """Sort registers in ``path`` by function then decimal address."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    registers = data["registers"]
+    sorted_regs = sorted(
+        registers,
+        key=lambda r: (int(str(r["function"])), int(r["address_dec"])),
+    )
+    if registers != sorted_regs:
+        data["registers"] = sorted_regs
+        path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sort register JSON by function and decimal address.",
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=str(DEFAULT_JSON),
+        help="Path to the register JSON file.",
+    )
+    args = parser.parse_args()
+    sort_registers_json(Path(args.path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper to sort register JSON file by function then address
- add test ensuring register file remains sorted
- document usage of new register sort tool

## Testing
- `python tools/sort_registers_json.py`
- `pytest tests/test_register_json_order.py -q`
- `isort tools/sort_registers_json.py tests/test_register_json_order.py --check -v`
- `ruff check tools/sort_registers_json.py tests/test_register_json_order.py`
- `flake8 tools/sort_registers_json.py tests/test_register_json_order.py -v`
- ⚠️ `pre-commit run --files tools/sort_registers_json.py tests/test_register_json_order.py tools/README.md` (InvalidManifestError: /root/.cache/pre-commit/repo0o0222m_/.pre-commit-hooks.yaml is not a file)


------
https://chatgpt.com/codex/tasks/task_e_68aad261804083269860e854348523ec