### PR TITLE
refactor: remove parse_schedule_bcd helper

### DIFF
--- a/custom_components/thessla_green_modbus/utils.py
+++ b/custom_components/thessla_green_modbus/utils.py
@@ -9,7 +9,6 @@ __all__ = [
     "_decode_register_time",
     "_decode_bcd_time",
     "_decode_aatt",
-    "parse_schedule_bcd",
     "BCD_TIME_PREFIXES",
     "TIME_REGISTER_PREFIXES",
 ]
@@ -67,20 +66,6 @@ def _decode_bcd_time(value: int) -> int | None:
     if 0 <= hours_dec <= 23 and 0 <= minutes_dec <= 59:
         return hours_dec * 60 + minutes_dec
     return None
-
-
-def parse_schedule_bcd(value: int) -> int | None:
-    """Parse schedule register values encoded as BCD HHMM.
-
-    The schedule registers use the BCD time representation but also employ
-    ``0x8000`` as a sentinel indicating that the entry is not configured.  This
-    helper wraps :func:`_decode_bcd_time` and converts the sentinel to
-    ``None`` while still validating the decoded time.
-    """
-
-    if value == 0x8000:
-        return None
-    return _decode_bcd_time(value)
 
 
 def _decode_aatt(value: int) -> tuple[int, float] | None:


### PR DESCRIPTION
## Summary
- drop unused parse_schedule_bcd helper and clean exports

## Testing
- `ruff check custom_components/thessla_green_modbus/utils.py`
- `pytest` *(fails: module 'pydantic' has no attribute 'model_validator')*


------
https://chatgpt.com/codex/tasks/task_e_68aad269fa188326b428c4b6c0887b72