### PR TITLE
chore: remove deprecated setting decoder alias

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner_helpers.py
@@ -24,8 +24,6 @@ REGISTER_ALLOWED_VALUES: dict[str, set[int]] = {
 # Registers storing combined airflow and temperature settings
 SETTING_PREFIX = "setting_"
 
-# Backwards compatibility: old name used in tests/utilities
-_decode_setting_value = _decode_aatt
 
 
 def _format_register_value(name: str, value: int) -> int | str | None:
@@ -101,7 +99,6 @@ __all__ = [
     "REGISTER_ALLOWED_VALUES",
     "SETTING_PREFIX",
     "_decode_aatt",
-    "_decode_setting_value",
     "_format_register_value",
     "_decode_season_mode",
     "SPECIAL_VALUE_DECODERS",


### PR DESCRIPTION
## Summary
- remove `_decode_setting_value` alias
- drop `_decode_setting_value` from `__all__`

## Testing
- `ruff check custom_components/thessla_green_modbus/scanner_helpers.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68aad26a7f4c8326a0349b1fb52cb87b