### PR TITLE
feat: add iteration helpers to device capabilities

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 import logging
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Self
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Self, cast
 
 from .capability_rules import CAPABILITY_PATTERNS
 from .const import (
@@ -125,17 +125,15 @@ class DeviceInfo:  # pragma: no cover
 # which features the device exposes; static analysis may therefore mark them
 # as unused even though they are relied upon.
 @dataclass
-class DeviceCapabilities:
+class DeviceCapabilities:  # pragma: no cover
     """Feature flags and sensor availability detected on the device.
 
     Although capabilities are typically determined once during the initial scan,
-    the dataclass caches the result of :meth:`as_dict` for efficiency.  Any
+    the dataclass caches the result of :meth:`as_dict` for efficiency. Any
     attribute assignment will clear this cache so subsequent calls reflect the
-    new values.  The capability sets are mutable; modify them via assignment to
+    new values. The capability sets are mutable; modify them via assignment to
     trigger cache invalidation.
     """
-class DeviceCapabilities:  # pragma: no cover
-    """Feature flags and sensor availability detected on the device."""
     basic_control: bool = False
     temperature_sensors: set[str] = field(default_factory=set)  # Names of temperature sensors
     flow_sensors: set[str] = field(default_factory=set)  # Airflow sensor identifiers  # pragma: no cover
@@ -178,6 +176,15 @@ class DeviceCapabilities:  # pragma: no cover
                     data[key] = sorted(value)
             self._as_dict_cache = data
         return self._as_dict_cache
+
+    def items(self):
+        return self.as_dict().items()
+
+    def keys(self):
+        return self.as_dict().keys()
+
+    def __iter__(self):
+        return iter(self.items())
 
 
 class ThesslaGreenDeviceScanner:
@@ -552,7 +559,9 @@ class ThesslaGreenDeviceScanner:
 
         # Basic firmware/serial information
         info_regs = await self._read_input(client, 0, 30) or []
-        major = minor = patch = None
+        major: int | None = None
+        minor: int | None = None
+        patch: int | None = None
         firmware_err: Exception | None = None
 
         for name in ("version_major", "version_minor", "version_patch"):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1519,3 +1519,9 @@ def test_device_capabilities_serialization():
     assert serialized["bypass_system"] is True
     # sets should be sorted lists for JSON serialization
     assert serialized["temperature_sensors"] == ["t1", "t2"]
+
+    # Iteration helpers should delegate to as_dict
+    # __iter__ should yield key/value pairs
+    assert list(caps) == list(serialized.items())
+    assert list(caps.keys()) == list(serialized.keys())
+    assert list(caps.items()) == list(serialized.items())


### PR DESCRIPTION
## Summary
- add items, keys, and iterator support to `DeviceCapabilities`
- test iteration support in config flow tests

## Testing
- `ruff check custom_components/thessla_green_modbus/scanner_core.py tests/test_config_flow.py`
- `mypy custom_components/thessla_green_modbus/scanner_core.py --follow-imports=skip --allow-untyped-defs --no-warn-return-any --disable-error-code=assignment --disable-error-code=unused-ignore`
- `pytest tests/test_config_flow.py::test_device_capabilities_serialization -q --override-ini=markers=asyncio`


------
https://chatgpt.com/codex/tasks/task_e_68aad26834788326a38f17a1b9c6e628