### PR TITLE
Persist ThesslaGreen capabilities across restarts

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -317,6 +317,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
                 f"{unique_host}:{self._data[CONF_PORT]}:{self._data[CONF_SLAVE_ID]}"
             )
             self._abort_if_unique_id_configured()
+            # Prepare capabilities for persistence
+            caps_obj = self._scan_result.get("capabilities")
+            if isinstance(caps_obj, DeviceCapabilities):
+                caps_dict = caps_obj.as_dict()
+            elif isinstance(caps_obj, dict):
+                try:
+                    caps_dict = DeviceCapabilities(**caps_obj).as_dict()
+                except (TypeError, ValueError):
+                    caps_dict = DeviceCapabilities().as_dict()
+            else:
+                caps_dict = DeviceCapabilities().as_dict()
+
             # Create entry with all data
             # Use both 'slave_id' and 'unit' for compatibility
             return self.async_create_entry(
@@ -327,6 +339,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
                     CONF_SLAVE_ID: self._data[CONF_SLAVE_ID],  # Standard key
                     "unit": self._data[CONF_SLAVE_ID],  # Legacy compatibility
                     CONF_NAME: self._data.get(CONF_NAME, DEFAULT_NAME),
+                    "capabilities": caps_dict,
                 },
                 options={CONF_DEEP_SCAN: self._data.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN)},
             )

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -162,6 +162,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Device info and capabilities
         self.device_info: dict[str, Any] = {}
         self.capabilities: DeviceCapabilities = DeviceCapabilities()
+        if entry and isinstance(entry.data.get("capabilities"), dict):
+            try:
+                self.capabilities = DeviceCapabilities(**entry.data["capabilities"])
+            except (TypeError, ValueError):
+                _LOGGER.debug("Invalid capabilities in config entry", exc_info=True)
         self.available_registers: dict[str, set[str]] = {
             "input_registers": set(),
             "holding_registers": set(),

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -125,7 +125,7 @@ class DeviceInfo:  # pragma: no cover
 # which features the device exposes; static analysis may therefore mark them
 # as unused even though they are relied upon.
 @dataclass
-class DeviceCapabilities:
+class DeviceCapabilities:  # pragma: no cover
     """Feature flags and sensor availability detected on the device.
 
     Although capabilities are typically determined once during the initial scan,
@@ -134,12 +134,17 @@ class DeviceCapabilities:
     new values.  The capability sets are mutable; modify them via assignment to
     trigger cache invalidation.
     """
-class DeviceCapabilities:  # pragma: no cover
-    """Feature flags and sensor availability detected on the device."""
+
     basic_control: bool = False
-    temperature_sensors: set[str] = field(default_factory=set)  # Names of temperature sensors
-    flow_sensors: set[str] = field(default_factory=set)  # Airflow sensor identifiers  # pragma: no cover
-    special_functions: set[str] = field(default_factory=set)  # Optional feature flags  # pragma: no cover
+    temperature_sensors: set[str] = field(
+        default_factory=set
+    )  # Names of temperature sensors
+    flow_sensors: set[str] = field(
+        default_factory=set
+    )  # Airflow sensor identifiers  # pragma: no cover
+    special_functions: set[str] = field(
+        default_factory=set
+    )  # Optional feature flags  # pragma: no cover
     expansion_module: bool = False  # pragma: no cover
     constant_flow: bool = False  # pragma: no cover
     gwc_system: bool = False  # pragma: no cover

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -229,7 +229,7 @@ async def test_form_user_success():
                 "firmware": "1.0",
                 "serial_number": "123",
             },
-            "capabilities": {"fan": True},
+            "capabilities": {"expansion_module": True},
             "register_count": 5,
         },
     }
@@ -270,15 +270,15 @@ async def test_form_user_success():
         result2 = await flow.async_step_confirm({})
 
     assert result2["type"] == "create_entry"
-    assert result2["type"] == "create_entry"
     assert result2["title"] == "My Device"
-    assert result2["data"] == {
-        CONF_HOST: "192.168.1.100",
-        CONF_PORT: 502,
-        "slave_id": 10,
-        "unit": 10,
-        CONF_NAME: "My Device",
-    }
+    data = result2["data"]
+    assert data[CONF_HOST] == "192.168.1.100"
+    assert data[CONF_PORT] == 502
+    assert data["slave_id"] == 10
+    assert data["unit"] == 10
+    assert data[CONF_NAME] == "My Device"
+    assert isinstance(data["capabilities"], dict)
+    assert data["capabilities"]["expansion_module"] is True
     assert result2["options"][CONF_DEEP_SCAN] is True
 
 
@@ -1261,6 +1261,8 @@ async def test_validate_input_capabilities_missing_fields():
         close=AsyncMock(),
     )
 
+    from custom_components.thessla_green_modbus import scanner_core
+
     orig_asdict = dataclasses.asdict
 
     def _missing_basic_control(obj):
@@ -1272,7 +1274,7 @@ async def test_validate_input_capabilities_missing_fields():
         "custom_components.thessla_green_modbus.config_flow.ThesslaGreenDeviceScanner.create",
         AsyncMock(return_value=scanner_instance),
     ), patch(
-        "custom_components.thessla_green_modbus.config_flow.dataclasses.asdict",
+        "custom_components.thessla_green_modbus.scanner_core.asdict",
         side_effect=_missing_basic_control,
     ):
         with pytest.raises(CannotConnect) as err:


### PR DESCRIPTION
## Summary
- store scanned device capabilities in config entry during configuration
- hydrate DeviceCapabilities from stored data when coordinator sets up
- add tests for capability persistence and fix DeviceCapabilities dataclass

## Testing
- `pytest tests/test_config_flow.py -q`
- `pytest tests/test_coordinator.py::test_async_write_invalid_register tests/test_coordinator.py::test_async_write_valid_register tests/test_coordinator.py::test_capabilities_loaded_from_config_entry -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad264c9688326b9e7a43fe4010ebb