### PR TITLE
feat: use serial-based unique IDs

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -24,6 +24,9 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     @property
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
+        serial = self.coordinator.device_info.get("serial_number")
+        if serial and serial != "Unknown":
+            return f"{DOMAIN}_{serial}_{self._key}"
         host = self.coordinator.host.replace(":", "-")
         return (
             f"{DOMAIN}_{host}_{self.coordinator.port}_"

--- a/tests/test_airflow_unit.py
+++ b/tests/test_airflow_unit.py
@@ -31,6 +31,7 @@ def _make_coordinator(unit):
     coord.host = "1.2.3.4"
     coord.port = 502
     coord.slave_id = 10
+    coord.device_info = {}
     coord.get_device_info.return_value = {}
     coord.entry = MagicMock()
     coord.entry.options = {CONF_AIRFLOW_UNIT: unit}

--- a/tests/test_legacy_entity_migration.py
+++ b/tests/test_legacy_entity_migration.py
@@ -78,6 +78,10 @@ async def test_legacy_fan_entity_migrated(hass, caplog):
     coordinator = MagicMock()
     coordinator.async_config_entry_first_refresh = AsyncMock()
     coordinator.async_setup = AsyncMock(return_value=True)
+    coordinator.host = host
+    coordinator.port = port
+    coordinator.slave_id = slave_id
+    coordinator.device_info = {"serial_number": "ABC123"}
     dummy_module.ThesslaGreenModbusCoordinator = MagicMock(return_value=coordinator)
 
     with (
@@ -98,7 +102,7 @@ async def test_legacy_fan_entity_migrated(hass, caplog):
         assert await async_setup_entry(hass, entry)  # nosec
 
     new_entity_id = "fan.rekuperator_fan"
-    new_unique_id = f"{DOMAIN}_{unique_host}_{port}_{slave_id}_fan"
+    new_unique_id = f"{DOMAIN}_ABC123_fan"
     assert registry.async_get(new_entity_id)  # nosec
     assert registry.entities[new_entity_id].unique_id == new_unique_id  # nosec
     assert old_entity_id not in registry.entities  # nosec


### PR DESCRIPTION
## Summary
- derive entity unique_id from device serial number when available
- migrate legacy host-based IDs to new serial format
- cover serial and legacy IDs in tests

## Testing
- `pytest tests/test_entity_unique_id.py tests/test_airflow_unit.py tests/test_legacy_entity_migration.py`
- `pytest` *(fails: ImportError: cannot import name 'ReadPlan' from 'custom_components.thessla_green_modbus.registers')*


------
https://chatgpt.com/codex/tasks/task_e_68aad263201483269e9b218859e0e6cb