### PR TITLE
Add test for register CSV conversion

### DIFF
--- a/tests/test_register_csv_conversion.py
+++ b/tests/test_register_csv_conversion.py
@@ -1,0 +1,27 @@
+"""Test CSV to JSON register conversion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.convert_registers_csv_to_json import convert
+
+
+def test_register_csv_conversion(tmp_path: Path) -> None:
+    """Ensure the converter output matches the committed JSON file."""
+
+    csv_path = Path("tools") / "modbus_registers.csv"
+    output_path = tmp_path / "registers.json"
+
+    convert(csv_path, output_path)
+
+    expected_path = (
+        Path("custom_components")
+        / "thessla_green_modbus"
+        / "registers"
+        / "thessla_green_registers_full.json"
+    )
+
+    assert output_path.read_text(encoding="utf-8") == expected_path.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
## Summary
- add regression test to verify Modbus register CSV converts to existing JSON

## Testing
- `pre-commit run --files tests/test_register_csv_conversion.py` *(fails: InvalidManifestError: .pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: ImportError: cannot import name 'ReadPlan' from 'custom_components.thessla_green_modbus.registers')*

------
https://chatgpt.com/codex/tasks/task_e_68aad4ae68208326b0aeed7109425b5b