### PR TITLE
Raise runtime error when register files missing or invalid

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -407,12 +407,12 @@ def _load_registers_from_file(
 
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:  # pragma: no cover - sanity check
-        _LOGGER.error("Register definition file missing: %s", path)
-        return []
-    except Exception:  # pragma: no cover - defensive
-        _LOGGER.exception("Failed to read register definitions from %s", path)
-        return []
+    except FileNotFoundError as err:  # pragma: no cover - sanity check
+        raise RuntimeError(f"Register definition file missing: {path}") from err
+    except Exception as err:  # pragma: no cover - defensive
+        raise RuntimeError(
+            f"Failed to read register definitions from {path}"
+        ) from err
 
     items = raw.get("registers", raw) if isinstance(raw, dict) else raw
 

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -1003,18 +1003,15 @@ class ThesslaGreenDeviceScanner:
         Dict[str, Tuple[Optional[int], Optional[int]]],
     ]:
         """Load Modbus register definitions and value ranges."""
-        try:
-            register_map: Dict[str, Dict[int, str]] = {"03": {}, "04": {}, "01": {}, "02": {}}
-            register_ranges: Dict[str, Tuple[Optional[int], Optional[int]]] = {}
-            for reg in get_all_registers():
-                if not reg.name:
-                    continue
-                register_map[reg.function][reg.address] = reg.name
-                if reg.min is not None or reg.max is not None:
-                    register_ranges[reg.name] = (reg.min, reg.max)
-            return register_map, register_ranges
-        except Exception as err:  # pragma: no cover - defensive
-            raise RuntimeError("Unable to load register definitions") from err
+        register_map: Dict[str, Dict[int, str]] = {"03": {}, "04": {}, "01": {}, "02": {}}
+        register_ranges: Dict[str, Tuple[Optional[int], Optional[int]]] = {}
+        for reg in get_all_registers():
+            if not reg.name:
+                continue
+            register_map[reg.function][reg.address] = reg.name
+            if reg.min is not None or reg.max is not None:
+                register_ranges[reg.name] = (reg.min, reg.max)
+        return register_map, register_ranges
 
     def _sleep_time(self, attempt: int) -> float:
         """Return delay for a retry attempt based on backoff."""

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -122,6 +122,29 @@ def test_duplicate_registers_raise_error(tmp_path, monkeypatch, registers) -> No
         loader._load_registers_from_file(path, file_hash="")
 
 
+def test_missing_register_file_raises_runtime_error(tmp_path) -> None:
+    """Missing register definition file should raise RuntimeError."""
+
+    from custom_components.thessla_green_modbus.registers import loader
+
+    path = tmp_path / "regs.json"
+    with pytest.raises(RuntimeError) as exc:
+        loader._load_registers_from_file(path, file_hash="")
+    assert str(path) in str(exc.value)
+
+
+def test_invalid_register_file_raises_runtime_error(tmp_path) -> None:
+    """Invalid register definition file should raise RuntimeError."""
+
+    from custom_components.thessla_green_modbus.registers import loader
+
+    path = tmp_path / "regs.json"
+    path.write_text("not json", encoding="utf-8")
+    with pytest.raises(RuntimeError) as exc:
+        loader._load_registers_from_file(path, file_hash="")
+    assert str(path) in str(exc.value)
+
+
 def test_register_file_sorted() -> None:
     """Ensure register JSON is sorted and loader preserves ordering."""
 


### PR DESCRIPTION
## Summary
- Raise `RuntimeError` with file path when register definition file is missing or invalid
- Let register loading errors bubble up in scanner core for clearer setup failures
- Add tests for missing/invalid register files

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py custom_components/thessla_green_modbus/scanner_core.py tests/test_register_loader.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoh6_9lroj/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: ImportError: cannot import name 'ReadPlan' from 'custom_components.thessla_green_modbus.registers')*
- `pytest tests/test_register_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68aad886053c83269e36585aeb656aa4