### PR TITLE
Mask IPv6 zone identifiers in diagnostics

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -107,11 +107,12 @@ def _redact_sensitive_data(data: dict[str, Any]) -> dict[str, Any]:
     def mask_ip(ip_str: str) -> str:
         """Return a redacted representation of an IP address."""
         try:
-            ip = ipaddress.ip_address(ip_str)
+            ip_str_clean = ip_str.split("%", 1)[0]
+            ip = ipaddress.ip_address(ip_str_clean)
         except ValueError:
             return ip_str
         if isinstance(ip, ipaddress.IPv4Address):
-            parts = ip_str.split(".")
+            parts = ip_str_clean.split(".")
             return f"{parts[0]}.xxx.xxx.{parts[3]}"
         segments = ip.exploded.split(":")
         return ":".join([segments[0]] + ["xxxx"] * 6 + [segments[-1]])

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -13,4 +13,8 @@ The Thessla Green Modbus integration exposes several fields via the Home Assista
 - `failed_addresses`: Addresses skipped during scanning due to errors.
 - `active_errors`: Currently active error or status codes with translations when available.
 
+All IP addresses shown in diagnostics are masked to hide network details. When an IPv6
+address includes a zone index (for example `fe80::1%eth0`), the zone portion is removed
+before masking so interface names are not revealed.
+
 These diagnostics make it easier to troubleshoot setup issues and confirm device behavior.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -18,6 +18,11 @@ registers_stub.plan_group_reads = lambda *args, **kwargs: []
 registers_stub.loader = SimpleNamespace(load=lambda *args, **kwargs: None)
 sys.modules["custom_components.thessla_green_modbus.registers"] = registers_stub
 sys.modules.setdefault("voluptuous", ModuleType("voluptuous"))
+sys.modules.setdefault("homeassistant.util", ModuleType("homeassistant.util"))
+sys.modules.setdefault("homeassistant.util.network", ModuleType("homeassistant.util.network"))
+config_flow_stub = ModuleType("custom_components.thessla_green_modbus.config_flow")
+config_flow_stub.CannotConnect = type("CannotConnect", (), {})
+sys.modules["custom_components.thessla_green_modbus.config_flow"] = config_flow_stub
 
 from custom_components.thessla_green_modbus.diagnostics import (
     _redact_sensitive_data,
@@ -54,6 +59,16 @@ def test_redact_ipv6_connection():
     redacted = _redact_sensitive_data(data)
 
     assert redacted["connection"]["host"] == ("2001:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:7334")
+
+
+def test_redact_ipv6_zone():
+    data = {"connection": {"host": "fe80::1%eth0"}}
+
+    redacted = _redact_sensitive_data(data)
+
+    assert redacted["connection"]["host"] == (
+        "fe80:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:0001"
+    )
 
 
 def test_original_diagnostics_unchanged():


### PR DESCRIPTION
## Summary
- redact IPv6 zone identifiers before masking IP addresses
- test diagnostics redaction for IPv6 addresses with zone index
- document that diagnostics strip zone indices from IP addresses

## Testing
- `pytest tests/test_diagnostics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad88b309483269279a54497f9449c