### PR TITLE
Add pydantic runtime dependency

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -15,6 +15,7 @@
     "registers/thessla_green_registers_full.json"
   ],
   "requirements": [
+    "pydantic>=2.0",
     "pymodbus>=3.5.0,<4.0.0",
     "voluptuous>=0.13.1"
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ requires-python = ">=3.12"
 dependencies = [
     "pymodbus>=3.5.0,<4.0.0",
     "voluptuous>=0.13.1",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@
 pymodbus>=3.5.0,<4.0.0
 
 # Data validation and schemas
+pydantic>=2.0
 voluptuous>=0.13.1


### PR DESCRIPTION
## Summary
- include `pydantic>=2.0` as runtime requirement
- expose `pydantic` in project metadata

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json requirements.txt pyproject.toml` *(fails: `/root/.cache/pre-commit/repowwmc6e47/.pre-commit-hooks.yaml is not a file`)*
- `python3.12 -m venv venv_pkg && source venv_pkg/bin/activate && pip install -e .`
- `python - <<'PY'
import importlib
try:
    importlib.import_module('custom_components.thessla_green_modbus')
    print('integration imported')
except Exception as e:
    print('import failed:', type(e).__name__, e)
PY` *(fails: `ModuleNotFoundError: No module named 'homeassistant'`)*

------
https://chatgpt.com/codex/tasks/task_e_68aad889f4b48326a62389645ee12d7d