### PR TITLE
Fix DeviceCapabilities dataclass definition

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -134,10 +134,8 @@ class DeviceInfo(collections.abc.Mapping):  # pragma: no cover
 # Attributes of this dataclass are read dynamically at runtime to determine
 # which features the device exposes; static analysis may therefore mark them
 # as unused even though they are relied upon.
-@dataclass
-class DeviceCapabilities(collections.abc.Mapping):  # pragma: no cover
 @dataclass(slots=True)
-class DeviceCapabilities:  # pragma: no cover
+class DeviceCapabilities(collections.abc.Mapping):  # pragma: no cover
     """Feature flags and sensor availability detected on the device.
 
     Although capabilities are typically determined once during the initial scan,


### PR DESCRIPTION
## Summary
- remove stray empty dataclass definition for DeviceCapabilities
- define DeviceCapabilities with slots and Mapping interface

## Testing
- `flake8` (fails: line too long E501 and others)
- `mypy .` (fails: missing modules and type annotations)
- `pytest` (fails: ModuleNotFoundError: No module named 'pydantic', etc.)


------
https://chatgpt.com/codex/tasks/task_e_68aadc1b257c83268dfe33e44ba07628