### PR TITLE
Fix DeviceCapabilities dataclass and mapping implementation

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -134,10 +134,8 @@ class DeviceInfo(collections.abc.Mapping):  # pragma: no cover
 # Attributes of this dataclass are read dynamically at runtime to determine
 # which features the device exposes; static analysis may therefore mark them
 # as unused even though they are relied upon.
-@dataclass
-class DeviceCapabilities(collections.abc.Mapping):  # pragma: no cover
 @dataclass(slots=True)
-class DeviceCapabilities:  # pragma: no cover
+class DeviceCapabilities(collections.abc.Mapping):  # pragma: no cover
     """Feature flags and sensor availability detected on the device.
 
     Although capabilities are typically determined once during the initial scan,


### PR DESCRIPTION
## Summary
- fix DeviceCapabilities definition by removing stray decorator and keeping a single `@dataclass(slots=True)` that inherits Mapping

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/scanner_core.py`
- `pytest` *(fails: AttributeError: module 'pydantic' has no attribute 'model_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68aadc0537ac832687da90479e582d4c