### PR TITLE
Update documentation URLs

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -6,7 +6,7 @@
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
+  "documentation": "https://github.com/blakinio/thesslagreen/blob/main/README_en.md",
   "homeassistant": ">=2025.7.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
   "name": "ThesslaGreen Modbus",
   "content_in_root": false,
   "render_readme": true,
-  "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha/blob/main/README_en.md",
+  "documentation": "https://github.com/blakinio/thesslagreen/blob/main/README_en.md",
   "domains": [
     "climate",
     "sensor",


### PR DESCRIPTION
## Summary
- point manifest documentation to current repo README
- point HACS metadata to current repo README

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/manifest.json`
- `python -m json.tool custom_components/thessla_green_modbus/manifest.json`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic'; IndentationError in scanner_core.py)*

------
https://chatgpt.com/codex/tasks/task_e_68aadc08d5b8832689d83bc9aff711d9