### PR TITLE
Validate Modbus slave ID bounds

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -112,7 +112,7 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> dict[str
     # Validate port and slave id ranges
     if not 1 <= port <= 65535:
         raise vol.Invalid("invalid_port")
-    if slave_id < 0:
+    if slave_id < 1:
         raise vol.Invalid("invalid_slave_low")
     if slave_id > 247:
         raise vol.Invalid("invalid_slave_high")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -874,7 +874,7 @@ async def test_validate_input_invalid_port(invalid_port: int):
 
 @pytest.mark.parametrize(
     ("invalid_slave", "err_code"),
-    [(-1, "invalid_slave_low"), (248, "invalid_slave_high")],
+    [(-1, "invalid_slave_low"), (0, "invalid_slave_low"), (248, "invalid_slave_high")],
 )
 async def test_validate_input_invalid_slave(invalid_slave: int, err_code: str):
     """Test validate_input rejects Device IDs outside valid range."""


### PR DESCRIPTION
## Summary
- ensure `validate_input` requires slave IDs between 1 and 247
- add unit test for slave ID 0

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py tests/test_config_flow.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo_4gbylqr/.pre-commit-hooks.yaml is not a file)*
- `python - <<'PY'
import sys
from types import SimpleNamespace
from unittest.mock import AsyncMock
sys.modules.setdefault(
    'custom_components.thessla_green_modbus.scanner_core',
    SimpleNamespace(
        DeviceCapabilities=SimpleNamespace,
        ThesslaGreenDeviceScanner=SimpleNamespace(create=AsyncMock()),
    ),
)
import pytest
raise SystemExit(pytest.main(['tests/test_config_flow.py::test_validate_input_invalid_slave']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aadc0da10c8326a1ba4dce00d9b728