### PR TITLE
Rename scanner DeviceInfo dataclass to avoid name clash

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -84,12 +84,15 @@ def _build_register_maps() -> None:
     )
 
 
+# Ensure register lookup maps are available before use
 def _ensure_register_maps() -> None:
     """Ensure register lookup maps are populated."""
     if not REGISTER_DEFINITIONS:
         _build_register_maps()
+
+
 @dataclass
-class DeviceInfo(collections.abc.Mapping):  # pragma: no cover
+class ScannerDeviceInfo(collections.abc.Mapping):  # pragma: no cover
     """Basic identifying information about a ThesslaGreen unit.
 
     The attributes are populated dynamically and accessed via ``as_dict`` in
@@ -581,7 +584,7 @@ class ThesslaGreenDeviceScanner:
         if client is None:
             raise ConnectionException("Client not connected")
 
-        device = DeviceInfo()
+        device = ScannerDeviceInfo()
 
         # Basic firmware/serial information
         info_regs = await self._read_input(client, 0, 30) or []

--- a/tests/test_device_mapping.py
+++ b/tests/test_device_mapping.py
@@ -1,10 +1,15 @@
 from collections.abc import Mapping
 
-from custom_components.thessla_green_modbus.scanner_core import DeviceInfo, DeviceCapabilities
+from custom_components.thessla_green_modbus.scanner_core import (
+    ScannerDeviceInfo,
+    DeviceCapabilities,
+)
 
 
 def test_device_info_mapping_and_values() -> None:
-    info = DeviceInfo(model="m", firmware="f", serial_number="s", capabilities=["c"])
+    info = ScannerDeviceInfo(
+        model="m", firmware="f", serial_number="s", capabilities=["c"]
+    )
     assert isinstance(info, Mapping)
     assert list(info.values()) == list(info.as_dict().values())
 

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -10,7 +10,7 @@ from custom_components.thessla_green_modbus.const import SENSOR_UNAVAILABLE
 from custom_components.thessla_green_modbus.registers import get_registers_by_function
 from custom_components.thessla_green_modbus.scanner_core import (
     DeviceCapabilities,
-    DeviceInfo,
+    ScannerDeviceInfo,
     ThesslaGreenDeviceScanner,
 )
 from custom_components.thessla_green_modbus.scanner_helpers import _format_register_value
@@ -1323,7 +1323,9 @@ async def test_capability_rules_detect_heating_and_bypass():
 async def test_scan_device_includes_capabilities_in_device_info():
     """Detected capabilities are exposed on device info returned by scanner."""
     scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
-    info = DeviceInfo(model="m", firmware="f", serial_number="s", capabilities=["heating_system"])
+    info = ScannerDeviceInfo(
+        model="m", firmware="f", serial_number="s", capabilities=["heating_system"]
+    )
     caps = DeviceCapabilities(heating_system=True)
 
     with patch.object(scanner, "scan", AsyncMock(return_value=(info, caps, {}))):


### PR DESCRIPTION
## Summary
- rename DeviceInfo dataclass to ScannerDeviceInfo
- update imports and references in tests

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ReadPlan' from 'custom_components.thessla_green_modbus.registers')*

------
https://chatgpt.com/codex/tasks/task_e_68aae0cfd92c83269e6e878a3b6bb219