### PR TITLE
docs: update manifest documentation link

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -6,7 +6,7 @@
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/blakinio/thesslagreen/blob/main/README_en.md",
+  "documentation": "https://github.com/blakinio/thesslagreen/blob/main/README.md",
   "homeassistant": ">=2025.7.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",


### PR DESCRIPTION
## Summary
- point manifest documentation to this repository's README

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/manifest.json`
- `python -m py_compile custom_components/thessla_green_modbus/manifest.json`
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json` *(fails: InvalidManifestError from home-assistant/actions repo)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aae0c9b47c8326aeaa04be2397d748