### PR TITLE
docs: describe registers map generation and ignore output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+custom_components/thessla_green_modbus/registers.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,11 +101,21 @@ pre-commit run --all-files
 
 Register addresses are defined in
 `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`
-and this file serves as the sole source of truth.  The integration reads the
-JSON directly; if you require a static Python mapping for other tools, run:
+and this file serves as the sole source of truth. The integration reads the JSON
+directly.
+
+If you need a static Python mapping for external tools, generate
+`custom_components/thessla_green_modbus/registers.py` using:
 
 ```bash
 python tools/generate_registers.py
+```
+
+The generated file is ignored by Git and should not be committed. You can verify
+that it matches the JSON source with:
+
+```bash
+python tools/validate_registers.py
 ```
 
 The test suite ensures the JSON definitions remain valid.

--- a/README.md
+++ b/README.md
@@ -502,11 +502,14 @@ Integracja korzysta bezpośrednio z pliku
 `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`,
 który stanowi jedyne źródło prawdy o rejestrach. Skrypt
 `tools/generate_registers.py` może wygenerować pomocniczy moduł
-`registers.py` dla zewnętrznych narzędzi, lecz plik ten nie jest
-przechowywany w repozytorium.
+`custom_components/thessla_green_modbus/registers.py` dla zewnętrznych
+narzędzi. Plik ten jest ignorowany przez Git (`.gitignore`) i nie powinien być
+przechowywany w repozytorium. Mapę można zweryfikować skryptem
+`tools/validate_registers.py`.
 
 ```bash
 python tools/generate_registers.py  # jeśli potrzebujesz statycznej mapy
+python tools/validate_registers.py  # opcjonalna walidacja
 ```
 
 ### Validate translations

--- a/README_en.md
+++ b/README_en.md
@@ -280,11 +280,13 @@ only for diagnostic purposes.
 The integration reads register definitions directly from
 `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`,
 which is the single source of truth. The script `tools/generate_registers.py`
-can create a helper `registers.py` module for external tools, but this file is
-not stored in the repository.
+can create a helper `custom_components/thessla_green_modbus/registers.py` module
+for external tools. The generated file is ignored via `.gitignore` and should
+not be committed. You can validate the mapping with `tools/validate_registers.py`.
 
 ```bash
 python tools/generate_registers.py  # if a static mapping is required
+python tools/validate_registers.py  # optional validation
 ```
 
 ### Validate translations


### PR DESCRIPTION
## Summary
- ignore generated `registers.py`
- document how to generate and validate the optional `registers.py` mapping

## Testing
- `python -m pre_commit run --files .gitignore README.md README_en.md CONTRIBUTING.md` *(fails: InvalidManifestError: /root/.cache/pre-commit/repohs1xlut1/.pre-commit-hooks.yaml is not a file)*
- `python tools/py_compile_all.py`
- `pytest tests -q` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aae669254483268b3cbf644453fe66