### PR TITLE
Reduce default Modbus block size

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pełne skanowanie wszystkich rejestrów (`full_register_scan=True`) i zwraca
 listę nieznanych adresów. Operacja może trwać kilka minut i znacząco obciąża
 urządzenie – używaj jej tylko do diagnostyki.
 ### Użycie `group_reads`
-Funkcja `group_reads` dzieli listę adresów na ciągłe bloki ograniczone parametrem `max_block_size` (domyślnie 64). Własne skrypty powinny z niej korzystać, aby minimalizować liczbę zapytań i nie przekraczać zalecanego rozmiaru bloku. W razie problemów z komunikacją można zmniejszyć `max_block_size`, np. do 16, co zapewnia stabilniejszy odczyt.
+Funkcja `group_reads` dzieli listę adresów na ciągłe bloki ograniczone parametrem `max_block_size` (domyślnie 16). Własne skrypty powinny z niej korzystać, aby minimalizować liczbę zapytań i nie przekraczać zalecanego rozmiaru bloku.
 
 ```python
 from custom_components.thessla_green_modbus.modbus_helpers import group_reads

--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -83,7 +83,7 @@ async def _call_modbus(
     return response
 
 
-def group_reads(addresses: Iterable[int], max_block_size: int = 64) -> List[Tuple[int, int]]:
+def group_reads(addresses: Iterable[int], max_block_size: int = 16) -> List[Tuple[int, int]]:
     """Group raw register addresses into contiguous read blocks.
 
     The addresses are sorted and sequential ranges are merged up to

--- a/custom_components/thessla_green_modbus/scanner_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner_helpers.py
@@ -74,8 +74,9 @@ SPECIAL_VALUE_DECODERS: Dict[str, Callable[[int], Optional[int]]] = {
     "season_mode": _decode_season_mode,
 }
 
-# Maximum registers per batch read (Modbus limit)
-MAX_BATCH_REGISTERS = 64
+# Maximum registers per batch read
+# A smaller default improves stability on some devices.
+MAX_BATCH_REGISTERS = 16
 
 # Optional UART configuration registers (Air-B and Air++ ports)
 # According to the Series 4 Modbus documentation, both the Air-B

--- a/tests/test_group_reads.py
+++ b/tests/test_group_reads.py
@@ -17,8 +17,8 @@ def test_group_reads_merges_consecutive_addresses():
 
 
 def test_group_reads_respects_max_block_size():
-    addresses = list(range(70))
-    assert group_reads(addresses, max_block_size=64) == [(0, 64), (64, 6)]
+    addresses = list(range(22))
+    assert group_reads(addresses, max_block_size=16) == [(0, 16), (16, 6)]
 def test_plan_group_reads_merges_consecutive_addresses(monkeypatch):
     regs = [
         Register("input", addr, f"r{addr}", "r")
@@ -29,11 +29,11 @@ def test_plan_group_reads_merges_consecutive_addresses(monkeypatch):
 
 
 def test_plan_group_reads_respects_max_block_size(monkeypatch):
-    regs = [Register("input", addr, f"r{addr}", "r") for addr in range(70)]
+    regs = [Register("input", addr, f"r{addr}", "r") for addr in range(22)]
     monkeypatch.setattr(loader, "_load_registers", lambda: regs)
-    assert plan_group_reads(max_block_size=64) == [
-        ReadPlan("input", 0, 64),
-        ReadPlan("input", 64, 6),
+    assert plan_group_reads(max_block_size=16) == [
+        ReadPlan("input", 0, 16),
+        ReadPlan("input", 16, 6),
     ]
 
 

--- a/tests/test_group_reads_max_size.py
+++ b/tests/test_group_reads_max_size.py
@@ -5,7 +5,8 @@ def test_group_reads_respects_max_block_size() -> None:
     """group_reads splits long address ranges based on ``max_block_size``."""
 
     addresses = list(range(40))
-    scanner = ThesslaGreenDeviceScanner("host", 502, scan_max_block_size=16)
+    scanner = ThesslaGreenDeviceScanner("host", 502)
+    scanner._known_missing_addresses = set()
     assert scanner._group_registers_for_batch_read(addresses) == [
         (0, 16),
         (16, 16),


### PR DESCRIPTION
## Summary
- lower group_reads default block size to 16
- default scanner batch size reduced to 16
- update tests and docs for new defaults

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/modbus_helpers.py custom_components/thessla_green_modbus/scanner_helpers.py tests/test_group_reads.py tests/test_group_reads_max_size.py README.md` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoz2r8ovir/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_group_reads.py -k test_group_reads_respects_max_block_size -q` *(fails: pydantic_core._pydantic_core.ValidationError: address_hex does not match address_dec)*

------
https://chatgpt.com/codex/tasks/task_e_68aae67d2e408326a83a3837e7a3055d