### PR TITLE
chore: relax pymodbus requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped minimum Home Assistant version to 2025.1.0
 - Regenerated Modbus register definitions from CSV and updated coverage test
 - Assigned new unique IDs for m³/h airflow sensors
+- Simplified runtime dependencies; only require `pymodbus>=3.5.0`
 
 ### Removed
 - Custom Modbus client in favor of native AsyncModbusTcpClient

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -15,11 +15,9 @@
     "registers/thessla_green_registers_full.json"
   ],
   "requirements": [
-    "pydantic>=2.0",
-    "pymodbus>=3.5.0,<4.0.0",
-    "voluptuous>=0.13.1"
+    "pymodbus>=3.5.0"
   ],
-  "version": "2.1.1",
+  "version": "2.1.2",
   "integration_type": "hub",
   "dhcp": [
     {

--- a/hacs.json
+++ b/hacs.json
@@ -12,5 +12,5 @@
     "switch"
   ],
   "iot_class": "local_polling",
-  "version": "2.1.1"
+  "version": "2.1.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thessla-green-modbus"
-version = "2.1.1"
+version = "2.1.2"
 description = "ThesslaGreen Modbus integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}
@@ -24,9 +24,7 @@ classifiers = [
 requires-python = ">=3.12"
 # Core dependencies
 dependencies = [
-    "pymodbus>=3.5.0,<4.0.0",
-    "voluptuous>=0.13.1",
-    "pydantic>=2.0",
+    "pymodbus>=3.5.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,4 @@
 # (minimum version declared in manifest.json)
 
 # Modbus communication library
-pymodbus>=3.5.0,<4.0.0
-
-# Data validation and schemas
-pydantic>=2.0
-voluptuous>=0.13.1
+pymodbus>=3.5.0


### PR DESCRIPTION
## Summary
- simplify runtime requirements to only `pymodbus>=3.5.0`
- drop extra dependencies from package metadata
- bump integration version to 2.1.2

## Testing
- `pip install homeassistant==2025.7.1` *(failed: No matching distribution found)*
- `pytest tests/test_modbus_helpers.py -q` *(failed: ValidationError in RegisterDefinition)*


------
https://chatgpt.com/codex/tasks/task_e_68aae664717083269378d3f4a4af8183