### PR TITLE
feat: validate register definitions

### DIFF
--- a/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
+++ b/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
@@ -4087,7 +4087,7 @@
     },
     {
       "function": "03",
-      "address_dec": 8392,
+      "address_dec": 8394,
       "address_hex": "0x20CA",
       "name": "e200",
       "access": "R/W",
@@ -4103,7 +4103,7 @@
     },
     {
       "function": "03",
-      "address_dec": 8393,
+      "address_dec": 8395,
       "address_hex": "0x20CB",
       "name": "e201",
       "access": "R/W",


### PR DESCRIPTION
## Summary
- add Pydantic schema checks for register definitions and list
- ensure register JSON addresses match their hex values
- test loader rejects invalid registers

## Testing
- `black custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py`
- `isort custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py --profile=black --line-length=79`
- `ruff check custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py`
- `flake8 custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py --max-line-length=100 --extend-ignore=E203`
- `mypy custom_components/thessla_green_modbus/registers/loader.py` *(fails: Incompatible types in assignment, missing annotations)*
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py` *(fails: InvalidManifestError: .pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_register_loader.py tests/test_register_loader_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68aae66875c48326b012a76a17877db0