### PR TITLE
Add extended diagnostics metrics

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1193,6 +1193,13 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if statistics.get("last_successful_update"):
             statistics["last_successful_update"] = statistics["last_successful_update"].isoformat()
         total_registers = sum(len(v) for v in self.available_registers.values())
+        total_registers_json = len(get_all_registers())
+        batch_sizes = [
+            count
+            for groups in self._register_groups.values()
+            for _, count in groups
+        ]
+        effective_batch = max(batch_sizes, default=0)
         error_stats = {
             "connection_errors": statistics.get("connection_errors", 0),
             "timeout_errors": statistics.get("timeout_errors", 0),
@@ -1213,6 +1220,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "last_scan": self.last_scan.isoformat() if self.last_scan else None,
             "firmware_version": self.device_info.get("firmware"),
             "total_available_registers": total_registers,
+            "total_registers_json": total_registers_json,
+            "effective_batch": effective_batch,
+            "deep_scan": self.deep_scan,
+            "force_full_register_list": self.force_full_register_list,
             "error_statistics": error_stats,
         }
 

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -3,7 +3,13 @@
   "auto_detected_note_success": "Auto-detection successful!",
   "diagnostics": {
     "registers_hash": "Register definitions hash",
-    "capabilities": "Device capabilities"
+    "capabilities": "Device capabilities",
+    "effective_batch": "Effective batch size",
+    "total_registers_json": "Total registers in JSON",
+    "total_available_registers": "Total available registers",
+    "deep_scan": "Deep scan enabled",
+    "force_full_register_list": "Force full register list",
+    "error_statistics": "Error statistics"
   },
   "config": {
     "abort": {

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -3,7 +3,13 @@
   "auto_detected_note_success": "Auto-detection successful!",
   "diagnostics": {
     "registers_hash": "Register definitions hash",
-    "capabilities": "Device capabilities"
+    "capabilities": "Device capabilities",
+    "effective_batch": "Effective batch size",
+    "total_registers_json": "Total registers in JSON",
+    "total_available_registers": "Total available registers",
+    "deep_scan": "Deep scan enabled",
+    "force_full_register_list": "Force full register list",
+    "error_statistics": "Error statistics"
   },
   "config": {
     "abort": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -3,7 +3,13 @@
   "auto_detected_note_success": "Automatyczne wykrywanie zakończone sukcesem!",
   "diagnostics": {
     "registers_hash": "Suma kontrolna rejestrów",
-    "capabilities": "Możliwości urządzenia"
+    "capabilities": "Możliwości urządzenia",
+    "effective_batch": "Efektywny rozmiar partii",
+    "total_registers_json": "Łączna liczba rejestrów w JSON",
+    "total_available_registers": "Łączna liczba dostępnych rejestrów",
+    "deep_scan": "Włączony głęboki skan",
+    "force_full_register_list": "Wymuś pełną listę rejestrów",
+    "error_statistics": "Statystyki błędów"
   },
   "config": {
     "abort": {

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -100,6 +100,8 @@ async def test_last_scan_in_diagnostics():
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
+            self.deep_scan = False
+            self.force_full_register_list = False
 
         def get_diagnostic_data(self):
             return {}
@@ -135,6 +137,8 @@ async def test_additional_diagnostic_fields():
             }
             self.statistics = {"connection_errors": 2, "timeout_errors": 1}
             self.capabilities = SimpleNamespace(as_dict=lambda: {"fan": True})
+            self.deep_scan = True
+            self.force_full_register_list = False
 
         def get_diagnostic_data(self):
             return {}
@@ -158,6 +162,10 @@ async def test_additional_diagnostic_fields():
         "connection_errors": 2,
         "timeout_errors": 1,
     }
+    assert result["total_registers_json"] == 0
+    assert result["effective_batch"] == 0
+    assert result["deep_scan"] is True
+    assert result["force_full_register_list"] is False
     assert result["last_scan"] == last_scan.isoformat()
 
 
@@ -185,6 +193,8 @@ async def test_unknown_registers_in_diagnostics():
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {"fan": True})
             self.unknown_registers = scan_result["unknown_registers"]
+            self.deep_scan = False
+            self.force_full_register_list = False
 
         def get_diagnostic_data(self):
             return {}
@@ -229,6 +239,8 @@ async def test_raw_registers_in_diagnostics():
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
+            self.deep_scan = False
+            self.force_full_register_list = False
 
         def get_diagnostic_data(self):
             return {}
@@ -269,6 +281,8 @@ async def test_diagnostics_json_serializable():
                 temperature_sensors={"t1", "t2"},
                 flow_sensors={"f1"},
             )
+            self.deep_scan = False
+            self.force_full_register_list = False
 
         def get_diagnostic_data(self):
             return {}
@@ -305,6 +319,8 @@ async def test_translation_failure_handled(caplog):
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
+            self.deep_scan = False
+            self.force_full_register_list = False
 
         def get_diagnostic_data(self):
             return {}


### PR DESCRIPTION
## Summary
- expose additional diagnostic metrics including batch size, register counts, and scan flags
- surface diagnostic fields with translation strings
- test diagnostics include new metrics

## Testing
- `pytest tests/test_diagnostics.py`
- `pytest tests/test_diagnostics.py tests/test_coordinator.py` *(fails: ValidationError for RegisterDefinition)*


------
https://chatgpt.com/codex/tasks/task_e_68aae66335c08326a0bcb94648c29434