### PR TITLE
Refactor ThesslaGreen unique IDs to address-based format

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -52,7 +52,10 @@ async def async_setup_entry(
 
         # Check if this register is available on the device
         if register_name in coordinator.available_registers.get(register_type, set()):
-            entities.append(ThesslaGreenBinarySensor(coordinator, register_name, sensor_def))
+            address = coordinator._register_maps[register_type][register_name]
+            entities.append(
+                ThesslaGreenBinarySensor(coordinator, register_name, address, sensor_def)
+            )
             _LOGGER.debug("Created binary sensor: %s", sensor_def["translation_key"])
 
     if entities:
@@ -83,10 +86,11 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         register_name: str,
+        address: int,
         sensor_definition: Dict[str, Any],
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(coordinator, register_name)
+        super().__init__(coordinator, register_name, address)
 
         self._register_name = register_name
         self._sensor_def = sensor_definition

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -66,10 +66,12 @@ async def async_setup_entry(
     # ThesslaGreenDeviceScanner.scan_device()
     for register_name, entity_config in number_mappings.items():
         if register_name in coordinator.available_registers.get("holding_registers", set()):
+            address = HOLDING_REGISTERS[register_name]
             entities.append(
                 ThesslaGreenNumber(
                     coordinator=coordinator,
                     register_name=register_name,
+                    address=address,
                     entity_config=entity_config,
                     register_type="holding_registers",
                 )
@@ -101,11 +103,12 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         register_name: str,
+        address: int,
         entity_config: dict[str, Any],
         register_type: str | None = None,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(coordinator, register_name)
+        super().__init__(coordinator, register_name, address)
 
         self.register_name = register_name
         self.entity_config = entity_config
@@ -213,7 +216,8 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
 
         # Add register information
         attributes["register_name"] = self.register_name
-        attributes["register_address"] = f"0x{HOLDING_REGISTERS.get(self.register_name, 0):04X}"
+        register_address = self._address if self._address is not None else 0
+        attributes["register_address"] = f"0x{register_address:04X}"
 
         # Add raw value for debugging
         if self.register_name in self.coordinator.data:

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -41,7 +41,10 @@ async def async_setup_entry(
     for register_name, select_def in ENTITY_MAPPINGS["select"].items():
         register_type = select_def["register_type"]
         if register_name in coordinator.available_registers.get(register_type, set()):
-            entities.append(ThesslaGreenSelect(coordinator, register_name, select_def))
+            address = coordinator._register_maps[register_type][register_name]
+            entities.append(
+                ThesslaGreenSelect(coordinator, register_name, address, select_def)
+            )
 
     if entities:
         try:
@@ -66,9 +69,10 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         register_name: str,
+        address: int,
         definition: dict[str, Any],
     ) -> None:
-        super().__init__(coordinator, register_name)
+        super().__init__(coordinator, register_name, address)
         self._register_name = register_name
 
         self._attr_translation_key = definition["translation_key"]  # pragma: no cover

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -57,7 +57,10 @@ async def async_setup_entry(
 
         # Check if this register is available on the device
         if register_name in coordinator.available_registers.get(register_type, set()):
-            entities.append(ThesslaGreenSensor(coordinator, register_name, sensor_def))
+            address = coordinator._register_maps[register_type][register_name]
+            entities.append(
+                ThesslaGreenSensor(coordinator, register_name, address, sensor_def)
+            )
             _LOGGER.debug("Created sensor: %s", sensor_def["translation_key"])
             if is_temp:
                 temp_created += 1
@@ -108,10 +111,11 @@ class ThesslaGreenSensor(ThesslaGreenEntity, SensorEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         register_name: str,
+        address: int,
         sensor_definition: dict[str, Any],
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, register_name)
+        super().__init__(coordinator, register_name, address)
 
         self._register_name = register_name
         self._sensor_def = sensor_definition

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -58,10 +58,15 @@ async def async_setup_entry(
                 is_available = True
 
         if is_available:
+            if config["register_type"] == "holding_registers":
+                address = HOLDING_REGISTERS[register_name]
+            else:
+                address = COIL_REGISTERS[register_name]
             entities.append(
                 ThesslaGreenSwitch(
                     coordinator=coordinator,
                     key=key,
+                    address=address,
                     entity_config=config,
                 )
             )
@@ -94,10 +99,11 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         key: str,
+        address: int,
         entity_config: dict[str, Any],
     ) -> None:
         """Initialize the switch entity."""
-        super().__init__(coordinator, key)
+        super().__init__(coordinator, key, address, bit=entity_config.get("bit"))
 
         self.entity_config = entity_config
         self.register_name = entity_config["register"]
@@ -178,11 +184,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
         attributes["register_name"] = self.register_name
         register_type = self.entity_config["register_type"]
 
-        if register_type == "holding_registers":
-            register_address = HOLDING_REGISTERS.get(self.register_name, 0)
-        else:
-            register_address = COIL_REGISTERS.get(self.register_name, 0)
-
+        register_address = self._address if self._address is not None else 0
         attributes["register_address"] = f"0x{register_address:04X}"
         attributes["register_type"] = register_type
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -412,6 +412,13 @@ def mock_config_entry():
 @pytest.fixture
 def mock_coordinator():
     """Return a mock coordinator."""
+    from custom_components.thessla_green_modbus.const import (
+        COIL_REGISTERS,
+        DISCRETE_INPUT_REGISTERS,
+        HOLDING_REGISTERS,
+        INPUT_REGISTERS,
+    )
+
     coordinator = CoordinatorMock()
     coordinator.host = "192.168.1.100"
     coordinator.port = 502
@@ -443,6 +450,12 @@ def mock_coordinator():
         "coil_registers": {"power_supply_fans", "bypass"},
         "discrete_inputs": {"expansion", "contamination_sensor"},
         "calculated": {"estimated_power", "total_energy"},
+    }
+    coordinator._register_maps = {
+        "input_registers": INPUT_REGISTERS,
+        "holding_registers": HOLDING_REGISTERS,
+        "coil_registers": COIL_REGISTERS,
+        "discrete_inputs": DISCRETE_INPUT_REGISTERS,
     }
     coordinator.async_write_register = AsyncMock(return_value=True)
     coordinator.async_request_refresh = AsyncMock()

--- a/tests/test_airflow_unit.py
+++ b/tests/test_airflow_unit.py
@@ -41,11 +41,12 @@ def _make_coordinator(unit):
 
 def test_unique_id_same_for_all_units():
     coord = _make_coordinator(AIRFLOW_UNIT_PERCENTAGE)
-    entity = ThesslaGreenEntity(coord, "supply_flow_rate")
+    address = 274
+    entity = ThesslaGreenEntity(coord, "supply_flow_rate", address)
     uid_percentage = entity.unique_id
 
     coord.entry.options[CONF_AIRFLOW_UNIT] = AIRFLOW_UNIT_M3H
-    entity = ThesslaGreenEntity(coord, "supply_flow_rate")
+    entity = ThesslaGreenEntity(coord, "supply_flow_rate", address)
     uid_m3h = entity.unique_id
 
     assert uid_percentage == uid_m3h  # nosec
@@ -55,7 +56,8 @@ def test_sensor_converts_to_percentage():
     coord = _make_coordinator(AIRFLOW_UNIT_PERCENTAGE)
     coord.data.update({"supply_flow_rate": 150, "nominal_supply_air_flow": 300})
     sensor_def = SENSOR_ENTITY_MAPPINGS["supply_flow_rate"]
-    sensor = ThesslaGreenSensor(coord, "supply_flow_rate", sensor_def)
+    address = 274
+    sensor = ThesslaGreenSensor(coord, "supply_flow_rate", address, sensor_def)
     assert sensor.native_unit_of_measurement == PERCENTAGE
     assert sensor.native_value == 50
 
@@ -64,6 +66,7 @@ def test_sensor_reports_m3h_by_default():
     coord = _make_coordinator(AIRFLOW_UNIT_M3H)
     coord.data.update({"supply_flow_rate": 150})
     sensor_def = SENSOR_ENTITY_MAPPINGS["supply_flow_rate"]
-    sensor = ThesslaGreenSensor(coord, "supply_flow_rate", sensor_def)
+    address = 274
+    sensor = ThesslaGreenSensor(coord, "supply_flow_rate", address, sensor_def)
     assert sensor.native_unit_of_measurement == UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR
     assert sensor.native_value == 150

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -66,8 +66,9 @@ def test_binary_sensor_creation_and_state(mock_coordinator: MagicMock) -> None:
     # Prepare coordinator data
     mock_coordinator.data["bypass"] = 0
 
+    address = 9
     sensor = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", BINARY_SENSOR_DEFINITIONS["bypass"]
+        mock_coordinator, "bypass", address, BINARY_SENSOR_DEFINITIONS["bypass"]
     )
     assert sensor.is_on is False  # nosec B101
 
@@ -81,9 +82,11 @@ def test_binary_sensor_icons(mock_coordinator: MagicMock) -> None:
 
     # Heating cable uses a heating icon when on
     mock_coordinator.data["heating_cable"] = 1
+    address = 12
     heating = ThesslaGreenBinarySensor(
         mock_coordinator,
         "heating_cable",
+        address,
         BINARY_SENSOR_DEFINITIONS["heating_cable"],
     )
     assert heating.icon == "mdi:heating-coil"  # nosec B101
@@ -94,8 +97,9 @@ def test_binary_sensor_icons(mock_coordinator: MagicMock) -> None:
 
     # Bypass uses pipe leak icon when active
     mock_coordinator.data["bypass"] = 1
+    address = 9
     bypass_sensor = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", BINARY_SENSOR_DEFINITIONS["bypass"]
+        mock_coordinator, "bypass", address, BINARY_SENSOR_DEFINITIONS["bypass"]
     )
     assert bypass_sensor.icon == "mdi:pipe-leak"  # nosec B101
 
@@ -109,7 +113,10 @@ def test_binary_sensor_icon_fallback(mock_coordinator: MagicMock) -> None:
     mock_coordinator.data["bypass"] = 1
     sensor_def = BINARY_SENSOR_DEFINITIONS["bypass"].copy()
     sensor_def.pop("icon", None)
-    sensor_without_icon = ThesslaGreenBinarySensor(mock_coordinator, "bypass", sensor_def)
+    address = 9
+    sensor_without_icon = ThesslaGreenBinarySensor(
+        mock_coordinator, "bypass", address, sensor_def
+    )
     assert sensor_without_icon.icon == "mdi:fan-off"  # nosec B101
 
 

--- a/tests/test_entity_unique_id.py
+++ b/tests/test_entity_unique_id.py
@@ -23,8 +23,8 @@ def test_unique_id_serial_based():
     coordinator.device_info = {"serial_number": "ABC123"}
     coordinator.get_device_info.return_value = {}
 
-    entity = ThesslaGreenEntity(coordinator, "test")
-    assert entity.unique_id == f"{DOMAIN}_ABC123_test"  # nosec
+    entity = ThesslaGreenEntity(coordinator, "test", 1)
+    assert entity.unique_id == f"{DOMAIN}_ABC123_10_1"  # nosec
 
 
 def test_unique_id_host_fallback():
@@ -36,8 +36,8 @@ def test_unique_id_host_fallback():
     coordinator.device_info = {}
     coordinator.get_device_info.return_value = {}
 
-    entity = ThesslaGreenEntity(coordinator, "test")
-    assert entity.unique_id == f"{DOMAIN}_fd00-1-2--1_502_10_test"  # nosec
+    entity = ThesslaGreenEntity(coordinator, "test", 2)
+    assert entity.unique_id == f"{DOMAIN}_fd00-1-2--1_502_10_2"  # nosec
 
 
 def test_unique_id_not_changed_by_airflow_unit():
@@ -51,11 +51,12 @@ def test_unique_id_not_changed_by_airflow_unit():
     coordinator.entry = MagicMock()
     coordinator.entry.options = {CONF_AIRFLOW_UNIT: AIRFLOW_UNIT_PERCENTAGE}
 
-    entity = ThesslaGreenEntity(coordinator, "supply_flow_rate")
+    address = 274
+    entity = ThesslaGreenEntity(coordinator, "supply_flow_rate", address)
     uid_percentage = entity.unique_id
 
     coordinator.entry.options[CONF_AIRFLOW_UNIT] = AIRFLOW_UNIT_M3H
-    entity = ThesslaGreenEntity(coordinator, "supply_flow_rate")
+    entity = ThesslaGreenEntity(coordinator, "supply_flow_rate", address)
     uid_m3h = entity.unique_id
 
     assert uid_percentage == uid_m3h  # nosec
@@ -123,7 +124,8 @@ async def test_migrate_entity_unique_ids(hass):
     )
 
     registry = FakeRegistry()
-    old_unique_id = f"{DOMAIN}_{host}_{port}_{slave_id}_sensor"
+    address = 274
+    old_unique_id = f"{DOMAIN}_{host}_{port}_{slave_id}_supply_flow_rate"
     dummy_entry = DummyEntry("sensor.test", old_unique_id, "sensor", DOMAIN)
     registry.entities[dummy_entry.entity_id] = dummy_entry
 
@@ -151,7 +153,20 @@ async def test_migrate_entity_unique_ids(hass):
 
         assert await async_setup_entry(hass, entry)  # nosec
 
-    new_unique_id = f"{DOMAIN}_ABC123_sensor"
+    new_unique_id = f"{DOMAIN}_ABC123_{slave_id}_{address}"
     entity_id = registry.async_get_entity_id("sensor", DOMAIN, new_unique_id)
     assert entity_id is not None  # nosec
     assert registry.entities[entity_id].unique_id == new_unique_id  # nosec
+
+
+def test_unique_id_bit_suffix():
+    """Bit-based entities should include bit position in unique_id."""
+    coordinator = MagicMock()
+    coordinator.host = "1.2.3.4"
+    coordinator.port = 502
+    coordinator.slave_id = 10
+    coordinator.device_info = {"serial_number": "ABC123"}
+    coordinator.get_device_info.return_value = {}
+
+    entity = ThesslaGreenEntity(coordinator, "test", 5, bit=0x04)
+    assert entity.unique_id == f"{DOMAIN}_ABC123_10_5_bit2"  # nosec

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -150,7 +150,8 @@ def test_number_creation_and_state(mock_coordinator):
     """Test creation and state changes of number entity."""
     mock_coordinator.data["required_temperature"] = 20
     entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
-    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
+    address = 8190
+    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", address, entity_config)
     assert number.native_value == 20
     assert "scale_factor" not in number.extra_state_attributes
 
@@ -162,7 +163,8 @@ def test_number_set_value(mock_coordinator):
     """Test setting a new value on the number entity."""
     mock_coordinator.data["required_temperature"] = 20
     entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
-    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
+    address = 8190
+    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", address, entity_config)
 
     asyncio.run(number.async_set_native_value(22))
     mock_coordinator.async_write_register.assert_awaited_with(
@@ -175,7 +177,8 @@ def test_number_set_value_modbus_failure(mock_coordinator):
     """Ensure Modbus errors are surfaced when setting the number."""
     mock_coordinator.data["required_temperature"] = 20
     entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
-    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
+    address = 8190
+    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", address, entity_config)
 
     mock_coordinator.async_write_register = AsyncMock(side_effect=ConnectionException("fail"))
     with pytest.raises(ConnectionException):
@@ -187,7 +190,8 @@ def test_number_set_value_write_failure(mock_coordinator):
     """Ensure failures to write registers raise RuntimeError."""
     mock_coordinator.data["required_temperature"] = 20
     entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
-    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
+    address = 8190
+    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", address, entity_config)
 
     mock_coordinator.async_write_register = AsyncMock(return_value=False)
     with pytest.raises(RuntimeError):
@@ -200,7 +204,8 @@ def test_number_set_value_other_errors(mock_coordinator, exc_cls):
     """Ensure ValueError and OSError propagate when setting the number."""
     mock_coordinator.data["required_temperature"] = 20
     entity_config = ENTITY_MAPPINGS["number"]["required_temperature"]
-    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", entity_config)
+    address = 8190
+    number = ThesslaGreenNumber(mock_coordinator, "required_temperature", address, entity_config)
 
     mock_coordinator.async_write_register = AsyncMock(side_effect=exc_cls("fail"))
     with pytest.raises(exc_cls):
@@ -219,7 +224,8 @@ def test_new_number_entities(mock_coordinator, register, value):
     """Test number entities for newly added registers."""
     mock_coordinator.data[register] = value
     entity_config = ENTITY_MAPPINGS["number"][register]
-    number = ThesslaGreenNumber(mock_coordinator, register, entity_config)
+    address = 4117 if register == "max_supply_air_flow_rate" else 4320
+    number = ThesslaGreenNumber(mock_coordinator, register, address, entity_config)
     assert number.native_value == value
 
 

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -11,7 +11,13 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from custom_components.thessla_green_modbus.const import SENSOR_UNAVAILABLE
+from custom_components.thessla_green_modbus.const import (
+    SENSOR_UNAVAILABLE,
+    COIL_REGISTERS,
+    DISCRETE_INPUT_REGISTERS,
+    HOLDING_REGISTERS,
+    INPUT_REGISTERS,
+)
 
 # Setup logging for tests
 logging.basicConfig(level=logging.DEBUG)
@@ -123,6 +129,12 @@ class TestThesslaGreenIntegration:
             },
             "coil_registers": {"power_supply_fans", "bypass", "gwc"},
             "discrete_inputs": {"expansion", "contamination_sensor"},
+        }
+        coordinator._register_maps = {
+            "input_registers": INPUT_REGISTERS,
+            "holding_registers": HOLDING_REGISTERS,
+            "coil_registers": COIL_REGISTERS,
+            "discrete_inputs": DISCRETE_INPUT_REGISTERS,
         }
 
         return coordinator
@@ -578,6 +590,12 @@ class TestThesslaGreenClimate:
             "special_mode": 0,
         }
         coordinator.async_write_register = AsyncMock(return_value=True)
+        coordinator._register_maps = {
+            "input_registers": INPUT_REGISTERS,
+            "holding_registers": HOLDING_REGISTERS,
+            "coil_registers": COIL_REGISTERS,
+            "discrete_inputs": DISCRETE_INPUT_REGISTERS,
+        }
         coordinator.async_request_refresh = AsyncMock()
         return coordinator
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -122,7 +122,8 @@ from custom_components.thessla_green_modbus.select import (  # noqa: E402
 def test_select_creation_and_state(mock_coordinator):
     """Test creation and state changes of select entity."""
     mock_coordinator.data["mode"] = 0
-    select_entity = ThesslaGreenSelect(mock_coordinator, "mode", ENTITY_MAPPINGS["select"]["mode"])
+    address = 4208
+    select_entity = ThesslaGreenSelect(mock_coordinator, "mode", address, ENTITY_MAPPINGS["select"]["mode"])
     assert select_entity.current_option == "auto"
 
     mock_coordinator.data["mode"] = 1
@@ -131,7 +132,8 @@ def test_select_creation_and_state(mock_coordinator):
 
 def test_select_option_change(mock_coordinator):
     mock_coordinator.data["mode"] = 0
-    select_entity = ThesslaGreenSelect(mock_coordinator, "mode", ENTITY_MAPPINGS["select"]["mode"])
+    address = 4208
+    select_entity = ThesslaGreenSelect(mock_coordinator, "mode", address, ENTITY_MAPPINGS["select"]["mode"])
     asyncio.run(select_entity.async_select_option("manual"))
     mock_coordinator.async_write_register.assert_awaited_with("mode", 1)
     mock_coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -267,7 +267,8 @@ def test_time_sensor_formats_value(mock_coordinator):
         "value_map": None,
     }
     mock_coordinator.data[register] = 8 * 60 + 5
-    sensor = ThesslaGreenSensor(mock_coordinator, register, sensor_def)
+    address = 0x2000  # example address for schedule register
+    sensor = ThesslaGreenSensor(mock_coordinator, register, address, sensor_def)
     assert sensor.native_value == "08:05"
 
 
@@ -283,7 +284,8 @@ def test_sensor_reports_unavailable_when_no_data():
     coord.data = {"outside_temperature": SENSOR_UNAVAILABLE}
     coord.last_update_success = True
     sensor_def = SENSOR_DEFINITIONS["outside_temperature"]
-    sensor = ThesslaGreenSensor(coord, "outside_temperature", sensor_def)
+    address = 16
+    sensor = ThesslaGreenSensor(coord, "outside_temperature", address, sensor_def)
     assert sensor.native_value == STATE_UNAVAILABLE
     assert sensor.available is False
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -152,8 +152,9 @@ ENTITY_MAPPINGS["switch"].setdefault(
 def test_switch_creation_and_state(mock_coordinator):
     """Test creation and state changes of coil switch."""
     mock_coordinator.data["bypass"] = 1
+    address = 9
     switch_entity = ThesslaGreenSwitch(
-        mock_coordinator, "bypass", ENTITY_MAPPINGS["switch"]["bypass"]
+        mock_coordinator, "bypass", address, ENTITY_MAPPINGS["switch"]["bypass"]
     )
     assert switch_entity.is_on is True  # nosec B101
 
@@ -163,8 +164,9 @@ def test_switch_creation_and_state(mock_coordinator):
 
 def test_switch_turn_on_off(mock_coordinator):
     mock_coordinator.data["bypass"] = 0
+    address = 9
     switch_entity = ThesslaGreenSwitch(
-        mock_coordinator, "bypass", ENTITY_MAPPINGS["switch"]["bypass"]
+        mock_coordinator, "bypass", address, ENTITY_MAPPINGS["switch"]["bypass"]
     )
     asyncio.run(switch_entity.async_turn_on())
     mock_coordinator.async_write_register.assert_awaited_with("bypass", 1, refresh=False)
@@ -180,8 +182,9 @@ def test_switch_turn_on_off(mock_coordinator):
 
 def test_switch_turn_on_modbus_failure(mock_coordinator):
     """Ensure Modbus errors are surfaced when turning on the switch."""
+    address = 9
     switch_entity = ThesslaGreenSwitch(
-        mock_coordinator, "bypass", ENTITY_MAPPINGS["switch"]["bypass"]
+        mock_coordinator, "bypass", address, ENTITY_MAPPINGS["switch"]["bypass"]
     )
     mock_coordinator.async_write_register = AsyncMock(side_effect=ConnectionException("fail"))
     with pytest.raises(ConnectionException):


### PR DESCRIPTION
## Summary
- build entity unique IDs using register addresses and bit positions
- provide address/bit info from platform factories
- migrate existing registry entries to new unique ID scheme

## Testing
- `pytest` *(fails: ValidationError for RegisterDefinition)*

------
https://chatgpt.com/codex/tasks/task_e_68aae665be588326b2e8487aa179ff8b