### PR TITLE
Add Pydantic-based JSON register validator

### DIFF
--- a/tests/test_validate_registers.py
+++ b/tests/test_validate_registers.py
@@ -1,0 +1,177 @@
+"""Tests for tools.validate_registers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools import validate_registers
+
+
+def _write(tmp_path: Path, regs: list[dict]) -> Path:
+    path = tmp_path / "regs.json"
+    path.write_text(json.dumps({"registers": regs}))
+    return path
+
+
+def test_validator_accepts_valid(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "valid_reg",
+                "access": "R/W",
+            }
+        ],
+    )
+
+    validate_registers.main(path)
+
+
+def test_validator_rejects_duplicate_name(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "dup",
+                "access": "R/W",
+            },
+            {
+                "function": "03",
+                "address_dec": 2,
+                "address_hex": "0x0002",
+                "name": "dup",
+                "access": "R/W",
+            },
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_duplicate_pair(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "first",
+                "access": "R/W",
+            },
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "second",
+                "access": "R/W",
+            },
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_bad_hex(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0002",
+                "name": "bad_hex",
+                "access": "R/W",
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_length_mismatch(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "bad_len",
+                "access": "R/W",
+                "length": 1,
+                "extra": {"type": "uint32"},
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_function_access_mismatch(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "01",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "bad_access",
+                "access": "R/W",
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_bits_without_bitmask(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "bad_bits",
+                "access": "R/W",
+                "bits": ["a"],
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_non_snake_case(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "NotSnake",
+                "access": "R/W",
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-"""Validate register addresses against JSON definition."""
+"""Validate register definitions in the bundled JSON file."""
 
 from __future__ import annotations
 
-import ast
 import json
+import re
+from collections import Counter
 from pathlib import Path
-from typing import Dict, Set
+from typing import Any, Literal
+
+import pydantic
+
 
 ROOT = Path(__file__).resolve().parents[1]
-
-# JSON register definitions bundled with the integration
-
 JSON_PATH = (
     ROOT
     / "custom_components"
@@ -19,76 +20,91 @@ JSON_PATH = (
     / "registers"
     / "thessla_green_registers_full.json"
 )
-REGISTERS_PATH = ROOT / "custom_components" / "thessla_green_modbus" / "registers.py"
-
-FUNCTION_MAP = {
-    "COIL_REGISTERS": "01",
-    "DISCRETE_INPUT_REGISTERS": "02",
-    "INPUT_REGISTERS": "04",
-    "HOLDING_REGISTERS": "03",
-}
 
 
-def parse_json(path: Path) -> tuple[Dict[str, Dict[str, Set[int]]], Dict[str, Set[int]]]:
-    """Return grouped and total addresses from the JSON file."""
-    groups: Dict[str, Dict[str, Set[int]]] = {}
-    totals: Dict[str, Set[int]] = {}
+class Register(pydantic.BaseModel):
+    """Schema for a single register entry."""
+
+    function: Literal["01", "02", "03", "04"]
+    address_dec: int
+    address_hex: str
+    name: str
+    access: Literal["R/-", "R/W", "R", "W"]
+    extra: dict[str, Any] | None = None
+    length: int = 1
+    bits: list[Any] | None = None
+
+    model_config = pydantic.ConfigDict(extra="allow")  # pragma: no cover
+
+    @pydantic.field_validator("name")
+    @classmethod
+    def name_is_snake(cls, v: str) -> str:  # pragma: no cover
+        if not re.fullmatch(r"[a-z0-9_]+", v):
+            raise ValueError("name must be snake_case")
+        return v
+
+    @pydantic.model_validator(mode="after")
+    def check_consistency(self) -> "Register":  # pragma: no cover
+        if int(self.address_hex, 16) != self.address_dec:
+            raise ValueError("address_hex does not match address_dec")
+
+        typ = (self.extra or {}).get("type")
+        expected_len = {
+            "uint32": 2,
+            "int32": 2,
+            "float32": 2,
+            "uint64": 4,
+            "int64": 4,
+            "float64": 4,
+        }.get(typ)
+        if expected_len is not None and self.length != expected_len:
+            raise ValueError("length does not match type")
+
+        if self.function in {"01", "02"} and self.access not in {"R", "R/-"}:
+            raise ValueError("read-only functions must have R access")
+
+        if self.bits is not None and not (self.extra and self.extra.get("bitmask")):
+            raise ValueError("bits provided without extra.bitmask")
+
+        return self
+
+
+def validate(path: Path) -> list[Register]:
+    """Validate ``path`` and return the parsed register definitions."""
+
     data = json.loads(path.read_text(encoding="utf-8"))
     registers = data.get("registers", data)
-    for reg in registers:
-        code = str(reg["function"]).zfill(2)
-        name = str(reg["name"]).strip()
-        addr = int(reg["address_dec"])
-        groups.setdefault(code, {}).setdefault(name, set()).add(addr)
-        totals.setdefault(code, set()).add(addr)
-    return groups, totals
+    parsed = [Register.model_validate(reg) for reg in registers]
+
+    name_counts = Counter(r.name for r in parsed)
+    dup_names = [name for name, count in name_counts.items() if count > 1]
+
+    pair_counts = Counter((r.function, r.address_dec) for r in parsed)
+    dup_pairs = [pair for pair, count in pair_counts.items() if count > 1]
+
+    if dup_names or dup_pairs:
+        errors: list[str] = []
+        if dup_names:
+            errors.append(f"duplicate names: {sorted(dup_names)}")
+        if dup_pairs:
+            errors.append(
+                f"duplicate (function, address_dec) pairs: {sorted(dup_pairs)}"
+            )
+        raise ValueError("; ".join(errors))
+
+    return parsed
 
 
-def parse_registers(path: Path) -> Dict[str, Set[int]]:
-    """Return a mapping of dictionary name to addresses from registers.py."""
-    tree = ast.parse(path.read_text())
-    result: Dict[str, Set[int]] = {}
-    for node in tree.body:
-        target = None
-        value = None
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            value = node.value
-        elif isinstance(node, ast.AnnAssign):
-            target = node.target
-            value = node.value
-        if isinstance(target, ast.Name) and target.id in FUNCTION_MAP:
-            name = target.id
-            values = set()
-            dict_node = value
-            if isinstance(dict_node, ast.Dict):
-                for val in dict_node.values:
-                    if isinstance(val, ast.Constant) and isinstance(val.value, int):
-                        values.add(val.value)
-            result[name] = values
-    return result
+def main(path: Path = JSON_PATH) -> None:
+    """Validate registers file, exiting with status 1 on error."""
 
-
-def main() -> None:
-    json_groups, json_totals = parse_json(JSON_PATH)
-    py_addrs = parse_registers(REGISTERS_PATH)
-    ok = True
-    for dict_name, func_code in FUNCTION_MAP.items():
-        py_set = py_addrs.get(dict_name, set())
-        missing: list[int] = []
-        for addr_set in json_groups.get(func_code, {}).values():
-            if addr_set.isdisjoint(py_set):
-                missing.extend(sorted(addr_set))
-        extra = py_set - json_totals.get(func_code, set())
-        if missing or extra:
-            ok = False
-            if missing:
-                print(f"{dict_name} missing addresses: {missing}")
-            if extra:
-                print(f"{dict_name} extra addresses: {sorted(extra)}")
-    if not ok:
+    try:
+        validate(path)
+    except Exception as err:  # pragma: no cover - error path
+        print(err)
         raise SystemExit(1)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
+


### PR DESCRIPTION
## Summary
- replace register validation script with standalone Pydantic schema validator
- add extensive unit tests covering valid and invalid register definitions

## Testing
- `python tools/validate_registers.py`
- `pytest tests/test_validate_registers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae92680d08326bb829e03f441c3bd