### PR TITLE
refactor: simplify manifest requirements

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -14,9 +14,7 @@
   "files": [
     "registers/thessla_green_registers_full.json"
   ],
-  "requirements": [
-    "pymodbus>=3.5.0"
-  ],
+  "requirements": ["pymodbus>=3.5.0"],
   "version": "2.1.2",
   "integration_type": "hub",
   "dhcp": [


### PR DESCRIPTION
## Summary
- simplify manifest requirements list to only include pymodbus

## Testing
- `python -m homeassistant --script check_config --config /tmp/ha_config`
- `pytest -q` *(fails: TypeError: 'type' object is not iterable)*
- `python tools/py_compile_all.py`

------
https://chatgpt.com/codex/tasks/task_e_68aae92da95c832693466b8351d5eb94