### PR TITLE
Refactor register loading with content+mtime caching

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -42,7 +42,7 @@ from .const import (
 )
 from .const import PLATFORMS as PLATFORM_DOMAINS
 from .modbus_exceptions import ConnectionException, ModbusException
-from .registers import loader
+from .registers.loader import load_registers
 
 # Informational message for start-up logs
 REGISTER_FORMAT_MESSAGE = (

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, SPECIAL_FUNCTION_MAP
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
-from .registers import get_registers_by_function
+from .registers.loader import get_registers_by_function
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Any, Dict, cast
 
-from .registers import get_registers_by_function
+from .registers.loader import get_registers_by_function
 
 
 def _build_map(fn: str) -> dict[str, int]:

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -91,7 +91,7 @@ from .const import (
     UNKNOWN_MODEL,
 )
 from .modbus_helpers import _call_modbus, group_reads
-from .registers import get_all_registers, get_registers_by_function
+from .registers.loader import get_all_registers, get_registers_by_function
 from .scanner_core import DeviceCapabilities, ThesslaGreenDeviceScanner
 
 REGISTER_DEFS = {r.name: r for r in get_all_registers()}

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import translation
 
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
-from .registers import get_all_registers, get_registers_hash
+from .registers.loader import get_all_registers, get_registers_hash
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -71,7 +71,7 @@ except Exception:  # pragma: no cover - executed only in tests
 
 from .const import SPECIAL_FUNCTION_MAP
 from .const import COIL_REGISTERS, DISCRETE_INPUT_REGISTERS, HOLDING_REGISTERS
-from .registers import get_all_registers
+from .registers.loader import get_all_registers
 from .utils import _to_snake_case
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -19,7 +19,7 @@ from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .modbus_exceptions import ConnectionException, ModbusException
-from .registers import get_registers_by_function
+from .registers.loader import get_registers_by_function
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -27,7 +27,7 @@ from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .entity_mappings import ENTITY_MAPPINGS
 from .modbus_exceptions import ConnectionException, ModbusException
-from .registers import get_registers_by_function
+from .registers.loader import get_registers_by_function
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/registers/__init__.py
+++ b/custom_components/thessla_green_modbus/registers/__init__.py
@@ -1,19 +1,7 @@
-"""Register definitions for the ThesslaGreen Modbus integration."""
+"""Helpers for loading ThesslaGreen register definitions.
 
-from __future__ import annotations
+Functionality is provided by the ``loader`` module; import helpers from
+``custom_components.thessla_green_modbus.registers.loader``.
+"""
 
-from .loader import (
-    Register,
-    get_all_registers,
-    get_registers_hash,
-    get_registers_by_function,
-    plan_group_reads,
-)
-
-__all__ = [
-    "Register",
-    "get_all_registers",
-    "get_registers_hash",
-    "get_registers_by_function",
-    "plan_group_reads",
-]
+__all__ = []

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -23,7 +23,7 @@ from .modbus_exceptions import (
     ModbusIOException,
 )
 from .modbus_helpers import _call_modbus, group_reads as _group_reads
-from .registers import get_all_registers
+from .registers.loader import get_all_registers
 from .utils import _decode_bcd_time, BCD_TIME_PREFIXES
 from .scanner_helpers import (
     REGISTER_ALLOWED_VALUES,

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -16,7 +16,7 @@ from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .entity_mappings import ENTITY_MAPPINGS
 from .modbus_exceptions import ConnectionException, ModbusException
-from .registers import get_registers_by_function
+from .registers.loader import get_registers_by_function
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,7 +142,10 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
             return func(*args)
 
     class ServiceCall:  # type: ignore[override]
-        pass
+        def __init__(self, *args, **kwargs):
+            self.domain = args[0] if len(args) > 0 else kwargs.get("domain")
+            self.service = args[1] if len(args) > 1 else kwargs.get("service")
+            self.data = args[2] if len(args) > 2 else kwargs.get("data")
 
     def callback(func):  # type: ignore[override]
         return func

--- a/tests/run_optimization_tests.py
+++ b/tests/run_optimization_tests.py
@@ -135,7 +135,9 @@ async def validate_register_coverage():
     print_section("MODBUS REGISTER COVERAGE VALIDATION")
 
     try:
-        from custom_components.thessla_green_modbus.registers import get_registers_by_function
+        from custom_components.thessla_green_modbus.registers.loader import (
+            get_registers_by_function,
+        )
 
         COIL_REGISTERS = {r.name: r.address for r in get_registers_by_function("01")}
         HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -56,7 +56,9 @@ from custom_components.thessla_green_modbus.binary_sensor import (  # noqa: E402
     async_setup_entry,
 )
 from custom_components.thessla_green_modbus.const import DOMAIN  # noqa: E402
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -108,8 +108,12 @@ from custom_components.thessla_green_modbus.climate import (  # noqa: E402
 from custom_components.thessla_green_modbus.coordinator import (  # noqa: E402
     ThesslaGreenModbusCoordinator,
 )
-from custom_components.thessla_green_modbus import loader  # noqa: E402
-from custom_components.thessla_green_modbus.registers import get_registers_by_function  # noqa: E402
+from custom_components.thessla_green_modbus.registers.loader import (  # noqa: E402
+    get_register_definition,
+)
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)  # noqa: E402
 
 HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
 
@@ -156,7 +160,7 @@ async def test_set_temperature_scaling():
     await climate.async_set_temperature(**{const.ATTR_TEMPERATURE: 21.5})
 
     addr_required = HOLDING_REGISTERS["required_temperature"]
-    expected = loader.get_register_definition("required_temperature").encode(21.5)
+    expected = get_register_definition("required_temperature").encode(21.5)
 
     assert coordinator.client.writes == [(addr_required, expected, coordinator.slave_id)]
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,8 +19,10 @@ from custom_components.thessla_green_modbus.modbus_exceptions import (
     ConnectionException,
     ModbusException,
 )
-from custom_components.thessla_green_modbus import loader
-from custom_components.thessla_green_modbus.registers import get_registers_by_function  # noqa: E402,F811,E501
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_register_definition,
+    get_registers_by_function,
+)  # noqa: E402,F811,E501
 
 # Stub minimal Home Assistant and pymodbus modules before importing the coordinator
 ha = types.ModuleType("homeassistant")
@@ -496,7 +498,7 @@ def test_process_register_value_extremes(coordinator, register_name, value, expe
 )
 def test_process_register_value_dac_boundaries(coordinator, register_name, value):
     """Process DAC registers across boundary and out-of-range values."""
-    expected = loader.get_register_definition(register_name).decode(value)
+    expected = get_register_definition(register_name).decode(value)
     result = coordinator._process_register_value(register_name, value)
     assert result == pytest.approx(expected)
 

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 
 from custom_components.thessla_green_modbus.const import SENSOR_UNAVAILABLE
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 from custom_components.thessla_green_modbus.scanner_core import (
     DeviceCapabilities,
     ScannerDeviceInfo,

--- a/tests/test_force_full_register_list.py
+++ b/tests/test_force_full_register_list.py
@@ -3,7 +3,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
 from custom_components.thessla_green_modbus.scanner_core import DeviceCapabilities
-from custom_components.thessla_green_modbus.registers import get_all_registers
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_all_registers,
+)
 from custom_components.thessla_green_modbus.entity_mappings import ENTITY_MAPPINGS
 from custom_components.thessla_green_modbus.const import DOMAIN
 

--- a/tests/test_group_reads.py
+++ b/tests/test_group_reads.py
@@ -2,7 +2,7 @@
 
 from custom_components.thessla_green_modbus.modbus_helpers import group_reads
 import custom_components.thessla_green_modbus.registers.loader as loader
-from custom_components.thessla_green_modbus.registers import (
+from custom_components.thessla_green_modbus.registers.loader import (
     ReadPlan,
     Register,
     plan_group_reads,
@@ -24,13 +24,13 @@ def test_plan_group_reads_merges_consecutive_addresses(monkeypatch):
         Register("input", addr, f"r{addr}", "r")
         for addr in [0, 1, 2, 3, 10, 11, 12]
     ]
-    monkeypatch.setattr(loader, "_load_registers", lambda: regs)
+    monkeypatch.setattr(loader, "load_registers", lambda: regs)
     assert plan_group_reads() == [ReadPlan("input", 0, 4), ReadPlan("input", 10, 3)]
 
 
 def test_plan_group_reads_respects_max_block_size(monkeypatch):
     regs = [Register("input", addr, f"r{addr}", "r") for addr in range(22)]
-    monkeypatch.setattr(loader, "_load_registers", lambda: regs)
+    monkeypatch.setattr(loader, "load_registers", lambda: regs)
     assert plan_group_reads(max_block_size=16) == [
         ReadPlan("input", 0, 16),
         ReadPlan("input", 16, 6),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,9 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 
 from custom_components.thessla_green_modbus import async_setup_entry, async_unload_entry
 from custom_components.thessla_green_modbus.const import DOMAIN
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 
 async def test_async_setup_entry_success():

--- a/tests/test_loader_smoke.py
+++ b/tests/test_loader_smoke.py
@@ -1,6 +1,5 @@
 from custom_components.thessla_green_modbus.modbus_helpers import group_reads
-from custom_components.thessla_green_modbus.registers import get_all_registers
-from custom_components.thessla_green_modbus.registers import (
+from custom_components.thessla_green_modbus.registers.loader import (
     get_all_registers,
     plan_group_reads,
 )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -9,8 +9,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
-from custom_components.thessla_green_modbus import loader
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_register_definition,
+    get_registers_by_function,
+)
 
 HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
 
@@ -108,7 +110,7 @@ class ThesslaGreenModbusCoordinator:  # pragma: no cover - simple stub
     async def async_write_register(self, *args, **kwargs):
         register, value = args[0], args[1]
         address = HOLDING_REGISTERS[register]
-        definition = loader.get_register_definition(register)
+        definition = get_register_definition(register)
         raw = definition.encode(value)
         await self.client.write_register(address, raw, slave=self.slave_id)
         return True

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -1,15 +1,16 @@
 import json
+import os
 from pathlib import Path
 
 from custom_components.thessla_green_modbus.registers.loader import (
-    clear_cache,
-    _load_registers,
     _REGISTERS_PATH,
+    clear_cache,
+    load_registers,
 )
 
 
-def test_register_cache_invalidation(tmp_path: Path, monkeypatch) -> None:
-    """Modifying the register JSON should trigger cache rebuilds."""
+def test_cache_invalidation_on_content_change(tmp_path: Path, monkeypatch) -> None:
+    """Changing file contents should invalidate cache."""
 
     tmp_json = tmp_path / "registers.json"
     tmp_json.write_text(_REGISTERS_PATH.read_text(), encoding="utf-8")
@@ -19,18 +20,35 @@ def test_register_cache_invalidation(tmp_path: Path, monkeypatch) -> None:
     )
 
     clear_cache()
-    first = _load_registers()[0]
+    first = load_registers()[0]
     assert first.description
-    assert first.description_en
 
     data = json.loads(tmp_json.read_text())
     data["registers"][0]["description"] = "changed description"
-    data["registers"][0]["description_en"] = "changed description en"
     tmp_json.write_text(json.dumps(data), encoding="utf-8")
 
-    clear_cache()
-    updated = _load_registers()[0]
+    updated = load_registers()[0]
     assert updated.description == "changed description"
-    assert updated.description_en == "changed description en"
+
+    clear_cache()
+
+
+def test_cache_invalidation_on_mtime_change(tmp_path: Path, monkeypatch) -> None:
+    """Touching file without content change should reload registers."""
+
+    tmp_json = tmp_path / "registers.json"
+    tmp_json.write_text(_REGISTERS_PATH.read_text(), encoding="utf-8")
+    monkeypatch.setattr(
+        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
+        tmp_json,
+    )
+
+    clear_cache()
+    first_id = id(load_registers())
+
+    os.utime(tmp_json, None)
+
+    second_id = id(load_registers())
+    assert first_id != second_id
 
     clear_cache()

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -12,7 +12,9 @@ from custom_components.thessla_green_modbus.utils import (
     _decode_register_time,
 )
 from custom_components.thessla_green_modbus.registers.loader import Register
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 
 def test_decode_register_time_valid():

--- a/tests/test_register_grouping.py
+++ b/tests/test_register_grouping.py
@@ -1,10 +1,10 @@
 from custom_components.thessla_green_modbus.scanner_core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.modbus_helpers import group_reads
-from custom_components.thessla_green_modbus.registers import (
+from custom_components.thessla_green_modbus.registers.loader import (
+    Register,
     get_registers_by_function,
     plan_group_reads,
 )
-from custom_components.thessla_green_modbus.registers.loader import Register
 
 INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function("04")}
 
@@ -66,7 +66,7 @@ def test_plan_group_reads_splits_large_block(monkeypatch):
     regs = [Register(function="04", address=i, name=f"r{i}", access="ro") for i in range(100)]
 
     monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.registers.loader._load_registers",
+        "custom_components.thessla_green_modbus.registers.loader.load_registers",
         lambda: regs,
     )
 
@@ -97,7 +97,7 @@ def test_plan_group_reads_handles_gaps_and_block_size(monkeypatch):
     ]
 
     monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.registers.loader._load_registers",
+        "custom_components.thessla_green_modbus.registers.loader.load_registers",
         lambda: regs,
     )
 

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from custom_components.thessla_green_modbus.registers import (
+from custom_components.thessla_green_modbus.registers.loader import (
     get_registers_by_function,
 )
 
@@ -75,7 +75,7 @@ def test_function_aliases() -> None:
 def test_registers_loaded_only_once(monkeypatch) -> None:
     """Ensure register file is read only once thanks to caching."""
 
-    from custom_components.thessla_green_modbus.registers import loader
+    import custom_components.thessla_green_modbus.registers.loader as loader
 
     read_calls = 0
     real_read_text = Path.read_text
@@ -115,14 +115,14 @@ def test_registers_loaded_only_once(monkeypatch) -> None:
 def test_duplicate_registers_raise_error(tmp_path, monkeypatch, registers) -> None:
     """Duplicate names or addresses should raise an error."""
 
-    from custom_components.thessla_green_modbus.registers import loader
+    import custom_components.thessla_green_modbus.registers.loader as loader
 
     path = tmp_path / "regs.json"
     path.write_text(json.dumps({"registers": registers}))
     monkeypatch.setattr(loader, "_REGISTERS_PATH", path)
 
     with pytest.raises(ValueError):
-        loader._load_registers_from_file(path, file_hash="")
+        loader._load_registers_from_file(path, file_hash="", mtime=0)
 
 
 @pytest.mark.parametrize(
@@ -164,43 +164,43 @@ def test_duplicate_registers_raise_error(tmp_path, monkeypatch, registers) -> No
 def test_invalid_registers_rejected(tmp_path, monkeypatch, register) -> None:
     """Registers violating schema constraints should raise an error."""
 
-    from custom_components.thessla_green_modbus.registers import loader
+    import custom_components.thessla_green_modbus.registers.loader as loader
 
     path = tmp_path / "regs.json"
     path.write_text(json.dumps({"registers": [register]}))
     monkeypatch.setattr(loader, "_REGISTERS_PATH", path)
 
     with pytest.raises(ValueError):
-        loader._load_registers_from_file(path, file_hash="")
+        loader._load_registers_from_file(path, file_hash="", mtime=0)
 
 
 def test_missing_register_file_raises_runtime_error(tmp_path) -> None:
     """Missing register definition file should raise RuntimeError."""
 
-    from custom_components.thessla_green_modbus.registers import loader
+    import custom_components.thessla_green_modbus.registers.loader as loader
 
     path = tmp_path / "regs.json"
     with pytest.raises(RuntimeError) as exc:
-        loader._load_registers_from_file(path, file_hash="")
+        loader._load_registers_from_file(path, file_hash="", mtime=0)
     assert str(path) in str(exc.value)
 
 
 def test_invalid_register_file_raises_runtime_error(tmp_path) -> None:
     """Invalid register definition file should raise RuntimeError."""
 
-    from custom_components.thessla_green_modbus.registers import loader
+    import custom_components.thessla_green_modbus.registers.loader as loader
 
     path = tmp_path / "regs.json"
     path.write_text("not json", encoding="utf-8")
     with pytest.raises(RuntimeError) as exc:
-        loader._load_registers_from_file(path, file_hash="")
+        loader._load_registers_from_file(path, file_hash="", mtime=0)
     assert str(path) in str(exc.value)
 
 
 def test_register_file_sorted() -> None:
     """Ensure register JSON is sorted and loader preserves ordering."""
 
-    from custom_components.thessla_green_modbus.registers import loader
+    import custom_components.thessla_green_modbus.registers.loader as loader
 
     data = json.loads(loader._REGISTERS_PATH.read_text(encoding="utf-8"))
     regs = data["registers"]
@@ -214,7 +214,7 @@ def test_register_file_sorted() -> None:
 def test_get_all_registers_sorted(monkeypatch, tmp_path) -> None:
     """get_all_registers should order registers by function then address."""
 
-    from custom_components.thessla_green_modbus.registers import loader
+    import custom_components.thessla_green_modbus.registers.loader as loader
 
     regs = [
         {

--- a/tests/test_register_mapping.py
+++ b/tests/test_register_mapping.py
@@ -1,5 +1,7 @@
 import pytest
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 from custom_components.thessla_green_modbus.utils import _to_snake_case
 
 from pathlib import Path

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -216,7 +216,9 @@ def test_error_codes_sensor_translates_active_registers(mock_coordinator, mock_c
 def test_sensor_registers_match_definition():
     """Cross-check register_type against registers module."""
 
-    from custom_components.thessla_green_modbus.registers import get_registers_by_function
+    from custom_components.thessla_green_modbus.registers.loader import (
+        get_registers_by_function,
+    )
 
     mapping = {
         "input_registers": {r.name for r in get_registers_by_function("04")},

--- a/tests/test_sensor_register_mapping.py
+++ b/tests/test_sensor_register_mapping.py
@@ -67,7 +67,9 @@ sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 # ---------------------------------------------------------------------------
 
 from custom_components.thessla_green_modbus.sensor import SENSOR_DEFINITIONS  # noqa: E402
-from custom_components.thessla_green_modbus.registers import get_registers_by_function  # noqa: E402
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)  # noqa: E402
 
 INPUT_REGISTERS = {r.name for r in get_registers_by_function("04")}
 HOLDING_REGISTERS = {r.name for r in get_registers_by_function("03")}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -226,7 +226,9 @@ for name, module in modules.items():
 # Ensure repository root on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 HOLDING_REGISTERS = {r.name for r in get_registers_by_function("03")}
 HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}

--- a/tests/test_services_scaling.py
+++ b/tests/test_services_scaling.py
@@ -6,8 +6,10 @@ from types import SimpleNamespace
 import pytest
 
 import custom_components.thessla_green_modbus.services as services
-from custom_components.thessla_green_modbus import loader
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_register_definition,
+    get_registers_by_function,
+)
 
 HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
 
@@ -22,7 +24,7 @@ class DummyCoordinator:
         self.available_registers = {"holding_registers": set()}
 
     async def async_write_register(self, register_name, value, refresh=True) -> None:
-        definition = loader.get_register_definition(register_name)
+        definition = get_register_definition(register_name)
         encoded = definition.encode(value)
         address = HOLDING_REGISTERS[register_name]
         self.writes.append((address, encoded, self.slave_id))
@@ -73,16 +75,16 @@ async def test_airflow_schedule_service_passes_user_values(monkeypatch):
 
     writes = coordinator.writes
 
-    expected_start = loader.get_register_definition(
+    expected_start = get_register_definition(
         "schedule_monday_period1_start"
     ).encode("06:30")
-    expected_end = loader.get_register_definition(
+    expected_end = get_register_definition(
         "schedule_monday_period1_end"
     ).encode("08:00")
-    expected_flow = loader.get_register_definition(
+    expected_flow = get_register_definition(
         "schedule_monday_period1_flow"
     ).encode(55)
-    expected_temp = loader.get_register_definition(
+    expected_temp = get_register_definition(
         "schedule_monday_period1_temp"
     ).encode(21.5)
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -133,7 +133,9 @@ SWITCH_KEYS = _load_keys(ROOT / "entity_mappings.py", "SWITCH_ENTITY_MAPPINGS") 
 )
 SELECT_KEYS = _load_keys(ROOT / "entity_mappings.py", "SELECT_ENTITY_MAPPINGS")
 NUMBER_KEYS = _load_keys(ROOT / "entity_mappings.py", "NUMBER_ENTITY_MAPPINGS")
-from custom_components.thessla_green_modbus.registers import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 REGISTER_KEYS = [r.name for r in get_registers_by_function("03")]
 # Add dynamically generated binary sensor keys from holding registers
 BINARY_KEYS = sorted(


### PR DESCRIPTION
## Summary
- add `RegisterDef` dataclass and expose `load_registers`
- cache register definitions by SHA256 and mtime
- drop package re-exports and update imports
- add register cache invalidation tests

## Testing
- `pytest tests/test_register_cache_invalidation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae9272aa48326b7b569f91f6d1d17