### PR TITLE
Normalize register hex addresses

### DIFF
--- a/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
+++ b/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
@@ -3,7 +3,7 @@
     {
       "function": "01",
       "address_dec": 5,
-      "address_hex": "0x0005",
+      "address_hex": "0x5",
       "name": "duct_water_heater_pump",
       "access": "R/-",
       "unit": null,
@@ -19,7 +19,7 @@
     {
       "function": "01",
       "address_dec": 9,
-      "address_hex": "0x0009",
+      "address_hex": "0x9",
       "name": "bypass",
       "access": "R/-",
       "unit": null,
@@ -35,7 +35,7 @@
     {
       "function": "01",
       "address_dec": 10,
-      "address_hex": "0x000A",
+      "address_hex": "0xa",
       "name": "info",
       "access": "R/-",
       "unit": null,
@@ -51,7 +51,7 @@
     {
       "function": "01",
       "address_dec": 11,
-      "address_hex": "0x000B",
+      "address_hex": "0xb",
       "name": "power_supply_fans",
       "access": "R/-",
       "unit": null,
@@ -67,7 +67,7 @@
     {
       "function": "01",
       "address_dec": 12,
-      "address_hex": "0x000C",
+      "address_hex": "0xc",
       "name": "heating_cable",
       "access": "R/-",
       "unit": null,
@@ -83,7 +83,7 @@
     {
       "function": "01",
       "address_dec": 13,
-      "address_hex": "0x000D",
+      "address_hex": "0xd",
       "name": "work_permit",
       "access": "R/-",
       "unit": null,
@@ -99,7 +99,7 @@
     {
       "function": "01",
       "address_dec": 14,
-      "address_hex": "0x000E",
+      "address_hex": "0xe",
       "name": "gwc",
       "access": "R/-",
       "unit": null,
@@ -115,7 +115,7 @@
     {
       "function": "01",
       "address_dec": 15,
-      "address_hex": "0x000F",
+      "address_hex": "0xf",
       "name": "hood_output",
       "access": "R/-",
       "unit": null,
@@ -131,7 +131,7 @@
     {
       "function": "02",
       "address_dec": 0,
-      "address_hex": "0x0000",
+      "address_hex": "0x0",
       "name": "duct_heater_protection",
       "access": "R/-",
       "unit": null,
@@ -147,7 +147,7 @@
     {
       "function": "02",
       "address_dec": 1,
-      "address_hex": "0x0001",
+      "address_hex": "0x1",
       "name": "expansion",
       "access": "R/-",
       "unit": null,
@@ -163,7 +163,7 @@
     {
       "function": "02",
       "address_dec": 3,
-      "address_hex": "0x0003",
+      "address_hex": "0x3",
       "name": "dp_duct_filter_overflow",
       "access": "R/-",
       "unit": null,
@@ -179,7 +179,7 @@
     {
       "function": "02",
       "address_dec": 4,
-      "address_hex": "0x0004",
+      "address_hex": "0x4",
       "name": "hood_switch",
       "access": "R/-",
       "unit": null,
@@ -195,7 +195,7 @@
     {
       "function": "02",
       "address_dec": 5,
-      "address_hex": "0x0005",
+      "address_hex": "0x5",
       "name": "contamination_sensor",
       "access": "R/-",
       "unit": null,
@@ -211,7 +211,7 @@
     {
       "function": "02",
       "address_dec": 6,
-      "address_hex": "0x0006",
+      "address_hex": "0x6",
       "name": "airing_sensor",
       "access": "R/-",
       "unit": null,
@@ -227,7 +227,7 @@
     {
       "function": "02",
       "address_dec": 7,
-      "address_hex": "0x0007",
+      "address_hex": "0x7",
       "name": "airing_switch",
       "access": "R/-",
       "unit": null,
@@ -243,7 +243,7 @@
     {
       "function": "02",
       "address_dec": 10,
-      "address_hex": "0x000A",
+      "address_hex": "0xa",
       "name": "airing_mini",
       "access": "R/-",
       "unit": null,
@@ -259,7 +259,7 @@
     {
       "function": "02",
       "address_dec": 11,
-      "address_hex": "0x000B",
+      "address_hex": "0xb",
       "name": "fan_speed_3",
       "access": "R/-",
       "unit": null,
@@ -275,7 +275,7 @@
     {
       "function": "02",
       "address_dec": 12,
-      "address_hex": "0x000C",
+      "address_hex": "0xc",
       "name": "fan_speed_2",
       "access": "R/-",
       "unit": null,
@@ -291,7 +291,7 @@
     {
       "function": "02",
       "address_dec": 13,
-      "address_hex": "0x000D",
+      "address_hex": "0xd",
       "name": "fan_speed_1",
       "access": "R/-",
       "unit": null,
@@ -307,7 +307,7 @@
     {
       "function": "02",
       "address_dec": 14,
-      "address_hex": "0x000E",
+      "address_hex": "0xe",
       "name": "fireplace",
       "access": "R/-",
       "unit": null,
@@ -323,7 +323,7 @@
     {
       "function": "02",
       "address_dec": 15,
-      "address_hex": "0x000F",
+      "address_hex": "0xf",
       "name": "fire_alarm",
       "access": "R/-",
       "unit": null,
@@ -339,7 +339,7 @@
     {
       "function": "02",
       "address_dec": 18,
-      "address_hex": "0x0012",
+      "address_hex": "0x12",
       "name": "dp_ahu_filter_overflow",
       "access": "R/-",
       "unit": null,
@@ -355,7 +355,7 @@
     {
       "function": "02",
       "address_dec": 19,
-      "address_hex": "0x0013",
+      "address_hex": "0x13",
       "name": "ahu_filter_protection",
       "access": "R/-",
       "unit": null,
@@ -371,7 +371,7 @@
     {
       "function": "02",
       "address_dec": 21,
-      "address_hex": "0x0015",
+      "address_hex": "0x15",
       "name": "empty_house",
       "access": "R/-",
       "unit": null,
@@ -387,7 +387,7 @@
     {
       "function": "03",
       "address_dec": 0,
-      "address_hex": "0x0000",
+      "address_hex": "0x0",
       "name": "date_time",
       "access": "R/W",
       "unit": "RRMM",
@@ -400,7 +400,7 @@
     {
       "function": "03",
       "address_dec": 1,
-      "address_hex": "0x0001",
+      "address_hex": "0x1",
       "name": "date_time_ddtt",
       "access": "R/W",
       "unit": "DDTT",
@@ -413,7 +413,7 @@
     {
       "function": "03",
       "address_dec": 2,
-      "address_hex": "0x0002",
+      "address_hex": "0x2",
       "name": "date_time_ggmm",
       "access": "R/W",
       "unit": "h",
@@ -426,7 +426,7 @@
     {
       "function": "03",
       "address_dec": 3,
-      "address_hex": "0x0003",
+      "address_hex": "0x3",
       "name": "date_time_sscc",
       "access": "R/W",
       "unit": "s",
@@ -439,7 +439,7 @@
     {
       "function": "03",
       "address_dec": 7,
-      "address_hex": "0x0007",
+      "address_hex": "0x7",
       "name": "lock_date",
       "access": "R/-",
       "unit": "[RR] - liczba dziesiątek i jedności roku; [MM] - miesiąc; [DD] - dzień miesiąca",
@@ -452,7 +452,7 @@
     {
       "function": "03",
       "address_dec": 8,
-      "address_hex": "0x0008",
+      "address_hex": "0x8",
       "name": "lock_date_00mm",
       "access": "R/-",
       "unit": "miesiąc",
@@ -465,7 +465,7 @@
     {
       "function": "03",
       "address_dec": 9,
-      "address_hex": "0x0009",
+      "address_hex": "0x9",
       "name": "lock_date_00dd",
       "access": "R/-",
       "unit": "dzień",
@@ -478,7 +478,7 @@
     {
       "function": "03",
       "address_dec": 13,
-      "address_hex": "0x000D",
+      "address_hex": "0xd",
       "name": "configuration_mode",
       "access": "R/W",
       "unit": null,
@@ -495,7 +495,7 @@
     {
       "function": "03",
       "address_dec": 15,
-      "address_hex": "0x000F",
+      "address_hex": "0xf",
       "name": "access_level",
       "access": "R/W",
       "unit": null,
@@ -512,7 +512,7 @@
     {
       "function": "03",
       "address_dec": 16,
-      "address_hex": "0x0010",
+      "address_hex": "0x10",
       "name": "schedule_summer_mon_1",
       "access": "R/W",
       "unit": "h",
@@ -525,7 +525,7 @@
     {
       "function": "03",
       "address_dec": 17,
-      "address_hex": "0x0011",
+      "address_hex": "0x11",
       "name": "schedule_summer_mon_2",
       "access": "R/W",
       "unit": "h",
@@ -538,7 +538,7 @@
     {
       "function": "03",
       "address_dec": 18,
-      "address_hex": "0x0012",
+      "address_hex": "0x12",
       "name": "schedule_summer_mon_3",
       "access": "R/W",
       "unit": "h",
@@ -551,7 +551,7 @@
     {
       "function": "03",
       "address_dec": 19,
-      "address_hex": "0x0013",
+      "address_hex": "0x13",
       "name": "schedule_summer_mon_4",
       "access": "R/W",
       "unit": "h",
@@ -564,7 +564,7 @@
     {
       "function": "03",
       "address_dec": 20,
-      "address_hex": "0x0014",
+      "address_hex": "0x14",
       "name": "schedule_summer_tue_1",
       "access": "R/W",
       "unit": "h",
@@ -577,7 +577,7 @@
     {
       "function": "03",
       "address_dec": 21,
-      "address_hex": "0x0015",
+      "address_hex": "0x15",
       "name": "schedule_summer_tue_2",
       "access": "R/W",
       "unit": "h",
@@ -590,7 +590,7 @@
     {
       "function": "03",
       "address_dec": 22,
-      "address_hex": "0x0016",
+      "address_hex": "0x16",
       "name": "schedule_summer_tue_3",
       "access": "R/W",
       "unit": "h",
@@ -603,7 +603,7 @@
     {
       "function": "03",
       "address_dec": 23,
-      "address_hex": "0x0017",
+      "address_hex": "0x17",
       "name": "schedule_summer_tue_4",
       "access": "R/W",
       "unit": "h",
@@ -616,7 +616,7 @@
     {
       "function": "03",
       "address_dec": 24,
-      "address_hex": "0x0018",
+      "address_hex": "0x18",
       "name": "schedule_summer_wed_1",
       "access": "R/W",
       "unit": "h",
@@ -629,7 +629,7 @@
     {
       "function": "03",
       "address_dec": 25,
-      "address_hex": "0x0019",
+      "address_hex": "0x19",
       "name": "schedule_summer_wed_2",
       "access": "R/W",
       "unit": "h",
@@ -642,7 +642,7 @@
     {
       "function": "03",
       "address_dec": 26,
-      "address_hex": "0x001A",
+      "address_hex": "0x1a",
       "name": "schedule_summer_wed_3",
       "access": "R/W",
       "unit": "h",
@@ -655,7 +655,7 @@
     {
       "function": "03",
       "address_dec": 27,
-      "address_hex": "0x001B",
+      "address_hex": "0x1b",
       "name": "schedule_summer_wed_4",
       "access": "R/W",
       "unit": "h",
@@ -668,7 +668,7 @@
     {
       "function": "03",
       "address_dec": 28,
-      "address_hex": "0x001C",
+      "address_hex": "0x1c",
       "name": "schedule_summer_thu_1",
       "access": "R/W",
       "unit": "h",
@@ -681,7 +681,7 @@
     {
       "function": "03",
       "address_dec": 29,
-      "address_hex": "0x001D",
+      "address_hex": "0x1d",
       "name": "schedule_summer_thu_2",
       "access": "R/W",
       "unit": "h",
@@ -694,7 +694,7 @@
     {
       "function": "03",
       "address_dec": 30,
-      "address_hex": "0x001E",
+      "address_hex": "0x1e",
       "name": "schedule_summer_thu_3",
       "access": "R/W",
       "unit": "h",
@@ -707,7 +707,7 @@
     {
       "function": "03",
       "address_dec": 31,
-      "address_hex": "0x001F",
+      "address_hex": "0x1f",
       "name": "schedule_summer_thu_4",
       "access": "R/W",
       "unit": "h",
@@ -720,7 +720,7 @@
     {
       "function": "03",
       "address_dec": 32,
-      "address_hex": "0x0020",
+      "address_hex": "0x20",
       "name": "schedule_summer_fri_1",
       "access": "R/W",
       "unit": "h",
@@ -733,7 +733,7 @@
     {
       "function": "03",
       "address_dec": 33,
-      "address_hex": "0x0021",
+      "address_hex": "0x21",
       "name": "schedule_summer_fri_2",
       "access": "R/W",
       "unit": "h",
@@ -746,7 +746,7 @@
     {
       "function": "03",
       "address_dec": 34,
-      "address_hex": "0x0022",
+      "address_hex": "0x22",
       "name": "schedule_summer_fri_3",
       "access": "R/W",
       "unit": "h",
@@ -759,7 +759,7 @@
     {
       "function": "03",
       "address_dec": 35,
-      "address_hex": "0x0023",
+      "address_hex": "0x23",
       "name": "schedule_summer_fri_4",
       "access": "R/W",
       "unit": "h",
@@ -772,7 +772,7 @@
     {
       "function": "03",
       "address_dec": 36,
-      "address_hex": "0x0024",
+      "address_hex": "0x24",
       "name": "schedule_summer_sat_1",
       "access": "R/W",
       "unit": "h",
@@ -785,7 +785,7 @@
     {
       "function": "03",
       "address_dec": 37,
-      "address_hex": "0x0025",
+      "address_hex": "0x25",
       "name": "schedule_summer_sat_2",
       "access": "R/W",
       "unit": "h",
@@ -798,7 +798,7 @@
     {
       "function": "03",
       "address_dec": 38,
-      "address_hex": "0x0026",
+      "address_hex": "0x26",
       "name": "schedule_summer_sat_3",
       "access": "R/W",
       "unit": "h",
@@ -811,7 +811,7 @@
     {
       "function": "03",
       "address_dec": 39,
-      "address_hex": "0x0027",
+      "address_hex": "0x27",
       "name": "schedule_summer_sat_4",
       "access": "R/W",
       "unit": "h",
@@ -824,7 +824,7 @@
     {
       "function": "03",
       "address_dec": 40,
-      "address_hex": "0x0028",
+      "address_hex": "0x28",
       "name": "schedule_summer_sun_1",
       "access": "R/W",
       "unit": "h",
@@ -837,7 +837,7 @@
     {
       "function": "03",
       "address_dec": 41,
-      "address_hex": "0x0029",
+      "address_hex": "0x29",
       "name": "schedule_summer_sun_2",
       "access": "R/W",
       "unit": "h",
@@ -850,7 +850,7 @@
     {
       "function": "03",
       "address_dec": 42,
-      "address_hex": "0x002A",
+      "address_hex": "0x2a",
       "name": "schedule_summer_sun_3",
       "access": "R/W",
       "unit": "h",
@@ -863,7 +863,7 @@
     {
       "function": "03",
       "address_dec": 43,
-      "address_hex": "0x002B",
+      "address_hex": "0x2b",
       "name": "schedule_summer_sun_4",
       "access": "R/W",
       "unit": "h",
@@ -876,7 +876,7 @@
     {
       "function": "03",
       "address_dec": 44,
-      "address_hex": "0x002C",
+      "address_hex": "0x2c",
       "name": "schedule_winter_mon_1",
       "access": "R/W",
       "unit": "h",
@@ -889,7 +889,7 @@
     {
       "function": "03",
       "address_dec": 45,
-      "address_hex": "0x002D",
+      "address_hex": "0x2d",
       "name": "schedule_winter_mon_2",
       "access": "R/W",
       "unit": "h",
@@ -902,7 +902,7 @@
     {
       "function": "03",
       "address_dec": 46,
-      "address_hex": "0x002E",
+      "address_hex": "0x2e",
       "name": "schedule_winter_mon_3",
       "access": "R/W",
       "unit": "h",
@@ -915,7 +915,7 @@
     {
       "function": "03",
       "address_dec": 47,
-      "address_hex": "0x002F",
+      "address_hex": "0x2f",
       "name": "schedule_winter_mon_4",
       "access": "R/W",
       "unit": "h",
@@ -928,7 +928,7 @@
     {
       "function": "03",
       "address_dec": 48,
-      "address_hex": "0x0030",
+      "address_hex": "0x30",
       "name": "schedule_winter_tue_1",
       "access": "R/W",
       "unit": "h",
@@ -941,7 +941,7 @@
     {
       "function": "03",
       "address_dec": 49,
-      "address_hex": "0x0031",
+      "address_hex": "0x31",
       "name": "schedule_winter_tue_2",
       "access": "R/W",
       "unit": "h",
@@ -954,7 +954,7 @@
     {
       "function": "03",
       "address_dec": 50,
-      "address_hex": "0x0032",
+      "address_hex": "0x32",
       "name": "schedule_winter_tue_3",
       "access": "R/W",
       "unit": "h",
@@ -967,7 +967,7 @@
     {
       "function": "03",
       "address_dec": 51,
-      "address_hex": "0x0033",
+      "address_hex": "0x33",
       "name": "schedule_winter_tue_4",
       "access": "R/W",
       "unit": "h",
@@ -980,7 +980,7 @@
     {
       "function": "03",
       "address_dec": 52,
-      "address_hex": "0x0034",
+      "address_hex": "0x34",
       "name": "schedule_winter_wed_1",
       "access": "R/W",
       "unit": "h",
@@ -993,7 +993,7 @@
     {
       "function": "03",
       "address_dec": 53,
-      "address_hex": "0x0035",
+      "address_hex": "0x35",
       "name": "schedule_winter_wed_2",
       "access": "R/W",
       "unit": "h",
@@ -1006,7 +1006,7 @@
     {
       "function": "03",
       "address_dec": 54,
-      "address_hex": "0x0036",
+      "address_hex": "0x36",
       "name": "schedule_winter_wed_3",
       "access": "R/W",
       "unit": "h",
@@ -1019,7 +1019,7 @@
     {
       "function": "03",
       "address_dec": 55,
-      "address_hex": "0x0037",
+      "address_hex": "0x37",
       "name": "schedule_winter_wed_4",
       "access": "R/W",
       "unit": "h",
@@ -1032,7 +1032,7 @@
     {
       "function": "03",
       "address_dec": 56,
-      "address_hex": "0x0038",
+      "address_hex": "0x38",
       "name": "schedule_winter_thu_1",
       "access": "R/W",
       "unit": "h",
@@ -1045,7 +1045,7 @@
     {
       "function": "03",
       "address_dec": 57,
-      "address_hex": "0x0039",
+      "address_hex": "0x39",
       "name": "schedule_winter_thu_2",
       "access": "R/W",
       "unit": "h",
@@ -1058,7 +1058,7 @@
     {
       "function": "03",
       "address_dec": 58,
-      "address_hex": "0x003A",
+      "address_hex": "0x3a",
       "name": "schedule_winter_thu_3",
       "access": "R/W",
       "unit": "h",
@@ -1071,7 +1071,7 @@
     {
       "function": "03",
       "address_dec": 59,
-      "address_hex": "0x003B",
+      "address_hex": "0x3b",
       "name": "schedule_winter_thu_4",
       "access": "R/W",
       "unit": "h",
@@ -1084,7 +1084,7 @@
     {
       "function": "03",
       "address_dec": 60,
-      "address_hex": "0x003C",
+      "address_hex": "0x3c",
       "name": "schedule_winter_fri_1",
       "access": "R/W",
       "unit": "h",
@@ -1097,7 +1097,7 @@
     {
       "function": "03",
       "address_dec": 61,
-      "address_hex": "0x003D",
+      "address_hex": "0x3d",
       "name": "schedule_winter_fri_2",
       "access": "R/W",
       "unit": "h",
@@ -1110,7 +1110,7 @@
     {
       "function": "03",
       "address_dec": 62,
-      "address_hex": "0x003E",
+      "address_hex": "0x3e",
       "name": "schedule_winter_fri_3",
       "access": "R/W",
       "unit": "h",
@@ -1123,7 +1123,7 @@
     {
       "function": "03",
       "address_dec": 63,
-      "address_hex": "0x003F",
+      "address_hex": "0x3f",
       "name": "schedule_winter_fri_4",
       "access": "R/W",
       "unit": "h",
@@ -1136,7 +1136,7 @@
     {
       "function": "03",
       "address_dec": 64,
-      "address_hex": "0x0040",
+      "address_hex": "0x40",
       "name": "schedule_winter_sat_1",
       "access": "R/W",
       "unit": "h",
@@ -1149,7 +1149,7 @@
     {
       "function": "03",
       "address_dec": 65,
-      "address_hex": "0x0041",
+      "address_hex": "0x41",
       "name": "schedule_winter_sat_2",
       "access": "R/W",
       "unit": "h",
@@ -1162,7 +1162,7 @@
     {
       "function": "03",
       "address_dec": 66,
-      "address_hex": "0x0042",
+      "address_hex": "0x42",
       "name": "schedule_winter_sat_3",
       "access": "R/W",
       "unit": "h",
@@ -1175,7 +1175,7 @@
     {
       "function": "03",
       "address_dec": 67,
-      "address_hex": "0x0043",
+      "address_hex": "0x43",
       "name": "schedule_winter_sat_4",
       "access": "R/W",
       "unit": "h",
@@ -1188,7 +1188,7 @@
     {
       "function": "03",
       "address_dec": 68,
-      "address_hex": "0x0044",
+      "address_hex": "0x44",
       "name": "schedule_winter_sun_1",
       "access": "R/W",
       "unit": "h",
@@ -1201,7 +1201,7 @@
     {
       "function": "03",
       "address_dec": 69,
-      "address_hex": "0x0045",
+      "address_hex": "0x45",
       "name": "schedule_winter_sun_2",
       "access": "R/W",
       "unit": "h",
@@ -1214,7 +1214,7 @@
     {
       "function": "03",
       "address_dec": 70,
-      "address_hex": "0x0046",
+      "address_hex": "0x46",
       "name": "schedule_winter_sun_3",
       "access": "R/W",
       "unit": "h",
@@ -1227,7 +1227,7 @@
     {
       "function": "03",
       "address_dec": 71,
-      "address_hex": "0x0047",
+      "address_hex": "0x47",
       "name": "schedule_winter_sun_4",
       "access": "R/W",
       "unit": "h",
@@ -1240,7 +1240,7 @@
     {
       "function": "03",
       "address_dec": 72,
-      "address_hex": "0x0048",
+      "address_hex": "0x48",
       "name": "setting_summer_mon_1",
       "access": "R/W",
       "unit": "%",
@@ -1253,7 +1253,7 @@
     {
       "function": "03",
       "address_dec": 73,
-      "address_hex": "0x0049",
+      "address_hex": "0x49",
       "name": "setting_summer_mon_2",
       "access": "R/W",
       "unit": "%",
@@ -1266,7 +1266,7 @@
     {
       "function": "03",
       "address_dec": 74,
-      "address_hex": "0x004A",
+      "address_hex": "0x4a",
       "name": "setting_summer_mon_3",
       "access": "R/W",
       "unit": "%",
@@ -1279,7 +1279,7 @@
     {
       "function": "03",
       "address_dec": 75,
-      "address_hex": "0x004B",
+      "address_hex": "0x4b",
       "name": "setting_summer_mon_4",
       "access": "R/W",
       "unit": "%",
@@ -1292,7 +1292,7 @@
     {
       "function": "03",
       "address_dec": 76,
-      "address_hex": "0x004C",
+      "address_hex": "0x4c",
       "name": "setting_summer_tue_1",
       "access": "R/W",
       "unit": "%",
@@ -1305,7 +1305,7 @@
     {
       "function": "03",
       "address_dec": 77,
-      "address_hex": "0x004D",
+      "address_hex": "0x4d",
       "name": "setting_summer_tue_2",
       "access": "R/W",
       "unit": "%",
@@ -1318,7 +1318,7 @@
     {
       "function": "03",
       "address_dec": 78,
-      "address_hex": "0x004E",
+      "address_hex": "0x4e",
       "name": "setting_summer_tue_3",
       "access": "R/W",
       "unit": "%",
@@ -1331,7 +1331,7 @@
     {
       "function": "03",
       "address_dec": 79,
-      "address_hex": "0x004F",
+      "address_hex": "0x4f",
       "name": "setting_summer_tue_4",
       "access": "R/W",
       "unit": "%",
@@ -1344,7 +1344,7 @@
     {
       "function": "03",
       "address_dec": 80,
-      "address_hex": "0x0050",
+      "address_hex": "0x50",
       "name": "setting_summer_wed_1",
       "access": "R/W",
       "unit": "%",
@@ -1357,7 +1357,7 @@
     {
       "function": "03",
       "address_dec": 81,
-      "address_hex": "0x0051",
+      "address_hex": "0x51",
       "name": "setting_summer_wed_2",
       "access": "R/W",
       "unit": "%",
@@ -1370,7 +1370,7 @@
     {
       "function": "03",
       "address_dec": 82,
-      "address_hex": "0x0052",
+      "address_hex": "0x52",
       "name": "setting_summer_wed_3",
       "access": "R/W",
       "unit": "%",
@@ -1383,7 +1383,7 @@
     {
       "function": "03",
       "address_dec": 83,
-      "address_hex": "0x0053",
+      "address_hex": "0x53",
       "name": "setting_summer_wed_4",
       "access": "R/W",
       "unit": "%",
@@ -1396,7 +1396,7 @@
     {
       "function": "03",
       "address_dec": 84,
-      "address_hex": "0x0054",
+      "address_hex": "0x54",
       "name": "setting_summer_thu_1",
       "access": "R/W",
       "unit": "%",
@@ -1409,7 +1409,7 @@
     {
       "function": "03",
       "address_dec": 85,
-      "address_hex": "0x0055",
+      "address_hex": "0x55",
       "name": "setting_summer_thu_2",
       "access": "R/W",
       "unit": "%",
@@ -1422,7 +1422,7 @@
     {
       "function": "03",
       "address_dec": 86,
-      "address_hex": "0x0056",
+      "address_hex": "0x56",
       "name": "setting_summer_thu_3",
       "access": "R/W",
       "unit": "%",
@@ -1435,7 +1435,7 @@
     {
       "function": "03",
       "address_dec": 87,
-      "address_hex": "0x0057",
+      "address_hex": "0x57",
       "name": "setting_summer_thu_4",
       "access": "R/W",
       "unit": "%",
@@ -1448,7 +1448,7 @@
     {
       "function": "03",
       "address_dec": 88,
-      "address_hex": "0x0058",
+      "address_hex": "0x58",
       "name": "setting_summer_fri_1",
       "access": "R/W",
       "unit": "%",
@@ -1461,7 +1461,7 @@
     {
       "function": "03",
       "address_dec": 89,
-      "address_hex": "0x0059",
+      "address_hex": "0x59",
       "name": "setting_summer_fri_2",
       "access": "R/W",
       "unit": "%",
@@ -1474,7 +1474,7 @@
     {
       "function": "03",
       "address_dec": 90,
-      "address_hex": "0x005A",
+      "address_hex": "0x5a",
       "name": "setting_summer_fri_3",
       "access": "R/W",
       "unit": "%",
@@ -1487,7 +1487,7 @@
     {
       "function": "03",
       "address_dec": 91,
-      "address_hex": "0x005B",
+      "address_hex": "0x5b",
       "name": "setting_summer_fri_4",
       "access": "R/W",
       "unit": "%",
@@ -1500,7 +1500,7 @@
     {
       "function": "03",
       "address_dec": 92,
-      "address_hex": "0x005C",
+      "address_hex": "0x5c",
       "name": "setting_summer_sat_1",
       "access": "R/W",
       "unit": "%",
@@ -1513,7 +1513,7 @@
     {
       "function": "03",
       "address_dec": 93,
-      "address_hex": "0x005D",
+      "address_hex": "0x5d",
       "name": "setting_summer_sat_2",
       "access": "R/W",
       "unit": "%",
@@ -1526,7 +1526,7 @@
     {
       "function": "03",
       "address_dec": 94,
-      "address_hex": "0x005E",
+      "address_hex": "0x5e",
       "name": "setting_summer_sat_3",
       "access": "R/W",
       "unit": "%",
@@ -1539,7 +1539,7 @@
     {
       "function": "03",
       "address_dec": 95,
-      "address_hex": "0x005F",
+      "address_hex": "0x5f",
       "name": "setting_summer_sat_4",
       "access": "R/W",
       "unit": "%",
@@ -1552,7 +1552,7 @@
     {
       "function": "03",
       "address_dec": 96,
-      "address_hex": "0x0060",
+      "address_hex": "0x60",
       "name": "setting_summer_sun_1",
       "access": "R/W",
       "unit": "%",
@@ -1565,7 +1565,7 @@
     {
       "function": "03",
       "address_dec": 97,
-      "address_hex": "0x0061",
+      "address_hex": "0x61",
       "name": "setting_summer_sun_2",
       "access": "R/W",
       "unit": "%",
@@ -1578,7 +1578,7 @@
     {
       "function": "03",
       "address_dec": 98,
-      "address_hex": "0x0062",
+      "address_hex": "0x62",
       "name": "setting_summer_sun_3",
       "access": "R/W",
       "unit": "%",
@@ -1591,7 +1591,7 @@
     {
       "function": "03",
       "address_dec": 99,
-      "address_hex": "0x0063",
+      "address_hex": "0x63",
       "name": "setting_summer_sun_4",
       "access": "R/W",
       "unit": "%",
@@ -1604,7 +1604,7 @@
     {
       "function": "03",
       "address_dec": 100,
-      "address_hex": "0x0064",
+      "address_hex": "0x64",
       "name": "setting_winter_mon_1",
       "access": "R/W",
       "unit": "%",
@@ -1617,7 +1617,7 @@
     {
       "function": "03",
       "address_dec": 101,
-      "address_hex": "0x0065",
+      "address_hex": "0x65",
       "name": "setting_winter_mon_2",
       "access": "R/W",
       "unit": "%",
@@ -1630,7 +1630,7 @@
     {
       "function": "03",
       "address_dec": 102,
-      "address_hex": "0x0066",
+      "address_hex": "0x66",
       "name": "setting_winter_mon_3",
       "access": "R/W",
       "unit": "%",
@@ -1643,7 +1643,7 @@
     {
       "function": "03",
       "address_dec": 103,
-      "address_hex": "0x0067",
+      "address_hex": "0x67",
       "name": "setting_winter_mon_4",
       "access": "R/W",
       "unit": "%",
@@ -1656,7 +1656,7 @@
     {
       "function": "03",
       "address_dec": 104,
-      "address_hex": "0x0068",
+      "address_hex": "0x68",
       "name": "setting_winter_tue_1",
       "access": "R/W",
       "unit": "%",
@@ -1669,7 +1669,7 @@
     {
       "function": "03",
       "address_dec": 105,
-      "address_hex": "0x0069",
+      "address_hex": "0x69",
       "name": "setting_winter_tue_2",
       "access": "R/W",
       "unit": "%",
@@ -1682,7 +1682,7 @@
     {
       "function": "03",
       "address_dec": 106,
-      "address_hex": "0x006A",
+      "address_hex": "0x6a",
       "name": "setting_winter_tue_3",
       "access": "R/W",
       "unit": "%",
@@ -1695,7 +1695,7 @@
     {
       "function": "03",
       "address_dec": 107,
-      "address_hex": "0x006B",
+      "address_hex": "0x6b",
       "name": "setting_winter_tue_4",
       "access": "R/W",
       "unit": "%",
@@ -1708,7 +1708,7 @@
     {
       "function": "03",
       "address_dec": 108,
-      "address_hex": "0x006C",
+      "address_hex": "0x6c",
       "name": "setting_winter_wed_1",
       "access": "R/W",
       "unit": "%",
@@ -1721,7 +1721,7 @@
     {
       "function": "03",
       "address_dec": 109,
-      "address_hex": "0x006D",
+      "address_hex": "0x6d",
       "name": "setting_winter_wed_2",
       "access": "R/W",
       "unit": "%",
@@ -1734,7 +1734,7 @@
     {
       "function": "03",
       "address_dec": 110,
-      "address_hex": "0x006E",
+      "address_hex": "0x6e",
       "name": "setting_winter_wed_3",
       "access": "R/W",
       "unit": "%",
@@ -1747,7 +1747,7 @@
     {
       "function": "03",
       "address_dec": 111,
-      "address_hex": "0x006F",
+      "address_hex": "0x6f",
       "name": "setting_winter_wed_4",
       "access": "R/W",
       "unit": "%",
@@ -1760,7 +1760,7 @@
     {
       "function": "03",
       "address_dec": 112,
-      "address_hex": "0x0070",
+      "address_hex": "0x70",
       "name": "setting_winter_thu_1",
       "access": "R/W",
       "unit": "%",
@@ -1773,7 +1773,7 @@
     {
       "function": "03",
       "address_dec": 113,
-      "address_hex": "0x0071",
+      "address_hex": "0x71",
       "name": "setting_winter_thu_2",
       "access": "R/W",
       "unit": "%",
@@ -1786,7 +1786,7 @@
     {
       "function": "03",
       "address_dec": 114,
-      "address_hex": "0x0072",
+      "address_hex": "0x72",
       "name": "setting_winter_thu_3",
       "access": "R/W",
       "unit": "%",
@@ -1799,7 +1799,7 @@
     {
       "function": "03",
       "address_dec": 115,
-      "address_hex": "0x0073",
+      "address_hex": "0x73",
       "name": "setting_winter_thu_4",
       "access": "R/W",
       "unit": "%",
@@ -1812,7 +1812,7 @@
     {
       "function": "03",
       "address_dec": 116,
-      "address_hex": "0x0074",
+      "address_hex": "0x74",
       "name": "setting_winter_fri_1",
       "access": "R/W",
       "unit": "%",
@@ -1825,7 +1825,7 @@
     {
       "function": "03",
       "address_dec": 117,
-      "address_hex": "0x0075",
+      "address_hex": "0x75",
       "name": "setting_winter_fri_2",
       "access": "R/W",
       "unit": "%",
@@ -1838,7 +1838,7 @@
     {
       "function": "03",
       "address_dec": 118,
-      "address_hex": "0x0076",
+      "address_hex": "0x76",
       "name": "setting_winter_fri_3",
       "access": "R/W",
       "unit": "%",
@@ -1851,7 +1851,7 @@
     {
       "function": "03",
       "address_dec": 119,
-      "address_hex": "0x0077",
+      "address_hex": "0x77",
       "name": "setting_winter_fri_4",
       "access": "R/W",
       "unit": "%",
@@ -1864,7 +1864,7 @@
     {
       "function": "03",
       "address_dec": 120,
-      "address_hex": "0x0078",
+      "address_hex": "0x78",
       "name": "setting_winter_sat_1",
       "access": "R/W",
       "unit": "%",
@@ -1877,7 +1877,7 @@
     {
       "function": "03",
       "address_dec": 121,
-      "address_hex": "0x0079",
+      "address_hex": "0x79",
       "name": "setting_winter_sat_2",
       "access": "R/W",
       "unit": "%",
@@ -1890,7 +1890,7 @@
     {
       "function": "03",
       "address_dec": 122,
-      "address_hex": "0x007A",
+      "address_hex": "0x7a",
       "name": "setting_winter_sat_3",
       "access": "R/W",
       "unit": "%",
@@ -1903,7 +1903,7 @@
     {
       "function": "03",
       "address_dec": 123,
-      "address_hex": "0x007B",
+      "address_hex": "0x7b",
       "name": "setting_winter_sat_4",
       "access": "R/W",
       "unit": "%",
@@ -1916,7 +1916,7 @@
     {
       "function": "03",
       "address_dec": 124,
-      "address_hex": "0x007C",
+      "address_hex": "0x7c",
       "name": "setting_winter_sun_1",
       "access": "R/W",
       "unit": "%",
@@ -1929,7 +1929,7 @@
     {
       "function": "03",
       "address_dec": 125,
-      "address_hex": "0x007D",
+      "address_hex": "0x7d",
       "name": "setting_winter_sun_2",
       "access": "R/W",
       "unit": "%",
@@ -1942,7 +1942,7 @@
     {
       "function": "03",
       "address_dec": 126,
-      "address_hex": "0x007E",
+      "address_hex": "0x7e",
       "name": "setting_winter_sun_3",
       "access": "R/W",
       "unit": "%",
@@ -1955,7 +1955,7 @@
     {
       "function": "03",
       "address_dec": 127,
-      "address_hex": "0x007F",
+      "address_hex": "0x7f",
       "name": "setting_winter_sun_4",
       "access": "R/W",
       "unit": "%",
@@ -1968,7 +1968,7 @@
     {
       "function": "03",
       "address_dec": 128,
-      "address_hex": "0x0080",
+      "address_hex": "0x80",
       "name": "airing_summer_mon",
       "access": "R/W",
       "unit": "hhmm",
@@ -1981,7 +1981,7 @@
     {
       "function": "03",
       "address_dec": 132,
-      "address_hex": "0x0084",
+      "address_hex": "0x84",
       "name": "airing_summer_tue",
       "access": "R/W",
       "unit": "hhmm",
@@ -1994,7 +1994,7 @@
     {
       "function": "03",
       "address_dec": 136,
-      "address_hex": "0x0088",
+      "address_hex": "0x88",
       "name": "airing_summer_wed",
       "access": "R/W",
       "unit": "hhmm",
@@ -2007,7 +2007,7 @@
     {
       "function": "03",
       "address_dec": 140,
-      "address_hex": "0x008C",
+      "address_hex": "0x8c",
       "name": "airing_summer_thu",
       "access": "R/W",
       "unit": "hhmm",
@@ -2020,7 +2020,7 @@
     {
       "function": "03",
       "address_dec": 144,
-      "address_hex": "0x0090",
+      "address_hex": "0x90",
       "name": "airing_summer_fri",
       "access": "R/W",
       "unit": "hhmm",
@@ -2033,7 +2033,7 @@
     {
       "function": "03",
       "address_dec": 148,
-      "address_hex": "0x0094",
+      "address_hex": "0x94",
       "name": "airing_summer_sat",
       "access": "R/W",
       "unit": "hhmm",
@@ -2046,7 +2046,7 @@
     {
       "function": "03",
       "address_dec": 152,
-      "address_hex": "0x0098",
+      "address_hex": "0x98",
       "name": "airing_summer_sun",
       "access": "R/W",
       "unit": "hhmm",
@@ -2059,7 +2059,7 @@
     {
       "function": "03",
       "address_dec": 156,
-      "address_hex": "0x009C",
+      "address_hex": "0x9c",
       "name": "airing_winter_mon",
       "access": "R/W",
       "unit": "hhmm",
@@ -2072,7 +2072,7 @@
     {
       "function": "03",
       "address_dec": 160,
-      "address_hex": "0x00A0",
+      "address_hex": "0xa0",
       "name": "airing_winter_tue",
       "access": "R/W",
       "unit": "hhmm",
@@ -2085,7 +2085,7 @@
     {
       "function": "03",
       "address_dec": 164,
-      "address_hex": "0x00A4",
+      "address_hex": "0xa4",
       "name": "airing_winter_wed",
       "access": "R/W",
       "unit": "hhmm",
@@ -2098,7 +2098,7 @@
     {
       "function": "03",
       "address_dec": 168,
-      "address_hex": "0x00A8",
+      "address_hex": "0xa8",
       "name": "airing_winter_thu",
       "access": "R/W",
       "unit": "hhmm",
@@ -2111,7 +2111,7 @@
     {
       "function": "03",
       "address_dec": 172,
-      "address_hex": "0x00AC",
+      "address_hex": "0xac",
       "name": "airing_winter_fri",
       "access": "R/W",
       "unit": "hhmm",
@@ -2124,7 +2124,7 @@
     {
       "function": "03",
       "address_dec": 176,
-      "address_hex": "0x00B0",
+      "address_hex": "0xb0",
       "name": "airing_winter_sat",
       "access": "R/W",
       "unit": "hhmm",
@@ -2137,7 +2137,7 @@
     {
       "function": "03",
       "address_dec": 180,
-      "address_hex": "0x00B4",
+      "address_hex": "0xb4",
       "name": "airing_winter_sun",
       "access": "R/W",
       "unit": "hhmm",
@@ -2150,7 +2150,7 @@
     {
       "function": "03",
       "address_dec": 192,
-      "address_hex": "0x00C0",
+      "address_hex": "0xc0",
       "name": "rtc_cal",
       "access": "R/W",
       "unit": "s",
@@ -2163,7 +2163,7 @@
     {
       "function": "03",
       "address_dec": 240,
-      "address_hex": "0x00F0",
+      "address_hex": "0xf0",
       "name": "cf_version",
       "access": "R/-",
       "unit": "Format zapisu wersji oprogramowania: [MM].[mm]",
@@ -2176,7 +2176,7 @@
     {
       "function": "03",
       "address_dec": 256,
-      "address_hex": "0x0100",
+      "address_hex": "0x100",
       "name": "supply_air_flow",
       "access": "R/-",
       "unit": "m3/h",
@@ -2189,7 +2189,7 @@
     {
       "function": "03",
       "address_dec": 257,
-      "address_hex": "0x0101",
+      "address_hex": "0x101",
       "name": "exhaust_air_flow",
       "access": "R/-",
       "unit": "m3/h",
@@ -2202,7 +2202,7 @@
     {
       "function": "03",
       "address_dec": 1280,
-      "address_hex": "0x0500",
+      "address_hex": "0x500",
       "name": "dac_supply",
       "access": "R/-",
       "unit": "V",
@@ -2215,7 +2215,7 @@
     {
       "function": "03",
       "address_dec": 1281,
-      "address_hex": "0x0501",
+      "address_hex": "0x501",
       "name": "dac_exhaust",
       "access": "R/-",
       "unit": "V",
@@ -2228,7 +2228,7 @@
     {
       "function": "03",
       "address_dec": 1282,
-      "address_hex": "0x0502",
+      "address_hex": "0x502",
       "name": "dac_heater",
       "access": "R/-",
       "unit": "V",
@@ -2241,7 +2241,7 @@
     {
       "function": "03",
       "address_dec": 1283,
-      "address_hex": "0x0503",
+      "address_hex": "0x503",
       "name": "dac_cooler",
       "access": "R/-",
       "unit": "V",
@@ -4184,7 +4184,7 @@
     {
       "function": "04",
       "address_dec": 0,
-      "address_hex": "0x0000",
+      "address_hex": "0x0",
       "name": "version_major",
       "access": "R/-",
       "unit": null,
@@ -4197,7 +4197,7 @@
     {
       "function": "04",
       "address_dec": 1,
-      "address_hex": "0x0001",
+      "address_hex": "0x1",
       "name": "version_minor",
       "access": "R/-",
       "unit": null,
@@ -4210,7 +4210,7 @@
     {
       "function": "04",
       "address_dec": 2,
-      "address_hex": "0x0002",
+      "address_hex": "0x2",
       "name": "day_of_week",
       "access": "R/-",
       "unit": null,
@@ -4231,7 +4231,7 @@
     {
       "function": "04",
       "address_dec": 3,
-      "address_hex": "0x0003",
+      "address_hex": "0x3",
       "name": "period",
       "access": "R/-",
       "unit": null,
@@ -4249,7 +4249,7 @@
     {
       "function": "04",
       "address_dec": 4,
-      "address_hex": "0x0004",
+      "address_hex": "0x4",
       "name": "version_patch",
       "access": "R/-",
       "unit": null,
@@ -4262,7 +4262,7 @@
     {
       "function": "04",
       "address_dec": 14,
-      "address_hex": "0x000E",
+      "address_hex": "0xe",
       "name": "compilation_days",
       "access": "R/-",
       "unit": "d",
@@ -4275,7 +4275,7 @@
     {
       "function": "04",
       "address_dec": 15,
-      "address_hex": "0x000F",
+      "address_hex": "0xf",
       "name": "compilation_seconds",
       "access": "R/-",
       "unit": "s",
@@ -4288,7 +4288,7 @@
     {
       "function": "04",
       "address_dec": 16,
-      "address_hex": "0x0010",
+      "address_hex": "0x10",
       "name": "outside_temperature",
       "access": "R/-",
       "unit": "°C",
@@ -4301,7 +4301,7 @@
     {
       "function": "04",
       "address_dec": 17,
-      "address_hex": "0x0011",
+      "address_hex": "0x11",
       "name": "supply_temperature",
       "access": "R/-",
       "unit": "°C",
@@ -4314,7 +4314,7 @@
     {
       "function": "04",
       "address_dec": 18,
-      "address_hex": "0x0012",
+      "address_hex": "0x12",
       "name": "exhaust_temperature",
       "access": "R/-",
       "unit": "°C",
@@ -4327,7 +4327,7 @@
     {
       "function": "04",
       "address_dec": 19,
-      "address_hex": "0x0013",
+      "address_hex": "0x13",
       "name": "fpx_temperature",
       "access": "R/-",
       "unit": "°C",
@@ -4340,7 +4340,7 @@
     {
       "function": "04",
       "address_dec": 20,
-      "address_hex": "0x0014",
+      "address_hex": "0x14",
       "name": "duct_supply_temperature",
       "access": "R/-",
       "unit": "°C",
@@ -4353,7 +4353,7 @@
     {
       "function": "04",
       "address_dec": 21,
-      "address_hex": "0x0015",
+      "address_hex": "0x15",
       "name": "gwc_temperature",
       "access": "R/-",
       "unit": "°C",
@@ -4366,7 +4366,7 @@
     {
       "function": "04",
       "address_dec": 22,
-      "address_hex": "0x0016",
+      "address_hex": "0x16",
       "name": "ambient_temperature",
       "access": "R/-",
       "unit": "°C",
@@ -4379,7 +4379,7 @@
     {
       "function": "04",
       "address_dec": 23,
-      "address_hex": "0x0017",
+      "address_hex": "0x17",
       "name": "heating_temperature",
       "access": "R/-",
       "unit": "°C",
@@ -4392,7 +4392,7 @@
     {
       "function": "04",
       "address_dec": 24,
-      "address_hex": "0x0018",
+      "address_hex": "0x18",
       "name": "serial_number",
       "access": "R/-",
       "unit": "ASCII",
@@ -4410,7 +4410,7 @@
     {
       "function": "04",
       "address_dec": 271,
-      "address_hex": "0x010F",
+      "address_hex": "0x10f",
       "name": "constant_flow_active",
       "access": "R/-",
       "unit": null,
@@ -4426,7 +4426,7 @@
     {
       "function": "04",
       "address_dec": 272,
-      "address_hex": "0x0110",
+      "address_hex": "0x110",
       "name": "supply_percentage",
       "access": "R/-",
       "unit": "%",
@@ -4439,7 +4439,7 @@
     {
       "function": "04",
       "address_dec": 273,
-      "address_hex": "0x0111",
+      "address_hex": "0x111",
       "name": "exhaust_percentage",
       "access": "R/-",
       "unit": "%",
@@ -4452,7 +4452,7 @@
     {
       "function": "04",
       "address_dec": 274,
-      "address_hex": "0x0112",
+      "address_hex": "0x112",
       "name": "supply_flow_rate",
       "access": "R/-",
       "unit": "m3/h",
@@ -4465,7 +4465,7 @@
     {
       "function": "04",
       "address_dec": 275,
-      "address_hex": "0x0113",
+      "address_hex": "0x113",
       "name": "exhaust_flow_rate",
       "access": "R/-",
       "unit": "m3/h",
@@ -4478,7 +4478,7 @@
     {
       "function": "04",
       "address_dec": 276,
-      "address_hex": "0x0114",
+      "address_hex": "0x114",
       "name": "min_percentage",
       "access": "R/-",
       "unit": "%",
@@ -4491,7 +4491,7 @@
     {
       "function": "04",
       "address_dec": 277,
-      "address_hex": "0x0115",
+      "address_hex": "0x115",
       "name": "max_percentage",
       "access": "R/-",
       "unit": "%",
@@ -4504,7 +4504,7 @@
     {
       "function": "04",
       "address_dec": 298,
-      "address_hex": "0x012A",
+      "address_hex": "0x12a",
       "name": "water_removal_active",
       "access": "R/-",
       "unit": null,


### PR DESCRIPTION
## Summary
- normalize `address_hex` fields to match `hex(address_dec)`

## Testing
- `pytest tests/test_register_loader_validation.py -q`
- `pre-commit run --files custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` *(fails: InvalidManifestError: /root/.cache/pre-commit/repof_nefaj3/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf11472f08326bcdcf2838a68f699