### PR TITLE
refactor: remove broad exception handling

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -299,11 +299,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
             except KeyError as err:
                 _LOGGER.error("Missing required data: %s", err)
                 errors["base"] = "invalid_input"
-            except Exception as err:  # pylint: disable=broad-except
-                _LOGGER.exception(
-                    "Unexpected error during configuration: %s", err
-                )
-                raise
             else:
                 self._abort_if_unique_id_configured()
                 # Show confirmation step with device info

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,7 @@
 import asyncio
 import sys
 import socket
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -30,15 +30,24 @@ sys.modules.setdefault(
 )
 sys.modules.setdefault("homeassistant.util.network", network_module)
 # Stub registers module to avoid heavy imports during tests
+registers_module = ModuleType("custom_components.thessla_green_modbus.registers")
+registers_module.__path__ = []
+registers_module.loader = None
+registers_module.get_registers_by_function = lambda *args, **kwargs: []
+registers_module.get_all_registers = lambda *args, **kwargs: []
+registers_module.get_registers_hash = lambda *args, **kwargs: ""
+registers_module.plan_group_reads = lambda *args, **kwargs: []
 sys.modules.setdefault(
-    "custom_components.thessla_green_modbus.registers",
-    SimpleNamespace(
-        loader=None,
-        get_registers_by_function=lambda *args, **kwargs: [],
-        get_all_registers=lambda *args, **kwargs: [],
-        get_registers_hash=lambda *args, **kwargs: "",
-        plan_group_reads=lambda *args, **kwargs: [],
-    ),
+    "custom_components.thessla_green_modbus.registers", registers_module
+)
+loader_module = ModuleType(
+    "custom_components.thessla_green_modbus.registers.loader"
+)
+loader_module.get_registers_by_function = lambda *args, **kwargs: []
+loader_module.load_registers = lambda *args, **kwargs: []
+loader_module.get_all_registers = lambda *args, **kwargs: []
+sys.modules.setdefault(
+    "custom_components.thessla_green_modbus.registers.loader", loader_module
 )
 
 from custom_components.thessla_green_modbus.const import (
@@ -780,9 +789,14 @@ async def test_form_user_invalid_value():
     flow = ConfigFlow()
     flow.hass = None
 
-    with patch(
-        "custom_components.thessla_green_modbus.config_flow.validate_input",
-        side_effect=ValueError,
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            side_effect=ValueError,
+        ),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow._LOGGER"
+        ) as logger_mock,
     ):
         result = await flow.async_step_user(
             {
@@ -795,6 +809,7 @@ async def test_form_user_invalid_value():
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "invalid_input"}
+    logger_mock.error.assert_called_once()
 
 
 async def test_form_user_missing_key():
@@ -802,9 +817,14 @@ async def test_form_user_missing_key():
     flow = ConfigFlow()
     flow.hass = None
 
-    with patch(
-        "custom_components.thessla_green_modbus.config_flow.validate_input",
-        side_effect=KeyError("test"),
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            side_effect=KeyError("test"),
+        ),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow._LOGGER"
+        ) as logger_mock,
     ):
         result = await flow.async_step_user(
             {
@@ -817,6 +837,7 @@ async def test_form_user_missing_key():
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "invalid_input"}
+    logger_mock.error.assert_called_once()
 
 
 async def test_form_user_unexpected_exception():
@@ -824,9 +845,14 @@ async def test_form_user_unexpected_exception():
     flow = ConfigFlow()
     flow.hass = None
 
-    with patch(
-        "custom_components.thessla_green_modbus.config_flow.validate_input",
-        side_effect=RuntimeError,
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            side_effect=RuntimeError,
+        ),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow._LOGGER"
+        ) as logger_mock,
     ):
         with pytest.raises(RuntimeError):
             await flow.async_step_user(
@@ -837,6 +863,8 @@ async def test_form_user_unexpected_exception():
                     CONF_NAME: "My Device",
                 }
             )
+
+    logger_mock.exception.assert_not_called()
 
 
 async def test_validate_input_success():


### PR DESCRIPTION
## Summary
- narrow exception handling in config flow to specific errors
- add logging assertions and unexpected exception checks to config flow tests

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py tests/test_config_flow.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repokptxlxf5/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_config_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf128dd6c8326ab2dd9ae69cefd47