### PR TITLE
Use WeakKeyDictionary for modbus helper caches

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 
 import inspect
 import logging
+import weakref
 from collections.abc import Awaitable, Callable, Iterable
 from typing import Any, List, Tuple
 
 _LOGGER = logging.getLogger(__name__)
 
 # Cache which keyword ("slave" or "unit") a given function accepts
-_KWARG_CACHE: dict[Callable[..., Awaitable[Any]], str | None] = {}
+_KWARG_CACHE: weakref.WeakKeyDictionary[
+    Callable[..., Awaitable[Any]], str | None
+] = weakref.WeakKeyDictionary()
 # Cache function signatures to avoid repeated inspection
-_SIG_CACHE: dict[Callable[..., Awaitable[Any]], inspect.Signature] = {}
+_SIG_CACHE: weakref.WeakKeyDictionary[
+    Callable[..., Awaitable[Any]], inspect.Signature
+] = weakref.WeakKeyDictionary()
 
 
 def _mask_frame(frame: bytes) -> str:


### PR DESCRIPTION
## Summary
- avoid cache memory leaks by using `WeakKeyDictionary` for cached modbus call metadata
- add tests to ensure cached signatures and kwargs are cleared once functions are garbage collected

## Testing
- `pytest -c tests/pytest.ini tests/test_modbus_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aaf12a176c8326a94ee13bb1ca6d1f