### PR TITLE
Add options flow test for max register clamping

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -486,11 +486,15 @@ class OptionsFlow(config_entries.OptionsFlow):
             max_regs = user_input.get(
                 CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
             )
-            if not 1 <= max_regs <= DEFAULT_MAX_REGISTERS_PER_REQUEST:
+            if max_regs < 1:
                 errors[CONF_MAX_REGISTERS_PER_REQUEST] = (
                     "invalid_max_registers_per_request"
                 )
             else:
+                user_input = dict(user_input)
+                user_input[CONF_MAX_REGISTERS_PER_REQUEST] = min(
+                    max_regs, DEFAULT_MAX_REGISTERS_PER_REQUEST
+                )
                 return self.async_create_entry(title="", data=user_input)
 
         # Get current values
@@ -561,7 +565,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                     CONF_MAX_REGISTERS_PER_REQUEST,
                     default=current_max_registers_per_request,
                     description={"advanced": True},
-                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=16)),
+                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=125)),
             }
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,12 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
         def __init_subclass__(cls, **kwargs):
             return
 
+        def async_show_form(self, **kwargs):  # type: ignore[override]
+            return {"type": "form", **kwargs}
+
+        def async_create_entry(self, **kwargs):  # type: ignore[override]
+            return {"type": "create_entry", **kwargs}
+
     config_entries.OptionsFlow = OptionsFlow
     helpers.DataUpdateCoordinator = DataUpdateCoordinator
     helpers.UpdateFailed = UpdateFailed

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,6 +4,7 @@
 import asyncio
 import sys
 import socket
+import types
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -29,26 +30,42 @@ sys.modules.setdefault(
     "homeassistant.util", SimpleNamespace(network=network_module)
 )
 sys.modules.setdefault("homeassistant.util.network", network_module)
+
 # Stub registers module to avoid heavy imports during tests
+registers_module = types.ModuleType(
+    "custom_components.thessla_green_modbus.registers"
+)
+registers_module.__path__ = []  # type: ignore[attr-defined]
+registers_loader = types.ModuleType(
+    "custom_components.thessla_green_modbus.registers.loader"
+)
+registers_loader.get_registers_by_function = lambda *args, **kwargs: []
+registers_loader.get_all_registers = lambda *args, **kwargs: []
+registers_loader.get_registers_hash = lambda *args, **kwargs: ""
+registers_loader.plan_group_reads = lambda *args, **kwargs: []
+registers_loader.load_registers = lambda *args, **kwargs: []
+registers_module.loader = registers_loader
+registers_module.get_registers_by_function = registers_loader.get_registers_by_function
+registers_module.get_all_registers = registers_loader.get_all_registers
+registers_module.get_registers_hash = registers_loader.get_registers_hash
+registers_module.plan_group_reads = registers_loader.plan_group_reads
 sys.modules.setdefault(
-    "custom_components.thessla_green_modbus.registers",
-    SimpleNamespace(
-        loader=None,
-        get_registers_by_function=lambda *args, **kwargs: [],
-        get_all_registers=lambda *args, **kwargs: [],
-        get_registers_hash=lambda *args, **kwargs: "",
-        plan_group_reads=lambda *args, **kwargs: [],
-    ),
+    "custom_components.thessla_green_modbus.registers", registers_module
+)
+sys.modules.setdefault(
+    "custom_components.thessla_green_modbus.registers.loader", registers_loader
 )
 
 from custom_components.thessla_green_modbus.const import (
     CONF_DEEP_SCAN,
     CONF_SLAVE_ID,
+    CONF_MAX_REGISTERS_PER_REQUEST,
 )
 
 from custom_components.thessla_green_modbus.config_flow import (
     CannotConnect,
     ConfigFlow,
+    OptionsFlow,
     InvalidAuth,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import (
@@ -1736,3 +1753,29 @@ def test_device_capabilities_serialization():
     assert list(caps.keys()) == list(serialized.keys())
     assert list(caps.items()) == list(serialized.items())
     assert list(caps.values()) == list(serialized.values())
+
+
+async def test_options_flow_max_registers_per_request_clamped():
+    """Options flow should clamp max registers per request to 16."""
+    config_entry = SimpleNamespace(options={})
+    flow = OptionsFlow(config_entry)
+
+    result = await flow.async_step_init()
+    schema_keys = {
+        key.schema if hasattr(key, "schema") else key
+        for key in result["data_schema"].schema
+    }
+    assert CONF_MAX_REGISTERS_PER_REQUEST in schema_keys
+
+    # Accept values within range
+    for value in (1, 16):
+        flow = OptionsFlow(SimpleNamespace(options={}))
+        result = await flow.async_step_init({CONF_MAX_REGISTERS_PER_REQUEST: value})
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_MAX_REGISTERS_PER_REQUEST] == value
+
+    # Clamp values above range to 16
+    flow = OptionsFlow(SimpleNamespace(options={}))
+    result = await flow.async_step_init({CONF_MAX_REGISTERS_PER_REQUEST: 20})
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_MAX_REGISTERS_PER_REQUEST] == 16


### PR DESCRIPTION
## Summary
- ensure options flow clamps `max_registers_per_request` to 16
- test options flow max register per request value

## Testing
- `pytest tests/test_config_flow.py`
- `pre-commit run --files tests/test_config_flow.py custom_components/thessla_green_modbus/config_flow.py tests/conftest.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repowcek7kov/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf11279508326a3a3aa18574c64c9