### PR TITLE
Use timezone-aware fallback timestamps

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -18,9 +18,9 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover
 
         @staticmethod
         def now():
-            from datetime import datetime
+            from datetime import datetime, timezone
 
-            return datetime.now()
+            return datetime.now(timezone.utc)
 
         @staticmethod
         def utcnow():


### PR DESCRIPTION
## Summary
- ensure `_DTUtil.now()` uses `timezone.utc`
- test that fallback `dt_util` returns timezone-aware values
- remove stub `homeassistant.util.dt` to exercise fallback

## Testing
- `pytest tests/test_coordinator.py::test_dt_util_timezone_awareness -vv`
- `pytest tests/test_coordinator.py` *(fails: KeyError: 'date_time_2', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf12824088326a2d707a83a9a145a