### PR TITLE
Clamp Modbus register batch size

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -124,7 +124,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         entry: ConfigEntry | None = None,
         skip_missing_registers: bool = False,
     ) -> None:
-        """Initialize the coordinator."""
+        """Initialize the coordinator.
+
+        ``max_registers_per_request`` is clamped to the safe Modbus range of
+        1-16 registers per request.
+        """
         if isinstance(scan_interval, timedelta):
             update_interval = scan_interval
             self.scan_interval = int(scan_interval.total_seconds())
@@ -150,8 +154,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.deep_scan = deep_scan
         self.entry = entry
         self.skip_missing_registers = skip_missing_registers
-        self.max_registers_per_request = max_registers_per_request
-        self.effective_batch = min(max_registers_per_request, 16)
+        # Clamp user-specified batch size to the Modbus-safe range (1-16)
+        self.max_registers_per_request = max(1, min(max_registers_per_request, 16))
+        # ``effective_batch`` mirrors the sanitized value
+        self.effective_batch = self.max_registers_per_request
 
         # Connection management
         self.client: AsyncModbusTcpClient | None = None

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -234,7 +234,11 @@ class ThesslaGreenDeviceScanner:
         full_register_scan: bool = False,
         max_registers_per_request: int = MAX_BATCH_REGISTERS,
     ) -> None:
-        """Initialize device scanner with consistent parameter names."""
+        """Initialize device scanner with consistent parameter names.
+
+        ``max_registers_per_request`` is clamped to the safe Modbus range of
+        1-16 registers per request.
+        """
         _ensure_register_maps()
         self.host = host
         self.port = port
@@ -247,8 +251,12 @@ class ThesslaGreenDeviceScanner:
         self.skip_known_missing = skip_known_missing
         self.deep_scan = deep_scan
         self.full_register_scan = full_register_scan
-        self.max_registers_per_request = max_registers_per_request
-        self.effective_batch = min(max_registers_per_request, MAX_BATCH_REGISTERS)
+        # Sanitize user input to remain within the Modbus-safe range (1-16)
+        self.max_registers_per_request = max(
+            1, min(max_registers_per_request, MAX_BATCH_REGISTERS)
+        )
+        # Dependent attributes mirror the clamped value
+        self.effective_batch = self.max_registers_per_request
 
         # Available registers storage
         self.available_registers: dict[str, set[str]] = {


### PR DESCRIPTION
## Summary
- Clamp coordinator's and scanner's `max_registers_per_request` to the Modbus-safe 1-16 range
- Update `effective_batch` and docstrings to reflect sanitized values

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/scanner_core.py` *(fails: InvalidManifestError)*
- `pytest` *(fails: JSONDecodeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf2a2d65c832692cf5d66c34874df