### PR TITLE
Refactor unique ID migration logic

### DIFF
--- a/tests/test_migrate_unique_id.py
+++ b/tests/test_migrate_unique_id.py
@@ -1,0 +1,47 @@
+import pytest
+
+from custom_components.thessla_green_modbus.const import DOMAIN, migrate_unique_id
+
+
+HOST = "fd00:1:2::1"
+PORT = 502
+SLAVE = 10
+REGISTER_NAME = "supply_flow_rate"
+REGISTER_ADDRESS = 274
+
+
+def test_migrate_unique_id_with_serial():
+    unique_id = f"{DOMAIN}_{HOST}_{PORT}_{SLAVE}_{REGISTER_NAME}"
+    new_uid = migrate_unique_id(
+        unique_id,
+        serial_number="ABC123",
+        host=HOST,
+        port=PORT,
+        slave_id=SLAVE,
+    )
+    assert new_uid == f"{DOMAIN}_ABC123_{SLAVE}_{REGISTER_ADDRESS}"
+
+
+def test_migrate_unique_id_without_serial():
+    unique_id = f"{DOMAIN}_{HOST}_{PORT}_{SLAVE}_{REGISTER_NAME}"
+    new_uid = migrate_unique_id(
+        unique_id,
+        serial_number=None,
+        host=HOST,
+        port=PORT,
+        slave_id=SLAVE,
+    )
+    host_sanitized = HOST.replace(":", "-")
+    assert new_uid == f"{DOMAIN}_{host_sanitized}_{PORT}_{SLAVE}_{REGISTER_ADDRESS}"
+
+
+def test_migrate_unique_id_register_name_to_address():
+    unique_id = f"{DOMAIN}_ABC123_{SLAVE}_{REGISTER_NAME}"
+    new_uid = migrate_unique_id(
+        unique_id,
+        serial_number="ABC123",
+        host=HOST,
+        port=PORT,
+        slave_id=SLAVE,
+    )
+    assert new_uid == f"{DOMAIN}_ABC123_{SLAVE}_{REGISTER_ADDRESS}"


### PR DESCRIPTION
## Summary
- refactor migrate_unique_id to sequentially handle prefix updates and register/address conversion
- add unit tests for unique ID migration including serial and host-based cases

## Testing
- `pytest tests/test_migrate_unique_id.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf2a472fc8326bbba1898a3039895