### PR TITLE
Use slots for scanner device dataclass

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -91,7 +91,7 @@ def _ensure_register_maps() -> None:
         _build_register_maps()
 
 
-@dataclass
+@dataclass(slots=True)
 class ScannerDeviceInfo(collections.abc.Mapping):  # pragma: no cover
     """Basic identifying information about a ThesslaGreen unit.
 

--- a/tests/test_device_mapping.py
+++ b/tests/test_device_mapping.py
@@ -14,6 +14,25 @@ def test_device_info_mapping_and_values() -> None:
     assert list(info.values()) == list(info.as_dict().values())
 
 
+def test_device_info_assignment_and_as_dict() -> None:
+    info = ScannerDeviceInfo()
+    info.device_name = "Unit"
+    info.model = "Model"
+    info.firmware = "1.0"
+    info.serial_number = "123"
+    info.capabilities.append("cap")
+
+    assert info.device_name == "Unit"
+    assert info.as_dict() == {
+        "device_name": "Unit",
+        "model": "Model",
+        "firmware": "1.0",
+        "serial_number": "123",
+        "firmware_available": True,
+        "capabilities": ["cap"],
+    }
+
+
 def test_device_capabilities_mapping_and_values() -> None:
     caps = DeviceCapabilities(basic_control=True, temperature_sensors={"t1"})
     assert isinstance(caps, Mapping)


### PR DESCRIPTION
## Summary
- use `slots=True` for `ScannerDeviceInfo`
- add regression test for dataclass assignment and `as_dict`

## Testing
- `python - <<'PY'
import sys, types, pytest
registers_loader = types.ModuleType('custom_components.thessla_green_modbus.registers.loader')
registers_loader.get_all_registers=lambda: []
registers_loader.get_registers_hash=lambda: 'hash'
registers_loader.get_registers_by_function=lambda *args, **kwargs: []
registers_loader.plan_group_reads=lambda *args, **kwargs: []
registers_loader.load=lambda *args, **kwargs: None
registers_loader.load_registers=lambda *args, **kwargs: None
sys.modules['custom_components.thessla_green_modbus.registers.loader']=registers_loader
sys.exit(pytest.main(['tests/test_diagnostics.py']))
PY`
- `pytest tests/test_device_mapping.py`

------
https://chatgpt.com/codex/tasks/task_e_68aaf29795a0832684aa46cc6c0fa3e8