### PR TITLE
refactor: streamline register request options

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1427,7 +1427,7 @@
   "options": {
     "error": {
       "invalid_max_registers_per_request_low": "Max registers per request must be at least 1.",
-      "invalid_max_registers_per_request_high": "Max registers per request must be 125 or less."
+      "invalid_max_registers_per_request_high": "Max registers per request must be 16 or less."
     },
     "step": {
       "init": {
@@ -1438,7 +1438,6 @@
           "skip_missing_registers": "Skip Known Missing Registers",
           "timeout": "Connection Timeout (seconds)",
           "deep_scan": "Deep Register Scan",
-          "scan_max_block_size": "Max Register Block Size",
           "max_registers_per_request": "Max Registers per Request"
         },
         "data_description": {
@@ -1448,13 +1447,9 @@
           "skip_missing_registers": "Do not poll registers known to be unavailable",
           "timeout": "Maximum time to wait for response (5-60 seconds)",
           "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
-          "max_registers_per_request": "Maximum registers per request (1-16)"
+          "max_registers_per_request": "Maximum registers per request (1–16)"
         },
         "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max registers per request: {current_max_registers_per_request}.",
-          "scan_max_block_size": "Maximum registers per batch read (1-125)",
-          "max_registers_per_request": "Maximum registers per Modbus request (1-125)"
-        },
-        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max block size: {current_scan_max_block_size}. Max registers per request: {current_max_registers_per_request}.",
         "title": "ThesslaGreen Modbus Options"
       }
     }

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1255,7 +1255,7 @@
   "options": {
     "error": {
       "invalid_max_registers_per_request_low": "Max registers per request must be at least 1.",
-      "invalid_max_registers_per_request_high": "Max registers per request must be 125 or less."
+      "invalid_max_registers_per_request_high": "Max registers per request must be 16 or less."
     },
     "step": {
       "init": {
@@ -1266,7 +1266,6 @@
           "skip_missing_registers": "Skip Known Missing Registers",
           "timeout": "Connection Timeout (seconds)",
           "deep_scan": "Deep Register Scan",
-          "scan_max_block_size": "Max Register Block Size",
           "max_registers_per_request": "Max Registers per Request"
         },
         "data_description": {
@@ -1276,13 +1275,9 @@
           "skip_missing_registers": "Do not poll registers known to be unavailable",
           "timeout": "Maximum time to wait for response (5-60 seconds)",
           "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
-          "max_registers_per_request": "Maximum registers per request (1-16)"
+          "max_registers_per_request": "Maximum registers per request (1–16)"
         },
         "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max registers per request: {current_max_registers_per_request}.",
-          "scan_max_block_size": "Maximum registers per batch read (1-125)",
-          "max_registers_per_request": "Maximum registers per Modbus request (1-125)"
-        },
-        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max block size: {current_scan_max_block_size}. Max registers per request: {current_max_registers_per_request}.",
         "title": "ThesslaGreen Modbus Options"
       }
     }

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -24,7 +24,7 @@
       "invalid_slave": "ID urządzenia musi być z zakresu 0–247.",
       "invalid_slave_low": "ID urządzenia musi być większe lub równe 0.",
       "invalid_slave_high": "ID urządzenia musi być mniejsze lub równe 247.",
-      "invalid_max_registers_per_request": "Maksymalna liczba rejestrów na zapytanie musi mieścić się w zakresie 1-16.",
+      "invalid_max_registers_per_request": "Maksymalna liczba rejestrów na zapytanie musi mieścić się w zakresie 1–16.",
       "dns_failure": "Nie można rozwiązać nazwy hosta.",
       "connection_refused": "Połączenie zostało odrzucone przez hosta.",
       "missing_method": "Brak wymaganej metody w skanerze. Sprawdź logi po szczegóły.",
@@ -1255,7 +1255,7 @@
   "options": {
     "error": {
       "invalid_max_registers_per_request_low": "Maksymalna liczba rejestrów na żądanie musi być co najmniej 1.",
-      "invalid_max_registers_per_request_high": "Maksymalna liczba rejestrów na żądanie musi być nie większa niż 125."
+      "invalid_max_registers_per_request_high": "Maksymalna liczba rejestrów na żądanie musi być nie większa niż 16."
     },
     "step": {
       "init": {
@@ -1267,8 +1267,6 @@
           "timeout": "Limit czasu połączenia (s)",
           "deep_scan": "Głęboki skan rejestrów",
           "max_registers_per_request": "Maksymalna liczba rejestrów na zapytanie"
-          "scan_max_block_size": "Maksymalny rozmiar bloku rejestrów",
-          "max_registers_per_request": "Maksymalna liczba rejestrów na żądanie"
         },
         "data_description": {
           "force_full_register_list": "Pomiń skanowanie i załaduj wszystkie rejestry (może powodować błędy)",
@@ -1277,13 +1275,9 @@
           "skip_missing_registers": "Nie odczytuj rejestrów, które są znane jako niedostępne",
           "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)",
           "deep_scan": "Odczyt surowych rejestrów 0x0000-0x012C do diagnostyki",
-          "max_registers_per_request": "Maksymalna liczba rejestrów w zapytaniu (1-16)"
+          "max_registers_per_request": "Maksymalna liczba rejestrów w zapytaniu (1–16)"
         },
         "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Maksymalna liczba rejestrów na zapytanie: {current_max_registers_per_request}.",
-          "scan_max_block_size": "Maksymalna liczba rejestrów w jednym odczycie (1-125)",
-          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-125)"
-        },
-        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Maksymalny rozmiar bloku: {current_scan_max_block_size}. Maksymalna liczba rejestrów na żądanie: {current_max_registers_per_request}.",
         "title": "Opcje ThesslaGreen Modbus"
       }
     }


### PR DESCRIPTION
## Summary
- drop scan_max_block_size references from translations
- clarify max_registers_per_request range and description

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json custom_components/thessla_green_modbus/strings.json` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoq9bu9bis/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: Interrupted: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf2a0c1448326ba362512dab3b9df