### PR TITLE
Remove deprecated scan_max_block_size option

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1438,7 +1438,6 @@
           "skip_missing_registers": "Skip Known Missing Registers",
           "timeout": "Connection Timeout (seconds)",
           "deep_scan": "Deep Register Scan",
-          "scan_max_block_size": "Max Register Block Size",
           "max_registers_per_request": "Max Registers per Request"
         },
         "data_description": {
@@ -1450,14 +1449,13 @@
           "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
           "max_registers_per_request": "Maximum registers per request (1-16)"
         },
-        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max registers per request: {current_max_registers_per_request}.",
-          "scan_max_block_size": "Maximum registers per batch read (1-125)",
+        "error": {
           "max_registers_per_request": "Maximum registers per Modbus request (1-125)"
         },
-        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max block size: {current_scan_max_block_size}. Max registers per request: {current_max_registers_per_request}.",
-        "title": "ThesslaGreen Modbus Options"
-      }
+        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max registers per request: {current_max_registers_per_request}.",
+      "title": "ThesslaGreen Modbus Options"
     }
+  }
   },
   "services": {
     "reset_filters": {

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1266,7 +1266,6 @@
           "skip_missing_registers": "Skip Known Missing Registers",
           "timeout": "Connection Timeout (seconds)",
           "deep_scan": "Deep Register Scan",
-          "scan_max_block_size": "Max Register Block Size",
           "max_registers_per_request": "Max Registers per Request"
         },
         "data_description": {
@@ -1278,11 +1277,10 @@
           "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
           "max_registers_per_request": "Maximum registers per request (1-16)"
         },
-        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max registers per request: {current_max_registers_per_request}.",
-          "scan_max_block_size": "Maximum registers per batch read (1-125)",
+        "error": {
           "max_registers_per_request": "Maximum registers per Modbus request (1-125)"
         },
-        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max block size: {current_scan_max_block_size}. Max registers per request: {current_max_registers_per_request}.",
+        "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max registers per request: {current_max_registers_per_request}.",
         "title": "ThesslaGreen Modbus Options"
       }
     }

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1266,8 +1266,6 @@
           "skip_missing_registers": "Pomijaj znane brakujące rejestry",
           "timeout": "Limit czasu połączenia (s)",
           "deep_scan": "Głęboki skan rejestrów",
-          "max_registers_per_request": "Maksymalna liczba rejestrów na zapytanie"
-          "scan_max_block_size": "Maksymalny rozmiar bloku rejestrów",
           "max_registers_per_request": "Maksymalna liczba rejestrów na żądanie"
         },
         "data_description": {
@@ -1279,11 +1277,10 @@
           "deep_scan": "Odczyt surowych rejestrów 0x0000-0x012C do diagnostyki",
           "max_registers_per_request": "Maksymalna liczba rejestrów w zapytaniu (1-16)"
         },
-        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Maksymalna liczba rejestrów na zapytanie: {current_max_registers_per_request}.",
-          "scan_max_block_size": "Maksymalna liczba rejestrów w jednym odczycie (1-125)",
+        "error": {
           "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-125)"
         },
-        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Maksymalny rozmiar bloku: {current_scan_max_block_size}. Maksymalna liczba rejestrów na żądanie: {current_max_registers_per_request}.",
+        "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Maksymalna liczba rejestrów na żądanie: {current_max_registers_per_request}.",
         "title": "Opcje ThesslaGreen Modbus"
       }
     }

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -122,11 +122,9 @@ class AddEntitiesCallback:  # pragma: no cover - simple stub
 entity_platform.AddEntitiesCallback = AddEntitiesCallback
 sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 
-from custom_components.thessla_green_modbus.sensor import (  # noqa: E402
-    SENSOR_DEFINITIONS,
-)
-
-SENSOR_KEYS = [v["translation_key"] for v in SENSOR_DEFINITIONS.values()] + [
+SENSOR_KEYS = _load_translation_keys(
+    ROOT / "entity_mappings.py", "SENSOR_ENTITY_MAPPINGS"
+) + [
     "error_codes"
 ]
 BINARY_KEYS = _load_translation_keys(
@@ -161,7 +159,6 @@ OPTION_KEYS = [
     "skip_missing_registers",
     "timeout",
     "deep_scan",
-    "scan_max_block_size",
     "max_registers_per_request",
 ]
 

--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -18,7 +18,6 @@ OPTION_KEYS = [
     "skip_missing_registers",
     "timeout",
     "deep_scan",
-    "scan_max_block_size",
     "max_registers_per_request",
 ]
 


### PR DESCRIPTION
## Summary
- drop `scan_max_block_size` from translation option checks
- adjust translation tests and templates for `max_registers_per_request`
- derive sensor translation keys directly from entity mappings

## Testing
- `python tools/check_translations.py`
- `pytest tests/test_translations.py::test_translation_structures_match`
- `pytest tests/test_translations.py` *(fails: missing binary_sensor translations)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf2a184bc832694a24d9267f46631