### PR TITLE
Validate max registers option

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -483,13 +483,14 @@ class OptionsFlow(config_entries.OptionsFlow):
             )
             if max_regs < 1:
                 errors[CONF_MAX_REGISTERS_PER_REQUEST] = (
-                    "invalid_max_registers_per_request"
+                    "invalid_max_registers_per_request_low"
+                )
+            elif max_regs > DEFAULT_MAX_REGISTERS_PER_REQUEST:
+                errors[CONF_MAX_REGISTERS_PER_REQUEST] = (
+                    "invalid_max_registers_per_request_high"
                 )
             else:
                 user_input = dict(user_input)
-                user_input[CONF_MAX_REGISTERS_PER_REQUEST] = min(
-                    max_regs, DEFAULT_MAX_REGISTERS_PER_REQUEST
-                )
                 return self.async_create_entry(title="", data=user_input)
 
         # Get current values
@@ -517,8 +518,11 @@ class OptionsFlow(config_entries.OptionsFlow):
         current_deep_scan = self.config_entry.options.get(
             CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN
         )
-        current_max_registers_per_request = self.config_entry.options.get(
-            CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
+        current_max_registers_per_request = min(
+            self.config_entry.options.get(
+                CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
+            ),
+            DEFAULT_MAX_REGISTERS_PER_REQUEST,
         )
 
         data_schema = vol.Schema(
@@ -560,7 +564,10 @@ class OptionsFlow(config_entries.OptionsFlow):
                     CONF_MAX_REGISTERS_PER_REQUEST,
                     default=current_max_registers_per_request,
                     description={"advanced": True},
-                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=125)),
+                ): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=1, max=DEFAULT_MAX_REGISTERS_PER_REQUEST),
+                ),
             }
         )
 


### PR DESCRIPTION
## Summary
- validate max registers per request with explicit min/max checks
- surface translation errors for invalid values
- test options flow error handling

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py tests/test_config_flow.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repocrj6rn_r/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_config_flow.py -k max_registers_per_request_validated`

------
https://chatgpt.com/codex/tasks/task_e_68aaf5412dcc832694cb2b3e0cb3c0e9