### PR TITLE
refactor: consolidate max register translation keys

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -20,7 +20,6 @@
       "invalid_auth": "Authentication error. Check Device ID settings.",
       "invalid_input": "Invalid configuration provided. Check values and try again.",
       "invalid_host": "Invalid IP address or hostname.",
-      "invalid_max_registers_per_request": "Max registers per request must be between 1 and 16.",
       "missing_method": "Scanner is missing required method. See logs for details.",
       "modbus_error": "Modbus communication error. Check wiring and settings.",
       "timeout": "Connection timed out. Verify host and port.",
@@ -1426,8 +1425,7 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request_low": "Max registers per request must be at least 1.",
-      "invalid_max_registers_per_request_high": "Max registers per request must be 16 or less."
+      "invalid_max_registers_per_request": "Max registers per request must be at least 1."
     },
     "step": {
       "init": {
@@ -1456,7 +1454,6 @@
         "title": "ThesslaGreen Modbus Options"
       }
     }
-  }
   },
   "services": {
     "reset_filters": {

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -24,7 +24,6 @@
       "invalid_slave": "Device ID must be between 0 and 247.",
       "invalid_slave_low": "Device ID must be 0 or greater.",
       "invalid_slave_high": "Device ID must be 247 or less.",
-      "invalid_max_registers_per_request": "Max registers per request must be between 1 and 16.",
       "dns_failure": "Hostname could not be resolved.",
       "connection_refused": "Connection was refused by the host.",
       "missing_method": "Scanner is missing required method. See logs for details.",
@@ -1254,8 +1253,7 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request_low": "Max registers per request must be at least 1.",
-      "invalid_max_registers_per_request_high": "Max registers per request must be 16 or less."
+      "invalid_max_registers_per_request": "Max registers per request must be at least 1."
     },
     "step": {
       "init": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -24,7 +24,6 @@
       "invalid_slave": "ID urządzenia musi być z zakresu 0–247.",
       "invalid_slave_low": "ID urządzenia musi być większe lub równe 0.",
       "invalid_slave_high": "ID urządzenia musi być mniejsze lub równe 247.",
-      "invalid_max_registers_per_request": "Maksymalna liczba rejestrów na zapytanie musi mieścić się w zakresie 1–16.",
       "dns_failure": "Nie można rozwiązać nazwy hosta.",
       "connection_refused": "Połączenie zostało odrzucone przez hosta.",
       "missing_method": "Brak wymaganej metody w skanerze. Sprawdź logi po szczegóły.",
@@ -1254,8 +1253,7 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request_low": "Maksymalna liczba rejestrów na żądanie musi być co najmniej 1.",
-      "invalid_max_registers_per_request_high": "Maksymalna liczba rejestrów na żądanie musi być nie większa niż 16."
+      "invalid_max_registers_per_request": "Maksymalna liczba rejestrów na żądanie musi być co najmniej 1."
     },
     "step": {
       "init": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -163,8 +163,7 @@ OPTION_KEYS = [
 ]
 
 OPTION_ERROR_KEYS = [
-    "invalid_max_registers_per_request_low",
-    "invalid_max_registers_per_request_high",
+    "invalid_max_registers_per_request",
 ]
 
 

--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -22,8 +22,7 @@ OPTION_KEYS = [
 ]
 
 OPTION_ERROR_KEYS = [
-    "invalid_max_registers_per_request_low",
-    "invalid_max_registers_per_request_high",
+    "invalid_max_registers_per_request",
 ]
 
 


### PR DESCRIPTION
## Summary
- remove unused max register per request translations
- update translation check script and tests

## Testing
- `python tools/check_translations.py`
- `pre-commit run --files custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json custom_components/thessla_green_modbus/strings.json tools/check_translations.py tests/test_translations.py` (fails: InvalidManifestError: /root/.cache/pre-commit/repo3sy9ds1v/.pre-commit-hooks.yaml is not a file)
- `pytest tests/test_translations.py` (fails: Missing binary_sensor translations: ['alarm', 'e_100', 'e_101', 'e_102', 'e_103', 'e_104', 'e_105', 'e_106', 'e_138', 'e_139', 'e_152', 'e_196_e_199', 'e_200', 'e_201', 'e_249', 'e_250', 'e_251', 'e_252', 'e_99', 'error', 's_10', 's_13', 's_14', 's_15', 's_16', 's_17', 's_19', 's_2', 's_20', 's_22', 's_23', 's_24', 's_25', 's_26', 's_29', 's_30', 's_31', 's_32', 's_6', 's_7', 's_8', 's_9'])


------
https://chatgpt.com/codex/tasks/task_e_68aaf548872483268dee398d3f1b8ac3