### PR TITLE
Validate max registers per request options

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -485,7 +485,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                 errors[CONF_MAX_REGISTERS_PER_REQUEST] = (
                     "invalid_max_registers_per_request_low"
                 )
-            elif max_regs > DEFAULT_MAX_REGISTERS_PER_REQUEST:
+            elif max_regs > 16:
                 errors[CONF_MAX_REGISTERS_PER_REQUEST] = (
                     "invalid_max_registers_per_request_high"
                 )
@@ -518,11 +518,8 @@ class OptionsFlow(config_entries.OptionsFlow):
         current_deep_scan = self.config_entry.options.get(
             CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN
         )
-        current_max_registers_per_request = min(
-            self.config_entry.options.get(
-                CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
-            ),
-            DEFAULT_MAX_REGISTERS_PER_REQUEST,
+        current_max_registers_per_request = self.config_entry.options.get(
+            CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
         )
 
         data_schema = vol.Schema(
@@ -564,10 +561,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                     CONF_MAX_REGISTERS_PER_REQUEST,
                     default=current_max_registers_per_request,
                     description={"advanced": True},
-                ): vol.All(
-                    vol.Coerce(int),
-                    vol.Range(min=1, max=DEFAULT_MAX_REGISTERS_PER_REQUEST),
-                ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=16)),
             }
         )
 

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1432,7 +1432,8 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request": "Max registers per request must be at least 1."
+      "invalid_max_registers_per_request_low": "Max registers per request must be at least 1.",
+      "invalid_max_registers_per_request_high": "Max registers per request must be at most 16."
     },
     "step": {
       "init": {
@@ -1455,7 +1456,7 @@
           "max_registers_per_request": "Maximum registers per request (1–16)"
         },
         "error": {
-          "max_registers_per_request": "Maximum registers per Modbus request (1-125)"
+          "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
         },
         "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max registers per request: {current_max_registers_per_request}.",
         "title": "ThesslaGreen Modbus Options"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1253,7 +1253,8 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request": "Max registers per request must be at least 1."
+      "invalid_max_registers_per_request_low": "Max registers per request must be at least 1.",
+      "invalid_max_registers_per_request_high": "Max registers per request must be at most 16."
     },
     "step": {
       "init": {
@@ -1276,7 +1277,7 @@
           "max_registers_per_request": "Maximum registers per request (1–16)"
         },
         "error": {
-          "max_registers_per_request": "Maximum registers per Modbus request (1-125)"
+          "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
         },
         "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Max registers per request: {current_max_registers_per_request}.",
         "title": "ThesslaGreen Modbus Options"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1253,7 +1253,8 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request": "Maksymalna liczba rejestrów na żądanie musi być co najmniej 1."
+      "invalid_max_registers_per_request_low": "Maksymalna liczba rejestrów na żądanie musi wynosić co najmniej 1.",
+      "invalid_max_registers_per_request_high": "Maksymalna liczba rejestrów na żądanie nie może przekraczać 16."
     },
     "step": {
       "init": {
@@ -1276,7 +1277,7 @@
           "max_registers_per_request": "Maksymalna liczba rejestrów w zapytaniu (1–16)"
         },
         "error": {
-          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-125)"
+          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-16)"
         },
         "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Maksymalna liczba rejestrów na żądanie: {current_max_registers_per_request}.",
         "title": "Opcje ThesslaGreen Modbus"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -163,7 +163,8 @@ OPTION_KEYS = [
 ]
 
 OPTION_ERROR_KEYS = [
-    "invalid_max_registers_per_request",
+    "invalid_max_registers_per_request_low",
+    "invalid_max_registers_per_request_high",
 ]
 
 

--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -22,7 +22,8 @@ OPTION_KEYS = [
 ]
 
 OPTION_ERROR_KEYS = [
-    "invalid_max_registers_per_request",
+    "invalid_max_registers_per_request_low",
+    "invalid_max_registers_per_request_high",
 ]
 
 


### PR DESCRIPTION
## Summary
- enforce explicit 1–16 bounds on `max_registers_per_request`
- add separate error messages for low and high values
- update translation checks

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/strings.json custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json tests/test_translations.py tools/check_translations.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo7tvegrj9/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_config_flow.py::test_options_flow_max_registers_per_request_validated`
- `python tools/check_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf83638608326a9396c0670ba1943