### PR TITLE
Remove deprecated Register from loader exports

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -470,7 +470,6 @@ def plan_group_reads(max_block_size: int = 64) -> list[ReadPlan]:
 
 __all__ = [
     "RegisterDef",
-    "Register",
     "RegisterDefinition",
     "load_registers",
     "clear_cache",


### PR DESCRIPTION
## Summary
- drop legacy `Register` symbol from loader exports

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py` *(fails: InvalidManifestError: .pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_register_loader.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aafbf0d4a4832686f850c76a26691a