### PR TITLE
Expand gitignore for common artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
 custom_components/thessla_green_modbus/registers.py
+
+# Byte-compiled / optimized files
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Unit test / coverage reports
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+.coverage
+
+# Logs
+*.log
+
+# OS files
+.DS_Store


### PR DESCRIPTION
## Summary
- ignore common Python cache, build and virtual environment files

## Testing
- `pre-commit run --files .gitignore` *(fails: InvalidManifestError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aafc02f704832682887df0e07c7197