### PR TITLE
refactor: remove unused re import

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 from typing import Any, Dict, cast
-import re
 
 from .registers.loader import get_registers_by_function
 


### PR DESCRIPTION
## Summary
- remove leftover `re` import from constants

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/const.py` *(fails: InvalidManifestError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68aafbf2d66083268d32337243d21917