### PR TITLE
Generate multi-register sizes dynamically

### DIFF
--- a/tools/generate_registers.py
+++ b/tools/generate_registers.py
@@ -25,11 +25,6 @@ JSON_PATH = (
 )
 OUTPUT_PATH = ROOT / "custom_components" / "thessla_green_modbus" / "registers.py"
 
-MULTI_REGISTER_SIZES: dict[str, int] = {
-    "date_time_1": 4,
-    "lock_date_1": 3,
-}
-
 
 def sort_registers_json() -> None:
     """Sort the canonical JSON register file.
@@ -97,7 +92,9 @@ def _build_register_map(rows: list[tuple[str, int]]) -> dict[str, int]:
 SNAKE_CASE = re.compile(r"^[a-z0-9_]+$")
 
 
-def load_registers() -> tuple[dict[str, int], dict[str, int], dict[str, int], dict[str, int]]:
+def load_registers() -> tuple[
+    dict[str, int], dict[str, int], dict[str, int], dict[str, int], dict[str, int]
+]:
     """Load registers from the JSON file grouped by function."""
     data = json.loads(JSON_PATH.read_text(encoding="utf-8"))
     registers = data.get("registers", data)
@@ -105,31 +102,65 @@ def load_registers() -> tuple[dict[str, int], dict[str, int], dict[str, int], di
         name = reg["name"]
         if not SNAKE_CASE.fullmatch(name):
             raise ValueError(f"Register name '{name}' is not snake_case")
+
     coil_rows: list[tuple[str, int]] = []
     discrete_rows: list[tuple[str, int]] = []
     input_rows: list[tuple[str, int]] = []
     holding_rows: list[tuple[str, int]] = []
+    multi_rows: list[tuple[str, str, int, int]] = []
+
     for reg in registers:
         name = _normalise_name(reg["name"])
         addr = int(reg["address_dec"])
-        func = str(reg["function"]).lower()
-        if func in {"01", "coil"}:
+        func_raw = str(reg["function"]).lower()
+        length = int(reg.get("length", 1))
+
+        if func_raw in {"01", "coil"}:
             coil_rows.append((name, addr))
-        elif func in {"02", "discrete"}:
+            func = "coil"
+        elif func_raw in {"02", "discrete"}:
             discrete_rows.append((name, addr))
-        elif func in {"04", "input"}:
+            func = "discrete"
+        elif func_raw in {"04", "input"}:
             input_rows.append((name, addr))
-        elif func in {"03", "holding"}:
+            func = "input"
+        elif func_raw in {"03", "holding"}:
             holding_rows.append((name, addr))
+            func = "holding"
+        else:  # pragma: no cover - defensive
+            continue
+
+        if length > 1:
+            multi_rows.append((func, name, addr, length))
+
     coils = _build_register_map(coil_rows)
     discrete_inputs = _build_register_map(discrete_rows)
     input_regs = _build_register_map(input_rows)
     holding_regs = _build_register_map(holding_rows)
+
     coils = dict(sorted(coils.items(), key=lambda kv: kv[1]))
     discrete_inputs = dict(sorted(discrete_inputs.items(), key=lambda kv: kv[1]))
     input_regs = dict(sorted(input_regs.items(), key=lambda kv: kv[1]))
     holding_regs = dict(sorted(holding_regs.items(), key=lambda kv: kv[1]))
-    return coils, discrete_inputs, input_regs, holding_regs
+
+    mapping_lookup = {
+        "coil": coils,
+        "discrete": discrete_inputs,
+        "input": input_regs,
+        "holding": holding_regs,
+    }
+    multi_sizes: list[tuple[str, int, int]] = []
+    for func, name, addr, length in multi_rows:
+        mapping = mapping_lookup[func]
+        for key, value in mapping.items():
+            if value == addr:
+                multi_sizes.append((key, addr, length))
+                break
+
+    multi_sizes.sort(key=lambda item: item[1])
+    multi_dict = {name: size for name, _, size in multi_sizes}
+
+    return coils, discrete_inputs, input_regs, holding_regs, multi_dict
 
 
 def write_file(
@@ -137,6 +168,7 @@ def write_file(
     discrete_inputs: dict[str, int],
     input_regs: dict[str, int],
     holding_regs: dict[str, int],
+    multi_register_sizes: dict[str, int],
 ) -> None:
     """Write the registers module to :data:`OUTPUT_PATH`."""
     with OUTPUT_PATH.open("w", newline="\n") as f:
@@ -160,7 +192,7 @@ def write_file(
         f.write("# Each key is the starting register name and the value is the number of\n")
         f.write("# registers in that block.\n")
         f.write("MULTI_REGISTER_SIZES: dict[str, int] = {\n")
-        for key, size in MULTI_REGISTER_SIZES.items():
+        for key, size in multi_register_sizes.items():
             f.write(f'    "{key}": {size},\n')
         f.write("}\n\n")
 
@@ -177,8 +209,8 @@ def write_file(
 
 def main() -> None:
     sort_registers_json()
-    coils, discrete_inputs, input_regs, holding_regs = load_registers()
-    write_file(coils, discrete_inputs, input_regs, holding_regs)
+    coils, discrete_inputs, input_regs, holding_regs, multi_sizes = load_registers()
+    write_file(coils, discrete_inputs, input_regs, holding_regs, multi_sizes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- derive multi-register block sizes from JSON register metadata
- remove hardcoded multi-register size mapping in generation tool

## Testing
- `pre-commit run --files tools/generate_registers.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoxg91q0b0/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aafd54dcb4832684b4128856e35d57