### PR TITLE
refactor: share register name utilities

### DIFF
--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -5,7 +5,7 @@ from typing import Any, Literal
 
 import pydantic
 
-from ..utils import _to_snake_case
+from ..utils import _normalise_name
 
 
 def _normalise_function(fn: str) -> str:
@@ -23,17 +23,6 @@ def _normalise_function(fn: str) -> str:
         "inputregisters": "04",
     }
     return mapping.get(fn.lower(), fn)
-
-
-def _normalise_name(name: str) -> str:
-    """Convert register names to ``snake_case`` and fix known typos."""
-    fixes = {
-        "duct_warter_heater_pump": "duct_water_heater_pump",
-        "required_temp": "required_temperature",
-        "specialmode": "special_mode",
-    }
-    snake = _to_snake_case(name)
-    return fixes.get(snake, snake)
 
 
 class RegisterDefinition(pydantic.BaseModel):

--- a/custom_components/thessla_green_modbus/utils.py
+++ b/custom_components/thessla_green_modbus/utils.py
@@ -6,6 +6,7 @@ import re
 
 __all__ = [
     "_to_snake_case",
+    "_normalise_name",
     "_decode_register_time",
     "_decode_bcd_time",
     "_decode_aatt",
@@ -27,6 +28,17 @@ def _to_snake_case(name: str) -> str:
     token_map = {"temp": "temperature"}
     tokens = [token_map.get(token, token) for token in name.split("_")]
     return "_".join(tokens)
+
+
+def _normalise_name(name: str) -> str:
+    """Convert register names to ``snake_case`` and fix known typos."""
+    fixes = {
+        "duct_warter_heater_pump": "duct_water_heater_pump",
+        "required_temp": "required_temperature",
+        "specialmode": "special_mode",
+    }
+    snake = _to_snake_case(name)
+    return fixes.get(snake, snake)
 
 
 def _decode_register_time(value: int) -> int | None:

--- a/tools/generate_registers.py
+++ b/tools/generate_registers.py
@@ -11,8 +11,13 @@ from __future__ import annotations
 import json
 import pathlib
 import re
+import sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from custom_components.thessla_green_modbus.utils import _normalise_name
 # Path to the canonical JSON register definition file bundled with the
 # integration.  ``registers.py`` is generated from this file and should never be
 # edited manually.
@@ -48,31 +53,6 @@ def sort_registers_json() -> None:
         json.dumps({"registers": registers}, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
-
-
-def _to_snake_case(name: str) -> str:
-    """Convert register names to snake_case."""
-    replacements = {"flowrate": "flow_rate"}
-    for old, new in replacements.items():
-        name = name.replace(old, new)
-    name = re.sub(r"[\s\-/]", "_", name)
-    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
-    name = re.sub(r"(?<=\D)(\d)", r"_\1", name)
-    name = re.sub(r"__+", "_", name)
-    name = name.lower()
-    token_map = {"temp": "temperature"}
-    tokens = [token_map.get(token, token) for token in name.split("_")]
-    return "_".join(tokens)
-
-
-def _normalise_name(name: str) -> str:
-    fixes = {
-        "duct_warter_heater_pump": "duct_water_heater_pump",
-        "required_temp": "required_temperature",
-        "specialmode": "special_mode",
-    }
-    snake = _to_snake_case(name)
-    return fixes.get(snake, snake)
 
 
 def _build_register_map(rows: list[tuple[str, int]]) -> dict[str, int]:


### PR DESCRIPTION
## Summary
- expose `_normalise_name` alongside `_to_snake_case` in shared utils
- reuse shared helpers in register schema and generator

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/utils.py custom_components/thessla_green_modbus/registers/schema.py tools/generate_registers.py` *(fails: InvalidManifestError)*
- `python tools/validate_registers.py`

------
https://chatgpt.com/codex/tasks/task_e_68aafd5347e4832680dded480d8226f6