### PR TITLE
refactor: centralize register JSON sorting

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -11,4 +11,5 @@ python tools/sort_registers_json.py
 
 By default the script operates on
 `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`
-but an alternate path may be supplied as an argument.
+but an alternate path may be supplied as an argument. Other helper scripts import
+this module to ensure the sorting logic lives in a single place.


### PR DESCRIPTION
## Summary
- import `sort_registers_json` from dedicated module in `generate_registers.py`
- document canonical sorting helper

## Testing
- `black tools/generate_registers.py`
- `isort tools/generate_registers.py`
- `ruff check tools/generate_registers.py`
- `pre-commit run --files tools/generate_registers.py tools/README.md` *(fails: InvalidManifestError for home-assistant/actions)*
- `pytest` *(fails: 22 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68aaff360c00832692a53a28aea21058