### PR TITLE
Optimize register file caching

### DIFF
--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -13,6 +13,7 @@ def _normalise_function(fn: str) -> str:
     mapping = {
         "coil": "01",
         "coils": "01",
+        "coil_registers": "01",
         "discrete_input": "02",
         "discrete_inputs": "02",
         "holding_register": "03",
@@ -22,7 +23,8 @@ def _normalise_function(fn: str) -> str:
         "inputregister": "04",
         "inputregisters": "04",
     }
-    return mapping.get(fn.lower(), fn)
+    key = fn.lower().replace(" ", "_")
+    return mapping.get(key, fn)
 
 
 def _normalise_name(name: str) -> str:


### PR DESCRIPTION
## Summary
- avoid recomputing register file hashes by caching path/mtime
- improve function alias normalisation
- exercise cache logic in tests

## Testing
- `pytest tests/test_register_loader.py tests/test_register_cache_invalidation.py`

------
https://chatgpt.com/codex/tasks/task_e_68aafd4f00e88326a7a78abd7bb27e94