### PR TITLE
docs: drop CSV migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,18 +544,10 @@ pytest tests/test_register_loader.py
 
 4. Dołącz zmieniony plik JSON do commitu.
 
-### Migracja z CSV na JSON
-
-Pliki CSV zostały oznaczone jako przestarzałe i ich obsługa będzie
-usunięta w przyszłych wersjach. Użycie pliku CSV zapisze ostrzeżenie w
-logach. Aby ręcznie przekonwertować dane:
-
-1. Otwórz dotychczasowy plik CSV z definicjami rejestrów.
-2. Dla każdego wiersza utwórz obiekt w `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`
-   z polami `function`, `address_dec`, `address_hex`, `name`, `description`, `description_en` i `access`.
-3. Zachowaj sortowanie według `function` i `address_dec` oraz format liczbowy (`0x` dla wartości hex).
-4. Usuń lub zignoruj plik CSV i uruchom walidację jak przy dodawaniu nowych
-   rejestrów.
+> Obsługa plików CSV została całkowicie usunięta – definicje rejestrów muszą
+> znajdować się w pliku JSON i spełniać schemat
+> `custom_components/thessla_green_modbus/registers/schema.py`. Zweryfikuj
+> zmiany za pomocą `pytest tests/test_register_loader.py`.
 
 ## 📄 Licencja
 

--- a/README_en.md
+++ b/README_en.md
@@ -322,6 +322,11 @@ Optional properties: `enum`, `multiplier`, `resolution`, `min`, `max`.
 pytest tests/test_register_loader.py
 ```
 
+> CSV register files are no longer supported – register definitions must be
+> provided as JSON and conform to
+> `custom_components/thessla_green_modbus/registers/schema.py`. Validate changes
+> using `pytest tests/test_register_loader.py`.
+
 ## 📄 License
 
 MIT License – see [LICENSE](LICENSE) for details.

--- a/docs/register_scanning.md
+++ b/docs/register_scanning.md
@@ -65,28 +65,7 @@ pytest tests/test_register_loader_validation.py::test_registers_match_pdf
 Jeżeli test zgłasza brakujące rejestry lub rozbieżności w atrybutach,
 należy zaktualizować plik JSON przed wysłaniem zmian.
 
-## Migracja z CSV na JSON
-Rejestry są definiowane wyłącznie w pliku JSON
-`custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`,
-który jest kanonicznym źródłem prawdy.
-Format CSV jest przestarzały i zostanie usunięty w przyszłych wersjach – jego
-użycie zapisuje ostrzeżenie w logach. Każdy obiekt w tablicy `registers` zawiera pola:
-
-- `function` – kod funkcji Modbus
-- `address_dec` / `address_hex` – adres rejestru
-- `name` – unikalna nazwa
-- `description` – opis po polsku
-- `description_en` – opis po angielsku
-- `access` – tryb dostępu (`R`/`W`)
-
-Opcjonalnie można zdefiniować `unit`, `enum`, `multiplier`, `resolution` i inne
-atrybuty.
-
-Aby ręcznie przekonwertować istniejący plik CSV:
-
-1. Otwórz plik CSV i odwzoruj kolumny na odpowiednie pola JSON.
-2. Dla każdego wiersza utwórz obiekt w `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`.
-3. Przekonwertuj adresy na postać dziesiętną i heksadecymalną (`0x...`).
-4. Po konwersji uruchom test i narzędzia z sekcji powyżej, aby zweryfikować plik.
-
-Po migracji usuń lub zignoruj plik CSV – integracja korzysta wyłącznie z definicji JSON.
+> Obsługa plików CSV została całkowicie usunięta — rejestry muszą być zapisane w
+> `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`
+> i spełniać schemat `registers/schema.py`. Zweryfikuj zmiany narzędziami i
+> testami opisanymi powyżej.


### PR DESCRIPTION
## Summary
- remove legacy CSV migration instructions
- clarify that register definitions must use JSON schema and validation test

## Testing
- `pytest tests/test_unused_translations.py` *(fails: SyntaxError in registers/loader.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab02b734508326b88010605705d0fd