### PR TITLE
Narrow exception handling in modbus integration

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -191,8 +191,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
     for platform in PLATFORM_DOMAINS:
         try:
             await hass.async_add_executor_job(import_module, f".{platform}", __name__)
-        except Exception:  # pragma: no cover - environment-dependent
-            _LOGGER.debug("Could not preload platform %s", platform, exc_info=True)
+        except (ImportError, ModuleNotFoundError) as err:  # pragma: no cover - environment-dependent
+            _LOGGER.debug("Could not preload platform %s: %s", platform, err)
+        except Exception as err:  # pragma: no cover - unexpected
+            _LOGGER.exception("Unexpected error preloading platform %s: %s", platform, err)
 
     # Setup platforms
     _LOGGER.debug("Setting up platforms: %s", PLATFORMS)

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import translation
 from homeassistant.util.network import is_host_valid
 
@@ -393,8 +394,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
             translations = await translation.async_get_translations(
                 self.hass, language, "component", [DOMAIN]
             )
-        except Exception as err:  # pragma: no cover - defensive
+        except (OSError, ValueError, HomeAssistantError) as err:  # pragma: no cover - defensive
             _LOGGER.debug("Translation load failed: %s", err)
+        except Exception as err:  # pragma: no cover - unexpected
+            _LOGGER.exception("Unexpected error loading translations: %s", err)
 
         key = "auto_detected_note_success" if register_count > 0 else "auto_detected_note_limited"
         auto_detected_note = translations.get(

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -429,7 +429,11 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 try:
                     definition = get_register_definition(reg)
                     length = max(1, definition.length)
-                except Exception:
+                except (KeyError, AttributeError, TypeError) as err:
+                    _LOGGER.debug("Missing definition for %s: %s", reg, err)
+                    length = 1
+                except Exception as err:  # pragma: no cover - unexpected
+                    _LOGGER.exception("Unexpected error getting definition for %s: %s", reg, err)
                     length = 1
                 addresses.extend(range(addr, addr + length))
 

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import translation
 
 from .const import DOMAIN
@@ -98,8 +99,10 @@ async def async_get_config_entry_diagnostics(
         translations = await translation.async_get_translations(
             hass, hass.config.language, f"component.{DOMAIN}"
         )
-    except Exception as err:  # pragma: no cover - defensive
+    except (OSError, ValueError, HomeAssistantError) as err:  # pragma: no cover - defensive
         _LOGGER.debug("Translation load failed: %s", err)
+    except Exception as err:  # pragma: no cover - unexpected
+        _LOGGER.exception("Unexpected error loading translations: %s", err)
     active_errors: dict[str, str] = {}
     if coordinator.data:
         for key, value in coordinator.data.items():

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -19,7 +19,7 @@ from typing import Any, Dict
 try:  # pragma: no cover - handle absence of Home Assistant
     from homeassistant.components.binary_sensor import BinarySensorDeviceClass
     from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-except Exception:  # pragma: no cover - executed in tests without HA
+except (ModuleNotFoundError, ImportError):  # pragma: no cover - executed in tests without HA
     class BinarySensorDeviceClass:  # type: ignore[no-redef]
         RUNNING = "running"
         OPENING = "opening"
@@ -48,7 +48,7 @@ try:  # pragma: no cover - use HA constants when available
         UnitOfTime,
         UnitOfVolumeFlowRate,
     )
-except Exception:  # pragma: no cover - executed only in tests
+except (ModuleNotFoundError, ImportError):  # pragma: no cover - executed only in tests
 
     class UnitOfElectricPotential:  # type: ignore[no-redef]
         VOLT = "V"
@@ -67,7 +67,7 @@ except Exception:  # pragma: no cover - executed only in tests
 
 try:  # pragma: no cover - fallback for tests without full HA constants
     from homeassistant.const import PERCENTAGE
-except Exception:  # pragma: no cover - executed only in tests
+except (ModuleNotFoundError, ImportError):  # pragma: no cover - executed only in tests
     PERCENTAGE = "%"
 
 from .const import SPECIAL_FUNCTION_MAP
@@ -286,7 +286,11 @@ def _load_translation_keys() -> dict[str, set[str]]:
             "switch": set(entity.get("switch", {}).keys()),
             "select": set(entity.get("select", {}).keys()),
         }
-    except Exception:  # pragma: no cover - fallback when translations missing
+    except (OSError, json.JSONDecodeError, ValueError) as err:  # pragma: no cover - fallback when translations missing
+        _LOGGER.debug("Failed to load translation keys: %s", err)
+        return {"binary_sensor": set(), "switch": set(), "select": set()}
+    except Exception as err:  # pragma: no cover - unexpected
+        _LOGGER.exception("Unexpected error loading translation keys: %s", err)
         return {"binary_sensor": set(), "switch": set(), "select": set()}
 
 


### PR DESCRIPTION
## Summary
- Replace broad `except Exception` clauses with targeted exception handling across the Modbus integration
- Log unexpected failures explicitly to aid debugging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'voluptuous'; SyntaxError in registers/loader.py)*


------
https://chatgpt.com/codex/tasks/task_e_68ab039d4058832681dbca843a9369a2