### PR TITLE
Load coordinator in executor to avoid blocking import

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -133,7 +133,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
     )
 
     # Create coordinator for managing device communication
-    from .coordinator import ThesslaGreenModbusCoordinator
+    coordinator_mod = await hass.async_add_executor_job(
+        import_module, ".coordinator", __name__
+    )
+    ThesslaGreenModbusCoordinator = coordinator_mod.ThesslaGreenModbusCoordinator
 
     coordinator = ThesslaGreenModbusCoordinator(
         hass=hass,


### PR DESCRIPTION
## Summary
- import ThesslaGreenModbusCoordinator using `async_add_executor_job` so coordinator module loads without blocking the event loop

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/__init__.py`
- `pytest` *(fails: SyntaxError in loader.py; Interrupted: 40 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68ab039c1d7c8326966d7a6901fe8465