### PR TITLE
Preload config flow during setup

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -89,6 +89,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
     _LOGGER.info(REGISTER_FORMAT_MESSAGE)
     _LOGGER.debug("Setting up ThesslaGreen Modbus integration for %s", entry.title)
 
+    await hass.async_add_executor_job(import_module, ".config_flow", __name__)
+
     # Get configuration - support both new and legacy keys
     host = entry.data[CONF_HOST]
     port = entry.data.get(


### PR DESCRIPTION
## Summary
- Preload `config_flow` module at the start of `async_setup_entry` using an executor to ensure it is available before other imports

## Testing
- ⚠️ `pre-commit run --files custom_components/thessla_green_modbus/__init__.py` (InvalidManifestError: /root/.cache/pre-commit/reposptusxr2/.pre-commit-hooks.yaml is not a file)
- ⚠️ `pytest` (SyntaxError: invalid syntax in registers/loader.py)


------
https://chatgpt.com/codex/tasks/task_e_68ab039b6b38832688c8092759f2890a