### PR TITLE
Refactor register loader caching and add hash tests

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -3,6 +3,11 @@
 from pathlib import Path
 from typing import Any, Dict, cast
 
+# Importing ``MAX_BATCH_REGISTERS`` from this module in ``modbus_helpers``
+# creates a circular dependency if it is defined after the registers loader is
+# imported.  Define it here before pulling in the loader to break the cycle.
+MAX_BATCH_REGISTERS = 16
+
 from .registers.loader import get_registers_by_function
 
 
@@ -79,7 +84,6 @@ AIRFLOW_RATE_REGISTERS = {"supply_flow_rate", "exhaust_flow_rate"}
 DEFAULT_SCAN_UART_SETTINGS = False
 DEFAULT_SKIP_MISSING_REGISTERS = False
 DEFAULT_DEEP_SCAN = False
-MAX_BATCH_REGISTERS = 16
 DEFAULT_MAX_REGISTERS_PER_REQUEST = MAX_BATCH_REGISTERS
 
 # Registers that are known to be unavailable on some devices

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from custom_components.thessla_green_modbus.registers.loader import (
     _REGISTERS_PATH,
     clear_cache,
+    get_registers_hash,
     load_registers,
 )
 
@@ -20,15 +21,19 @@ def test_cache_invalidation_on_content_change(tmp_path: Path, monkeypatch) -> No
     )
 
     clear_cache()
+    first_hash = get_registers_hash()
     first = load_registers()[0]
     assert first.description
+    assert first_hash
 
     data = json.loads(tmp_json.read_text())
     data["registers"][0]["description"] = "changed description"
     tmp_json.write_text(json.dumps(data), encoding="utf-8")
 
+    second_hash = get_registers_hash()
     updated = load_registers()[0]
     assert updated.description == "changed description"
+    assert first_hash != second_hash
 
     clear_cache()
 


### PR DESCRIPTION
## Summary
- simplify register loading by reusing a single `_get_file_info` path
- expose register file hash directly via `_get_file_info`
- verify register hash caching and invalidation

## Testing
- `pytest tests/test_register_loader.py tests/test_register_cache_invalidation.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab02ac505c8326a0fd7f20edeccee2