### PR TITLE
Refactor register loader caching

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -95,10 +95,6 @@ class RegisterDef:
                 encoding = self.extra.get("encoding", "ascii")
                 data = b"".join(w.to_bytes(2, "big") for w in raw_list)
                 return data.rstrip(b"\x00").decode(encoding)
-                buffer = bytearray()
-                for word in raw_list:
-                    buffer.extend(word.to_bytes(2, "big"))
-                return buffer.rstrip(b"\x00").decode(encoding)
 
             endianness = "big"
             if self.extra:
@@ -128,9 +124,6 @@ class RegisterDef:
                 steps = round(value / self.resolution)
                 value = steps * self.resolution
             return value
-                steps = round(result / self.resolution)
-                result = steps * self.resolution
-            return result
 
         if isinstance(raw, Sequence):
             # Defensive: unexpected sequence for single register
@@ -383,13 +376,14 @@ def _load_registers_from_file(
         )
 
     return registers
+
+
 def _compute_file_hash(path: Path, mtime: float) -> str:
-    """Return the SHA256 hash of ``path``.
+    """Return the SHA256 hash of ``path`` and cache the result.
 
     The hash is cached using ``(path_str, mtime, hash)`` so the file is only
     read when its modification time changes.
     """
-    """Return the SHA256 hash of ``path`` and cache the result."""
 
     global _cached_file_info
     path_str = str(path)


### PR DESCRIPTION
## Summary
- clean up register decoding logic
- consolidate file hash helpers and rely on them from `load_registers`
- add test ensuring register JSON changes trigger reload

## Testing
- `pytest tests/test_register_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab2d761f708326aa04e8f10328c378