### PR TITLE
refactor register grouping plan

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 # Shared grouping helper
-from ..modbus_helpers import group_reads
+from ..modbus_helpers import group_reads as _group_reads
 from ..schedule_helpers import bcd_to_time, time_to_bcd
 from .schema import RegisterList, _normalise_function, _normalise_name
 
@@ -128,9 +128,6 @@ class RegisterDef:
                 steps = round(value / self.resolution)
                 value = steps * self.resolution
             return value
-                steps = round(result / self.resolution)
-                result = steps * self.resolution
-            return result
 
         if isinstance(raw, Sequence):
             # Defensive: unexpected sequence for single register
@@ -507,7 +504,7 @@ def plan_group_reads(max_block_size: int = 64) -> list[ReadPlan]:
         regs_by_fn.setdefault(reg.function, []).extend(addr_range)
 
     for fn, addresses in regs_by_fn.items():
-        for start, length in group_reads(addresses, max_block_size=max_block_size):
+        for start, length in _group_reads(addresses, max_block_size=max_block_size):
             plans.append(ReadPlan(fn, start, length))
 
     return plans


### PR DESCRIPTION
## Summary
- simplify register read planning to iterate `_group_reads` once per function
- update register grouping tests for new `ReadPlan` blocks

## Testing
- `pytest tests/test_register_grouping.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2d757f308326bb3afa63d1d76d60