### PR TITLE
Clean up multi-word decode logic

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -95,10 +95,6 @@ class RegisterDef:
                 encoding = self.extra.get("encoding", "ascii")
                 data = b"".join(w.to_bytes(2, "big") for w in raw_list)
                 return data.rstrip(b"\x00").decode(encoding)
-                buffer = bytearray()
-                for word in raw_list:
-                    buffer.extend(word.to_bytes(2, "big"))
-                return buffer.rstrip(b"\x00").decode(encoding)
 
             endianness = "big"
             if self.extra:
@@ -128,9 +124,6 @@ class RegisterDef:
                 steps = round(value / self.resolution)
                 value = steps * self.resolution
             return value
-                steps = round(result / self.resolution)
-                result = steps * self.resolution
-            return result
 
         if isinstance(raw, Sequence):
             # Defensive: unexpected sequence for single register


### PR DESCRIPTION
## Summary
- remove duplicated string conversion and leftover resolution block in `RegisterDef.decode`

## Testing
- `pytest tests/test_register_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab2d60a4e4832697ca5f9301359493