### PR TITLE
Refactor register loader caching and add tests

### DIFF
--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -140,6 +140,39 @@ def test_register_cache_invalidation(tmp_path, monkeypatch) -> None:
     assert hash_before != hash_after
 
 
+def test_compute_file_hash_uses_cache(tmp_path, monkeypatch) -> None:
+    """_compute_file_hash should avoid re-reading unchanged files."""
+
+    import custom_components.thessla_green_modbus.registers.loader as loader
+    import os
+
+    path = tmp_path / "regs.json"
+    path.write_text("data")
+    mtime = path.stat().st_mtime
+
+    read_calls = 0
+    real_read_bytes = Path.read_bytes
+
+    def spy_read_bytes(self):
+        nonlocal read_calls
+        read_calls += 1
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", spy_read_bytes)
+
+    digest1 = loader._compute_file_hash(path, mtime)
+    digest2 = loader._compute_file_hash(path, mtime)
+
+    assert digest1 == digest2
+    assert read_calls == 1
+
+    path.write_text("data2")
+    os.utime(path, (mtime + 1, mtime + 1))
+    mtime2 = path.stat().st_mtime
+    loader._compute_file_hash(path, mtime2)
+
+    assert read_calls == 2
+
 def test_registers_reload_on_file_change(tmp_path, monkeypatch) -> None:
     """Changing the register JSON file triggers a reload."""
 


### PR DESCRIPTION
## Summary
- consolidate file hashing and register loading helpers
- cache file hash based on mtime and reload registers only when needed
- add tests for register loader cache behavior

## Testing
- `pytest tests/test_register_loader.py`
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo6dcg4qyi/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f8ebea88326aec92904998fa7e0