### PR TITLE
Refactor read planning to reuse grouping helper

### DIFF
--- a/tests/test_group_reads.py
+++ b/tests/test_group_reads.py
@@ -46,6 +46,18 @@ def test_plan_group_reads_respects_max_block_size(monkeypatch):
     ]
 
 
+@pytest.mark.parametrize("size", [1, 4, MAX_BATCH_REGISTERS, 32])
+def test_plan_group_reads_varied_block_sizes(monkeypatch, size):
+    regs = [Register("input", addr, f"r{addr}", "r") for addr in range(10)]
+    monkeypatch.setattr(loader, "load_registers", lambda: regs)
+    addresses = [r.address for r in regs]
+    expected = [
+        ReadPlan("input", start, length)
+        for start, length in group_reads(addresses, max_block_size=size)
+    ]
+    assert plan_group_reads(max_block_size=size) == expected
+
+
 @pytest.mark.skipif(ThesslaGreenDeviceScanner is None, reason="scanner unavailable")
 def test_scanner_respects_default_max_block_size():
     scanner = ThesslaGreenDeviceScanner("host", 502)


### PR DESCRIPTION
## Summary
- streamline register plan grouping to use shared `group_reads`
- expand coverage for `plan_group_reads` across varied block sizes
- ensure register loader hashing and decoding work during tests

## Testing
- `pytest tests/test_group_reads.py tests/test_register_grouping.py tests/test_group_reads_max_size.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2f90107c8326817679d06b507bdd