### PR TITLE
Unify max registers per request error

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -483,10 +483,8 @@ class OptionsFlow(config_entries.OptionsFlow):
             max_regs = user_input.get(
                 CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
             )
-            if max_regs < 1:
-                errors[CONF_MAX_REGISTERS_PER_REQUEST] = "invalid_max_registers_per_request_low"
-            elif max_regs > MAX_BATCH_REGISTERS:
-                errors[CONF_MAX_REGISTERS_PER_REQUEST] = "invalid_max_registers_per_request_high"
+            if not 1 <= max_regs <= MAX_BATCH_REGISTERS:
+                errors[CONF_MAX_REGISTERS_PER_REQUEST] = "max_registers_range"
             else:
                 user_input = dict(user_input)
                 return self.async_create_entry(title="", data=user_input)

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1253,8 +1253,7 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request_low": "Max registers per request must be at least 1.",
-      "invalid_max_registers_per_request_high": "Max registers per request cannot exceed 16."
+      "max_registers_range": "Max registers per request must be between 1 and 16."
     },
     "step": {
       "init": {

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1253,8 +1253,7 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request_low": "Max registers per request must be at least 1.",
-      "invalid_max_registers_per_request_high": "Max registers per request cannot exceed 16."
+      "max_registers_range": "Max registers per request must be between 1 and 16."
     },
     "step": {
       "init": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1253,8 +1253,7 @@
   },
   "options": {
     "error": {
-      "invalid_max_registers_per_request_low": "Maksymalna liczba rejestrów na żądanie musi wynosić co najmniej 1.",
-      "invalid_max_registers_per_request_high": "Maksymalna liczba rejestrów na żądanie nie może przekraczać 16."
+      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1-16."
     },
     "step": {
       "init": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1772,14 +1772,10 @@ async def test_options_flow_max_registers_per_request_validated():
     flow = OptionsFlow(SimpleNamespace(options={}))
     result = await flow.async_step_init({CONF_MAX_REGISTERS_PER_REQUEST: 0})
     assert result["type"] == "form"
-    assert (
-        result["errors"][CONF_MAX_REGISTERS_PER_REQUEST] == "invalid_max_registers_per_request_low"
-    )
+    assert result["errors"][CONF_MAX_REGISTERS_PER_REQUEST] == "max_registers_range"
 
     # Reject values above range
     flow = OptionsFlow(SimpleNamespace(options={}))
     result = await flow.async_step_init({CONF_MAX_REGISTERS_PER_REQUEST: 20})
     assert result["type"] == "form"
-    assert (
-        result["errors"][CONF_MAX_REGISTERS_PER_REQUEST] == "invalid_max_registers_per_request_high"
-    )
+    assert result["errors"][CONF_MAX_REGISTERS_PER_REQUEST] == "max_registers_range"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -150,8 +150,7 @@ OPTION_KEYS = [
 ]
 
 OPTION_ERROR_KEYS = [
-    "invalid_max_registers_per_request_low",
-    "invalid_max_registers_per_request_high",
+    "max_registers_range",
 ]
 
 

--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -22,8 +22,7 @@ OPTION_KEYS = [
 ]
 
 OPTION_ERROR_KEYS = [
-    "invalid_max_registers_per_request_low",
-    "invalid_max_registers_per_request_high",
+    "max_registers_range",
 ]
 
 


### PR DESCRIPTION
## Summary
- Combine max registers per request validation into a single `max_registers_range` error
- Replace old error keys in translations and strings
- Update translation checks and tests for new error key

## Testing
- `python tools/check_translations.py`
- `pytest tests/test_config_flow.py::test_options_flow_max_registers_per_request_validated tests/test_translations.py::test_translation_keys_present tests/test_translations.py::test_translation_structures_match`
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json custom_components/thessla_green_modbus/strings.json tools/check_translations.py tests/test_config_flow.py tests/test_translations.py` *(fails: /root/.cache/pre-commit/repokh3r2udb/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f90a04483269ed3a2c1acd188a1