### PR TITLE
Fix binary sensor instantiation and constructor

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -56,10 +56,11 @@ async def async_setup_entry(
             address = coordinator._register_maps[register_type][register_name]
             entities.append(
                 ThesslaGreenBinarySensor(
-                    coordinator, register_name, sensor_def, address
+                    coordinator,
+                    register_name,
+                    address,
+                    sensor_def,
                 )
-                ThesslaGreenBinarySensor(coordinator, register_name, address, sensor_def)
-
             )
             _LOGGER.debug("Created binary sensor: %s", sensor_def["translation_key"])
 
@@ -93,10 +94,14 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
         register_name: str,
         address: int,
         sensor_definition: Dict[str, Any],
-        address: int,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(coordinator, register_name, address, sensor_definition.get("bit"))
+        super().__init__(
+            coordinator,
+            register_name,
+            address,
+            bit=sensor_definition.get("bit"),
+        )
 
         self._register_name = register_name
         self._sensor_def = sensor_definition


### PR DESCRIPTION
## Summary
- Instantiate each binary sensor once with properly ordered arguments
- Refactor `ThesslaGreenBinarySensor` constructor to accept each parameter once and forward bit via keyword

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repowj8xhz0s/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: Interrupted: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3f91a3c48326b3b1f6e2aa28b50b