### PR TITLE
refactor unique id

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -34,35 +34,22 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
         serial = self.coordinator.device_info.get("serial_number")
-        bit_suffix = ""
-        key_part: str
-        if self._bit is not None:
-            bit_index = self._bit.bit_length() - 1
-            bit_suffix = f"_bit{bit_index}"
-        if self._address is not None:
-            key_part = f"{self.coordinator.slave_id}_{self._address}{bit_suffix}"
-        else:
-            key_part = self._key
-
         if serial and serial != "Unknown":
-            return f"{DOMAIN}_{serial}_{key_part}"
-        host = self.coordinator.host.replace(":", "-")
-        return f"{DOMAIN}_{host}_{self.coordinator.port}_{key_part}"
             prefix = f"{DOMAIN}_{serial}"
         else:
             host = self.coordinator.host.replace(":", "-")
             prefix = f"{DOMAIN}_{host}_{self.coordinator.port}"
 
-        if self._address is not None:
-            bit_suffix = (
-                f"_bit{self._bit.bit_length() - 1}" if self._bit is not None else ""
-            )
-            return f"{prefix}_{self.coordinator.slave_id}_{self._address}{bit_suffix}"
+        bit_suffix = (
+            f"_bit{self._bit.bit_length() - 1}" if self._bit is not None else ""
+        )
 
-        # Fallback to legacy key-based unique ID
-        if serial and serial != "Unknown":
-            return f"{prefix}_{self._key}"
-        return f"{prefix}_{self.coordinator.slave_id}_{self._key}"
+        if self._address is not None:
+            key_part = f"{self.coordinator.slave_id}_{self._address}{bit_suffix}"
+        else:
+            key_part = self._key
+
+        return f"{prefix}_{key_part}"
 
     @property
     def available(self) -> bool:  # pragma: no cover


### PR DESCRIPTION
## Summary
- simplify unique id generation in ThesslaGreenEntity
- drop unreachable legacy code

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repogf32819s/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3f9090e08326906acf8cead6db1e