### PR TITLE
Clean up binary sensor initialization

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -58,8 +58,6 @@ async def async_setup_entry(
                 ThesslaGreenBinarySensor(
                     coordinator, register_name, sensor_def, address
                 )
-                ThesslaGreenBinarySensor(coordinator, register_name, address, sensor_def)
-
             )
             _LOGGER.debug("Created binary sensor: %s", sensor_def["translation_key"])
 
@@ -91,7 +89,6 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         register_name: str,
-        address: int,
         sensor_definition: Dict[str, Any],
         address: int,
     ) -> None:
@@ -137,10 +134,7 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
 
         elif register_type == "holding_registers":
             # Holding registers: depends on register
-            if self._register_name == "on_off_panel_mode":
-                return bool(value)
-            else:
-                return bool(value)
+            return bool(value)
 
         return False
 


### PR DESCRIPTION
## Summary
- remove duplicate binary sensor creation
- fix ThesslaGreenBinarySensor constructor signature and remove redundant code
- simplify holding register state handling

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py` *(fails: InvalidManifestError)*
- `pytest` *(fails: Interrupted: 39 errors during collection)*
- `python -m py_compile custom_components/thessla_green_modbus/binary_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab3f6c33fc83269cd3a9a8d4b17cb5