### PR TITLE
Fix select entity constructor signature

### DIFF
--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -71,7 +71,6 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
         register_name: str,
         address: int,
         definition: dict[str, Any],
-        address: int,
     ) -> None:
         super().__init__(coordinator, register_name, address)
         self._register_name = register_name


### PR DESCRIPTION
## Summary
- correct ThesslaGreenSelect constructor signature and usage

## Testing
- `SKIP=hassfest pre-commit run --files custom_components/thessla_green_modbus/select.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repozcmyr8cb/.pre-commit-hooks.yaml is not a file)*
- `python -m py_compile custom_components/thessla_green_modbus/select.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab40e9f2c883269da5a0d2247a7d8d