### PR TITLE
refactor unique id generation

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -33,26 +33,16 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     @property
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
-        serial = self.coordinator.device_info.get("serial_number")
-        prefix = (
-            f"{DOMAIN}_{serial}"
-            if serial and serial != "Unknown"
-            else (
-                f"{DOMAIN}_{self.coordinator.host.replace(':', '-')}_{self.coordinator.port}"
-            )
-        )
-
+        host = self.coordinator.host.replace(":", "-")
         bit_suffix = (
             f"_bit{self._bit.bit_length() - 1}" if self._bit is not None else ""
         )
-
         key_part = (
             f"{self.coordinator.slave_id}_{self._address}{bit_suffix}"
             if self._address is not None
             else self._key
         )
-
-        return f"{prefix}_{key_part}"
+        return f"{DOMAIN}_{host}_{self.coordinator.port}_{key_part}"
 
     @property
     def available(self) -> bool:  # pragma: no cover


### PR DESCRIPTION
## Summary
- simplify unique id generation by removing unused serial prefix

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/entity.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoc64ffnbp/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68ab432a7f4c832688ff4b8179880c79