### PR TITLE
Simplify number entity mappings retrieval

### DIFF
--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -53,11 +53,7 @@ async def async_setup_entry(
     entities = []
 
     # Get number entity mappings
-    try:
-        number_mappings: dict[str, dict[str, Any]] = ENTITY_MAPPINGS["number"]
-    except KeyError:  # pragma: no cover - should not happen
-        _LOGGER.debug("No number entity mappings found; skipping setup")
-        return
+    number_mappings: dict[str, dict[str, Any]] = ENTITY_MAPPINGS["number"]
 
     # Create number entities only for registers discovered by
     # ThesslaGreenDeviceScanner.scan_device()


### PR DESCRIPTION
## Summary
- remove try/except around number entity mappings lookup

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/number.py` (fails: InvalidManifestError for https://github.com/home-assistant/actions)
- `pytest` (fails: 35 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68ab432a07d083269b0036f8133db90c