### PR TITLE
Fix switch initialization

### DIFF
--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -110,8 +110,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
         else:
             address = COIL_REGISTERS.get(register_name, 0)
         bit = entity_config.get("bit")
-        super().__init__(coordinator, key, address, bit)
-        super().__init__(coordinator, key, address, bit=entity_config.get("bit"))
+        super().__init__(coordinator, key, address, bit=bit)
 
         self.entity_config = entity_config
         self.register_name = register_name


### PR DESCRIPTION
## Summary
- avoid duplicate super initialization in ThesslaGreenSwitch and pass bit from entity_config

## Testing
- `pytest tests/test_switch.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68ab43275a388326991adbeb0a479f4c