### PR TITLE
Refactor binary sensor to derive register address internally

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -53,12 +53,10 @@ async def async_setup_entry(
 
         # Check if this register is available on the device
         if register_name in coordinator.available_registers.get(register_type, set()):
-            address = coordinator._register_maps[register_type][register_name]
             entities.append(
                 ThesslaGreenBinarySensor(
                     coordinator,
                     register_name,
-                    address,
                     sensor_def,
                 )
             )
@@ -95,6 +93,8 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
         sensor_definition: Dict[str, Any],
     ) -> None:
         """Initialize the binary sensor."""
+        register_type = sensor_definition["register_type"]
+        address = coordinator._register_maps.get(register_type, {}).get(register_name)
         super().__init__(
             coordinator,
             register_name,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -46,6 +46,16 @@ class AddEntitiesCallback:  # pragma: no cover - simple stub
 entity_platform.AddEntitiesCallback = AddEntitiesCallback
 sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 
+network_mod = cast(Any, types.ModuleType("homeassistant.util.network"))
+
+
+def is_host_valid(host: str) -> bool:  # pragma: no cover - simple stub
+    return True
+
+
+network_mod.is_host_valid = is_host_valid
+sys.modules["homeassistant.util.network"] = network_mod
+
 # ---------------------------------------------------------------------------
 # Actual tests
 # ---------------------------------------------------------------------------
@@ -68,9 +78,8 @@ def test_binary_sensor_creation_and_state(mock_coordinator: MagicMock) -> None:
     # Prepare coordinator data
     mock_coordinator.data["bypass"] = 0
 
-    address = 9
     sensor = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", address, BINARY_SENSOR_DEFINITIONS["bypass"]
+        mock_coordinator, "bypass", BINARY_SENSOR_DEFINITIONS["bypass"]
     )
     assert sensor.is_on is False  # nosec B101
 
@@ -84,11 +93,9 @@ def test_binary_sensor_icons(mock_coordinator: MagicMock) -> None:
 
     # Heating cable uses a heating icon when on
     mock_coordinator.data["heating_cable"] = 1
-    address = 12
     heating = ThesslaGreenBinarySensor(
         mock_coordinator,
         "heating_cable",
-        address,
         BINARY_SENSOR_DEFINITIONS["heating_cable"],
     )
     assert heating.icon == "mdi:heating-coil"  # nosec B101
@@ -99,9 +106,8 @@ def test_binary_sensor_icons(mock_coordinator: MagicMock) -> None:
 
     # Bypass uses pipe leak icon when active
     mock_coordinator.data["bypass"] = 1
-    address = 9
     bypass_sensor = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", address, BINARY_SENSOR_DEFINITIONS["bypass"]
+        mock_coordinator, "bypass", BINARY_SENSOR_DEFINITIONS["bypass"]
     )
     assert bypass_sensor.icon == "mdi:pipe-leak"  # nosec B101
 
@@ -115,9 +121,8 @@ def test_binary_sensor_icon_fallback(mock_coordinator: MagicMock) -> None:
     mock_coordinator.data["bypass"] = 1
     sensor_def = BINARY_SENSOR_DEFINITIONS["bypass"].copy()
     sensor_def.pop("icon", None)
-    address = 9
     sensor_without_icon = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", address, sensor_def
+        mock_coordinator, "bypass", sensor_def
     )
     assert sensor_without_icon.icon == "mdi:fan-off"  # nosec B101
 


### PR DESCRIPTION
## Summary
- simplify binary sensor creation by computing register address in the entity
- update binary sensor tests and add stub for network validation

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py tests/test_binary_sensor.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo4wm4okfi/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_binary_sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab43267b648326a8af59b605e313bb