### PR TITLE
Fix binary sensor address parameter

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -53,10 +53,12 @@ async def async_setup_entry(
 
         # Check if this register is available on the device
         if register_name in coordinator.available_registers.get(register_type, set()):
+            address = coordinator._register_maps.get(register_type, {}).get(register_name)
             entities.append(
                 ThesslaGreenBinarySensor(
                     coordinator,
                     register_name,
+                    address,
                     sensor_def,
                 )
             )
@@ -90,11 +92,10 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         register_name: str,
+        address: int,
         sensor_definition: Dict[str, Any],
     ) -> None:
         """Initialize the binary sensor."""
-        register_type = sensor_definition["register_type"]
-        address = coordinator._register_maps.get(register_type, {}).get(register_name)
         super().__init__(
             coordinator,
             register_name,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -77,9 +77,10 @@ def test_binary_sensor_creation_and_state(mock_coordinator: MagicMock) -> None:
     """Test creation and state changes of binary sensor."""
     # Prepare coordinator data
     mock_coordinator.data["bypass"] = 0
-
+    reg_type = BINARY_SENSOR_DEFINITIONS["bypass"]["register_type"]
+    address = mock_coordinator._register_maps[reg_type]["bypass"]
     sensor = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", BINARY_SENSOR_DEFINITIONS["bypass"]
+        mock_coordinator, "bypass", address, BINARY_SENSOR_DEFINITIONS["bypass"]
     )
     assert sensor.is_on is False  # nosec B101
 
@@ -93,9 +94,12 @@ def test_binary_sensor_icons(mock_coordinator: MagicMock) -> None:
 
     # Heating cable uses a heating icon when on
     mock_coordinator.data["heating_cable"] = 1
+    reg_type = BINARY_SENSOR_DEFINITIONS["heating_cable"]["register_type"]
+    address = mock_coordinator._register_maps[reg_type]["heating_cable"]
     heating = ThesslaGreenBinarySensor(
         mock_coordinator,
         "heating_cable",
+        address,
         BINARY_SENSOR_DEFINITIONS["heating_cable"],
     )
     assert heating.icon == "mdi:heating-coil"  # nosec B101
@@ -106,8 +110,10 @@ def test_binary_sensor_icons(mock_coordinator: MagicMock) -> None:
 
     # Bypass uses pipe leak icon when active
     mock_coordinator.data["bypass"] = 1
+    reg_type = BINARY_SENSOR_DEFINITIONS["bypass"]["register_type"]
+    address = mock_coordinator._register_maps[reg_type]["bypass"]
     bypass_sensor = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", BINARY_SENSOR_DEFINITIONS["bypass"]
+        mock_coordinator, "bypass", address, BINARY_SENSOR_DEFINITIONS["bypass"]
     )
     assert bypass_sensor.icon == "mdi:pipe-leak"  # nosec B101
 
@@ -121,8 +127,10 @@ def test_binary_sensor_icon_fallback(mock_coordinator: MagicMock) -> None:
     mock_coordinator.data["bypass"] = 1
     sensor_def = BINARY_SENSOR_DEFINITIONS["bypass"].copy()
     sensor_def.pop("icon", None)
+    reg_type = BINARY_SENSOR_DEFINITIONS["bypass"]["register_type"]
+    address = mock_coordinator._register_maps[reg_type]["bypass"]
     sensor_without_icon = ThesslaGreenBinarySensor(
-        mock_coordinator, "bypass", sensor_def
+        mock_coordinator, "bypass", address, sensor_def
     )
     assert sensor_without_icon.icon == "mdi:fan-off"  # nosec B101
 


### PR DESCRIPTION
## Summary
- forward register address to ThesslaGreenBinarySensor during setup
- accept address once in ThesslaGreenBinarySensor constructor
- adapt binary sensor tests for new constructor signature

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/binary_sensor.py tests/test_binary_sensor.py` *(fails: InvalidManifestError)*
- `pytest tests/test_binary_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab5787e3a883269e6436f75c191930