### PR TITLE
Refactor switch init

### DIFF
--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -109,12 +109,11 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
             address = HOLDING_REGISTERS.get(register_name, 0)
         else:
             address = COIL_REGISTERS.get(register_name, 0)
-        bit = entity_config.get("bit")
-        super().__init__(coordinator, key, address, bit=bit)
+        super().__init__(coordinator, key, address, bit=entity_config.get("bit"))
 
         self.entity_config = entity_config
         self.register_name = register_name
-        self.bit = bit
+        self.bit = entity_config.get("bit")
 
         # Entity configuration
         self._attr_translation_key = entity_config["translation_key"]  # pragma: no cover


### PR DESCRIPTION
## Summary
- inline bit lookup in switch initialization

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/switch.py` *(fails: InvalidManifestError: ... .pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab578a4fc883268c42b65ca9b6503c