### PR TITLE
refactor: simplify unique id logic

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -34,15 +34,14 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
         host = self.coordinator.host.replace(":", "-")
-        bit_suffix = (
-            f"_bit{self._bit.bit_length() - 1}" if self._bit is not None else ""
-        )
+        port = self.coordinator.port
+        bit_suffix = f"_bit{self._bit.bit_length() - 1}" if self._bit is not None else ""
         key_part = (
             f"{self.coordinator.slave_id}_{self._address}{bit_suffix}"
             if self._address is not None
             else self._key
         )
-        return f"{DOMAIN}_{host}_{self.coordinator.port}_{key_part}"
+        return f"{DOMAIN}_{host}_{port}_{key_part}"
 
     @property
     def available(self) -> bool:  # pragma: no cover


### PR DESCRIPTION
## Summary
- simplify ThesslaGreenEntity unique ID generation and ensure single return path

## Testing
- `ruff check custom_components/thessla_green_modbus/entity.py`
- `flake8 custom_components/thessla_green_modbus/entity.py --max-line-length=100`
- `pytest tests/test_entity_unique_id.py` *(fails: AssertionError - unique ID expectation and TypeError from MagicMock awaitable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5788528c8326b7a48b0a620d0691