### PR TITLE
feat: defer HA imports for external tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regenerated Modbus register definitions from CSV and updated coverage test
 - Assigned new unique IDs for m³/h airflow sensors
 - Simplified runtime dependencies; only require `pymodbus>=3.5.0`
+- Deferred `homeassistant` imports in `custom_components/thessla_green_modbus` so
+  utility modules can be imported without Home Assistant installed
 
 ### Removed
 - Custom Modbus client in favor of native AsyncModbusTcpClient

--- a/README.md
+++ b/README.md
@@ -451,6 +451,10 @@ podłączenie i wersję firmware.
 Po aktualizacji integracji możesz usunąć nieużywane encje przy pomocy
 skryptu `tools/cleanup_old_entities.py`.
 
+> **Nowość:** Skrypty i moduły narzędziowe można importować bez
+> zainstalowanego pakietu Home Assistant – importy specyficzne dla HA są
+> ładowane tylko podczas działania integracji.
+
 ```bash
 python3 tools/cleanup_old_entities.py
 ```

--- a/README_en.md
+++ b/README_en.md
@@ -293,6 +293,10 @@ stores the complete register specification and is the single canonical source
 of truth (the former `registers/` copy was removed). All tools in `tools/`
 operate exclusively on this JSON format.
 
+> **New:** Utility modules can now be imported without the `homeassistant`
+> package installed. HA-specific imports are loaded only when the integration
+> runs inside Home Assistant.
+
 ### File format
 
 Each entry in the file is an object with fields:


### PR DESCRIPTION
## Summary
- move `homeassistant` imports inside functions and add stub fallbacks
- lazily resolve platform enums so package imports without Home Assistant
- document ability to run utility scripts without HA

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/__init__.py README.md README_en.md CHANGELOG.md` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoe8k9vf53/.pre-commit-hooks.yaml is not a file)*
- `python -m py_compile custom_components/thessla_green_modbus/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ac256848326acc14d9784064e15