### PR TITLE
Add pydantic dependency across project

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -14,7 +14,7 @@
   "files": [
     "registers/thessla_green_registers_full.json"
   ],
-  "requirements": ["pymodbus>=3.5.0"],
+  "requirements": ["pymodbus>=3.5.0", "pydantic>=2.0"],
   "version": "2.1.2",
   "integration_type": "hub",
   "dhcp": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires-python = ">=3.12"
 # Core dependencies
 dependencies = [
     "pymodbus>=3.5.0",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 
 # Modbus communication library
 pymodbus>=3.5.0
+pydantic>=2.0


### PR DESCRIPTION
## Summary
- include `pydantic>=2.0` in Home Assistant manifest
- add `pydantic>=2.0` to Python packaging and requirements

## Testing
- `pytest -q` *(fails: 'type' object is not iterable and other import errors, likely due to incompatible Home Assistant version)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ac2e8b08326ab72042d7a965de6