### PR TITLE
Add pydantic runtime dependency

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -14,7 +14,10 @@
   "files": [
     "registers/thessla_green_registers_full.json"
   ],
-  "requirements": ["pymodbus>=3.5.0"],
+  "requirements": [
+    "pymodbus>=3.5.0",
+    "pydantic>=2.0"
+  ],
   "version": "2.1.2",
   "integration_type": "hub",
   "dhcp": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 
 # Modbus communication library
 pymodbus>=3.5.0
+pydantic>=2.0


### PR DESCRIPTION
## Summary
- include pydantic>=2.0 in runtime requirements
- document pydantic requirement in integration manifest

## Testing
- `pip install -r requirements.txt`
- `pip install --pre homeassistant`
- `python - <<'PY'
import importlib
importlib.import_module('custom_components.thessla_green_modbus')
PY`
- `pytest` *(fails: ImportError: cannot import name 'get_register_definition')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5aa340988326a503a066dff66565