### PR TITLE
refactor: consolidate const imports

### DIFF
--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -31,7 +31,6 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover
 
     dt_util = _DTUtil()  # type: ignore
 
-from .const import DOMAIN, SPECIAL_FUNCTION_MAP
 from .const import (
     BYPASS_MODES,
     DAYS_OF_WEEK,


### PR DESCRIPTION
## Summary
- consolidate duplicate constant imports in services module

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/services.py` *(fails: InvalidManifestError: .../.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 35 errors during collection)*
- `python tools/py_compile_all.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab5ab729c483268bdfcd0f48243924