### PR TITLE
fix: update manifest documentation URL

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -6,7 +6,7 @@
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/blakinio/thesslagreen/blob/main/README.md",
+  "documentation": "https://github.com/thesslagreen/thessla-green-modbus-ha",
   "homeassistant": ">=2025.7.0",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",


### PR DESCRIPTION
## Summary
- point manifest documentation to thessla-green-modbus-ha repository

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoy6lz8ypb/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5d10abd48326af4b8260a7731532