### PR TITLE
Ensure manifest includes all runtime data files

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -11,13 +11,27 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",
-  "requirements": ["pymodbus>=3.5.0"],
-  "files": [
-    "registers/thessla_green_registers_full.json"
-  ],
   "requirements": [
     "pymodbus>=3.5.0",
     "pydantic>=2.0"
+  ],
+  "files": [
+    "options/bypass_modes.json",
+    "options/days_of_week.json",
+    "options/filter_types.json",
+    "options/gwc_modes.json",
+    "options/modbus_baud_rates.json",
+    "options/modbus_parity.json",
+    "options/modbus_ports.json",
+    "options/modbus_stop_bits.json",
+    "options/periods.json",
+    "options/reset_types.json",
+    "options/special_modes.json",
+    "registers/thessla_green_registers_full.json",
+    "services.yaml",
+    "strings.json",
+    "translations/en.json",
+    "translations/pl.json"
   ],
   "version": "2.1.2",
   "integration_type": "hub",

--- a/tests/test_manifest_files.py
+++ b/tests/test_manifest_files.py
@@ -1,0 +1,25 @@
+"""Validate manifest `files` array lists all required static resources."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "thessla_green_modbus"
+MANIFEST = COMPONENT / "manifest.json"
+
+
+def _expected_files() -> list[str]:
+    files: list[str] = ["services.yaml", "strings.json"]
+    for folder in ("options", "registers", "translations"):
+        for path in (COMPONENT / folder).glob("*.json"):
+            files.append(f"{folder}/{path.name}")
+    return sorted(files)
+
+
+def test_manifest_files_list_is_complete() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert sorted(manifest["files"]) == _expected_files()
+


### PR DESCRIPTION
## Summary
- list options, translations, registers, and other data files in `files`
- test that manifest `files` list matches packaged resources

## Testing
- `python -m pre_commit run --files custom_components/thessla_green_modbus/manifest.json tests/test_manifest_files.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repov0yry0um/.pre-commit-hooks.yaml is not a file)*
- `python -m pytest tests/test_manifest_files.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab5d11963483269931b75603bd5877