### PR TITLE
Detect register definition changes in scanner

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -23,7 +23,7 @@ from .modbus_exceptions import (
     ModbusIOException,
 )
 from .modbus_helpers import _call_modbus, group_reads as _group_reads
-from .registers.loader import get_all_registers
+from .registers.loader import get_all_registers, get_registers_hash
 from .utils import _decode_bcd_time, BCD_TIME_PREFIXES
 from .scanner_helpers import (
     REGISTER_ALLOWED_VALUES,
@@ -45,11 +45,14 @@ HOLDING_REGISTERS: dict[str, int] = {}
 COIL_REGISTERS: dict[str, int] = {}
 DISCRETE_INPUT_REGISTERS: dict[str, int] = {}
 MULTI_REGISTER_SIZES: dict[str, int] = {}
+REGISTER_HASH: str | None = None
 
 
 def _build_register_maps() -> None:
     """Populate register lookup maps from current register definitions."""
+    global REGISTER_HASH
     regs = get_all_registers()
+    REGISTER_HASH = get_registers_hash()
 
     REGISTER_DEFINITIONS.clear()
     REGISTER_DEFINITIONS.update({r.name: r for r in regs})
@@ -87,7 +90,8 @@ def _build_register_maps() -> None:
 # Ensure register lookup maps are available before use
 def _ensure_register_maps() -> None:
     """Ensure register lookup maps are populated."""
-    if not REGISTER_DEFINITIONS:
+    current_hash = get_registers_hash()
+    if not REGISTER_DEFINITIONS or current_hash != REGISTER_HASH:
         _build_register_maps()
 
 

--- a/tests/test_scanner_register_cache_invalidation.py
+++ b/tests/test_scanner_register_cache_invalidation.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import custom_components.thessla_green_modbus.scanner_core as sc
+from custom_components.thessla_green_modbus.registers.loader import (
+    _REGISTERS_PATH,
+    clear_cache,
+)
+
+
+def test_scanner_register_cache_invalidation(tmp_path: Path, monkeypatch) -> None:
+    """Scanner should rebuild register maps when definitions change."""
+    tmp_json = tmp_path / "registers.json"
+    tmp_json.write_text(_REGISTERS_PATH.read_text(), encoding="utf-8")
+    monkeypatch.setattr(
+        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
+        tmp_json,
+    )
+
+    clear_cache()
+    sc.REGISTER_DEFINITIONS.clear()
+    sc.INPUT_REGISTERS.clear()
+    sc.HOLDING_REGISTERS.clear()
+    sc.COIL_REGISTERS.clear()
+    sc.DISCRETE_INPUT_REGISTERS.clear()
+    sc.MULTI_REGISTER_SIZES.clear()
+    sc.REGISTER_HASH = None
+    sc._ensure_register_maps()
+
+    first_hash = sc.REGISTER_HASH
+    first_reg_name = next(iter(sc.REGISTER_DEFINITIONS))
+
+    data = json.loads(tmp_json.read_text())
+    data["registers"][0]["description"] = "changed description"
+    tmp_json.write_text(json.dumps(data), encoding="utf-8")
+
+    sc._ensure_register_maps()
+    second_hash = sc.REGISTER_HASH
+
+    assert first_hash != second_hash
+    assert sc.REGISTER_DEFINITIONS[first_reg_name].description == "changed description"
+
+    clear_cache()
+    sc.REGISTER_DEFINITIONS.clear()
+    sc.INPUT_REGISTERS.clear()
+    sc.HOLDING_REGISTERS.clear()
+    sc.COIL_REGISTERS.clear()
+    sc.DISCRETE_INPUT_REGISTERS.clear()
+    sc.MULTI_REGISTER_SIZES.clear()
+    sc.REGISTER_HASH = None


### PR DESCRIPTION
## Summary
- Track register definition hash and rebuild register maps when definitions change
- Add unit test validating scanner cache invalidation

## Testing
- `pytest tests/test_scanner_register_cache_invalidation.py -q`
- `pytest tests/test_register_cache_invalidation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5d12322c8326bf47f2d6b2a17f55