### PR TITLE
Move file reads to async setup

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -42,9 +42,11 @@ from .const import (
     DOMAIN,
     AIRFLOW_UNIT_M3H,
     AIRFLOW_UNIT_PERCENTAGE,
+    async_setup_options,
     migrate_unique_id,
 )
 from .const import PLATFORMS as PLATFORM_DOMAINS
+from .entity_mappings import async_setup_entity_mappings
 from .modbus_exceptions import ConnectionException, ModbusException
 from .registers.loader import load_registers
 
@@ -220,6 +222,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
 
     # Migrate entity unique IDs (replace ':' in host with '-')
     await _async_migrate_unique_ids(hass, entry)
+
+    # Load option lists and entity mappings
+    await async_setup_options(hass)
+    await async_setup_entity_mappings(hass)
 
     # Preload platform modules in the executor to avoid blocking the event loop
     for platform in PLATFORM_DOMAINS:


### PR DESCRIPTION
## Summary
- move JSON option loading to async helper and defer to runtime
- build entity mappings during setup using executor
- call async setup helpers before platform/service initialization

## Testing
- `pytest` *(fails: ImportError: cannot import name 'get_register_definition' from '<unknown module name>' (unknown location))*

------
https://chatgpt.com/codex/tasks/task_e_68ab5d1622c88326a81793e0d2d84b6e