### PR TITLE
Clarify base entity module docstring

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -1,4 +1,4 @@
-"""Base entity for ThesslaGreen Modbus Integration."""
+"""Base entity classes for ThesslaGreen Modbus integration."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- clarify module docstring for base entity definitions

## Testing
- `pytest` *(fails: cannot import name 'get_register_definition' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_68ab605f90108326bf5d35854cfcd97f