### PR TITLE
chore: remove unused imports from integration init

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -40,15 +40,12 @@ from .const import (
     DEFAULT_DEEP_SCAN,
     DEFAULT_MAX_REGISTERS_PER_REQUEST,
     DOMAIN,
-    AIRFLOW_UNIT_M3H,
-    AIRFLOW_UNIT_PERCENTAGE,
     async_setup_options,
     migrate_unique_id,
 )
 from .const import PLATFORMS as PLATFORM_DOMAINS
 from .entity_mappings import async_setup_entity_mappings
 from .modbus_exceptions import ConnectionException, ModbusException
-from .registers.loader import load_registers
 
 # Informational message for start-up logs
 REGISTER_FORMAT_MESSAGE = (


### PR DESCRIPTION
## Summary
- remove unused airflow unit and register loader imports from integration init to fix ruff F401

## Testing
- `ruff check custom_components/thessla_green_modbus/__init__.py`
- `pre-commit run --files custom_components/thessla_green_modbus/__init__.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repormjitkrf/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: ImportError: cannot import name 'get_register_definition' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_68ab604917748326a6a4bf65198f6485