### PR TITLE
Fix positional argument usage in coordinator

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -464,7 +464,9 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 test_addresses = [reg.address for reg in get_registers_by_function("04")][:3]
 
                 for addr in test_addresses:
-                    response = await self.client.read_input_registers(addr, 1, unit=self.slave_id)
+                    response = await self.client.read_input_registers(
+                        addr, count=1, unit=self.slave_id
+                    )
                     if response.isError():
                         raise ConnectionException(f"Cannot read register {addr:#06x}")
 


### PR DESCRIPTION
## Summary
- fix call to `read_input_registers` to use keyword `count=1`

## Testing
- `mypy custom_components/thessla_green_modbus/coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab604cddd08326902c5499ced43e4b