### PR TITLE
Resolve import order and adjust batch size helper

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -11,12 +11,13 @@ from typing import TYPE_CHECKING, Any, Dict, cast
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from homeassistant.core import HomeAssistant
 
-# Importing ``MAX_BATCH_REGISTERS`` from this module in ``modbus_helpers``
-# creates a circular dependency if it is defined after the registers loader is
-# imported.  Define it here before pulling in the loader to break the cycle.
-MAX_BATCH_REGISTERS = 16
-
 from .registers.loader import get_registers_by_function
+
+# Maximum number of registers that can be read in a single request.
+# The registers loader previously created a circular dependency with
+# ``modbus_helpers`` but this has been resolved, allowing the import to
+# appear before this constant.
+MAX_BATCH_REGISTERS = 16
 
 
 def _build_map(fn: str) -> dict[str, int]:

--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -8,7 +8,7 @@ import weakref
 from collections.abc import Awaitable, Callable, Iterable
 from typing import Any, List, Tuple
 
-from .const import MAX_BATCH_REGISTERS
+from . import const
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -194,7 +194,7 @@ async def _call_modbus(
 
 def group_reads(
     addresses: Iterable[int],
-    max_block_size: int = MAX_BATCH_REGISTERS,
+    max_block_size: int | None = None,
 ) -> List[Tuple[int, int]]:
     """Group raw register addresses into contiguous read blocks.
 
@@ -203,7 +203,9 @@ def group_reads(
     tuples suitable for bulk Modbus read operations.
     """
 
-    max_block_size = min(max_block_size, MAX_BATCH_REGISTERS)
+    if max_block_size is None:
+        max_block_size = const.MAX_BATCH_REGISTERS
+    max_block_size = min(max_block_size, const.MAX_BATCH_REGISTERS)
     sorted_addresses = sorted(set(addresses))
     if not sorted_addresses:
         return []


### PR DESCRIPTION
## Summary
- Move registers loader import before MAX_BATCH_REGISTERS and update comment
- Refactor modbus_helpers to avoid circular import and use optional max_block_size

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/const.py custom_components/thessla_green_modbus/modbus_helpers.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo1iej3vfz/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: ImportError: cannot import name 'get_register_definition' from '<unknown module name>' (unknown location))*

------
https://chatgpt.com/codex/tasks/task_e_68ab604bc2388326973df423b54953d4