### PR TITLE
Restrict pymodbus to <4.0

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",
   "requirements": [
-    "pymodbus>=3.5.0",
+    "pymodbus>=3.5.0,<4.0",
     "pydantic>=2.0"
   ],
   "files": [


### PR DESCRIPTION
## Summary
- constrain pymodbus dependency below v4

## Testing
- `python -m pip install "pymodbus>=3.5.0,<4.0" pydantic>=2.0`
- `python -m pre_commit run --files custom_components/thessla_green_modbus/manifest.json` *(fails: InvalidManifestError)*
- `pytest` *(fails: cannot import name 'get_register_definition')*

------
https://chatgpt.com/codex/tasks/task_e_68ab603e31c48326845b2815cc50e627