### PR TITLE
Fix duplicate MagicMock import in airflow unit test

### DIFF
--- a/tests/test_airflow_unit.py
+++ b/tests/test_airflow_unit.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 
 import sys
 import types
-from unittest.mock import MagicMock
 
 const = sys.modules.setdefault("homeassistant.const", types.ModuleType("homeassistant.const"))
 setattr(const, "PERCENTAGE", "%")


### PR DESCRIPTION
## Summary
- remove duplicate MagicMock import

## Testing
- `pytest tests/test_airflow_unit.py` *(fails: ModuleNotFoundError: No module named 'voluptuous')*

------
https://chatgpt.com/codex/tasks/task_e_68ab62346dfc8326b7dca2937876a071