### PR TITLE
Move loader import before type checking block

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -8,10 +8,10 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, cast
 
+from .registers.loader import get_registers_by_function
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from homeassistant.core import HomeAssistant
-
-from .registers.loader import get_registers_by_function
 
 # Maximum number of registers that can be read in a single request.
 # The registers loader previously created a circular dependency with


### PR DESCRIPTION
## Summary
- place `get_registers_by_function` import before type checking block in `const.py`

## Testing
- `ruff check custom_components/thessla_green_modbus/const.py`
- `pre-commit run --files custom_components/thessla_green_modbus/const.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo7k7spwku/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab62346f988326af70759f9e571675