### PR TITLE
docs: document Modbus helper utilities

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -1,4 +1,4 @@
-"""Modbus utility helpers."""
+"""Utility helpers for Modbus communication and read grouping."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- describe Modbus helper utilities and read grouping

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/modbus_helpers.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repog0wc0csu/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_68ab62303d488326a248092ef8cad83c