### PR TITLE
Separate json and pathlib imports in generate_strings

### DIFF
--- a/tools/generate_strings.py
+++ b/tools/generate_strings.py
@@ -1,4 +1,5 @@
-import json, pathlib
+import json
+import pathlib
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 REG = ROOT / 'custom_components' / 'thessla_green_modbus' / 'registers' / 'thessla_green_registers_full.json'


### PR DESCRIPTION
## Summary
- split combined json/pathlib import into separate statements

## Testing
- `pre-commit run --files tools/generate_strings.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoz7j_j4j_/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6236fc408326be572ef67df1e2fc