### PR TITLE
refactor: fix sensor register mapping test

### DIFF
--- a/tests/test_sensor_register_mapping.py
+++ b/tests/test_sensor_register_mapping.py
@@ -66,10 +66,14 @@ sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
 # Actual test
 # ---------------------------------------------------------------------------
 
-from custom_components.thessla_green_modbus.sensor import SENSOR_DEFINITIONS  # noqa: E402
-from custom_components.thessla_green_modbus.registers.loader import (
+from custom_components.thessla_green_modbus.entity_mappings import (  # noqa: E402
+    ENTITY_MAPPINGS,
+)
+from custom_components.thessla_green_modbus.registers.loader import (  # noqa: E402
     get_registers_by_function,
-)  # noqa: E402
+)
+
+SENSOR_DEFINITIONS = ENTITY_MAPPINGS.get("sensor", {})
 
 INPUT_REGISTERS = {r.name for r in get_registers_by_function("04")}
 HOLDING_REGISTERS = {r.name for r in get_registers_by_function("03")}
@@ -86,7 +90,7 @@ def test_sensor_register_mapping() -> None:
             assert register_name in HOLDING_REGISTERS
             assert register_name not in INPUT_REGISTERS
         elif register_type == "calculated":
-            assert register_name not in registers.INPUT_REGISTERS
-            assert register_name not in registers.HOLDING_REGISTERS
+            assert register_name not in INPUT_REGISTERS
+            assert register_name not in HOLDING_REGISTERS
         else:
             pytest.fail(f"Unknown register_type {register_type} for {register_name}")


### PR DESCRIPTION
## Summary
- replace nonexistent `registers` references with local register sets in sensor mapping test
- load sensor definitions from `entity_mappings` to avoid heavy imports

## Testing
- `pre-commit run --files tests/test_sensor_register_mapping.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo1d_c4dj1/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_sensor_register_mapping.py` *(fails: AssertionError: assert 'supply_air_flow' in {...})*


------
https://chatgpt.com/codex/tasks/task_e_68ab62360da08326a537bf3c99cc1b26