### PR TITLE
chore: remove unused pytest import

### DIFF
--- a/tests/test_force_full_register_list_integration.py
+++ b/tests/test_force_full_register_list_integration.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.thessla_green_modbus import async_setup_entry


### PR DESCRIPTION
## Summary
- remove unused pytest import

## Testing
- `pre-commit run --files tests/test_force_full_register_list_integration.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repox90ba6jq/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_force_full_register_list_integration.py` *(fails: AttributeError: 'FakeCoordinator' object has no attribute '_register_maps')*

------
https://chatgpt.com/codex/tasks/task_e_68ab6236a99c8326af3454d2c5acf3d0