### PR TITLE
Fix import order to avoid E402 warnings

### DIFF
--- a/tools/validate_register_pdf.py
+++ b/tools/validate_register_pdf.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 """Parse MODBUS register definitions from the official PDF.
 
 This module extracts register metadata such as address, function code, access,
@@ -6,6 +5,8 @@ unit, multiplier, resolution and enumerated values from the documentation
 PDF.  It is used in tests to verify that the bundled JSON definition is in
 sync with the vendor documentation.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -9,17 +9,6 @@ from pathlib import Path
 import types
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
-
-# Provide a stub package to avoid importing Home Assistant dependencies
-sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
-tg_pkg = types.ModuleType("custom_components.thessla_green_modbus")
-tg_pkg.__path__ = [str(ROOT / "custom_components" / "thessla_green_modbus")]
-sys.modules["custom_components.thessla_green_modbus"] = tg_pkg
-
-from custom_components.thessla_green_modbus.registers.schema import (
-    RegisterDefinition,
-)
 JSON_PATH = (
     ROOT
     / "custom_components"
@@ -29,8 +18,22 @@ JSON_PATH = (
 )
 
 
+def _prepare_environment() -> None:
+    """Add repository root and stub package to ``sys`` modules."""
+
+    sys.path.insert(0, str(ROOT))
+    sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+    tg_pkg = types.ModuleType("custom_components.thessla_green_modbus")
+    tg_pkg.__path__ = [str(ROOT / "custom_components" / "thessla_green_modbus")]
+    sys.modules["custom_components.thessla_green_modbus"] = tg_pkg
+
+
 def validate(path: Path) -> list[RegisterDefinition]:
     """Validate ``path`` and return the parsed register definitions."""
+    _prepare_environment()
+    from custom_components.thessla_green_modbus.registers.schema import (
+        RegisterDefinition,
+    )
 
     data = json.loads(path.read_text(encoding="utf-8"))
     registers = data.get("registers", data)


### PR DESCRIPTION
## Summary
- ensure module docstring precedes imports in validate_register_pdf
- move sys.path manipulation before importing schema in validate_registers

## Testing
- `pre-commit run --files tools/validate_register_pdf.py tools/validate_registers.py` *(fails: InvalidManifestError)*
- `pytest tests/test_validate_registers.py tests/test_register_loader_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab62381df48326b8e07be4f68f0012