### PR TITLE
Validate register bit definitions

### DIFF
--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -80,6 +80,26 @@ class RegisterDefinition(pydantic.BaseModel):
         if self.bits is not None:
             if not (self.extra and self.extra.get("bitmask")):
                 raise ValueError("bits provided without extra.bitmask")
+
+            if len(self.bits) > 16:
+                raise ValueError("bits index out of range")
+
+            for idx, bit in enumerate(self.bits):
+                if not isinstance(bit, dict):
+                    raise ValueError("bits entries must be objects")
+
+                name = bit.get("name")
+                if not isinstance(name, str) or not re.fullmatch(r"[a-z0-9_]+", name):
+                    raise ValueError("bit name must be snake_case")
+
+                index = bit.get("index", idx)
+                if not isinstance(index, int) or isinstance(index, bool):
+                    raise ValueError("bit index must be an integer")
+                if index != idx:
+                    raise ValueError("bits must be in implicit index order")
+                if not 0 <= index <= 15:
+                    raise ValueError("bit index out of range")
+
             bitmask_val = self.extra.get("bitmask") if self.extra else None
             mask_int: int | None = None
             if isinstance(bitmask_val, str):

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -333,7 +333,7 @@ def test_duplicate_registers_raise_error(tmp_path, monkeypatch, registers) -> No
             "address_hex": "0x0",
             "name": "bad_bits",
             "access": "R",
-            "bits": ["a"],
+            "bits": [{"name": "a"}],
         },
         {
             "function": "03",
@@ -348,10 +348,37 @@ def test_duplicate_registers_raise_error(tmp_path, monkeypatch, registers) -> No
             "function": "03",
             "address_dec": 0,
             "address_hex": "0x0",
+            "name": "bad_bit_name",
+            "access": "R",
+            "extra": {"bitmask": 0b1},
+            "bits": [{"name": "BadName"}],
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "address_hex": "0x0",
+            "name": "bad_bit_index",
+            "access": "R",
+            "extra": {"bitmask": 0b1},
+            "bits": [{"name": "a", "index": 1}],
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "address_hex": "0x0",
+            "name": "bit_index_out_of_range",
+            "access": "R",
+            "extra": {"bitmask": 0xFFFF},
+            "bits": [{"name": f"b{i}"} for i in range(17)],
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "address_hex": "0x0",
             "name": "too_many_bits",
             "access": "R",
             "extra": {"bitmask": 0b11},
-            "bits": ["a", "b", "c"],
+            "bits": [{"name": "a"}, {"name": "b"}, {"name": "c"}],
         },
     ],
 )
@@ -380,7 +407,7 @@ def test_bits_within_bitmask_width(tmp_path, monkeypatch) -> None:
         "name": "good_bits",
         "access": "R",
         "extra": {"bitmask": 0b11},
-        "bits": ["a", "b"],
+        "bits": [{"name": "a"}, {"name": "b"}],
     }
     path = tmp_path / "regs.json"
     path.write_text(json.dumps({"registers": [reg]}))

--- a/tests/test_validate_registers.py
+++ b/tests/test_validate_registers.py
@@ -149,7 +149,67 @@ def test_validator_rejects_bits_without_bitmask(tmp_path: Path) -> None:
                 "address_hex": "0x0001",
                 "name": "bad_bits",
                 "access": "R/W",
-                "bits": ["a"],
+                "bits": [{"name": "a"}],
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_bit_name(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "bad_bit_name",
+                "access": "R/W",
+                "extra": {"bitmask": 0b1},
+                "bits": [{"name": "BadName"}],
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_bit_index(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "bad_bit_index",
+                "access": "R/W",
+                "extra": {"bitmask": 0b1},
+                "bits": [{"name": "a", "index": 1}],
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_bit_index_out_of_range(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "bit_index_out_of_range",
+                "access": "R/W",
+                "extra": {"bitmask": 0xFFFF},
+                "bits": [{"name": f"b{i}"} for i in range(17)],
             }
         ],
     )

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -72,8 +72,10 @@ def validate(path: Path) -> list[RegisterDefinition]:
         if reg.function in {"01", "02"} and reg.access not in {"R", "R/-"}:
             raise ValueError("read-only functions must have R access")
 
-        if item.get("bits") is not None and not ((reg.extra or {}).get("bitmask")):
-            raise ValueError("bits provided without extra.bitmask")
+        if reg.bits is not None:
+            for idx, bit in enumerate(reg.bits):
+                if bit.get("index", idx) != idx:
+                    raise ValueError("bits must be in implicit index order")
 
         parsed.append(reg)
 


### PR DESCRIPTION
## Summary
- ensure register bits are defined as objects with snake_case names and sequential indexes
- verify bits index order in register validation tool
- expand tests for bit definition validation

## Testing
- `pytest tests/test_register_loader.py tests/test_validate_registers.py`
- `pre-commit run --files custom_components/thessla_green_modbus/registers/schema.py tools/validate_registers.py tests/test_register_loader.py tests/test_validate_registers.py` *(failed: InvalidManifestError: /root/.cache/pre-commit/repoe0gcika_/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6525dba08326824fd7981274c56b