### PR TITLE
feat: use number selector for max registers option

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import translation
+from homeassistant.helpers import selector, translation
 from homeassistant.util.network import is_host_valid
 
 from .const import (
@@ -549,7 +549,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                     CONF_MAX_REGISTERS_PER_REQUEST,
                     default=current_max_registers_per_request,
                     description={"advanced": True},
-                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=MAX_BATCH_REGISTERS)),
+                ): selector.NumberSelector(min=1, max=16, step=1),
             }
         )
 

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1273,7 +1273,7 @@
           "skip_missing_registers": "Do not poll registers known to be unavailable",
           "timeout": "Maximum time to wait for response (5-60 seconds)",
           "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
-          "max_registers_per_request": "Maximum registers per request (1–16)"
+          "max_registers_per_request": "Maximum registers per request"
         },
         "error": {
           "max_registers_per_request": "Maximum registers per Modbus request (1-16)"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1273,7 +1273,7 @@
           "skip_missing_registers": "Do not poll registers known to be unavailable",
           "timeout": "Maximum time to wait for response (5-60 seconds)",
           "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
-          "max_registers_per_request": "Maximum registers per request (1–16)"
+          "max_registers_per_request": "Maximum registers per request"
         },
         "error": {
           "max_registers_per_request": "Maximum registers per Modbus request (1-16)"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1273,7 +1273,7 @@
           "skip_missing_registers": "Nie odczytuj rejestrów, które są znane jako niedostępne",
           "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)",
           "deep_scan": "Odczyt surowych rejestrów 0x0000-0x012C do diagnostyki",
-          "max_registers_per_request": "Maksymalna liczba rejestrów w zapytaniu (1–16)"
+          "max_registers_per_request": "Maksymalna liczba rejestrów w zapytaniu"
         },
         "error": {
           "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-16)"


### PR DESCRIPTION
## Summary
- use NumberSelector for max registers option in options flow
- update option descriptions to match selector usage

## Testing
- `python -m pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'voluptuous')*
- `python tools/py_compile_all.py`
- `pre-commit run --all-files` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6523d2b88326afb4f6d3ab408038