### PR TITLE
Use absolute imports for register loader

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -20,7 +20,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, SPECIAL_FUNCTION_MAP
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
-from .registers.loader import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -8,7 +8,9 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, cast
 
-from .registers.loader import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from homeassistant.core import HomeAssistant

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -91,7 +91,10 @@ from .const import (
     UNKNOWN_MODEL,
 )
 from .modbus_helpers import _call_modbus, group_reads
-from .registers.loader import get_all_registers, get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_all_registers,
+    get_registers_by_function,
+)
 from .scanner_core import DeviceCapabilities, ThesslaGreenDeviceScanner
 
 REGISTER_DEFS = {r.name: r for r in get_all_registers()}

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -18,7 +18,10 @@ from homeassistant.helpers import translation
 
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
-from .registers.loader import get_all_registers, get_registers_hash
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_all_registers,
+    get_registers_hash,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -80,7 +80,9 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover - executed only i
 
 from .const import SPECIAL_FUNCTION_MAP
 from .const import COIL_REGISTERS, DISCRETE_INPUT_REGISTERS, HOLDING_REGISTERS
-from .registers.loader import get_all_registers
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_all_registers,
+)
 from .utils import _to_snake_case
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -19,7 +19,9 @@ from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .modbus_exceptions import ConnectionException, ModbusException
-from .registers.loader import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -23,7 +23,9 @@ from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .entity_mappings import ENTITY_MAPPINGS
 from .modbus_exceptions import ConnectionException, ModbusException
-from .registers.loader import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -23,7 +23,10 @@ from .modbus_exceptions import (
     ModbusIOException,
 )
 from .modbus_helpers import _call_modbus, group_reads as _group_reads
-from .registers.loader import get_all_registers, get_registers_hash
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_all_registers,
+    get_registers_hash,
+)
 from .utils import _decode_bcd_time, BCD_TIME_PREFIXES
 from .scanner_helpers import (
     REGISTER_ALLOWED_VALUES,

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -16,7 +16,9 @@ from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .entity_mappings import ENTITY_MAPPINGS
 from .modbus_exceptions import ConnectionException, ModbusException
-from .registers.loader import get_registers_by_function
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_registers_by_function,
+)
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- use absolute path for `registers.loader` imports across integration modules

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/number.py custom_components/thessla_green_modbus/scanner_core.py custom_components/thessla_green_modbus/coordinator.py custom_components/thessla_green_modbus/const.py custom_components/thessla_green_modbus/switch.py custom_components/thessla_green_modbus/entity_mappings.py custom_components/thessla_green_modbus/diagnostics.py custom_components/thessla_green_modbus/climate.py custom_components/thessla_green_modbus/fan.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repox5xkmtjf/.pre-commit-hooks.yaml is not a file)*
- `pytest tests` *(fails: AttributeError: module 'pydantic' has no attribute 'model_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68ab651fc2f88326b652565a285e5f84