### PR TITLE
Validate register write bounds

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1254,7 +1254,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                             )
                             return False
                         continue
-                    except (OSError, ValueError):
+                    except OSError:
                         _LOGGER.exception("Unexpected error writing register %s", register_name)
                         return False
 

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -121,6 +121,24 @@ def test_register_bitmask_decode_encode():
     assert reg.decode(5) == ["A", "C"]
     assert reg.encode(["A", "C"]) == 5
 
+
+def test_register_encode_numeric_bounds():
+    """Numeric registers enforce configured min/max limits."""
+    reg = Register(function="holding", address=0, name="num", access="rw", min=0, max=10)
+    assert reg.encode(0) == 0
+    assert reg.encode(10) == 10
+    with pytest.raises(ValueError):
+        reg.encode(-1)
+    with pytest.raises(ValueError):
+        reg.encode(11)
+
+
+def test_register_encode_enum_invalid():
+    """Enum registers raise when provided invalid values."""
+    reg = Register(function="holding", address=0, name="mode", access="rw", enum={0: "off", 1: "on"})
+    with pytest.raises(ValueError):
+        reg.encode("invalid")
+
 def test_register_decode_encode_string_multi():
     reg = next(r for r in get_registers_by_function("03") if r.name == "device_name")
     value = "Test AirPack"


### PR DESCRIPTION
## Summary
- enforce min/max limits in RegisterDef.encode and validate enum values
- surface encoding errors from async_write_register
- test boundary violations for numeric and enum registers

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py custom_components/thessla_green_modbus/coordinator.py tests/test_coordinator.py tests/test_register_decoders.py` (failed: InvalidManifestError)
- `pytest tests/test_register_decoders.py::test_register_encode_numeric_bounds tests/test_register_decoders.py::test_register_encode_enum_invalid tests/test_coordinator.py::test_async_write_register_numeric_out_of_range tests/test_coordinator.py::test_async_write_register_enum_invalid`


------
https://chatgpt.com/codex/tasks/task_e_68ab6523d8b48326b7635e62013e2b32