### PR TITLE
feat: add optional json path and sha256 helper

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -39,9 +39,9 @@ _LOGGER = logging.getLogger(__name__)
 _REGISTERS_PATH = Path(
     str(resources.files(__package__).joinpath("thessla_green_registers_full.json"))
 )
-# Cache for the last (path, mtime, hash) triple of the registers file.  The
-# hash is only recomputed when either the path or ``mtime`` changes.
-_cached_file_info: tuple[str, float, str] | None = None
+# Cache for file metadata keyed by path. Each entry stores ``(mtime, sha256)``
+# for the most recently seen state of that file.
+_cached_file_info: dict[str, tuple[float, str]] = {}
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
@@ -286,7 +286,7 @@ except Exception as err:  # pragma: no cover - unexpected
 # ---------------------------------------------------------------------------
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=None)
 def _load_registers_from_file(
     path: Path, *, mtime: float, file_hash: str
 ) -> list[RegisterDef]:
@@ -361,56 +361,36 @@ def _load_registers_from_file(
     return registers
 
 
-def _compute_file_hash(path: Path, mtime: float) -> str:
-    """Return the SHA256 hash of ``path``.
+def registers_sha256(json_path: Path | str) -> str:
+    """Return the SHA256 hash of ``json_path``.
 
     Results are cached based on the file path and modification time so repeated
     calls for an unchanged file avoid reading from disk.
     """
 
-    global _cached_file_info
+    path = Path(json_path)
+    mtime = path.stat().st_mtime
     path_str = str(path)
-    if (
-        _cached_file_info
-        and _cached_file_info[0] == path_str
-        and _cached_file_info[1] == mtime
-    ):
-        return _cached_file_info[2]
+    cached = _cached_file_info.get(path_str)
+    if cached and cached[0] == mtime:
+        return cached[1]
 
     digest = hashlib.sha256(path.read_bytes()).hexdigest()
-    _cached_file_info = (path_str, mtime, digest)
+    _cached_file_info[path_str] = (mtime, digest)
     return digest
 
 
-def _get_file_info() -> tuple[float, str]:
-    """Return ``(mtime, hash)`` for the bundled registers file.
+def load_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
+    """Return cached register definitions, reloading if the file changed.
 
-    ``_compute_file_hash`` is only invoked when the modification time changes so
-    repeated calls avoid both hashing and disk access.
+    ``json_path`` may be provided to load register definitions from an
+    alternate file.  When omitted, the bundled definitions are used.
     """
 
-    stat = _REGISTERS_PATH.stat()
-    mtime = stat.st_mtime
-    path_str = str(_REGISTERS_PATH)
-
-    if (
-        _cached_file_info
-        and _cached_file_info[0] == path_str
-        and _cached_file_info[1] == mtime
-    ):
-        return mtime, _cached_file_info[2]
-
-    file_hash = _compute_file_hash(_REGISTERS_PATH, mtime)
-    return mtime, file_hash
-
-
-def load_registers() -> list[RegisterDef]:
-    """Return cached register definitions, reloading if the file changed."""
-
-    mtime, file_hash = _get_file_info()
-    registers = _load_registers_from_file(
-        _REGISTERS_PATH, mtime=mtime, file_hash=file_hash
-    )
+    path = Path(json_path) if json_path is not None else _REGISTERS_PATH
+    file_hash = registers_sha256(path)
+    mtime = _cached_file_info[str(path)][0]
+    registers = _load_registers_from_file(path, mtime=mtime, file_hash=file_hash)
     return registers
 
 
@@ -420,8 +400,7 @@ def clear_cache() -> None:  # pragma: no cover
     Exposed for tests and tooling that need to reload register
     definitions.
     """
-    global _cached_file_info
-    _cached_file_info = None
+    _cached_file_info.clear()
     _load_registers_from_file.cache_clear()
     _register_map.cache_clear()
 
@@ -431,21 +410,25 @@ def clear_cache() -> None:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 
-def get_all_registers() -> list[RegisterDef]:
-    """Return a list of all known registers ordered by function and address."""
-    return sorted(load_registers(), key=lambda r: (r.function, r.address))
+def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
+    """Return all known registers ordered by function and address."""
+    return sorted(
+        load_registers(json_path), key=lambda r: (r.function, r.address)
+    )
 
 
-def get_registers_by_function(fn: str) -> list[RegisterDef]:
+def get_registers_by_function(
+    fn: str, json_path: Path | str | None = None
+) -> list[RegisterDef]:
     """Return registers for the given function code or name."""
     code = _normalise_function(fn)
-    return [r for r in load_registers() if r.function == code]
+    return [r for r in load_registers(json_path) if r.function == code]
 
 
-def get_registers_hash() -> str:
-    """Return the hash of the currently loaded register file."""
+def get_registers_hash(json_path: Path | str | None = None) -> str:
+    """Return the hash of the register definition file."""
     try:
-        return _get_file_info()[1]
+        return registers_sha256(json_path or _REGISTERS_PATH)
     except Exception:  # pragma: no cover - defensive
         return ""
 

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -2,27 +2,18 @@ import json
 import os
 from pathlib import Path
 
-from custom_components.thessla_green_modbus.registers.loader import (
-    _REGISTERS_PATH,
-    clear_cache,
-    get_registers_hash,
-    load_registers,
-)
+import custom_components.thessla_green_modbus.registers.loader as loader
 
 
-def test_cache_invalidation_on_content_change(tmp_path: Path, monkeypatch) -> None:
+def test_cache_invalidation_on_content_change(tmp_path: Path) -> None:
     """Changing file contents should invalidate cache."""
 
     tmp_json = tmp_path / "registers.json"
-    tmp_json.write_text(_REGISTERS_PATH.read_text(), encoding="utf-8")
-    monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
-        tmp_json,
-    )
+    tmp_json.write_text(loader._REGISTERS_PATH.read_text(), encoding="utf-8")
 
-    clear_cache()
-    first_hash = get_registers_hash()
-    first = load_registers()[0]
+    loader.clear_cache()
+    first_hash = loader.registers_sha256(tmp_json)
+    first = loader.load_registers(tmp_json)[0]
     assert first.description
     assert first_hash
 
@@ -30,30 +21,26 @@ def test_cache_invalidation_on_content_change(tmp_path: Path, monkeypatch) -> No
     data["registers"][0]["description"] = "changed description"
     tmp_json.write_text(json.dumps(data), encoding="utf-8")
 
-    second_hash = get_registers_hash()
-    updated = load_registers()[0]
+    second_hash = loader.registers_sha256(tmp_json)
+    updated = loader.load_registers(tmp_json)[0]
     assert updated.description == "changed description"
     assert first_hash != second_hash
 
-    clear_cache()
+    loader.clear_cache()
 
 
-def test_cache_invalidation_on_mtime_change(tmp_path: Path, monkeypatch) -> None:
+def test_cache_invalidation_on_mtime_change(tmp_path: Path) -> None:
     """Touching file without content change should reload registers."""
 
     tmp_json = tmp_path / "registers.json"
-    tmp_json.write_text(_REGISTERS_PATH.read_text(), encoding="utf-8")
-    monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.registers.loader._REGISTERS_PATH",
-        tmp_json,
-    )
+    tmp_json.write_text(loader._REGISTERS_PATH.read_text(), encoding="utf-8")
 
-    clear_cache()
-    first_id = id(load_registers())
+    loader.clear_cache()
+    first_id = id(loader.load_registers(tmp_json))
 
     os.utime(tmp_json, None)
 
-    second_id = id(load_registers())
+    second_id = id(loader.load_registers(tmp_json))
     assert first_id != second_id
 
-    clear_cache()
+    loader.clear_cache()


### PR DESCRIPTION
## Summary
- refactor register loader to accept optional JSON path and expose `registers_sha256`
- cache register metadata per file path and include SHA256 digest
- update tests to use new helper and path override

## Testing
- `pytest tests/test_register_cache_invalidation.py tests/test_register_loader.py::test_registers_sha256_uses_cache tests/test_register_loader.py::test_registers_reload_on_file_change tests/test_register_loader.py::test_clear_cache_resets_file_hash tests/test_register_loader.py::test_duplicate_registers_raise_error tests/test_register_loader.py::test_invalid_registers_rejected tests/test_register_loader.py::test_bits_within_bitmask_width tests/test_register_loader.py::test_get_all_registers_sorted -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'voluptuous')*

------
https://chatgpt.com/codex/tasks/task_e_68ab652091ec832686750e2c484f0a6c