### PR TITLE
Normalize function codes and add type enum

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1165,7 +1165,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 address = definition.address
                 for attempt in range(1, self.retry + 1):
                     try:
-                        if definition.function == "03":
+                        if definition.function == 3:
                             if encoded_values is not None:
                                 success = True
                                 for offset in range(0, len(encoded_values), self.effective_batch):
@@ -1196,7 +1196,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                                     value=int(value),
                                     attempt=attempt,
                                 )
-                        elif definition.function == "01":
+                        elif definition.function == 1:
                             response = await self._call_modbus(
                                 self.client.write_coil,
                                 address=address,

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -210,7 +210,7 @@ def _load_number_mappings() -> dict[str, dict[str, Any]]:
     number_configs: dict[str, dict[str, Any]] = {}
 
     for reg in get_all_registers():
-        if reg.function != "03" or not reg.name:
+        if reg.function != 3 or not reg.name:
             continue
         register = reg.name
         info = _get_register_info(register)
@@ -381,10 +381,10 @@ def _load_discrete_mappings() -> tuple[
 
     # Registers exposing bitmask flags
     func_map = {
-        "01": "coil_registers",
-        "02": "discrete_inputs",
-        "03": "holding_registers",
-        "04": "input_registers",
+        1: "coil_registers",
+        2: "discrete_inputs",
+        3: "holding_registers",
+        4: "input_registers",
     }
     for reg in get_all_registers():
         if not reg.name:
@@ -1079,7 +1079,7 @@ def _extend_entity_mappings_from_registers() -> None:
     """Populate entity mappings for registers not explicitly defined."""
 
     for reg in get_all_registers():
-        if reg.function != "03" or not reg.name:
+        if reg.function != 3 or not reg.name:
             continue
         register = reg.name
         if register in NUMBER_ENTITY_MAPPINGS:

--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -51,7 +51,7 @@ _cached_file_info: tuple[str, float, str] | None = None
 class RegisterDef:
     """Definition of a single Modbus register."""
 
-    function: str
+    function: int
     address: int
     name: str
     access: str
@@ -100,14 +100,14 @@ class RegisterDef:
             data = b"".join(w.to_bytes(2, "big") for w in words)
 
             typ = self.extra.get("type") if self.extra else None
-            if typ in {"float32", "float64"}:
+            if typ in {"f32", "f64"}:
                 fmt = ">" if endianness == "big" else "<"
-                fmt += "f" if typ == "float32" else "d"
+                fmt += "f" if typ == "f32" else "d"
                 value = struct.unpack(fmt, data)[0]
+            elif typ in {"i32", "u32", "i64", "u64"}:
+                value = int.from_bytes(data, "big", signed=typ.startswith("i"))
             else:
-                value = int.from_bytes(
-                    data, "big", signed=typ in {"int32", "int64"}
-                )
+                value = int.from_bytes(data, "big", signed=False)
 
             if self.multiplier is not None:
                 value *= self.multiplier
@@ -139,6 +139,10 @@ class RegisterDef:
                 return self.enum[raw]
             if str(raw) in self.enum:
                 return self.enum[str(raw)]
+
+        typ = self.extra.get("type") if self.extra else None
+        if typ == "i16":
+            raw = raw if raw < 0x8000 else raw - 0x10000
 
         value: Any = raw
 
@@ -193,18 +197,13 @@ class RegisterDef:
                 raw_val = int(round(float(raw_val) / step) * step)
 
             typ = self.extra.get("type") if self.extra else None
-            if typ == "float32":
+            if typ == "f32":
                 data = struct.pack(">f" if endianness == "big" else "<f", float(raw_val))
-            elif typ == "float64":
+            elif typ == "f64":
                 data = struct.pack(">d" if endianness == "big" else "<d", float(raw_val))
-            elif typ == "int32":
-                data = int(raw_val).to_bytes(4, "big", signed=True)
-            elif typ == "uint32":
-                data = int(raw_val).to_bytes(4, "big", signed=False)
-            elif typ == "int64":
-                data = int(raw_val).to_bytes(8, "big", signed=True)
-            elif typ == "uint64":
-                data = int(raw_val).to_bytes(8, "big", signed=False)
+            elif typ in {"i32", "u32", "i64", "u64"}:
+                size = 4 if typ in {"i32", "u32"} else 8
+                data = int(raw_val).to_bytes(size, "big", signed=typ.startswith("i"))
             else:
                 data = int(raw_val).to_bytes(self.length * 2, "big", signed=False)
 
@@ -256,6 +255,9 @@ class RegisterDef:
         if self.resolution is not None:
             step = self.resolution
             raw = int(round(float(raw) / step) * step)
+        typ = self.extra.get("type") if self.extra else None
+        if typ == "i16":
+            return int(raw) & 0xFFFF
         return int(raw)
 
 
@@ -313,9 +315,9 @@ def _load_registers_from_file(
         raw_address = int(parsed.address_dec)
 
         address = raw_address
-        if function == "02":
+        if function == 2:
             address -= 1
-        elif function == "03" and address >= 111:
+        elif function == 3 and address >= 111:
             address -= 111
 
         name = _normalise_name(parsed.name)
@@ -436,7 +438,7 @@ def get_all_registers() -> list[RegisterDef]:
     return sorted(load_registers(), key=lambda r: (r.function, r.address))
 
 
-def get_registers_by_function(fn: str) -> list[RegisterDef]:
+def get_registers_by_function(fn: int | str) -> list[RegisterDef]:
     """Return registers for the given function code or name."""
     code = _normalise_function(fn)
     return [r for r in load_registers() if r.function == code]
@@ -464,7 +466,7 @@ def get_register_definition(name: str) -> RegisterDef:
 class ReadPlan:
     """Plan describing a consecutive block of registers to read."""
 
-    function: str
+    function: int
     address: int
     length: int
 
@@ -472,7 +474,7 @@ class ReadPlan:
 def plan_group_reads(max_block_size: int = 64) -> list[ReadPlan]:
     """Group registers into contiguous blocks for efficient reading."""
 
-    regs_by_fn: dict[str, list[int]] = {}
+    regs_by_fn: dict[int, list[int]] = {}
     for reg in load_registers():
         addr_range = range(reg.address, reg.address + reg.length)
         regs_by_fn.setdefault(reg.function, []).extend(addr_range)

--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from enum import Enum
 from typing import Any, Literal
 
 import pydantic
@@ -8,29 +9,63 @@ import pydantic
 from ..utils import _normalise_name
 
 
-def _normalise_function(fn: str) -> str:
-    """Normalise function codes to two-digit strings."""
+def _normalise_function(fn: int | str) -> int:
+    """Return canonical integer Modbus function code.
+
+    String aliases like ``"coil_registers"`` or zero-padded values are mapped to
+    their numeric equivalents. Values outside the 1–4 range raise ``ValueError``.
+    """
+
     mapping = {
-        "coil": "01",
-        "coils": "01",
-        "coil_registers": "01",
-        "discrete_input": "02",
-        "discrete_inputs": "02",
-        "holding_register": "03",
-        "holding_registers": "03",
-        "input_register": "04",
-        "input_registers": "04",
-        "inputregister": "04",
-        "inputregisters": "04",
+        "coil": 1,
+        "coils": 1,
+        "coil_registers": 1,
+        "discrete": 2,
+        "discrete_input": 2,
+        "discrete_inputs": 2,
+        "holding": 3,
+        "holding_register": 3,
+        "holding_registers": 3,
+        "input": 4,
+        "input_register": 4,
+        "input_registers": 4,
+        "inputregister": 4,
+        "inputregisters": 4,
     }
-    key = fn.lower().replace(" ", "_")
-    return mapping.get(key, fn)
+
+    if isinstance(fn, str):
+        key = fn.lower().replace(" ", "_")
+        fn = mapping.get(key, fn)
+        try:
+            fn = int(fn)
+        except (TypeError, ValueError) as err:  # pragma: no cover - defensive
+            raise ValueError(f"unknown function code: {fn}") from err
+
+    if fn not in {1, 2, 3, 4}:  # pragma: no cover - defensive
+        raise ValueError(f"unknown function code: {fn}")
+
+    return fn
+
+
+class RegisterType(str, Enum):
+    """Supported register data types."""
+
+    U16 = "u16"
+    I16 = "i16"
+    U32 = "u32"
+    I32 = "i32"
+    F32 = "f32"
+    U64 = "u64"
+    I64 = "i64"
+    F64 = "f64"
+    STRING = "string"
+    BITMASK = "bitmask"
 
 
 class RegisterDefinition(pydantic.BaseModel):
     """Schema describing a raw register definition from JSON."""
 
-    function: Literal["01", "02", "03", "04"]
+    function: int
     address_dec: int
     address_hex: str
     name: str
@@ -53,28 +88,49 @@ class RegisterDefinition(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(extra="allow")  # pragma: no cover
 
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _normalise_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        # Allow string/int function codes and normalise them early
+        if "function" in data:
+            data["function"] = _normalise_function(data["function"])
+        return data
+
     @pydantic.model_validator(mode="after")
     def check_consistency(self) -> "RegisterDefinition":  # pragma: no cover
         if int(self.address_hex, 16) != self.address_dec:
             raise ValueError("address_hex does not match address_dec")
 
         typ = (self.extra or {}).get("type")
-        if typ == "string":
+        if typ is not None:
+            try:
+                reg_type = RegisterType(typ)
+            except ValueError as err:
+                raise ValueError(f"unsupported type: {typ}") from err
+        else:
+            reg_type = None
+
+        type_lengths = {
+            RegisterType.U16: 1,
+            RegisterType.I16: 1,
+            RegisterType.BITMASK: 1,
+            RegisterType.U32: 2,
+            RegisterType.I32: 2,
+            RegisterType.F32: 2,
+            RegisterType.U64: 4,
+            RegisterType.I64: 4,
+            RegisterType.F64: 4,
+        }
+
+        if reg_type == RegisterType.STRING:
             if self.length < 1:
                 raise ValueError("string type requires length >= 1")
-        else:
-            expected_len = {
-                "uint32": 2,
-                "int32": 2,
-                "float32": 2,
-                "uint64": 4,
-                "int64": 4,
-                "float64": 4,
-            }.get(typ)
-            if expected_len is not None and self.length != expected_len:
+        elif reg_type in type_lengths:
+            expected = type_lengths[reg_type]
+            if self.length != expected:
                 raise ValueError("length does not match type")
 
-        if self.function in {"01", "02"} and self.access not in {"R", "R/-"}:
+        if self.function in {1, 2} and self.access not in {"R", "R/-"}:
             raise ValueError("read-only functions must have R access")
 
         if self.bits is not None:
@@ -91,6 +147,14 @@ class RegisterDefinition(pydantic.BaseModel):
                 mask_int = bitmask_val
             if mask_int is not None and len(self.bits) > mask_int.bit_length():
                 raise ValueError("bits exceed bitmask width")
+            if len(self.bits) > 16:
+                raise ValueError("bits exceed 16 entries")
+            for idx, bit in enumerate(self.bits):
+                if idx > 15:
+                    raise ValueError("bit index out of range")
+                name = bit.get("name") if isinstance(bit, dict) else str(bit)
+                if name and not re.fullmatch(r"[a-z0-9_]+", name):
+                    raise ValueError("bit names must be snake_case")
 
         return self
 
@@ -107,7 +171,7 @@ class RegisterList(pydantic.RootModel[list[RegisterDefinition]]):
 
     @pydantic.model_validator(mode="after")
     def unique(self) -> "RegisterList":  # pragma: no cover
-        seen_pairs: set[tuple[str, int]] = set()
+        seen_pairs: set[tuple[int, int]] = set()
         seen_names: set[str] = set()
         for reg in self.root:
             fn = _normalise_function(reg.function)

--- a/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
+++ b/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
@@ -3463,7 +3463,7 @@
       "description": "Klucz produktu użytkownika",
       "length": 2,
       "extra": {
-        "type": "uint32",
+        "type": "u32",
         "endianness": "little"
       },
       "description_en": "Klucz produktu użytkownika"

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -59,22 +59,22 @@ def _build_register_maps() -> None:
 
     INPUT_REGISTERS.clear()
     INPUT_REGISTERS.update(
-        {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "04"}
+        {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == 4}
     )
 
     HOLDING_REGISTERS.clear()
     HOLDING_REGISTERS.update(
-        {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "03"}
+        {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == 3}
     )
 
     COIL_REGISTERS.clear()
     COIL_REGISTERS.update(
-        {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "01"}
+        {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == 1}
     )
 
     DISCRETE_INPUT_REGISTERS.clear()
     DISCRETE_INPUT_REGISTERS.update(
-        {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == "02"}
+        {name: reg.address for name, reg in REGISTER_DEFINITIONS.items() if reg.function == 2}
     )
 
     MULTI_REGISTER_SIZES.clear()
@@ -82,7 +82,7 @@ def _build_register_maps() -> None:
         {
             name: reg.length
             for name, reg in REGISTER_DEFINITIONS.items()
-            if reg.function == "03" and reg.length > 1
+            if reg.function == 3 and reg.length > 1
         }
     )
 
@@ -274,7 +274,7 @@ class ThesslaGreenDeviceScanner:
         self.capabilities: DeviceCapabilities = DeviceCapabilities()
 
         # Placeholder for register map and value ranges loaded asynchronously
-        self._registers: Dict[str, Dict[int, str]] = {}
+        self._registers: Dict[int, Dict[int, str]] = {}
         self._register_ranges: Dict[str, Tuple[Optional[int], Optional[int]]] = {}
 
         # Track holding registers that consistently fail to respond so we
@@ -415,7 +415,7 @@ class ThesslaGreenDeviceScanner:
                     continue
                 addr = reg.address
                 try:
-                    if func == "04":
+                    if func == 4:
                         await asyncio.wait_for(
                             _call_modbus(
                                 client.read_input_registers,
@@ -425,7 +425,7 @@ class ThesslaGreenDeviceScanner:
                             ),
                             timeout=self.timeout,
                         )
-                    else:  # "03"
+                    else:  # holding register
                         await asyncio.wait_for(
                             _call_modbus(
                                 client.read_holding_registers,
@@ -698,10 +698,10 @@ class ThesslaGreenDeviceScanner:
             "discrete_inputs": 0,
         }
 
-        input_max = max(self._registers.get("04", {}).keys(), default=-1)
-        holding_max = max(self._registers.get("03", {}).keys(), default=-1)
-        coil_max = max(self._registers.get("01", {}).keys(), default=-1)
-        discrete_max = max(self._registers.get("02", {}).keys(), default=-1)
+        input_max = max(self._registers.get(4, {}).keys(), default=-1)
+        holding_max = max(self._registers.get(3, {}).keys(), default=-1)
+        coil_max = max(self._registers.get(1, {}).keys(), default=-1)
+        discrete_max = max(self._registers.get(2, {}).keys(), default=-1)
 
         if self.full_register_scan:
             for start, count in _group_reads(
@@ -719,7 +719,7 @@ class ThesslaGreenDeviceScanner:
                         )
                         if not single:
                             continue
-                        reg_name = self._registers.get("04", {}).get(addr)
+                        reg_name = self._registers.get(4, {}).get(addr)
                         if reg_name and self._is_valid_register_value(
                             reg_name, single[0]
                         ):
@@ -736,7 +736,7 @@ class ThesslaGreenDeviceScanner:
                     continue
                 for offset, value in enumerate(input_data):
                     addr = start + offset
-                    reg_name = self._registers.get("04", {}).get(addr)
+                    reg_name = self._registers.get(4, {}).get(addr)
                     if reg_name and self._is_valid_register_value(reg_name, value):
                         self.available_registers["input_registers"].add(reg_name)
                     else:
@@ -762,7 +762,7 @@ class ThesslaGreenDeviceScanner:
                         )
                         if not single:
                             continue
-                        reg_name = self._registers.get("03", {}).get(addr)
+                        reg_name = self._registers.get(3, {}).get(addr)
                         if reg_name and self._is_valid_register_value(
                             reg_name, single[0]
                         ):
@@ -779,7 +779,7 @@ class ThesslaGreenDeviceScanner:
                     continue
                 for offset, value in enumerate(holding_data):
                     addr = start + offset
-                    reg_name = self._registers.get("03", {}).get(addr)
+                    reg_name = self._registers.get(3, {}).get(addr)
                     if reg_name and self._is_valid_register_value(reg_name, value):
                         self.available_registers["holding_registers"].add(reg_name)
                     else:
@@ -802,7 +802,7 @@ class ThesslaGreenDeviceScanner:
                         if not single_coil:
                             continue
                         if (
-                            reg_name := self._registers.get("01", {}).get(addr)
+                            reg_name := self._registers.get(1, {}).get(addr)
                         ) is not None:
                             self.available_registers["coil_registers"].add(reg_name)
                         else:
@@ -810,7 +810,7 @@ class ThesslaGreenDeviceScanner:
                     continue
                 for offset, value in enumerate(coil_data):
                     addr = start + offset
-                    if (reg_name := self._registers.get("01", {}).get(addr)) is not None:
+                    if (reg_name := self._registers.get(1, {}).get(addr)) is not None:
                         self.available_registers["coil_registers"].add(reg_name)
                     else:
                         unknown_registers["coil_registers"][addr] = value
@@ -827,7 +827,7 @@ class ThesslaGreenDeviceScanner:
                         if not single_discrete:
                             continue
                         if (
-                            reg_name := self._registers.get("02", {}).get(addr)
+                            reg_name := self._registers.get(2, {}).get(addr)
                         ) is not None:
                             self.available_registers["discrete_inputs"].add(
                                 reg_name
@@ -837,7 +837,7 @@ class ThesslaGreenDeviceScanner:
                     continue
                 for offset, value in enumerate(discrete_data):
                     addr = start + offset
-                    if (reg_name := self._registers.get("02", {}).get(addr)) is not None:
+                    if (reg_name := self._registers.get(2, {}).get(addr)) is not None:
                         self.available_registers["discrete_inputs"].add(reg_name)
                     else:
                         unknown_registers["discrete_inputs"][addr] = value
@@ -1136,11 +1136,11 @@ class ThesslaGreenDeviceScanner:
     async def _load_registers(
         self,
     ) -> Tuple[
-        Dict[str, Dict[int, str]],
+        Dict[int, Dict[int, str]],
         Dict[str, Tuple[Optional[int], Optional[int]]],
     ]:
         """Load Modbus register definitions and value ranges."""
-        register_map: Dict[str, Dict[int, str]] = {"03": {}, "04": {}, "01": {}, "02": {}}
+        register_map: Dict[int, Dict[int, str]] = {3: {}, 4: {}, 1: {}, 2: {}}
         register_ranges: Dict[str, Tuple[Optional[int], Optional[int]]] = {}
         for reg in get_all_registers():
             if not reg.name:

--- a/custom_components/thessla_green_modbus/scanner_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner_helpers.py
@@ -87,10 +87,10 @@ UART_OPTIONAL_REGS = range(0x1164, 0x116C)
 # Each entry is a tuple of Modbus function code and register name. The
 # corresponding addresses are resolved from the JSON register definitions at
 # runtime, ensuring we do not hardcode register addresses here.
-SAFE_REGISTERS: list[tuple[str, str]] = [
-    ("04", "version_major"),
-    ("04", "version_minor"),
-    ("03", "date_time_rrmm"),
+SAFE_REGISTERS: list[tuple[int, str]] = [
+    (4, "version_major"),
+    (4, "version_minor"),
+    (3, "date_time_rrmm"),
 ]
 
 __all__ = [

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -360,7 +360,7 @@ async def test_async_write_register_chunks(coordinator, batch, expected_calls, m
 
     import custom_components.thessla_green_modbus.coordinator as coordinator_mod
 
-    fake_def = SimpleNamespace(length=4, address=0, function="03", encode=lambda v: v)
+    fake_def = SimpleNamespace(length=4, address=0, function=3, encode=lambda v: v)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: fake_def)
 
     result = await coordinator.async_write_register("date_time_1", [1, 2, 3, 4])
@@ -387,7 +387,7 @@ async def test_async_write_register_truncates_over_limit(coordinator, monkeypatc
 
     import custom_components.thessla_green_modbus.coordinator as coordinator_mod
 
-    fake_def = SimpleNamespace(length=20, address=0, function="03", encode=lambda v: v)
+    fake_def = SimpleNamespace(length=20, address=0, function=3, encode=lambda v: v)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: fake_def)
 
     result = await coordinator.async_write_register("large", list(range(20)))

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -26,10 +26,10 @@ from custom_components.thessla_green_modbus.modbus_exceptions import (
     ModbusIOException,
 )
 
-COIL_REGISTERS = {r.name: r.address for r in get_registers_by_function("01")}
-DISCRETE_INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function("02")}
-HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
-INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function("04")}
+COIL_REGISTERS = {r.name: r.address for r in get_registers_by_function(1)}
+DISCRETE_INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function(2)}
+HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function(3)}
+INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function(4)}
 
 pytestmark = pytest.mark.asyncio
 
@@ -579,10 +579,10 @@ async def test_read_discrete_retries_on_failure(caplog):
 async def test_scan_device_success_static(mock_modbus_response):
     """Test successful device scan with predefined registers."""
     regs = {
-        "04": {16: "outside_temperature"},
-        "03": {0: "mode"},
-        "01": {0: "power_supply_fans"},
-        "02": {0: "expansion"},
+        4: {16: "outside_temperature"},
+        3: {0: "mode"},
+        1: {0: "power_supply_fans"},
+        2: {0: "expansion"},
     }
     with patch.object(
         ThesslaGreenDeviceScanner,
@@ -637,7 +637,7 @@ async def test_scan_device_connection_failure():
 
 async def test_scan_device_firmware_unavailable(caplog):
     """Missing firmware registers should log info and report unknown firmware."""
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner, "_load_registers", AsyncMock(return_value=(empty_regs, {}))
     ):
@@ -683,7 +683,7 @@ async def test_scan_device_firmware_unavailable(caplog):
 
 async def test_scan_device_firmware_bulk_fallback():
     """Bulk firmware read failure should fall back to individual reads."""
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner, "_load_registers", AsyncMock(return_value=(empty_regs, {}))
     ):
@@ -727,7 +727,7 @@ async def test_scan_device_firmware_bulk_fallback():
 
 async def test_scan_device_firmware_partial_bulk_fallback():
     """Partial firmware bulk read should fall back to individual reads."""
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner, "_load_registers", AsyncMock(return_value=(empty_regs, {}))
     ):
@@ -772,7 +772,7 @@ async def test_scan_device_firmware_partial_bulk_fallback():
 async def test_scan_blocks_propagated():
     """Ensure scan_device returns discovered register blocks."""
     # Avoid scanning full register set for test speed
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner,
         "_load_registers",
@@ -832,7 +832,7 @@ async def test_scan_blocks_propagated():
 
 async def test_full_register_scan_collects_unknown_registers():
     """Ensure full register scan returns unknown registers and statistics."""
-    reg_map = {"04": {0: "ir0", 2: "ir2"}, "03": {0: "hr0", 2: "hr2"}, "01": {}, "02": {}}
+    reg_map = {4: {0: "ir0", 2: "ir2"}, 3: {0: "hr0", 2: "hr2"}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner,
         "_load_registers",
@@ -873,7 +873,7 @@ async def test_full_register_scan_collects_unknown_registers():
 
 async def test_scan_device_batch_fallback():
     """Batch read failures should fall back to single-register reads."""
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner, "_load_registers", AsyncMock(return_value=(empty_regs, {}))
     ):
@@ -951,7 +951,7 @@ async def test_scan_device_batch_fallback():
 
 async def test_missing_register_logged_once(caplog):
     """Each missing register should trigger only one read and log entry."""
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner,
         "_load_registers",
@@ -1338,7 +1338,7 @@ async def test_scan_device_includes_capabilities_in_device_info():
 
 async def test_capability_count_includes_booleans(caplog):
     """Log should count boolean capabilities even though bool is an int subclass."""
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner,
         "_load_registers",
@@ -1375,7 +1375,7 @@ async def test_scan_populates_device_name():
     """Scanner should include device_name in returned device info."""
     scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
     scanner._client = object()
-    scanner._registers = {"04": {}, "03": {}, "01": {}, "02": {}}
+    scanner._registers = {4: {}, 3: {}, 1: {}, 2: {}}
     scanner.available_registers = {
         "input_registers": set(),
         "holding_registers": set(),
@@ -1410,10 +1410,10 @@ async def test_scan_reports_diagnostic_registers_on_error():
     scanner._client = object()
     diag_regs = {"alarm": 0, "error": 1, "e_99": 2, "s_2": 3}
     scanner._registers = {
-        "04": {},
-        "03": {addr: name for name, addr in diag_regs.items()},
-        "01": {},
-        "02": {},
+        4: {},
+        3: {addr: name for name, addr in diag_regs.items()},
+        1: {},
+        2: {},
     }
     scanner.available_registers = {
         "input_registers": set(),

--- a/tests/test_force_full_register_list.py
+++ b/tests/test_force_full_register_list.py
@@ -26,13 +26,13 @@ async def _setup_coordinator():
         "discrete_inputs": [],
     }
     for reg in get_all_registers():
-        if reg.function == "04":
+        if reg.function == 4:
             scan_regs["input_registers"].append(reg.name)
-        elif reg.function == "03":
+        elif reg.function == 3:
             scan_regs["holding_registers"].append(reg.name)
-        elif reg.function == "01":
+        elif reg.function == 1:
             scan_regs["coil_registers"].append(reg.name)
-        elif reg.function == "02":
+        elif reg.function == 2:
             scan_regs["discrete_inputs"].append(reg.name)
 
     scanner = AsyncMock()

--- a/tests/test_input_range_fallback.py
+++ b/tests/test_input_range_fallback.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_input_range_read_after_block_failure():
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with (
         patch.object(
             ThesslaGreenDeviceScanner,
@@ -76,7 +76,7 @@ async def test_input_range_read_after_block_failure():
 
 
 async def test_block_exception_allows_single_register_reads():
-    empty_regs = {"04": {}, "03": {}, "01": {}, "02": {}}
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner,
         "_load_registers",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -160,7 +160,7 @@ async def test_write_retries_logged(monkeypatch, caplog):
 
     class Def:
         address = 0
-        function = "03"
+        function = 3
         length = 1
 
         def encode(self, val):

--- a/tests/test_register_decoders.py
+++ b/tests/test_register_decoders.py
@@ -75,14 +75,14 @@ def test_schedule_and_setting_defaults_valid():
 
 
 def test_register_decode_encode_bcd():
-    reg = Register(function="holding", address=0, name="schedule_test_start", access="rw", bcd=True)
+    reg = Register(function=3, address=0, name="schedule_test_start", access="rw", bcd=True)
     assert reg.decode(0x0815) == "08:15"
     assert reg.encode("08:15") == 0x0815
 
 
 def test_register_decode_encode_aatt():
     reg = Register(
-        function="holding",
+        function=3,
         address=0,
         name="setting_test",
         access="rw",
@@ -94,7 +94,7 @@ def test_register_decode_encode_aatt():
 
 def test_register_decode_unavailable_value():
     """Sentinel value 0x8000 should decode to None."""
-    reg = Register(function="input", address=0, name="temp", access="ro")
+    reg = Register(function=4, address=0, name="temp", access="ro")
     assert reg.decode(0x8000) is None
 
 
@@ -111,7 +111,7 @@ def test_format_register_value_special_values():
 
 def test_register_bitmask_decode_encode():
     reg = Register(
-        function="holding",
+        function=3,
         address=0,
         name="errors",
         access="rw",
@@ -138,12 +138,12 @@ def test_register_decode_encode_uint32():
 
 def test_register_decode_encode_float32():
     reg = Register(
-        function="holding",
+        function=3,
         address=0,
         name="float_reg",
         access="rw",
         length=2,
-        extra={"type": "float32"},
+        extra={"type": "f32"},
     )
     raw = reg.encode(12.34)
     assert isinstance(raw, list)
@@ -153,7 +153,7 @@ def test_register_decode_encode_float32():
 def test_multi_register_decode_string() -> None:
     """Multi-register string values decode correctly."""
     reg = Register(
-        function="holding",
+        function=3,
         address=0,
         name="string_reg",
         access="ro",
@@ -167,12 +167,12 @@ def test_multi_register_decode_string() -> None:
 def test_multi_register_decode_float32() -> None:
     """Multi-register float values decode correctly."""
     reg = Register(
-        function="holding",
+        function=3,
         address=0,
         name="float_multi",
         access="ro",
         length=2,
-        extra={"type": "float32"},
+        extra={"type": "f32"},
     )
     value = 12.34
     raw_bytes = struct.pack(">f", value)
@@ -183,12 +183,12 @@ def test_multi_register_decode_float32() -> None:
 def test_multi_register_decode_int32() -> None:
     """Multi-register integer values decode correctly."""
     reg = Register(
-        function="holding",
+        function=3,
         address=0,
         name="int_multi",
         access="ro",
         length=2,
-        extra={"type": "int32"},
+        extra={"type": "i32"},
     )
     raw = [0x1234, 0x5678]
     assert reg.decode(raw) == 0x12345678
@@ -196,12 +196,12 @@ def test_multi_register_decode_int32() -> None:
 def float32_register() -> Register:
     """Register representing a 32-bit floating point value."""
     return Register(
-        function="holding",
+        function=3,
         address=0,
         name="float32_test",
         access="rw",
         length=2,
-        extra={"type": "float32"},
+        extra={"type": "f32"},
     )
 
 
@@ -209,12 +209,12 @@ def float32_register() -> Register:
 def float64_register() -> Register:
     """Register representing a 64-bit floating point value."""
     return Register(
-        function="holding",
+        function=3,
         address=0,
         name="float64_test",
         access="rw",
         length=4,
-        extra={"type": "float64"},
+        extra={"type": "f64"},
     )
 
 
@@ -222,12 +222,12 @@ def float64_register() -> Register:
 def int32_register() -> Register:
     """Register representing a signed 32-bit integer."""
     return Register(
-        function="holding",
+        function=3,
         address=0,
         name="int32_test",
         access="rw",
         length=2,
-        extra={"type": "int32"},
+        extra={"type": "i32"},
     )
 
 
@@ -235,12 +235,12 @@ def int32_register() -> Register:
 def uint32_register() -> Register:
     """Register representing an unsigned 32-bit integer."""
     return Register(
-        function="holding",
+        function=3,
         address=0,
         name="uint32_test",
         access="rw",
         length=2,
-        extra={"type": "uint32"},
+        extra={"type": "u32"},
     )
 
 
@@ -248,12 +248,12 @@ def uint32_register() -> Register:
 def int64_register() -> Register:
     """Register representing a signed 64-bit integer."""
     return Register(
-        function="holding",
+        function=3,
         address=0,
         name="int64_test",
         access="rw",
         length=4,
-        extra={"type": "int64"},
+        extra={"type": "i64"},
     )
 
 
@@ -261,12 +261,12 @@ def int64_register() -> Register:
 def uint64_register() -> Register:
     """Register representing an unsigned 64-bit integer."""
     return Register(
-        function="holding",
+        function=3,
         address=0,
         name="uint64_test",
         access="rw",
         length=4,
-        extra={"type": "uint64"},
+        extra={"type": "u64"},
     )
 
 
@@ -279,12 +279,12 @@ def test_register_float64_encode_decode(float64_register: Register, value: float
 @pytest.mark.parametrize("value", [0.0, 12.5, -7.25, 1e20])
 def test_register_float64_little_endian(float64_register: Register, value: float) -> None:
     reg_le = Register(
-        function="holding",
+        function=3,
         address=0,
         name="float64_le_test",
         access="rw",
         length=4,
-        extra={"type": "float64", "endianness": "little"},
+        extra={"type": "f64", "endianness": "little"},
     )
     raw = reg_le.encode(value)
     assert reg_le.decode(raw) == pytest.approx(value)

--- a/tests/test_register_examples.py
+++ b/tests/test_register_examples.py
@@ -5,31 +5,31 @@ from custom_components.thessla_green_modbus.registers.loader import Register
 
 def test_coil_and_discrete_enum():
     """Registers for function 01 and 02 should decode enums correctly."""
-    coil = Register(function="01", address=5, name="coil", access="ro", enum={0: "OFF", 1: "ON"})
+    coil = Register(function=1, address=5, name="coil", access="ro", enum={0: "OFF", 1: "ON"})
     assert coil.decode(1) == "ON"
     assert coil.encode("OFF") == 0
 
-    discrete = Register(function="02", address=0, name="discrete", access="ro", enum={0: "brak", 1: "jest"})
+    discrete = Register(function=2, address=0, name="discrete", access="ro", enum={0: "brak", 1: "jest"})
     assert discrete.decode(0) == "brak"
     assert discrete.encode("jest") == 1
 
 
 def test_holding_multiplier_resolution_and_bcd():
     """Function 03 registers may use multiplier/resolution and BCD."""
-    scaling = Register(function="03", address=4096, name="temp", access="rw", multiplier=0.5, resolution=0.5)
+    scaling = Register(function=3, address=4096, name="temp", access="rw", multiplier=0.5, resolution=0.5)
     assert scaling.decode(45) == 22.5
     assert scaling.encode(22.5) == 45
 
-    schedule = Register(function="03", address=4097, name="schedule", access="rw", bcd=True)
+    schedule = Register(function=3, address=4097, name="schedule", access="rw", bcd=True)
     assert schedule.decode(0x0815) == "08:15"
     assert schedule.encode("08:15") == 0x0815
 
 
 def test_input_extra_aatt_and_sentinel():
     """Function 04 registers support extra aatt and sentinel values."""
-    combined = Register(function="04", address=16, name="combined", access="ro", extra={"aatt": True})
+    combined = Register(function=4, address=16, name="combined", access="ro", extra={"aatt": True})
     assert combined.decode(0x3C28) == (60, 20.0)
     assert combined.encode((60, 20.0)) == 0x3C28
 
-    sensor = Register(function="04", address=17, name="sensor", access="ro")
+    sensor = Register(function=4, address=17, name="sensor", access="ro")
     assert sensor.decode(0x8000) is None

--- a/tests/test_register_grouping.py
+++ b/tests/test_register_grouping.py
@@ -11,7 +11,7 @@ INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function("04")}
 
 
 def _expanded_addresses(fn: str) -> list[int]:
-    plans = [p for p in plan_group_reads(max_block_size=32) if p.function == fn]
+    plans = [p for p in plan_group_reads(max_block_size=32) if p.function == int(fn)]
     return [addr for plan in plans for addr in range(plan.address, plan.address + plan.length)]
 
 
@@ -52,14 +52,14 @@ def test_plan_group_reads_from_json():
     for reg in regs:
         addresses.extend(range(reg.address, reg.address + reg.length))
     expected = group_reads(addresses, max_block_size=64)
-    plans = [p for p in plan_group_reads(max_block_size=64) if p.function == "04"]
+    plans = [p for p in plan_group_reads(max_block_size=64) if p.function == 4]
     assert [(p.address, p.length) for p in plans] == expected
 
 
 def test_plan_group_reads_splits_large_block(monkeypatch):
     """A long list of consecutive addresses is split into multiple blocks."""
 
-    regs = [Register(function="04", address=i, name=f"r{i}", access="ro") for i in range(100)]
+    regs = [Register(function=4, address=i, name=f"r{i}", access="ro") for i in range(100)]
 
     monkeypatch.setattr(
         "custom_components.thessla_green_modbus.registers.loader.load_registers",
@@ -71,7 +71,7 @@ def test_plan_group_reads_splits_large_block(monkeypatch):
     plans = [
         p
         for p in plan_group_reads(max_block_size=MAX_BATCH_REGISTERS)
-        if p.function == "04"
+        if p.function == 4
     ]
 
     assert [(p.address, p.length) for p in plans] == expected
@@ -84,7 +84,7 @@ def test_plan_group_reads_handles_gaps_and_block_size(monkeypatch):
     first = list(range(32))
     second = list(range(40, 80))
     regs = [
-        Register(function="04", address=i, name=f"r{i}", access="ro")
+        Register(function=4, address=i, name=f"r{i}", access="ro")
         for i in first + second
     ]
 
@@ -98,7 +98,7 @@ def test_plan_group_reads_handles_gaps_and_block_size(monkeypatch):
     plans = [
         p
         for p in plan_group_reads(max_block_size=MAX_BATCH_REGISTERS)
-        if p.function == "04"
+        if p.function == 4
     ]
 
     assert [(p.address, p.length) for p in plans] == expected

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -63,7 +63,7 @@ def test_multi_register_metadata() -> None:
 
     lock = next(r for r in holding_regs if r.name == "lock_pass")
     assert lock.length == 2
-    assert lock.extra["type"] == "uint32"
+    assert lock.extra["type"] == "u32"
     assert lock.extra["endianness"] == "little"
 
     input_regs = get_registers_by_function("04")
@@ -75,7 +75,7 @@ def test_multi_register_metadata() -> None:
 def test_decode_multi_register_string() -> None:
     """Multi-register strings decode without applying scaling."""
     reg = RegisterDef(
-        function="holding",
+        function=3,
         address=0,
         name="device_name",
         access="ro",
@@ -91,12 +91,12 @@ def test_decode_multi_register_string() -> None:
 def test_decode_multi_register_number_scaled_once() -> None:
     """Numeric multi-register values apply multiplier/resolution exactly once."""
     reg = RegisterDef(
-        function="holding",
+        function=3,
         address=0,
         name="counter",
         access="ro",
         length=2,
-        extra={"type": "int32"},
+        extra={"type": "i32"},
         multiplier=10,
         resolution=1,
     )
@@ -107,7 +107,7 @@ def test_decode_multi_register_number_scaled_once() -> None:
 def test_decode_bitmask_ignores_scaling() -> None:
     """Bitmask registers return labels without scaling the raw value."""
     reg = RegisterDef(
-        function="holding",
+        function=3,
         address=0,
         name="flags",
         access="ro",
@@ -318,7 +318,7 @@ def test_duplicate_registers_raise_error(tmp_path, monkeypatch, registers) -> No
             "name": "bad_len",
             "access": "R",
             "length": 1,
-            "extra": {"type": "uint32"},
+            "extra": {"type": "u32"},
         },
         {
             "function": "01",

--- a/tests/test_register_loader_validation.py
+++ b/tests/test_register_loader_validation.py
@@ -50,10 +50,10 @@ RegisterDefinition = _load_schema()
 
 
 EXPECTED = {
-    "01": {"min": 5, "max": 15, "count": 8},
-    "02": {"min": 0, "max": 21, "count": 16},
-    "03": {"min": 0, "max": 8444, "count": 270},
-    "04": {"min": 0, "max": 298, "count": 24},
+    1: {"min": 5, "max": 15, "count": 8},
+    2: {"min": 0, "max": 21, "count": 16},
+    3: {"min": 0, "max": 8444, "count": 270},
+    4: {"min": 0, "max": 298, "count": 24},
 }
 
 # Registers present in the vendor PDF but intentionally omitted in the JSON

--- a/tests/test_scanner_register_cache_invalidation.py
+++ b/tests/test_scanner_register_cache_invalidation.py
@@ -33,7 +33,7 @@ def test_scanner_register_cache_invalidation(tmp_path: Path, monkeypatch) -> Non
 @pytest.mark.asyncio
 async def test_full_register_scan_batches_reads() -> None:
     """Full register scans should batch contiguous addresses."""
-    reg_map = {"04": {0: "ir0", 2: "ir2"}, "03": {0: "hr0", 2: "hr2"}, "01": {}, "02": {}}
+    reg_map = {4: {0: "ir0", 2: "ir2"}, 3: {0: "hr0", 2: "hr2"}, 1: {}, 2: {}}
     with patch.object(
         sc.ThesslaGreenDeviceScanner,
         "_load_registers",

--- a/tests/test_validate_registers.py
+++ b/tests/test_validate_registers.py
@@ -112,7 +112,7 @@ def test_validator_rejects_length_mismatch(tmp_path: Path) -> None:
                 "name": "bad_len",
                 "access": "R/W",
                 "length": 1,
-                "extra": {"type": "uint32"},
+                "extra": {"type": "u32"},
             }
         ],
     )

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 import types
@@ -39,7 +40,7 @@ def validate(path: Path) -> list[RegisterDefinition]:
     registers = data.get("registers", data)
 
     parsed: list[RegisterDefinition] = []
-    seen_pairs: set[tuple[str, int]] = set()
+    seen_pairs: set[tuple[int, int]] = set()
     seen_names: set[str] = set()
     for item in registers:
         reg = RegisterDefinition.model_validate(item)
@@ -59,21 +60,34 @@ def validate(path: Path) -> list[RegisterDefinition]:
                 raise ValueError("string type requires length >= 1")
         else:
             expected_len = {
-                "uint32": 2,
-                "int32": 2,
-                "float32": 2,
-                "uint64": 4,
-                "int64": 4,
-                "float64": 4,
+                "u16": 1,
+                "i16": 1,
+                "bitmask": 1,
+                "u32": 2,
+                "i32": 2,
+                "f32": 2,
+                "u64": 4,
+                "i64": 4,
+                "f64": 4,
             }.get(typ)
             if expected_len is not None and length != expected_len:
                 raise ValueError("length does not match type")
 
-        if reg.function in {"01", "02"} and reg.access not in {"R", "R/-"}:
+        if reg.function in {1, 2} and reg.access not in {"R", "R/-"}:
             raise ValueError("read-only functions must have R access")
 
-        if item.get("bits") is not None and not ((reg.extra or {}).get("bitmask")):
-            raise ValueError("bits provided without extra.bitmask")
+        if item.get("bits") is not None:
+            if not ((reg.extra or {}).get("bitmask")):
+                raise ValueError("bits provided without extra.bitmask")
+            bits = item["bits"]
+            if len(bits) > 16:
+                raise ValueError("bits exceed 16 entries")
+            for idx, bit in enumerate(bits):
+                name = bit.get("name") if isinstance(bit, dict) else str(bit)
+                if name and not re.fullmatch(r"[a-z0-9_]+", name):
+                    raise ValueError("bit names must be snake_case")
+                if idx > 15:
+                    raise ValueError("bit index out of range")
 
         parsed.append(reg)
 


### PR DESCRIPTION
## Summary
- represent register function codes as integers with alias normalization
- introduce `RegisterType` enum and validate lengths and bit definitions
- update loader, validator, and helpers for new function codes and types

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.util.network')*


------
https://chatgpt.com/codex/tasks/task_e_68ab65220e0c8326afab234a810543f3