### PR TITLE
feat: expose registers_sha256

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import translation
 
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
-from .registers.loader import get_all_registers, get_registers_hash
+from .registers.loader import get_all_registers, registers_sha256
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ async def async_get_config_entry_diagnostics(
 
     # Gather comprehensive diagnostic data from the coordinator
     diagnostics = coordinator.get_diagnostic_data()
-    diagnostics.setdefault("registers_hash", get_registers_hash())
+    diagnostics.setdefault("registers_hash", registers_sha256())
     diagnostics.setdefault("capabilities", coordinator.capabilities.as_dict())
     diagnostics.setdefault("total_registers_json", len(get_all_registers()))
     if "effective_batch" not in diagnostics:

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -23,7 +23,7 @@ from .modbus_exceptions import (
     ModbusIOException,
 )
 from .modbus_helpers import _call_modbus, group_reads as _group_reads
-from .registers.loader import get_all_registers, get_registers_hash
+from .registers.loader import get_all_registers, registers_sha256
 from .utils import _decode_bcd_time, BCD_TIME_PREFIXES
 from .scanner_helpers import (
     REGISTER_ALLOWED_VALUES,
@@ -52,7 +52,7 @@ def _build_register_maps() -> None:
     """Populate register lookup maps from current register definitions."""
     global REGISTER_HASH
     regs = get_all_registers()
-    REGISTER_HASH = get_registers_hash()
+    REGISTER_HASH = registers_sha256()
 
     REGISTER_DEFINITIONS.clear()
     REGISTER_DEFINITIONS.update({r.name: r for r in regs})
@@ -90,7 +90,7 @@ def _build_register_maps() -> None:
 # Ensure register lookup maps are available before use
 def _ensure_register_maps() -> None:
     """Ensure register lookup maps are populated."""
-    current_hash = get_registers_hash()
+    current_hash = registers_sha256()
     if not REGISTER_DEFINITIONS or current_hash != REGISTER_HASH:
         _build_register_maps()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -36,13 +36,13 @@ registers_module.__path__ = []  # type: ignore[attr-defined]
 registers_loader = types.ModuleType("custom_components.thessla_green_modbus.registers.loader")
 registers_loader.get_registers_by_function = lambda *args, **kwargs: []
 registers_loader.get_all_registers = lambda *args, **kwargs: []
-registers_loader.get_registers_hash = lambda *args, **kwargs: ""
+registers_loader.registers_sha256 = lambda *args, **kwargs: ""
 registers_loader.plan_group_reads = lambda *args, **kwargs: []
 registers_loader.load_registers = lambda *args, **kwargs: []
 registers_module.loader = registers_loader
 registers_module.get_registers_by_function = registers_loader.get_registers_by_function
 registers_module.get_all_registers = registers_loader.get_all_registers
-registers_module.get_registers_hash = registers_loader.get_registers_hash
+registers_module.registers_sha256 = registers_loader.registers_sha256
 registers_module.plan_group_reads = registers_loader.plan_group_reads
 sys.modules.setdefault("custom_components.thessla_green_modbus.registers", registers_module)
 sys.modules.setdefault("custom_components.thessla_green_modbus.registers.loader", registers_loader)
@@ -51,13 +51,14 @@ registers_module.__path__ = []
 registers_module.loader = None
 registers_module.get_registers_by_function = lambda *args, **kwargs: []
 registers_module.get_all_registers = lambda *args, **kwargs: []
-registers_module.get_registers_hash = lambda *args, **kwargs: ""
+registers_module.registers_sha256 = lambda *args, **kwargs: ""
 registers_module.plan_group_reads = lambda *args, **kwargs: []
 sys.modules.setdefault("custom_components.thessla_green_modbus.registers", registers_module)
 loader_module = ModuleType("custom_components.thessla_green_modbus.registers.loader")
 loader_module.get_registers_by_function = lambda *args, **kwargs: []
 loader_module.load_registers = lambda *args, **kwargs: []
 loader_module.get_all_registers = lambda *args, **kwargs: []
+loader_module.registers_sha256 = lambda *args, **kwargs: ""
 sys.modules.setdefault("custom_components.thessla_green_modbus.registers.loader", loader_module)
 
 from custom_components.thessla_green_modbus.const import (

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from custom_components.thessla_green_modbus.registers.loader import (
     _REGISTERS_PATH,
     clear_cache,
-    get_registers_hash,
+    registers_sha256,
     load_registers,
 )
 
@@ -21,7 +21,7 @@ def test_cache_invalidation_on_content_change(tmp_path: Path, monkeypatch) -> No
     )
 
     clear_cache()
-    first_hash = get_registers_hash()
+    first_hash = registers_sha256()
     first = load_registers()[0]
     assert first.description
     assert first_hash
@@ -30,7 +30,7 @@ def test_cache_invalidation_on_content_change(tmp_path: Path, monkeypatch) -> No
     data["registers"][0]["description"] = "changed description"
     tmp_json.write_text(json.dumps(data), encoding="utf-8")
 
-    second_hash = get_registers_hash()
+    second_hash = registers_sha256()
     updated = load_registers()[0]
     assert updated.description == "changed description"
     assert first_hash != second_hash

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -168,7 +168,7 @@ def test_register_cache_invalidation(tmp_path, monkeypatch) -> None:
     loader.clear_cache()
 
     # Initial load populates cache
-    hash_before = loader.get_registers_hash()
+    hash_before = loader.registers_sha256()
     loader.get_all_registers()
     loader.get_all_registers()
 
@@ -180,7 +180,7 @@ def test_register_cache_invalidation(tmp_path, monkeypatch) -> None:
     path.write_text(real_read_text(path) + "\n")
 
     loader.get_all_registers()
-    hash_after = loader.get_registers_hash()
+    hash_after = loader.registers_sha256()
 
     # After modification both read and hash are recomputed
     assert read_calls == 2


### PR DESCRIPTION
## Summary
- rename `get_registers_hash` to `registers_sha256` and allow passing a custom path
- update diagnostics and scanner core to use the new hash helper
- adjust tests and stubs for the renamed helper

## Testing
- `pytest -q -c tests/pytest.ini tests/test_register_loader.py::test_register_cache_invalidation tests/test_register_loader.py::test_compute_file_hash_uses_cache`
- `pytest -q -c tests/pytest.ini tests/test_register_cache_invalidation.py tests/test_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab652533c0832683c7e939108b9609