### PR TITLE
Enforce explicit bit indices

### DIFF
--- a/tests/test_validate_registers.py
+++ b/tests/test_validate_registers.py
@@ -149,7 +149,7 @@ def test_validator_rejects_bits_without_bitmask(tmp_path: Path) -> None:
                 "address_hex": "0x0001",
                 "name": "bad_bits",
                 "access": "R/W",
-                "bits": [{"name": "a"}],
+                "bits": [{"name": "a", "index": 0}],
             }
         ],
     )
@@ -169,7 +169,7 @@ def test_validator_rejects_bit_name(tmp_path: Path) -> None:
                 "name": "bad_bit_name",
                 "access": "R/W",
                 "extra": {"bitmask": 0b1},
-                "bits": [{"name": "BadName"}],
+                "bits": [{"name": "BadName", "index": 0}],
             }
         ],
     )
@@ -189,7 +189,50 @@ def test_validator_rejects_bit_index(tmp_path: Path) -> None:
                 "name": "bad_bit_index",
                 "access": "R/W",
                 "extra": {"bitmask": 0b1},
-                "bits": [{"name": "a", "index": 1}],
+                "bits": [{"name": "a", "index": 16}],
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_missing_bit_index(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "missing_bit_index",
+                "access": "R/W",
+                "extra": {"bitmask": 0b1},
+                "bits": [{"name": "a"}],
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_duplicate_bit_index(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "dup_bit_index",
+                "access": "R/W",
+                "extra": {"bitmask": 0b11},
+                "bits": [
+                    {"name": "a", "index": 0},
+                    {"name": "b", "index": 0},
+                ],
             }
         ],
     )
@@ -209,7 +252,7 @@ def test_validator_rejects_bit_index_out_of_range(tmp_path: Path) -> None:
                 "name": "bit_index_out_of_range",
                 "access": "R/W",
                 "extra": {"bitmask": 0xFFFF},
-                "bits": [{"name": f"b{i}"} for i in range(17)],
+                "bits": [{"name": f"b{i}", "index": i} for i in range(17)],
             }
         ],
     )
@@ -283,7 +326,7 @@ def test_validator_rejects_bad_bit_name(tmp_path: Path) -> None:
                 "name": "bad_bit_name",
                 "access": "R/W",
                 "extra": {"bitmask": 0b1},
-                "bits": ["BadBit"],
+                "bits": [{"name": "BadBit", "index": 0}],
             }
         ],
     )


### PR DESCRIPTION
## Summary
- tighten bit definitions in register schema: require dict entries with explicit index and snake_case name, reject duplicates and out-of-range values
- mirror stricter bit validation in `tools/validate_registers.py`
- expand register validation tests for missing or duplicate bit indices

## Testing
- `python tools/validate_registers.py`
- `pytest tests/test_validate_registers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab68ee2c7883269c0be30b1e2ad151