### PR TITLE
Allow flexible register schema inputs

### DIFF
--- a/tests/test_validate_registers.py
+++ b/tests/test_validate_registers.py
@@ -311,3 +311,63 @@ def test_validator_rejects_min_max_mismatch(tmp_path: Path) -> None:
     with pytest.raises(SystemExit):
         validate_registers.main(path)
 
+
+def test_accepts_string_address_dec(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": 3,
+                "address_dec": "0x1",
+                "address_hex": "0x0001",
+                "name": "addr_str",
+                "access": "R/W",
+            }
+        ],
+    )
+
+    regs = validate_registers.validate(path)
+    assert regs[0].address_dec == 1
+    assert regs[0].address_hex == "0x1"
+
+
+def test_accepts_count_alias(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "count_alias",
+                "access": "R/W",
+                "count": 2,
+                "extra": {"type": "u32"},
+            }
+        ],
+    )
+
+    regs = validate_registers.validate(path)
+    assert regs[0].length == 2
+
+
+def test_accepts_shorthand_type(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "shorthand",
+                "access": "R/W",
+                "type": "u32",
+            }
+        ],
+    )
+
+    regs = validate_registers.validate(path)
+    reg = regs[0]
+    assert reg.length == 2
+    assert (reg.extra or {}).get("type") == "u32"
+

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -54,7 +54,7 @@ def validate(path: Path) -> list[RegisterDefinition]:
         seen_names.add(reg.name)
 
         typ = (reg.extra or {}).get("type")
-        length = item.get("length", item.get("count", 1))
+        length = reg.length
         if typ == "string":
             if length < 1:
                 raise ValueError("string type requires length >= 1")


### PR DESCRIPTION
## Summary
- Normalise `function` and `address_dec` so both integers and strings are accepted, canonicalising addresses to hex and supporting a `count` alias for `length`
- Map shorthand register `type` identifiers (`u16`, `i32`, etc.) to the internal representation with automatic word-count validation
- Use normalised lengths in the register validation tool and add tests for new schema behaviour

## Testing
- `pytest tests/test_validate_registers.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'voluptuous'; SyntaxError: expected 'except' or 'finally' block; ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68ab68ecbdd48326ad618186a88d3290