### PR TITLE
Simplify runtime dependencies

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -12,8 +12,7 @@
   "issue_tracker": "https://github.com/thesslagreen/thessla-green-modbus-ha/issues",
   "quality_scale": "silver",
   "requirements": [
-    "pymodbus>=3.5.0,<4.0",
-    "pydantic>=2.0"
+    "pymodbus>=3.5.0"
   ],
   "files": [
     "options/bypass_modes.json",
@@ -33,7 +32,7 @@
     "translations/en.json",
     "translations/pl.json"
   ],
-  "version": "2.1.2",
+  "version": "2.1.3",
   "integration_type": "hub",
   "dhcp": [
     {

--- a/hacs.json
+++ b/hacs.json
@@ -12,5 +12,5 @@
     "switch"
   ],
   "iot_class": "local_polling",
-  "version": "2.1.2"
+  "version": "2.1.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thessla-green-modbus"
-version = "2.1.2"
+version = "2.1.3"
 description = "ThesslaGreen Modbus integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}
@@ -25,7 +25,6 @@ requires-python = ">=3.12"
 # Core dependencies
 dependencies = [
     "pymodbus>=3.5.0",
-    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@
 
 # Modbus communication library
 pymodbus>=3.5.0
-pydantic>=2.0


### PR DESCRIPTION
## Summary
- drop `pydantic` runtime dependency and rely only on `pymodbus>=3.5.0`
- bump version metadata to 2.1.3

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/manifest.json pyproject.toml requirements.txt hacs.json` *(fails: InvalidManifestError: /root/.cache/pre-commit/repok9nekkmx/.pre-commit-hooks.yaml is not a file)*
- `pip install -r requirements-dev.txt` *(fails: dependency resolution error involving pydantic and pytest-homeassistant-custom-component)*
- `pytest` *(fails: IndentationError in registers/schema.py and 24 additional collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab704429d88326947f916b3937b5fe