### PR TITLE
Refactor entity unique IDs to use slave addresses

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -17,7 +17,7 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         key: str,
-        address: int | None = None,
+        address: int,
         *,
         bit: int | None = None,
     ) -> None:
@@ -33,15 +33,8 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     @property
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
-        host = self.coordinator.host.replace(":", "-")
-        port = self.coordinator.port
         bit_suffix = f"_bit{self._bit.bit_length() - 1}" if self._bit is not None else ""
-        key_part = (
-            f"{self.coordinator.slave_id}_{self._address}{bit_suffix}"
-            if self._address is not None
-            else self._key
-        )
-        return f"{DOMAIN}_{host}_{port}_{key_part}"
+        return f"{DOMAIN}_{self.coordinator.slave_id}_{self._address}{bit_suffix}"
 
     @property
     def available(self) -> bool:  # pragma: no cover

--- a/tests/test_legacy_entity_migration.py
+++ b/tests/test_legacy_entity_migration.py
@@ -102,7 +102,7 @@ async def test_legacy_fan_entity_migrated(hass, caplog):
         assert await async_setup_entry(hass, entry)  # nosec
 
     new_entity_id = "fan.rekuperator_fan"
-    new_unique_id = f"{DOMAIN}_ABC123_fan"
+    new_unique_id = f"{DOMAIN}_{slave_id}_0"
     assert registry.async_get(new_entity_id)  # nosec
     assert registry.entities[new_entity_id].unique_id == new_unique_id  # nosec
     assert old_entity_id not in registry.entities  # nosec

--- a/tests/test_migrate_unique_id.py
+++ b/tests/test_migrate_unique_id.py
@@ -1,7 +1,4 @@
-import pytest
-
 from custom_components.thessla_green_modbus.const import DOMAIN, migrate_unique_id
-
 
 HOST = "fd00:1:2::1"
 PORT = 502
@@ -19,7 +16,7 @@ def test_migrate_unique_id_with_serial():
         port=PORT,
         slave_id=SLAVE,
     )
-    assert new_uid == f"{DOMAIN}_ABC123_{SLAVE}_{REGISTER_ADDRESS}"
+    assert new_uid == f"{DOMAIN}_{SLAVE}_{REGISTER_ADDRESS}"
 
 
 def test_migrate_unique_id_without_serial():
@@ -31,8 +28,7 @@ def test_migrate_unique_id_without_serial():
         port=PORT,
         slave_id=SLAVE,
     )
-    host_sanitized = HOST.replace(":", "-")
-    assert new_uid == f"{DOMAIN}_{host_sanitized}_{PORT}_{SLAVE}_{REGISTER_ADDRESS}"
+    assert new_uid == f"{DOMAIN}_{SLAVE}_{REGISTER_ADDRESS}"
 
 
 def test_migrate_unique_id_register_name_to_address():
@@ -44,4 +40,4 @@ def test_migrate_unique_id_register_name_to_address():
         port=PORT,
         slave_id=SLAVE,
     )
-    assert new_uid == f"{DOMAIN}_ABC123_{SLAVE}_{REGISTER_ADDRESS}"
+    assert new_uid == f"{DOMAIN}_{SLAVE}_{REGISTER_ADDRESS}"


### PR DESCRIPTION
## Summary
- Build entity unique IDs from Modbus slave ID and register address
- Update unique ID migration and all tests for the new format
- Require explicit register address when creating entities

## Testing
- `pytest` *(fails: IndentationError in custom_components/thessla_green_modbus/registers/schema.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7042c0b483268084f6636815133c