### PR TITLE
Expose register file hash caching

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import translation
 
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
-from .registers.loader import get_all_registers, registers_sha256
+from .registers import loader as registers_loader
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,9 +35,14 @@ async def async_get_config_entry_diagnostics(
 
     # Gather comprehensive diagnostic data from the coordinator
     diagnostics = coordinator.get_diagnostic_data()
-    diagnostics.setdefault("registers_hash", registers_sha256())
+    diagnostics.setdefault(
+        "registers_hash",
+        registers_loader.registers_sha256(registers_loader._REGISTERS_PATH),
+    )
     diagnostics.setdefault("capabilities", coordinator.capabilities.as_dict())
-    diagnostics.setdefault("total_registers_json", len(get_all_registers()))
+    diagnostics.setdefault(
+        "total_registers_json", len(registers_loader.get_all_registers())
+    )
     if "effective_batch" not in diagnostics:
         batch_sizes = [
             count

--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -408,15 +408,14 @@ def _load_registers_from_file(
     return registers
 
 
-def registers_sha256(json_path: Path | str | None = None) -> str:
+def registers_sha256(json_path: Path) -> str:
     """Return the SHA256 hash of ``json_path``.
 
-    When ``json_path`` is not provided, the bundled register definition file is
-    used. The result is cached based on the file's modification time so
-    repeated calls for an unchanged file avoid reading from disk.
+    The result is cached using the file's modification time so repeated calls
+    for an unchanged file avoid re-reading from disk.
     """
 
-    path = Path(json_path) if json_path is not None else _REGISTERS_PATH
+    path = Path(json_path)
     mtime = path.stat().st_mtime
     path_str = str(path)
     cached = _cached_file_info.get(path_str)
@@ -430,14 +429,16 @@ def load_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
     """Return cached register definitions, reloading if the file changed.
 
     ``json_path`` may be provided to load register definitions from an
-    alternate file.  When omitted, the bundled definitions are used.
+    alternate file. When omitted, the bundled definitions are used.
+
+    The cache key is derived from the tuple ``(path, mtime, sha256)`` so
+    changes to either timestamp or content trigger a reload.
     """
 
     path = Path(json_path) if json_path is not None else _REGISTERS_PATH
     file_hash = registers_sha256(path)
     mtime = _cached_file_info[str(path)][0]
-    registers = _load_registers_from_file(path, mtime=mtime, file_hash=file_hash)
-    return registers
+    return _load_registers_from_file(path, mtime=mtime, file_hash=file_hash)
 
 
 def clear_cache() -> None:  # pragma: no cover

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,6 +6,7 @@ import asyncio
 import sys
 import socket
 import types
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -39,6 +40,7 @@ registers_loader.get_all_registers = lambda *args, **kwargs: []
 registers_loader.registers_sha256 = lambda *args, **kwargs: ""
 registers_loader.plan_group_reads = lambda *args, **kwargs: []
 registers_loader.load_registers = lambda *args, **kwargs: []
+registers_loader._REGISTERS_PATH = Path("dummy")
 registers_module.loader = registers_loader
 registers_module.get_registers_by_function = registers_loader.get_registers_by_function
 registers_module.get_all_registers = registers_loader.get_all_registers
@@ -59,6 +61,7 @@ loader_module.get_registers_by_function = lambda *args, **kwargs: []
 loader_module.load_registers = lambda *args, **kwargs: []
 loader_module.get_all_registers = lambda *args, **kwargs: []
 loader_module.registers_sha256 = lambda *args, **kwargs: ""
+loader_module._REGISTERS_PATH = Path("dummy")
 sys.modules.setdefault("custom_components.thessla_green_modbus.registers.loader", loader_module)
 
 from custom_components.thessla_green_modbus.const import (

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,6 +2,7 @@ import copy
 import json
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace, ModuleType
 from unittest.mock import AsyncMock, patch
 import sys
@@ -27,6 +28,7 @@ loader_module.get_all_registers = lambda: []
 loader_module.registers_sha256 = lambda *args, **kwargs: "hash"
 loader_module.get_registers_by_function = lambda *args, **kwargs: []
 loader_module.plan_group_reads = lambda *args, **kwargs: []
+loader_module._REGISTERS_PATH = Path("dummy")
 registers_module.loader = loader_module
 registers_module.get_all_registers = loader_module.get_all_registers
 registers_module.registers_sha256 = loader_module.registers_sha256
@@ -34,6 +36,7 @@ registers_module.get_registers_by_function = (
     loader_module.get_registers_by_function
 )
 registers_module.plan_group_reads = loader_module.plan_group_reads
+registers_module._REGISTERS_PATH = loader_module._REGISTERS_PATH
 root_pkg.registers = registers_module
 sys.modules[
     "custom_components.thessla_green_modbus",


### PR DESCRIPTION
## Summary
- accept an optional register JSON path and cache loads keyed by path, mtime and hash
- require an explicit path when computing registers_sha256 and pass it from callers
- adjust tests to stub register paths for imports

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py custom_components/thessla_green_modbus/scanner_core.py custom_components/thessla_green_modbus/diagnostics.py tests/test_diagnostics.py tests/test_config_flow.py` *(failed: InvalidManifestError)*
- `pytest` *(failed: IndentationError in registers/schema.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab704051b48326afaf75ba0c593a57