### PR TITLE
Use selector for max registers per request

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -549,7 +549,14 @@ class OptionsFlow(config_entries.OptionsFlow):
                     CONF_MAX_REGISTERS_PER_REQUEST,
                     default=current_max_registers_per_request,
                     description={"advanced": True},
-                ): selector.NumberSelector(min=1, max=16, step=1),
+                    selector={
+                        "number": {
+                            "min": 1,
+                            "max": MAX_BATCH_REGISTERS,
+                            "step": 1,
+                        }
+                    },
+                ): int,
             }
         )
 

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1273,7 +1273,7 @@
           "skip_missing_registers": "Do not poll registers known to be unavailable",
           "timeout": "Maximum time to wait for response (5-60 seconds)",
           "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
-          "max_registers_per_request": "Maximum registers per request"
+          "max_registers_per_request": "Select maximum registers per request (1-16)"
         },
         "error": {
           "max_registers_per_request": "Maximum registers per Modbus request (1-16)"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1273,7 +1273,7 @@
           "skip_missing_registers": "Do not poll registers known to be unavailable",
           "timeout": "Maximum time to wait for response (5-60 seconds)",
           "deep_scan": "Read raw registers 0x0000-0x012C for diagnostics",
-          "max_registers_per_request": "Maximum registers per request"
+          "max_registers_per_request": "Select maximum registers per request (1-16)"
         },
         "error": {
           "max_registers_per_request": "Maximum registers per Modbus request (1-16)"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1273,7 +1273,7 @@
           "skip_missing_registers": "Nie odczytuj rejestrów, które są znane jako niedostępne",
           "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)",
           "deep_scan": "Odczyt surowych rejestrów 0x0000-0x012C do diagnostyki",
-          "max_registers_per_request": "Maksymalna liczba rejestrów w zapytaniu"
+          "max_registers_per_request": "Wybierz maksymalną liczbę rejestrów w zapytaniu (1-16)"
         },
         "error": {
           "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-16)"


### PR DESCRIPTION
## Summary
- switch max registers per request option to a number selector
- clarify selector usage in option descriptions

## Testing
- `python tools/py_compile_all.py` *(fails: IndentationError in custom_components/thessla_green_modbus/registers/schema.py)*
- `find custom_components -path '*/translations/*.json' -exec python -m json.tool {} \; | tail -n 20`
- `vulture custom_components/thessla_green_modbus tests --min-confidence=80` *(fails: IndentationError in custom_components/thessla_green_modbus/registers/schema.py)*
- `pytest -ra` *(fails: multiple ImportError/IndentationError issues)*
- `python tools/check_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab704221208326890bfff7f866c011