### PR TITLE
Use fully qualified registers loader import

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -18,7 +18,10 @@ from homeassistant.helpers import translation
 
 from .const import DOMAIN
 from .coordinator import ThesslaGreenModbusCoordinator
-from .registers.loader import get_all_registers, registers_sha256
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_all_registers,
+    registers_sha256,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -23,7 +23,10 @@ from .modbus_exceptions import (
     ModbusIOException,
 )
 from .modbus_helpers import _call_modbus, group_reads as _group_reads
-from .registers.loader import get_all_registers, registers_sha256
+from custom_components.thessla_green_modbus.registers.loader import (
+    get_all_registers,
+    registers_sha256,
+)
 from .utils import _decode_bcd_time, BCD_TIME_PREFIXES
 from .scanner_helpers import (
     REGISTER_ALLOWED_VALUES,


### PR DESCRIPTION
## Summary
- use fully qualified registers loader import in diagnostics
- use fully qualified registers loader import in scanner core

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/diagnostics.py custom_components/thessla_green_modbus/scanner_core.py` *(fails: InvalidManifestError: .../.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: IndentationError in custom_components/thessla_green_modbus/registers/schema.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab703fb4248326b29b40bc257fc697