### PR TITLE
Remove domain prefix from unique IDs

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -33,8 +33,10 @@ class ThesslaGreenEntity(CoordinatorEntity[ThesslaGreenModbusCoordinator]):
     @property
     def unique_id(self) -> str:
         """Return unique ID for this entity."""
-        bit_suffix = f"_bit{self._bit.bit_length() - 1}" if self._bit is not None else ""
-        return f"{DOMAIN}_{self.coordinator.slave_id}_{self._address}{bit_suffix}"
+        bit_suffix = (
+            f"_bit{self._bit.bit_length() - 1}" if self._bit is not None else ""
+        )
+        return f"{self.coordinator.slave_id}_{self._address}{bit_suffix}"
 
     @property
     def available(self) -> bool:  # pragma: no cover

--- a/tests/test_entity_unique_id.py
+++ b/tests/test_entity_unique_id.py
@@ -21,7 +21,7 @@ def test_unique_id_format():
     coordinator.get_device_info.return_value = {}
 
     entity = ThesslaGreenEntity(coordinator, "test", 1)
-    assert entity.unique_id == f"{DOMAIN}_10_1"  # nosec
+    assert entity.unique_id == "10_1"  # nosec
 
 
 def test_unique_id_varies_with_address():
@@ -31,9 +31,9 @@ def test_unique_id_varies_with_address():
     coordinator.get_device_info.return_value = {}
 
     entity = ThesslaGreenEntity(coordinator, "test", 1)
-    assert entity.unique_id == f"{DOMAIN}_10_1"  # nosec
+    assert entity.unique_id == "10_1"  # nosec
     entity = ThesslaGreenEntity(coordinator, "test", 2)
-    assert entity.unique_id == f"{DOMAIN}_10_2"  # nosec
+    assert entity.unique_id == "10_2"  # nosec
 
 
 def test_unique_id_not_changed_by_airflow_unit():
@@ -145,7 +145,7 @@ async def test_migrate_entity_unique_ids(hass):
 
         assert await async_setup_entry(hass, entry)  # nosec
 
-    new_unique_id = f"{DOMAIN}_{slave_id}_{address}"
+    new_unique_id = f"{slave_id}_{address}"
     entity_id = registry.async_get_entity_id("sensor", DOMAIN, new_unique_id)
     assert entity_id is not None  # nosec
     assert registry.entities[entity_id].unique_id == new_unique_id  # nosec
@@ -158,5 +158,5 @@ def test_unique_id_bit_suffix():
     coordinator.get_device_info.return_value = {}
 
     entity = ThesslaGreenEntity(coordinator, "test", 5, bit=0x04)
-    assert entity.unique_id == f"{DOMAIN}_10_5_bit2"  # nosec
+    assert entity.unique_id == "10_5_bit2"  # nosec
 

--- a/tests/test_legacy_entity_migration.py
+++ b/tests/test_legacy_entity_migration.py
@@ -102,7 +102,7 @@ async def test_legacy_fan_entity_migrated(hass, caplog):
         assert await async_setup_entry(hass, entry)  # nosec
 
     new_entity_id = "fan.rekuperator_fan"
-    new_unique_id = f"{DOMAIN}_{slave_id}_0"
+    new_unique_id = f"{slave_id}_0"
     assert registry.async_get(new_entity_id)  # nosec
     assert registry.entities[new_entity_id].unique_id == new_unique_id  # nosec
     assert old_entity_id not in registry.entities  # nosec

--- a/tests/test_migrate_unique_id.py
+++ b/tests/test_migrate_unique_id.py
@@ -16,7 +16,7 @@ def test_migrate_unique_id_with_serial():
         port=PORT,
         slave_id=SLAVE,
     )
-    assert new_uid == f"{DOMAIN}_{SLAVE}_{REGISTER_ADDRESS}"
+    assert new_uid == f"{SLAVE}_{REGISTER_ADDRESS}"
 
 
 def test_migrate_unique_id_without_serial():
@@ -28,7 +28,7 @@ def test_migrate_unique_id_without_serial():
         port=PORT,
         slave_id=SLAVE,
     )
-    assert new_uid == f"{DOMAIN}_{SLAVE}_{REGISTER_ADDRESS}"
+    assert new_uid == f"{SLAVE}_{REGISTER_ADDRESS}"
 
 
 def test_migrate_unique_id_register_name_to_address():
@@ -40,4 +40,4 @@ def test_migrate_unique_id_register_name_to_address():
         port=PORT,
         slave_id=SLAVE,
     )
-    assert new_uid == f"{DOMAIN}_{SLAVE}_{REGISTER_ADDRESS}"
+    assert new_uid == f"{SLAVE}_{REGISTER_ADDRESS}"


### PR DESCRIPTION
## Summary
- Drop integration domain prefix from entity unique IDs
- Adjust unique ID migration to new '<slave>_<addr>[_bitX]' format
- Update tests for new unique ID pattern

## Testing
- `pytest` *(fails: cannot import name 'get_register_definition')*
- `pre-commit run --files custom_components/thessla_green_modbus/const.py custom_components/thessla_green_modbus/entity.py tests/test_entity_unique_id.py tests/test_legacy_entity_migration.py tests/test_migrate_unique_id.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repojegt8x9s/.pre-commit-hooks.yaml is not a file)*


------
https://chatgpt.com/codex/tasks/task_e_68ab76d9e8508326a004937c08366965