### PR TITLE
Handle DeviceCapabilities dataclasses in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -106,6 +106,19 @@ class InvalidAuth(Exception):
     """Error to indicate there is invalid auth."""
 
 
+def _caps_to_dict(obj: Any) -> dict[str, Any]:
+    """Return a JSON-serializable dict from a capabilities object."""
+
+    if hasattr(obj, "as_dict"):
+        data = obj.as_dict()
+    else:  # Fallback for older dataclass versions without as_dict()
+        data = dataclasses.asdict(obj)
+    for key, value in data.items():
+        if isinstance(value, set):
+            data[key] = sorted(value)
+    return data
+
+
 async def validate_input(
     hass: HomeAssistant | None, data: dict[str, Any]
 ) -> dict[str, Any]:
@@ -173,26 +186,29 @@ async def validate_input(
             backoff=CONFIG_FLOW_BACKOFF,
         )
 
+        if not isinstance(scan_result, dict) or not scan_result:
+            raise CannotConnect("invalid_format")
+
         caps_obj = scan_result.get("capabilities")
         if caps_obj is None:
             raise CannotConnect("invalid_capabilities")
 
-        if isinstance(caps_obj, capabilities_cls):
+        if dataclasses.is_dataclass(caps_obj):
+            try:
+                caps_dict = _caps_to_dict(caps_obj)
+            except (TypeError, ValueError, AttributeError) as err:
+                _LOGGER.error("Capabilities missing required fields: %s", err)
+                raise CannotConnect("invalid_capabilities") from err
             required_fields = {
                 field.name for field in dataclasses.fields(capabilities_cls)
             }
-            try:
-                caps_dict = caps_obj.as_dict()
-            except AttributeError as err:  # pragma: no cover - defensive
-                _LOGGER.error("Capabilities missing required fields: %s", err)
-                raise CannotConnect("invalid_capabilities") from err
             missing = [f for f in required_fields if f not in caps_dict]
             if missing:
                 _LOGGER.error("Capabilities missing required fields: %s", set(missing))
                 raise CannotConnect("invalid_capabilities")
         elif isinstance(caps_obj, dict):
             try:
-                caps_dict = capabilities_cls(**caps_obj).as_dict()
+                caps_dict = _caps_to_dict(capabilities_cls(**caps_obj))
             except (TypeError, ValueError) as exc:
                 _LOGGER.error("Error parsing capabilities: %s", exc)
                 raise CannotConnect("invalid_capabilities") from exc
@@ -201,9 +217,6 @@ async def validate_input(
 
         # Store dictionary form of capabilities for serialization
         scan_result["capabilities"] = caps_dict
-
-        if not scan_result:
-            raise CannotConnect("Device scan failed - no data received")
 
         device_info = scan_result.get("device_info", {})
 
@@ -221,7 +234,7 @@ async def validate_input(
     except ModbusIOException as exc:
         _LOGGER.error("Modbus IO error during device validation: %s", exc)
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
-        raise CannotConnect("timeout") from exc
+        raise CannotConnect("io_error") from exc
     except asyncio.TimeoutError as exc:
         _LOGGER.error("Timeout during device validation: %s", exc)
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
@@ -354,7 +367,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
             self._abort_if_unique_id_configured()
             # Prepare capabilities for persistence
             caps_obj = self._scan_result.get("capabilities")
-            if isinstance(caps_obj, dict):
+            if dataclasses.is_dataclass(caps_obj):
+                caps_dict = _caps_to_dict(caps_obj)
+            elif isinstance(caps_obj, dict):
                 try:
                     caps_dict = cap_cls(**caps_obj).as_dict()
                 except (TypeError, ValueError):
@@ -387,7 +402,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
         # Get scan statistics
         available_registers = self._scan_result.get("available_registers", {})
         caps_obj = self._scan_result.get("capabilities")
-        if isinstance(caps_obj, dict):
+        if dataclasses.is_dataclass(caps_obj):
+            try:
+                caps_data = cap_cls(**_caps_to_dict(caps_obj))
+            except (TypeError, ValueError):
+                caps_data = cap_cls()
+        elif isinstance(caps_obj, dict):
             try:
                 caps_data = cap_cls(**caps_obj)
             except TypeError:

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -27,6 +27,9 @@
       "dns_failure": "Hostname could not be resolved.",
       "connection_refused": "Connection was refused by the host.",
       "missing_method": "Scanner is missing required method. See logs for details.",
+      "io_error": "I/O error during device communication. Check wiring and connection.",
+      "invalid_capabilities": "Device capabilities data invalid or missing.",
+      "invalid_format": "Received malformed response from device.",
       "modbus_error": "Modbus communication error. Check wiring and settings.",
       "timeout": "Connection timed out. Verify host and port.",
       "unknown": "Unexpected error. Check logs for details."

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -27,6 +27,9 @@
       "dns_failure": "Hostname could not be resolved.",
       "connection_refused": "Connection was refused by the host.",
       "missing_method": "Scanner is missing required method. See logs for details.",
+      "io_error": "I/O error during device communication. Check wiring and connection.",
+      "invalid_capabilities": "Device capabilities data invalid or missing.",
+      "invalid_format": "Received malformed response from device.",
       "modbus_error": "Modbus communication error. Check wiring and settings.",
       "timeout": "Connection timed out. Verify host and port.",
       "unknown": "Unexpected error. Check logs for details."

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -27,6 +27,9 @@
       "dns_failure": "Nie można rozwiązać nazwy hosta.",
       "connection_refused": "Połączenie zostało odrzucone przez hosta.",
       "missing_method": "Brak wymaganej metody w skanerze. Sprawdź logi po szczegóły.",
+      "io_error": "Błąd wejścia/wyjścia podczas komunikacji z urządzeniem.",
+      "invalid_capabilities": "Nieprawidłowe dane możliwości urządzenia.",
+      "invalid_format": "Odebrano nieprawidłową odpowiedź z urządzenia.",
       "modbus_error": "Błąd komunikacji Modbus. Sprawdź okablowanie i ustawienia.",
       "timeout": "Przekroczono czas połączenia. Sprawdź host i port.",
       "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1347,6 +1347,77 @@ async def test_validate_input_invalid_capabilities():
     scanner_instance.close.assert_awaited_once()
 
 
+async def test_validate_input_invalid_scan_result_format():
+    """Non-dict scan result should raise invalid_format."""
+    from custom_components.thessla_green_modbus.config_flow import (
+        CannotConnect,
+        validate_input,
+    )
+
+    data = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "Test",
+    }
+
+    scanner_instance = SimpleNamespace(
+        verify_connection=AsyncMock(),
+        scan_device=AsyncMock(return_value=[]),
+        close=AsyncMock(),
+    )
+
+    with patch(
+        "custom_components.thessla_green_modbus.scanner_core.ThesslaGreenDeviceScanner.create",
+        AsyncMock(return_value=scanner_instance),
+    ):
+        with pytest.raises(CannotConnect) as err:
+            await validate_input(None, data)
+
+    assert str(err.value) == "invalid_format"
+    scanner_instance.close.assert_awaited_once()
+
+
+async def test_validate_input_dataclass_capabilities_serialization():
+    """Dataclass capabilities without mapping should serialize correctly."""
+    from dataclasses import dataclass
+
+    from custom_components.thessla_green_modbus.config_flow import validate_input
+
+    @dataclass
+    class SimpleCaps:
+        expansion_module: bool = False
+
+    data = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 502,
+        "slave_id": 10,
+        CONF_NAME: "Test",
+    }
+
+    scan_result = {
+        "device_info": {},
+        "available_registers": {},
+        "capabilities": SimpleCaps(expansion_module=True),
+    }
+
+    scanner_instance = SimpleNamespace(
+        verify_connection=AsyncMock(),
+        scan_device=AsyncMock(return_value=scan_result),
+        close=AsyncMock(),
+    )
+
+    with patch(
+        "custom_components.thessla_green_modbus.scanner_core.ThesslaGreenDeviceScanner.create",
+        AsyncMock(return_value=scanner_instance),
+    ):
+        result = await validate_input(None, data)
+
+    caps = result["scan_result"]["capabilities"]
+    assert caps["expansion_module"] is True
+    scanner_instance.close.assert_awaited_once()
+
+
 async def test_validate_input_missing_capabilities():
     """Missing capabilities should raise CannotConnect."""
     from custom_components.thessla_green_modbus.config_flow import (
@@ -1638,9 +1709,11 @@ async def test_validate_input_retries_transient_failures():
     ]
 
 
-@pytest.mark.parametrize("exc", [asyncio.TimeoutError, ModbusIOException])
-async def test_validate_input_timeout_errors(exc):
-    """Timeout-related errors should map to timeout in UI."""
+@pytest.mark.parametrize(
+    "exc,err_key", [(asyncio.TimeoutError, "timeout"), (ModbusIOException, "io_error")]
+)
+async def test_validate_input_timeout_errors(exc, err_key):
+    """Timeout and IO errors should map to appropriate UI errors."""
     from custom_components.thessla_green_modbus.config_flow import (
         CannotConnect,
         validate_input,
@@ -1672,7 +1745,7 @@ async def test_validate_input_timeout_errors(exc):
         with pytest.raises(CannotConnect) as err:
             await validate_input(None, data)
 
-    assert err.value.args[0] == "timeout"
+    assert err.value.args[0] == err_key
     scanner_instance.close.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- Handle DeviceCapabilities dataclasses using `dataclasses.asdict`
- Add detailed error translations for I/O, timeout, and format failures
- Expand config flow tests for error handling and dataclass capabilities

## Testing
- `python tools/check_translations.py`
- `pytest` *(fails: ImportError: cannot import name 'get_register_definition')*


------
https://chatgpt.com/codex/tasks/task_e_68ab76da6f248326ade67c1547c25318