### PR TITLE
Ensure translation files match strings.json

### DIFF
--- a/tests/test_strings_translations.py
+++ b/tests/test_strings_translations.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "custom_components" / "thessla_green_modbus"
+
+
+def _collect_keys(obj, prefix=""):
+    keys = set()
+    if isinstance(obj, dict):
+        for key, val in obj.items():
+            path = f"{prefix}.{key}" if prefix else key
+            keys.add(path)
+            keys |= _collect_keys(val, path)
+    elif isinstance(obj, list):
+        for item in obj:
+            keys |= _collect_keys(item, prefix)
+    return keys
+
+
+def test_strings_and_translations_match() -> None:
+    strings = json.loads((ROOT / "strings.json").read_text(encoding="utf-8"))
+    ref_keys = _collect_keys(strings)
+    for lang in ("en", "pl"):
+        data = json.loads((ROOT / "translations" / f"{lang}.json").read_text(encoding="utf-8"))
+        data_keys = _collect_keys(data)
+        missing = ref_keys - data_keys
+        extra = data_keys - ref_keys
+        assert not missing and not extra, (
+            f"{lang}: missing keys {sorted(missing)}, extra keys {sorted(extra)}"
+        )


### PR DESCRIPTION
## Summary
- extend translation check script to compare translation JSON files with strings.json and report missing or extra keys
- add unit test verifying strings.json and translations stay in sync

## Testing
- `pytest tests/test_strings_translations.py tests/test_translations.py tests/test_unused_translations.py tests/test_strings_json_generation.py`
- `pre-commit run --files tools/check_translations.py tests/test_strings_translations.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo8zflw0gv/.pre-commit-hooks.yaml is not a file)*


------
https://chatgpt.com/codex/tasks/task_e_68ab76de0a0c83269ac79a91ffb50792