### PR TITLE
Expose max registers per request option

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -376,7 +376,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
                     CONF_NAME: self._data.get(CONF_NAME, DEFAULT_NAME),
                     "capabilities": caps_dict,
                 },
-                options={CONF_DEEP_SCAN: self._data.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN)},
+                options={
+                    CONF_DEEP_SCAN: self._data.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN),
+                    CONF_MAX_REGISTERS_PER_REQUEST: self._data.get(
+                        CONF_MAX_REGISTERS_PER_REQUEST,
+                        DEFAULT_MAX_REGISTERS_PER_REQUEST,
+                    ),
+                },
             )
 
         # Prepare description with device info
@@ -549,14 +555,13 @@ class OptionsFlow(config_entries.OptionsFlow):
                     CONF_MAX_REGISTERS_PER_REQUEST,
                     default=current_max_registers_per_request,
                     description={"advanced": True},
-                    selector={
-                        "number": {
-                            "min": 1,
-                            "max": MAX_BATCH_REGISTERS,
-                            "step": 1,
-                        }
-                    },
-                ): int,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1,
+                        max=MAX_BATCH_REGISTERS,
+                        step=1,
+                    )
+                ),
             }
         )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -69,6 +69,7 @@ from custom_components.thessla_green_modbus.const import (
     CONF_SLAVE_ID,
     CONF_MAX_REGISTERS_PER_REQUEST,
     MAX_BATCH_REGISTERS,
+    DEFAULT_MAX_REGISTERS_PER_REQUEST,
 )
 
 from custom_components.thessla_green_modbus.config_flow import (
@@ -372,6 +373,10 @@ async def test_form_user_success():
     assert isinstance(data["capabilities"], dict)
     assert data["capabilities"]["expansion_module"] is True
     assert result2["options"][CONF_DEEP_SCAN] is True
+    assert (
+        result2["options"][CONF_MAX_REGISTERS_PER_REQUEST]
+        == DEFAULT_MAX_REGISTERS_PER_REQUEST
+    )
 
 
 async def test_duplicate_entry_aborts():


### PR DESCRIPTION
## Summary
- add max_registers_per_request option stored in config entry and exposed via NumberSelector in options
- test that default option is persisted

## Testing
- `pytest tests/test_config_flow.py::test_form_user_success tests/test_config_flow.py::test_options_flow_max_registers_per_request_validated -q`
- `pytest` *(fails: ImportError: cannot import name 'get_register_definition')*


------
https://chatgpt.com/codex/tasks/task_e_68ab76e04924832685a4310ea69e0f0a