### PR TITLE
Normalize function codes and support count alias

### DIFF
--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -9,8 +9,8 @@ new capabilities while keeping the validation logic focused and explicit.
 
 Key features implemented:
 
-* ``function`` accepts integers or strings and is normalised to a two digit
-  string (``"01"`` … ``"04"``).
+* ``function`` accepts integers or strings and is normalised to the canonical
+  integer form (``1`` … ``4``).
 * ``address_dec`` may be provided as either an integer or string.  A canonical
   ``0x`` prefixed form is stored in ``address_hex`` and the two representations
   are cross‑checked for consistency.
@@ -25,6 +25,7 @@ from enum import Enum
 from typing import Any, Literal
 
 import pydantic
+from pydantic import AliasChoices, Field
 
 from ..utils import _normalise_name
 
@@ -105,7 +106,7 @@ _TYPE_LENGTHS: dict[str, int | None] = {
 class RegisterDefinition(pydantic.BaseModel):
     """Schema describing a raw register definition from JSON."""
 
-    function: str
+    function: int
     address_dec: int
     address_hex: str
     name: str
@@ -122,7 +123,7 @@ class RegisterDefinition(pydantic.BaseModel):
     notes: str | None = None
     information: str | None = None
     extra: dict[str, Any] | None = None
-    length: int = 1
+    length: int = Field(1, validation_alias=AliasChoices("length", "count"))
     bcd: bool = False
     bits: list[Any] | None = None
     type: RegisterType | None = None
@@ -138,13 +139,10 @@ class RegisterDefinition(pydantic.BaseModel):
     def _normalise_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Normalise raw input from JSON."""
 
-        if "count" in data and "length" not in data:
-            data["length"] = data.pop("count")
-
-        # Normalise function code -> two digit string
+        # Normalise function code -> canonical integer
         if "function" in data:
             fn_int = _normalise_function(data["function"])
-            data["function"] = f"{fn_int:02d}"
+            data["function"] = fn_int
 
         # Normalise address_dec
         addr_dec = data.get("address_dec")
@@ -174,12 +172,11 @@ class RegisterDefinition(pydantic.BaseModel):
         typ = data.pop("type", None)
         extra = data.get("extra")
         if typ is None and isinstance(extra, dict):
-            typ = extra.pop("type", None)
-            if not extra:
-                data.pop("extra")
-        elif extra is None:
+            typ = extra.get("type")
+        if extra is None:
             extra = {}
         if typ is not None:
+            extra.setdefault("type", typ)
             data["type"] = typ
         if extra:
             data["extra"] = extra
@@ -205,9 +202,9 @@ class RegisterDefinition(pydantic.BaseModel):
 
     @pydantic.field_validator("function")
     @classmethod
-    def _check_function(cls, v: str) -> str:  # pragma: no cover - defensive
-        if v not in {"01", "02", "03", "04"}:
-            raise ValueError("function code must be between 01 and 04")
+    def _check_function(cls, v: int) -> int:  # pragma: no cover - defensive
+        if v not in {1, 2, 3, 4}:
+            raise ValueError("function code must be between 1 and 4")
         return v
 
     # ------------------------------------------------------------------
@@ -231,7 +228,7 @@ class RegisterDefinition(pydantic.BaseModel):
             elif self.length != expected:
                 raise ValueError("length does not match type")
 
-        if self.function in {"01", "02"} and self.access not in {"R", "R/-"}:
+        if self.function in {1, 2} and self.access not in {"R", "R/-"}:
             raise ValueError("read-only functions must have R access")
 
         if self.enum is not None:

--- a/tests/test_register_loader_validation.py
+++ b/tests/test_register_loader_validation.py
@@ -50,10 +50,10 @@ RegisterDefinition = _load_schema()
 
 
 EXPECTED = {
-    "01": {"min": 5, "max": 15, "count": 8},
-    "02": {"min": 0, "max": 21, "count": 16},
-    "03": {"min": 0, "max": 8444, "count": 271},
-    "04": {"min": 0, "max": 298, "count": 24},
+    1: {"min": 5, "max": 15, "count": 8},
+    2: {"min": 0, "max": 21, "count": 16},
+    3: {"min": 0, "max": 8444, "count": 271},
+    4: {"min": 0, "max": 298, "count": 24},
 }
 
 # Registers present in the vendor PDF but intentionally omitted in the JSON
@@ -137,7 +137,7 @@ def test_register_file_valid() -> None:
 
     parsed = [RegisterDefinition.model_validate(item) for item in registers]
 
-    by_fn: dict[str, list[int]] = {}
+    by_fn: dict[int, list[int]] = {}
     for reg in parsed:
         by_fn.setdefault(reg.function, []).append(reg.address_dec)
 
@@ -230,19 +230,19 @@ def test_schema_rejects_string_with_invalid_length(length: int) -> None:
         RegisterDefinition.model_validate(bad)
 
 
-def test_function_coerces_to_string() -> None:
-    """Integer function codes are normalised to two-digit strings."""
+def test_function_coerces_to_int() -> None:
+    """Function codes provided as strings become integers."""
 
     reg = RegisterDefinition.model_validate(
         {
             "name": "x",
-            "function": 3,
+            "function": "03",
             "address_dec": 0,
             "address_hex": "0x0",
             "access": "R",
         }
     )
-    assert reg.function == "03"
+    assert reg.function == 3
 
 
 def test_address_hex_mismatch() -> None:


### PR DESCRIPTION
## Summary
- store register function codes as canonical integers and accept `count` as an alias for `length`
- ensure shorthand type identifiers populate `extra.type` and enforce expected register counts
- update tests for integer function codes and the new length alias

## Testing
- `pytest tests/test_register_loader_validation.py::test_function_coerces_to_int`
- `pytest tests/test_validate_registers.py::test_accepts_count_alias`
- `pytest tests/test_validate_registers.py::test_accepts_shorthand_type`
- `pytest` *(fails: ImportError: cannot import name '_REGISTERS_PATH' ...)*


------
https://chatgpt.com/codex/tasks/task_e_68abff509ba08326b333b7c35c0acf09