### PR TITLE
Enforce structured bit definitions and validation

### DIFF
--- a/tests/test_validate_registers.py
+++ b/tests/test_validate_registers.py
@@ -218,6 +218,46 @@ def test_validator_rejects_missing_bit_index(tmp_path: Path) -> None:
         validate_registers.main(path)
 
 
+def test_validator_rejects_non_mapping_bit(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "non_mapping_bit",
+                "access": "R/W",
+                "extra": {"bitmask": 0b1},
+                "bits": ["a"],
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
+def test_validator_rejects_missing_bit_name(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "function": "03",
+                "address_dec": 1,
+                "address_hex": "0x0001",
+                "name": "missing_bit_name",
+                "access": "R/W",
+                "extra": {"bitmask": 0b1},
+                "bits": [{"index": 0}],
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        validate_registers.main(path)
+
+
 def test_validator_rejects_duplicate_bit_index(tmp_path: Path) -> None:
     path = _write(
         tmp_path,

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -8,6 +8,8 @@ import sys
 import types
 from pathlib import Path
 
+import pydantic
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -53,7 +55,10 @@ def validate(path: Path) -> list[RegisterDefinition]:
     data = json.loads(path.read_text(encoding="utf-8"))
     registers = data.get("registers", data)
 
-    parsed_list = RegisterList.model_validate(registers)
+    try:
+        parsed_list = RegisterList.model_validate(registers)
+    except pydantic.ValidationError as err:
+        raise ValueError(err) from err
     return parsed_list.root
 
 


### PR DESCRIPTION
## Summary
- require bit entries to declare indexed snake_case names and enforce uniqueness
- tighten register validation CLI to surface schema errors
- cover new bit validation rules with tests

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/schema.py tools/validate_registers.py tests/test_validate_registers.py` *(failed: InvalidManifestError: /root/.cache/pre-commit/repocp_1w7jf/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_validate_registers.py`

------
https://chatgpt.com/codex/tasks/task_e_68abff51a69c832693f772bcb0051acf