### PR TITLE
feat: expand register validation and translation checks

### DIFF
--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -118,9 +118,8 @@ def main() -> int:
         data = _load(lang)
         problems.extend(_check_options(data, lang))
         problems.extend(_check_strings(data, strings, lang))
-        if lang != BASE_LANG:
-            problems.extend(_check_diagnostics(data, ref, lang))
-            problems.extend(_check_errors(data, ref, lang))
+        problems.extend(_check_diagnostics(data, ref, lang))
+        problems.extend(_check_errors(data, ref, lang))
 
     if problems:
         for p in problems:


### PR DESCRIPTION
## Summary
- enhance register validation to normalize addresses, enforce type/bitmask rules and verify enum/bit definitions
- check translations for missing diagnostic fields and config error strings in all languages

## Testing
- `python tools/validate_registers.py`
- `python tools/check_translations.py`
- `pytest tests/test_validate_registers.py tests/test_translations.py tests/test_strings_translations.py`
- ⚠️ `pre-commit run --files tools/validate_registers.py tools/check_translations.py` *(InvalidManifestError: /root/.cache/pre-commit/repoej97b61m/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68abff583d8c8326866a495d927ceed9