### PR TITLE
Support full register list entity creation

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -51,13 +51,14 @@ async def async_setup_entry(
         register_type = sensor_def["register_type"]
         register_name = sensor_def.get("register", key)
 
+        register_map = coordinator._register_maps.get(register_type, {})
         available = coordinator.available_registers.get(register_type, set())
-        force_create = coordinator.force_full_register_list and register_name in coordinator._register_maps.get(register_type, {})
+        force_create = coordinator.force_full_register_list and register_name in register_map
 
         # Check if this register is available on the device or should be
         # forcibly added from the full register list.
         if register_name in available or force_create:
-            address = coordinator._register_maps.get(register_type, {}).get(register_name)
+            address = register_map.get(register_name)
             entities.append(
                 ThesslaGreenBinarySensor(
                     coordinator,

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -41,13 +41,12 @@ async def async_setup_entry(
     # ``force_full_register_list`` is enabled.
     for register_name, select_def in ENTITY_MAPPINGS["select"].items():
         register_type = select_def["register_type"]
+        register_map = coordinator._register_maps.get(register_type, {})
         available = coordinator.available_registers.get(register_type, set())
-        force_create = coordinator.force_full_register_list and register_name in coordinator._register_maps.get(register_type, {})
+        force_create = coordinator.force_full_register_list and register_name in register_map
         if register_name in available or force_create:
-            address = coordinator._register_maps[register_type][register_name]
-            entities.append(
-                ThesslaGreenSelect(coordinator, register_name, address, select_def)
-            )
+            address = register_map[register_name]
+            entities.append(ThesslaGreenSelect(coordinator, register_name, address, select_def))
 
     if entities:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import pytest
 
 try:
     from homeassistant.util import dt as _ha_dt  # noqa: F401
+
     importlib.import_module("homeassistant.util")  # ensure util submodule is loaded for plugins
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
@@ -29,8 +30,10 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
     device_registry = types.ModuleType("homeassistant.helpers.device_registry")
     service_helper = types.ModuleType("homeassistant.helpers.service")
     entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+
     def _async_entries_for_config_entry(*args, **kwargs):
         return []
+
     entity_registry.async_entries_for_config_entry = _async_entries_for_config_entry
     script_helper = types.ModuleType("homeassistant.helpers.script")
     script_helper._schedule_stop_scripts_after_shutdown = lambda *args, **kwargs: None
@@ -99,6 +102,7 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
         @property
         def native_unit_of_measurement(self):
             return getattr(self, "_attr_native_unit_of_measurement", None)
+
     sensor_comp.SensorDeviceClass = SensorDeviceClass
     sensor_comp.SensorStateClass = SensorStateClass
     sensor_comp.SensorEntity = SensorEntity
@@ -133,7 +137,7 @@ except ModuleNotFoundError:  # pragma: no cover - simplify test environment
             return None
 
         def add_update_listener(self, listener):
-             return listener
+            return listener
 
         def async_on_unload(self, func):
             return func
@@ -469,6 +473,7 @@ def mock_coordinator():
         "coil_registers": COIL_REGISTERS,
         "discrete_inputs": DISCRETE_INPUT_REGISTERS,
     }
+    coordinator.force_full_register_list = False
     coordinator.async_write_register = AsyncMock(return_value=True)
     coordinator.async_request_refresh = AsyncMock()
     return coordinator


### PR DESCRIPTION
## Summary
- create entities from register map when force_full_register_list is enabled
- default to autoscan list otherwise

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/sensor.py custom_components/thessla_green_modbus/binary_sensor.py custom_components/thessla_green_modbus/select.py custom_components/thessla_green_modbus/number.py custom_components/thessla_green_modbus/climate.py tests/test_number.py tests/conftest.py` *(failed: InvalidManifestError)*
- `pytest tests/test_number.py`
- `pytest tests/test_sensor_platform.py tests/test_binary_sensor.py tests/test_climate.py` *(failed: ModuleNotFoundError: No module named 'voluptuous')*


------
https://chatgpt.com/codex/tasks/task_e_68abff59eb64832695dcf9feb555378e