### PR TITLE
feat: add number selector for max registers option

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -574,14 +574,17 @@ class OptionsFlow(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_MAX_REGISTERS_PER_REQUEST,
                     default=current_max_registers_per_request,
-                    description={"advanced": True},
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=1,
-                        max=MAX_BATCH_REGISTERS,
-                        step=1,
-                    )
-                ),
+                    description={
+                        "advanced": True,
+                        "selector": {
+                            "number": {
+                                "min": 1,
+                                "max": MAX_BATCH_REGISTERS,
+                                "step": 1,
+                            }
+                        },
+                    },
+                ): int,
             }
         )
 


### PR DESCRIPTION
## Summary
- use number selector for max register per request option

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo7q9coe97/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_config_flow.py -k max_registers_per_request -q`

------
https://chatgpt.com/codex/tasks/task_e_68abff5c0a5483269e14ca78e3c0ac8c