### PR TITLE
Use dataclass conversion for capabilities and refine errors

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -27,11 +27,11 @@
       "dns_failure": "Hostname could not be resolved.",
       "connection_refused": "Connection was refused by the host.",
       "missing_method": "Scanner is missing required method. See logs for details.",
-      "io_error": "I/O error during device communication. Check wiring and connection.",
+      "io_error": "Input/output error during device communication. Check cabling and network connection.",
       "invalid_capabilities": "Device capabilities data invalid or missing.",
-      "invalid_format": "Received malformed response from device.",
+      "invalid_format": "Received data in an unexpected format from device.",
       "modbus_error": "Modbus communication error. Check wiring and settings.",
-      "timeout": "Connection timed out. Verify host and port.",
+      "timeout": "Device did not respond in time. Verify network connectivity and address.",
       "unknown": "Unexpected error. Check logs for details."
     },
     "step": {

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -27,11 +27,11 @@
       "dns_failure": "Hostname could not be resolved.",
       "connection_refused": "Connection was refused by the host.",
       "missing_method": "Scanner is missing required method. See logs for details.",
-      "io_error": "I/O error during device communication. Check wiring and connection.",
+      "io_error": "Input/output error during device communication. Check cabling and network connection.",
       "invalid_capabilities": "Device capabilities data invalid or missing.",
-      "invalid_format": "Received malformed response from device.",
+      "invalid_format": "Received data in an unexpected format from device.",
       "modbus_error": "Modbus communication error. Check wiring and settings.",
-      "timeout": "Connection timed out. Verify host and port.",
+      "timeout": "Device did not respond in time. Verify network connectivity and address.",
       "unknown": "Unexpected error. Check logs for details."
     },
     "step": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -27,11 +27,11 @@
       "dns_failure": "Nie można rozwiązać nazwy hosta.",
       "connection_refused": "Połączenie zostało odrzucone przez hosta.",
       "missing_method": "Brak wymaganej metody w skanerze. Sprawdź logi po szczegóły.",
-      "io_error": "Błąd wejścia/wyjścia podczas komunikacji z urządzeniem.",
+      "io_error": "Błąd wejścia/wyjścia podczas komunikacji z urządzeniem. Sprawdź okablowanie i połączenie sieciowe.",
       "invalid_capabilities": "Nieprawidłowe dane możliwości urządzenia.",
-      "invalid_format": "Odebrano nieprawidłową odpowiedź z urządzenia.",
+      "invalid_format": "Odebrano dane w nieoczekiwanym formacie z urządzenia.",
       "modbus_error": "Błąd komunikacji Modbus. Sprawdź okablowanie i ustawienia.",
-      "timeout": "Przekroczono czas połączenia. Sprawdź host i port.",
+      "timeout": "Urządzenie nie odpowiedziało na czas. Sprawdź połączenie sieciowe i adres.",
       "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
     },
     "step": {


### PR DESCRIPTION
## Summary
- ensure DeviceCapabilities objects are safely converted to dictionaries in config flow
- improve config flow error messages and provide translations

## Testing
- `python tools/check_translations.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/strings.json custom_components/thessla_green_modbus/translations/en.json custom_components/thessla_green_modbus/translations/pl.json` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0463ce5c8326b8daa0dfc1384f9a