### PR TITLE
Align logging levels for retries and timeouts

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -92,7 +92,7 @@ async def _run_with_retry(
                 try:
                     await asyncio.sleep(delay)
                 except asyncio.CancelledError:
-                    _LOGGER.debug("Retry sleep cancelled")
+                    _LOGGER.info("Retry sleep cancelled")
                     raise
     # Should never reach here
     raise RuntimeError("Retry wrapper failed without raising")
@@ -236,7 +236,7 @@ async def validate_input(
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
         raise CannotConnect("io_error") from exc
     except asyncio.TimeoutError as exc:
-        _LOGGER.error("Timeout during device validation: %s", exc)
+        _LOGGER.warning("Timeout during device validation: %s", exc)
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
         raise CannotConnect("timeout") from exc
     except ModbusException as exc:

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -1453,7 +1453,7 @@ class ThesslaGreenDeviceScanner:
                 try:
                     await asyncio.sleep(self._sleep_time(attempt))
                 except asyncio.CancelledError:
-                    _LOGGER.debug("Sleep cancelled while retrying input 0x%04X", address)
+                    _LOGGER.info("Sleep cancelled while retrying input 0x%04X", address)
                     raise
 
         self.failed_addresses["modbus_exceptions"]["input_registers"].update(
@@ -1591,7 +1591,7 @@ class ThesslaGreenDeviceScanner:
                 try:
                     await asyncio.sleep(self._sleep_time(attempt))
                 except asyncio.CancelledError:
-                    _LOGGER.debug("Sleep cancelled while retrying holding 0x%04X", address)
+                    _LOGGER.info("Sleep cancelled while retrying holding 0x%04X", address)
                     raise
 
         _LOGGER.error(
@@ -1665,7 +1665,7 @@ class ThesslaGreenDeviceScanner:
                 try:
                     await asyncio.sleep(self._sleep_time(attempt))
                 except asyncio.CancelledError:
-                    _LOGGER.debug("Sleep cancelled while retrying coil 0x%04X", address)
+                    _LOGGER.info("Sleep cancelled while retrying coil 0x%04X", address)
                     raise
         self.failed_addresses["modbus_exceptions"]["coil_registers"].update(
             range(address, address + count)
@@ -1741,7 +1741,7 @@ class ThesslaGreenDeviceScanner:
                 try:
                     await asyncio.sleep(self._sleep_time(attempt))
                 except asyncio.CancelledError:
-                    _LOGGER.debug("Sleep cancelled while retrying discrete 0x%04X", address)
+                    _LOGGER.info("Sleep cancelled while retrying discrete 0x%04X", address)
                     raise
         self.failed_addresses["modbus_exceptions"]["discrete_inputs"].update(
             range(address, address + count)


### PR DESCRIPTION
## Summary
- log retry cancellation steps at INFO instead of DEBUG
- warn rather than error on device validation timeouts

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/config_flow.py custom_components/thessla_green_modbus/scanner_core.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repop30vn4v0/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac04652c7483268f9a7e7f83f48ffa