### PR TITLE
Expose max registers per request in config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -288,6 +288,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
 
         if user_input is not None:
             try:
+                max_regs = user_input.get(
+                    CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
+                )
+                if not 1 <= max_regs <= MAX_BATCH_REGISTERS:
+                    raise vol.Invalid(
+                        "max_registers_range", path=[CONF_MAX_REGISTERS_PER_REQUEST]
+                    )
+
                 # Validate input and get device info
                 info = await validate_input(self.hass, user_input)
 
@@ -344,6 +352,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
                     default=DEFAULT_DEEP_SCAN,
                     description={"advanced": True},
                 ): bool,
+                vol.Optional(
+                    CONF_MAX_REGISTERS_PER_REQUEST,
+                    default=DEFAULT_MAX_REGISTERS_PER_REQUEST,
+                    description={
+                        "selector": {
+                            "number": {
+                                "min": 1,
+                                "max": MAX_BATCH_REGISTERS,
+                                "step": 1,
+                            }
+                        }
+                    },
+                ): int,
             }
         )
 

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -32,7 +32,8 @@
       "invalid_format": "Received malformed response from device.",
       "modbus_error": "Modbus communication error. Check wiring and settings.",
       "timeout": "Connection timed out. Verify host and port.",
-      "unknown": "Unexpected error. Check logs for details."
+      "unknown": "Unexpected error. Check logs for details.",
+      "max_registers_range": "Max registers per request must be between 1 and 16."
     },
     "step": {
       "confirm": {
@@ -45,14 +46,16 @@
           "name": "Name",
           "port": "Port",
           "slave_id": "Device ID",
-          "deep_scan": "Deep Register Scan"
+          "deep_scan": "Deep Register Scan",
+          "max_registers_per_request": "Max Registers per Request"
         },
         "data_description": {
           "host": "IP address of the AirPack device on your local network",
           "name": "Device name in Home Assistant",
           "port": "Modbus TCP port (default 502)",
           "slave_id": "Modbus device ID (default 10)",
-          "deep_scan": "Read all registers for diagnostics (may be slow)"
+          "deep_scan": "Read all registers for diagnostics (may be slow)",
+          "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
         },
         "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP. The integration automatically detects device functions and registers.",
         "title": "ThesslaGreen Modbus Configuration"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -32,7 +32,8 @@
       "invalid_format": "Received malformed response from device.",
       "modbus_error": "Modbus communication error. Check wiring and settings.",
       "timeout": "Connection timed out. Verify host and port.",
-      "unknown": "Unexpected error. Check logs for details."
+      "unknown": "Unexpected error. Check logs for details.",
+      "max_registers_range": "Max registers per request must be between 1 and 16."
     },
     "step": {
       "confirm": {
@@ -45,14 +46,16 @@
           "name": "Name",
           "port": "Port",
           "slave_id": "Device ID",
-          "deep_scan": "Deep Register Scan"
+          "deep_scan": "Deep Register Scan",
+          "max_registers_per_request": "Max Registers per Request"
         },
         "data_description": {
           "host": "IP address of the AirPack device on your local network",
           "name": "Device name in Home Assistant",
           "port": "Modbus TCP port (default 502)",
           "slave_id": "Modbus device ID (default 10)",
-          "deep_scan": "Read all registers for diagnostics (may be slow)"
+          "deep_scan": "Read all registers for diagnostics (may be slow)",
+          "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
         },
         "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP. The integration automatically detects device functions and registers.",
         "title": "ThesslaGreen Modbus Configuration"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -32,7 +32,8 @@
       "invalid_format": "Odebrano nieprawidłową odpowiedź z urządzenia.",
       "modbus_error": "Błąd komunikacji Modbus. Sprawdź okablowanie i ustawienia.",
       "timeout": "Przekroczono czas połączenia. Sprawdź host i port.",
-      "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
+      "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły.",
+      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1-16."
     },
     "step": {
       "confirm": {
@@ -46,14 +47,16 @@
           "port": "Port",
           "slave_id": "ID Urządzenia",
           "name": "Nazwa",
-          "deep_scan": "Głęboki skan rejestrów"
+          "deep_scan": "Głęboki skan rejestrów",
+          "max_registers_per_request": "Maksymalna liczba rejestrów na żądanie"
         },
         "data_description": {
           "host": "IP address of the AirPack device on your local network",
           "name": "Device name in Home Assistant",
           "port": "Modbus TCP port (default 502)",
           "slave_id": "Modbus device ID (default 10)",
-          "deep_scan": "Odczytaj wszystkie rejestry do diagnostyki (może być wolne)"
+          "deep_scan": "Odczytaj wszystkie rejestry do diagnostyki (może być wolne)",
+          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-16)"
         },
         "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP. The integration automatically detects device functions and registers."
       }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -357,6 +357,7 @@ async def test_form_user_success():
                 "slave_id": 10,
                 CONF_NAME: "My Device",
                 CONF_DEEP_SCAN: True,
+                CONF_MAX_REGISTERS_PER_REQUEST: 5,
             }
         )
         assert result["type"] == "form"
@@ -379,10 +380,7 @@ async def test_form_user_success():
     assert isinstance(data["capabilities"], dict)
     assert data["capabilities"]["expansion_module"] is True
     assert result2["options"][CONF_DEEP_SCAN] is True
-    assert (
-        result2["options"][CONF_MAX_REGISTERS_PER_REQUEST]
-        == DEFAULT_MAX_REGISTERS_PER_REQUEST
-    )
+    assert result2["options"][CONF_MAX_REGISTERS_PER_REQUEST] == 5
 
 
 async def test_duplicate_entry_aborts():
@@ -1832,6 +1830,74 @@ def test_device_capabilities_serialization():
     assert list(caps.keys()) == list(serialized.keys())
     assert list(caps.items()) == list(serialized.items())
     assert list(caps.values()) == list(serialized.values())
+
+
+async def test_config_flow_max_registers_per_request_validated():
+    """Config flow validates max registers per request."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace()
+    result = await flow.async_step_user()
+    schema_keys = {
+        key.schema if hasattr(key, "schema") else key for key in result["data_schema"].schema
+    }
+    assert CONF_MAX_REGISTERS_PER_REQUEST in schema_keys
+
+    validation_result = {"device_info": {}, "scan_result": {}}
+    for value in (1, MAX_BATCH_REGISTERS):
+        flow = ConfigFlow()
+        flow.hass = SimpleNamespace()
+        with patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            return_value=validation_result,
+        ), patch(
+            "custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"
+        ), patch(
+            "custom_components.thessla_green_modbus.config_flow.ConfigFlow._abort_if_unique_id_configured"
+        ):
+            result = await flow.async_step_user(
+                {
+                    CONF_HOST: "192.168.1.100",
+                    CONF_PORT: 502,
+                    CONF_SLAVE_ID: 10,
+                    CONF_MAX_REGISTERS_PER_REQUEST: value,
+                }
+            )
+            assert result["type"] == "form"
+            assert result["step_id"] == "confirm"
+
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace()
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow.validate_input"
+    ) as mock_validate:
+        result = await flow.async_step_user(
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 502,
+                CONF_SLAVE_ID: 10,
+                CONF_MAX_REGISTERS_PER_REQUEST: 0,
+            }
+        )
+        assert result["type"] == "form"
+        assert result["errors"][CONF_MAX_REGISTERS_PER_REQUEST] == "max_registers_range"
+        mock_validate.assert_not_called()
+
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace()
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow.validate_input"
+    ) as mock_validate:
+        result = await flow.async_step_user(
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 502,
+                CONF_SLAVE_ID: 10,
+                CONF_MAX_REGISTERS_PER_REQUEST: 20,
+            }
+        )
+        assert result["type"] == "form"
+        assert result["errors"][CONF_MAX_REGISTERS_PER_REQUEST] == "max_registers_range"
+        mock_validate.assert_not_called()
 
 
 async def test_options_flow_max_registers_per_request_validation():


### PR DESCRIPTION
## Summary
- allow configuring max registers per request during initial setup
- add translations and tests for new config field

## Testing
- `python tools/check_translations.py`
- `pytest tests/test_config_flow.py::test_config_flow_max_registers_per_request_validated tests/test_config_flow.py::test_options_flow_max_registers_per_request_validated -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac04603ab083268948bbc532780e82