### PR TITLE
refactor: update loader imports

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 
 # Stub loader module to avoid heavy imports during tests
 sys.modules.setdefault(
-    "custom_components.thessla_green_modbus.loader",
+    "custom_components.thessla_green_modbus.registers.loader",
     SimpleNamespace(plan_group_reads=lambda *args, **kwargs: []),
 )
 # Stub network validation to avoid homeassistant dependency
@@ -77,12 +77,6 @@ from custom_components.thessla_green_modbus.config_flow import (
     ConfigFlow,
     InvalidAuth,
     OptionsFlow,
-)
-from custom_components.thessla_green_modbus.const import (
-    CONF_DEEP_SCAN,
-    CONF_MAX_REGISTERS_PER_REQUEST,
-    CONF_SLAVE_ID,
-    MAX_BATCH_REGISTERS,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import (
     ConnectionException,

--- a/tests/test_force_full_register_list_integration.py
+++ b/tests/test_force_full_register_list_integration.py
@@ -21,7 +21,7 @@ if not hasattr(binary_sensor_mod, "BinarySensorEntity"):
 
 ha_const.STATE_UNAVAILABLE = "unavailable"
 
-from custom_components.thessla_green_modbus import binary_sensor, sensor
+from custom_components.thessla_green_modbus import binary_sensor, sensor  # noqa: E402
 
 SENSOR_MAP = {
     "outside_temperature": {
@@ -145,7 +145,8 @@ def test_force_full_register_list_integration():
         ), patch.dict(sensor.SENSOR_DEFINITIONS, SENSOR_MAP, clear=True), patch.dict(
             binary_sensor.BINARY_SENSOR_DEFINITIONS, BINARY_MAP, clear=True
         ), patch.dict(
-            sys.modules, {"custom_components.thessla_green_modbus.loader": MagicMock()}
+            sys.modules,
+            {"custom_components.thessla_green_modbus.registers.loader": MagicMock()},
         ), patch(
             "custom_components.thessla_green_modbus.services.async_setup_services",
             AsyncMock(),
@@ -188,7 +189,8 @@ def test_force_full_register_list_integration():
         ), patch.dict(sensor.SENSOR_DEFINITIONS, SENSOR_MAP, clear=True), patch.dict(
             binary_sensor.BINARY_SENSOR_DEFINITIONS, BINARY_MAP, clear=True
         ), patch.dict(
-            sys.modules, {"custom_components.thessla_green_modbus.loader": MagicMock()}
+            sys.modules,
+            {"custom_components.thessla_green_modbus.registers.loader": MagicMock()},
         ), patch(
             "custom_components.thessla_green_modbus.services.async_setup_services",
             AsyncMock(),

--- a/tests/test_full_register_list_option.py
+++ b/tests/test_full_register_list_option.py
@@ -12,7 +12,7 @@ from custom_components.thessla_green_modbus.const import (
 
 ha_const.STATE_UNAVAILABLE = "unavailable"
 
-from custom_components.thessla_green_modbus import async_setup_entry, sensor
+from custom_components.thessla_green_modbus import async_setup_entry, sensor  # noqa: E402
 
 # Minimal sensor definitions for testing
 SENSOR_MAP = {
@@ -119,7 +119,8 @@ async def _setup_entities(force: bool) -> set[str]:
         "custom_components.thessla_green_modbus._async_migrate_unique_ids",
         AsyncMock(),
     ), patch.dict(sensor.SENSOR_DEFINITIONS, SENSOR_MAP, clear=True), patch.dict(
-        sys.modules, {"custom_components.thessla_green_modbus.loader": MagicMock()}
+        sys.modules,
+        {"custom_components.thessla_green_modbus.registers.loader": MagicMock()},
     ), patch(
         "custom_components.thessla_green_modbus.services.async_setup_services",
         AsyncMock(),

--- a/tests/test_group_reads.py
+++ b/tests/test_group_reads.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import custom_components.thessla_green_modbus.registers.loader as loader
 from custom_components.thessla_green_modbus.modbus_helpers import group_reads
 from custom_components.thessla_green_modbus.registers.loader import (
     ReadPlan,
@@ -37,13 +36,19 @@ def test_group_reads_respects_max_block_size(size):
 
 def test_plan_group_reads_merges_consecutive_addresses(monkeypatch):
     regs = [Register("input", addr, f"r{addr}", "r") for addr in [0, 1, 2, 3, 10, 11, 12]]
-    monkeypatch.setattr(loader, "load_registers", lambda: regs)
+    monkeypatch.setattr(
+        "custom_components.thessla_green_modbus.registers.loader.load_registers",
+        lambda: regs,
+    )
     assert plan_group_reads() == [ReadPlan("input", 0, 4), ReadPlan("input", 10, 3)]
 
 
 def test_plan_group_reads_respects_max_block_size(monkeypatch):
     regs = [Register("input", addr, f"r{addr}", "r") for addr in range(22)]
-    monkeypatch.setattr(loader, "load_registers", lambda: regs)
+    monkeypatch.setattr(
+        "custom_components.thessla_green_modbus.registers.loader.load_registers",
+        lambda: regs,
+    )
     assert plan_group_reads(max_block_size=MAX_BATCH_REGISTERS) == [
         ReadPlan("input", 0, MAX_BATCH_REGISTERS),
         ReadPlan("input", MAX_BATCH_REGISTERS, 6),
@@ -53,7 +58,10 @@ def test_plan_group_reads_respects_max_block_size(monkeypatch):
 @pytest.mark.parametrize("size", [1, 4, MAX_BATCH_REGISTERS, 32])
 def test_plan_group_reads_varied_block_sizes(monkeypatch, size):
     regs = [Register("input", addr, f"r{addr}", "r") for addr in range(10)]
-    monkeypatch.setattr(loader, "load_registers", lambda: regs)
+    monkeypatch.setattr(
+        "custom_components.thessla_green_modbus.registers.loader.load_registers",
+        lambda: regs,
+    )
     addresses = [r.address for r in regs]
     expected = [
         ReadPlan("input", start, length)

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -2,18 +2,23 @@ import json
 import os
 from pathlib import Path
 
-import custom_components.thessla_green_modbus.registers.loader as loader
+from custom_components.thessla_green_modbus.registers.loader import (
+    _REGISTERS_PATH,
+    clear_cache,
+    load_registers,
+    registers_sha256,
+)
 
 
 def test_cache_invalidation_on_content_change(tmp_path: Path) -> None:
     """Changing file contents should invalidate the cache."""
 
     tmp_json = tmp_path / "registers.json"
-    tmp_json.write_text(loader._REGISTERS_PATH.read_text(), encoding="utf-8")
+    tmp_json.write_text(_REGISTERS_PATH.read_text(), encoding="utf-8")
 
-    loader.clear_cache()
-    first_hash = loader.registers_sha256(tmp_json)
-    first = loader.load_registers(tmp_json)[0]
+    clear_cache()
+    first_hash = registers_sha256(tmp_json)
+    first = load_registers(tmp_json)[0]
     assert first.description
     assert first_hash
 
@@ -21,26 +26,26 @@ def test_cache_invalidation_on_content_change(tmp_path: Path) -> None:
     data["registers"][0]["description"] = "changed description"
     tmp_json.write_text(json.dumps(data), encoding="utf-8")
 
-    second_hash = loader.registers_sha256(tmp_json)
-    updated = loader.load_registers(tmp_json)[0]
+    second_hash = registers_sha256(tmp_json)
+    updated = load_registers(tmp_json)[0]
     assert updated.description == "changed description"
     assert first_hash != second_hash
 
-    loader.clear_cache()
+    clear_cache()
 
 
 def test_cache_invalidation_on_mtime_change(tmp_path: Path) -> None:
     """Touching file without content change should reload registers."""
 
     tmp_json = tmp_path / "registers.json"
-    tmp_json.write_text(loader._REGISTERS_PATH.read_text(), encoding="utf-8")
+    tmp_json.write_text(_REGISTERS_PATH.read_text(), encoding="utf-8")
 
-    loader.clear_cache()
-    first_id = id(loader.load_registers(tmp_json))
+    clear_cache()
+    first_id = id(load_registers(tmp_json))
 
     os.utime(tmp_json, None)
 
-    second_id = id(loader.load_registers(tmp_json))
+    second_id = id(load_registers(tmp_json))
     assert first_id != second_id
 
-    loader.clear_cache()
+    clear_cache()


### PR DESCRIPTION
## Summary
- replace legacy loader paths with `custom_components.thessla_green_modbus.registers.loader`
- adjust tests to use direct imports from the loader module
- sort imports with `ruff`

## Testing
- `ruff check --fix .` *(fails: SyntaxError in custom_components/thessla_green_modbus/diagnostics.py)*
- `ruff check --fix tests/test_config_flow.py tests/test_force_full_register_list_integration.py tests/test_full_register_list_option.py tests/test_group_reads.py tests/test_register_cache_invalidation.py tests/test_register_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac045b610c8326a548cc9557c68e3f