### PR TITLE
feat: enhance register loader validation and caching

### DIFF
--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -198,6 +198,11 @@ class RegisterDefinition(pydantic.BaseModel):
                 else:
                     data["length"] = expected
 
+        if data.get("multiplier") is None:
+            data["multiplier"] = 1
+        if data.get("resolution") is None:
+            data["resolution"] = 1
+
         return data
 
     @pydantic.field_validator("function")
@@ -228,7 +233,7 @@ class RegisterDefinition(pydantic.BaseModel):
             elif self.length != expected:
                 raise ValueError("length does not match type")
 
-        if self.function in {1, 2} and self.access not in {"R", "R/-"}:
+        if self.function != 3 and self.access not in {"R", "R/-"}:
             raise ValueError("read-only functions must have R access")
 
         if self.enum is not None:


### PR DESCRIPTION
## Summary
- add register cache keyed by file hash and mtime
- default multiplier/resolution to 1 and validate access rules
- expose registers_sha256 and allow optional JSON path for register loading

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py custom_components/thessla_green_modbus/registers/schema.py` *(fails: command not found)*
- `pytest tests/test_register_loader.py tests/test_register_cache_invalidation.py tests/test_register_loader_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac045c7d7083268207a44bdafdd703