### PR TITLE
docs: remove csv references and refine register descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,11 +548,6 @@ pytest tests/test_register_loader.py
 
 4. Dołącz zmieniony plik JSON do commitu.
 
-> Obsługa plików CSV została całkowicie usunięta – definicje rejestrów muszą
-> znajdować się w pliku JSON i spełniać schemat
-> `custom_components/thessla_green_modbus/registers/schema.py`. Zweryfikuj
-> zmiany za pomocą `pytest tests/test_register_loader.py`.
-
 ## 📄 Licencja
 
 MIT License - Zobacz [LICENSE](LICENSE) dla szczegółów.

--- a/README_en.md
+++ b/README_en.md
@@ -326,11 +326,6 @@ Optional properties: `enum`, `multiplier`, `resolution`, `min`, `max`.
 pytest tests/test_register_loader.py
 ```
 
-> CSV register files are no longer supported – register definitions must be
-> provided as JSON and conform to
-> `custom_components/thessla_green_modbus/registers/schema.py`. Validate changes
-> using `pytest tests/test_register_loader.py`.
-
 ## 📄 License
 
 MIT License – see [LICENSE](LICENSE) for details.

--- a/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
+++ b/custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json
@@ -3462,7 +3462,7 @@
         "type": "string",
         "encoding": "ascii"
       },
-      "description_en": "Nazwa urządzenia"
+      "description_en": "Device name"
     },
     {
       "function": "03",
@@ -3481,7 +3481,7 @@
         "type": "u32",
         "endianness": "little"
       },
-      "description_en": "Klucz produktu użytkownika"
+      "description_en": "User product key"
     },
     {
       "function": "03",
@@ -3497,7 +3497,7 @@
       "multiplier": 1.0,
       "resolution": 1.0,
       "description": "Aktywacja blokady urządzenia",
-      "description_en": "Aktywacja blokady urządzenia"
+      "description_en": "Device lock activation"
     },
     {
       "function": "03",
@@ -4421,7 +4421,7 @@
         "type": "string",
         "encoding": "ascii"
       },
-      "description_en": "Numer seryjny sterownika"
+      "description_en": "Controller serial number"
     },
     {
       "function": "04",

--- a/docs/register_scanning.md
+++ b/docs/register_scanning.md
@@ -64,8 +64,3 @@ pytest tests/test_register_loader_validation.py::test_registers_match_pdf
 
 Jeżeli test zgłasza brakujące rejestry lub rozbieżności w atrybutach,
 należy zaktualizować plik JSON przed wysłaniem zmian.
-
-> Obsługa plików CSV została całkowicie usunięta — rejestry muszą być zapisane w
-> `custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json`
-> i spełniać schemat `registers/schema.py`. Zweryfikuj zmiany narzędziami i
-> testami opisanymi powyżej.


### PR DESCRIPTION
## Summary
- add English descriptions for serial_number, device_name and lock registers
- drop obsolete CSV guidance from documentation

## Testing
- `pre-commit run --files README.md README_en.md docs/register_scanning.md custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json` *(fails: InvalidManifestError)*
- `pytest tests/test_register_loader.py -q`
- `pytest tests/test_register_loader_validation.py::test_registers_match_pdf -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac045f6ea0832686ede65aff72fffd