### PR TITLE
Default missing scaling factors

### DIFF
--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -62,6 +62,25 @@ def test_enum_multiplier_resolution_handling() -> None:
     assert required.decode(45) == 22.5
 
 
+def test_default_multiplier_resolution(tmp_path) -> None:
+    """Omitted multiplier/resolution fields default to 1."""
+
+    reg = {
+        "function": "03",
+        "address_dec": 0,
+        "address_hex": "0x0000",
+        "name": "noscale",
+        "access": "R",
+    }
+
+    path = tmp_path / "regs.json"
+    path.write_text(json.dumps({"registers": [reg]}))
+
+    loaded = _load_registers_from_file(path, mtime=0, file_hash="")[0]
+    assert loaded.multiplier == 1
+    assert loaded.resolution == 1
+
+
 def test_multi_register_metadata() -> None:
     """Registers spanning multiple words expose length and type info."""
 


### PR DESCRIPTION
## Summary
- ensure registers without `multiplier` or `resolution` default to 1
- add regression test for implicit scaling
- tidy decode helper for type checking

## Testing
- `ruff check custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py`
- `mypy custom_components/thessla_green_modbus/registers/loader.py --follow-imports=skip`
- `pytest tests/test_register_loader.py::test_default_multiplier_resolution tests/test_register_loader.py::test_enum_multiplier_resolution_handling -q`
- `pre-commit run --files custom_components/thessla_green_modbus/registers/loader.py tests/test_register_loader.py` *(fails: InvalidManifestError: .../.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac09f8840083268b9743c0ba464dec