### PR TITLE
Translate Polish config descriptions

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -33,10 +33,10 @@
       "modbus_error": "Modbus communication error. Check wiring and settings.",
       "timeout": "Connection timed out. Verify host and port.",
       "unknown": "Unexpected error. Check logs for details.",
-      "max_registers_range": "Max registers per request must be between 1 and 16."
-      "timeout": "Device did not respond in time. Verify network connectivity and address.",
-      "unknown": "Unexpected error. Check logs for details."
-    },
+        "max_registers_range": "Max registers per request must be between 1 and 16.",
+        "timeout": "Device did not respond in time. Verify network connectivity and address.",
+        "unknown": "Unexpected error. Check logs for details."
+      },
     "step": {
       "confirm": {
         "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID: {slave_id}. Firmware version: {firmware_version}. Registers found: {register_count}. Scan success rate: {scan_success_rate}. Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Continue with this configuration?",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -33,10 +33,10 @@
       "modbus_error": "Modbus communication error. Check wiring and settings.",
       "timeout": "Connection timed out. Verify host and port.",
       "unknown": "Unexpected error. Check logs for details.",
-      "max_registers_range": "Max registers per request must be between 1 and 16."
-      "timeout": "Device did not respond in time. Verify network connectivity and address.",
-      "unknown": "Unexpected error. Check logs for details."
-    },
+        "max_registers_range": "Max registers per request must be between 1 and 16.",
+        "timeout": "Device did not respond in time. Verify network connectivity and address.",
+        "unknown": "Unexpected error. Check logs for details."
+      },
     "step": {
       "confirm": {
         "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID: {slave_id}. Firmware version: {firmware_version}. Registers found: {register_count}. Scan success rate: {scan_success_rate}. Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Continue with this configuration?",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -33,10 +33,10 @@
       "modbus_error": "Błąd komunikacji Modbus. Sprawdź okablowanie i ustawienia.",
       "timeout": "Przekroczono czas połączenia. Sprawdź host i port.",
       "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły.",
-      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1-16."
-      "timeout": "Urządzenie nie odpowiedziało na czas. Sprawdź połączenie sieciowe i adres.",
-      "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
-    },
+        "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1-16.",
+        "timeout": "Urządzenie nie odpowiedziało na czas. Sprawdź połączenie sieciowe i adres.",
+        "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
+      },
     "step": {
       "confirm": {
         "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia: {slave_id}. Wersja oprogramowania: {firmware_version}. Znalezione rejestry: {register_count}. Skuteczność skanowania: {scan_success_rate}. Możliwości ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Kontynuować z tą konfiguracją?",
@@ -53,10 +53,10 @@
           "max_registers_per_request": "Maksymalna liczba rejestrów na żądanie"
         },
         "data_description": {
-          "host": "IP address of the AirPack device on your local network",
-          "name": "Device name in Home Assistant",
-          "port": "Modbus TCP port (default 502)",
-          "slave_id": "Modbus device ID (default 10)",
+          "host": "Adres IP urządzenia AirPack w lokalnej sieci",
+          "name": "Nazwa urządzenia w Home Assistant",
+          "port": "Port Modbus TCP (domyślnie 502)",
+          "slave_id": "ID urządzenia Modbus (domyślnie 10)",
           "deep_scan": "Odczytaj wszystkie rejestry do diagnostyki (może być wolne)",
           "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-16)"
         },


### PR DESCRIPTION
## Summary
- localize configuration field descriptions in Polish
- fix JSON syntax in translation files

## Testing
- `pytest tests/test_translations.py`
- `python tools/check_translations.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac09e337208326868c110462df752e