### PR TITLE
Include effective batch in diagnostics output

### DIFF
--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -39,6 +39,7 @@ async def async_get_config_entry_diagnostics(
     coordinator: ThesslaGreenModbusCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     diagnostics = coordinator.get_diagnostic_data()
+    diagnostics.setdefault("effective_batch", coordinator.effective_batch)
     diagnostics.setdefault("registers_hash", registers_sha256(_REGISTERS_PATH))
     diagnostics.setdefault("capabilities", coordinator.capabilities.as_dict())
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -142,6 +142,7 @@ async def test_last_scan_in_diagnostics():
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
             self.deep_scan = False
             self.force_full_register_list = False
+            self.effective_batch = 0
 
         def get_diagnostic_data(self):
             return {}
@@ -182,7 +183,7 @@ async def test_additional_diagnostic_fields():
             self.effective_batch = 7
 
         def get_diagnostic_data(self):
-            return {"effective_batch": self.effective_batch}
+            return {}
 
     coord = DummyCoordinator()
     entry = SimpleNamespace(entry_id="test")
@@ -242,6 +243,7 @@ async def test_unknown_registers_in_diagnostics():
             self.unknown_registers = scan_result["unknown_registers"]
             self.deep_scan = False
             self.force_full_register_list = False
+            self.effective_batch = 0
 
         def get_diagnostic_data(self):
             return {}
@@ -288,6 +290,7 @@ async def test_raw_registers_in_diagnostics():
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
             self.deep_scan = False
             self.force_full_register_list = False
+            self.effective_batch = 0
 
         def get_diagnostic_data(self):
             return {}
@@ -330,6 +333,7 @@ async def test_diagnostics_json_serializable():
             )
             self.deep_scan = False
             self.force_full_register_list = False
+            self.effective_batch = 0
 
         def get_diagnostic_data(self):
             return {}
@@ -368,6 +372,7 @@ async def test_translation_failure_handled(caplog):
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
             self.deep_scan = False
             self.force_full_register_list = False
+            self.effective_batch = 0
 
         def get_diagnostic_data(self):
             return {}


### PR DESCRIPTION
## Summary
- include coordinator's effective batch in diagnostics data
- test diagnostics defaults when `effective_batch` is missing

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/diagnostics.py tests/test_diagnostics.py` *(fails: InvalidManifestError: `/root/.cache/pre-commit/repoz3egzut2/.pre-commit-hooks.yaml` is not a file)*
- `pytest tests/test_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac0e3612548326bb37d3847a4ceac5