### PR TITLE
Require register descriptions in schema and validation

### DIFF
--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -115,8 +115,8 @@ class RegisterDefinition(pydantic.BaseModel):
     enum: dict[str, Any] | None = None
     multiplier: float | None = None
     resolution: float | None = None
-    description: str | None = None
-    description_en: str | None = None
+    description: str = Field(min_length=1)
+    description_en: str = Field(min_length=1)
     min: float | None = None
     max: float | None = None
     default: float | None = None

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -106,6 +106,9 @@ def validate(path: Path) -> list[RegisterDefinition]:
     seen_pairs: set[tuple[int, int]] = set()
     seen_names: set[str] = set()
     for reg in parsed_list.root:
+        if not reg.description.strip() or not reg.description_en.strip():
+            raise ValueError(f"{reg.name}: missing description fields")
+
         # Function/access combinations
         if reg.function in {1, 2} and reg.access != "R":
             raise ValueError(f"{reg.name}: functions 1 and 2 must have R access")


### PR DESCRIPTION
## Summary
- Make `description` and `description_en` required for every register
- Validate that register descriptions are present and non-empty
- Test that loaders and validation scripts reject registers missing descriptions

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/registers/schema.py tools/validate_registers.py tests/test_register_loader.py tests/test_validate_registers.py` *(failed: InvalidManifestError: /root/.cache/pre-commit/repovv_wlbr1/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_register_loader.py tests/test_validate_registers.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac0e4384448326b2c0db83bd87da02