### PR TITLE
Remove stray translation error keys

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -35,12 +35,6 @@
       "timeout": "Device did not respond in time. Verify network connectivity and address.",
       "unknown": "Unexpected error. Check logs for details."
     },
-      "timeout": "Connection timed out. Verify host and port.",
-      "unknown": "Unexpected error. Check logs for details.",
-        "max_registers_range": "Max registers per request must be between 1 and 16.",
-        "timeout": "Device did not respond in time. Verify network connectivity and address.",
-        "unknown": "Unexpected error. Check logs for details."
-      },
     "step": {
       "confirm": {
         "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID: {slave_id}. Firmware version: {firmware_version}. Registers found: {register_count}. Scan success rate: {scan_success_rate}. Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Continue with this configuration?",

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -35,12 +35,6 @@
       "timeout": "Device did not respond in time. Verify network connectivity and address.",
       "unknown": "Unexpected error. Check logs for details."
     },
-      "timeout": "Connection timed out. Verify host and port.",
-      "unknown": "Unexpected error. Check logs for details.",
-        "max_registers_range": "Max registers per request must be between 1 and 16.",
-        "timeout": "Device did not respond in time. Verify network connectivity and address.",
-        "unknown": "Unexpected error. Check logs for details."
-      },
     "step": {
       "confirm": {
         "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID: {slave_id}. Firmware version: {firmware_version}. Registers found: {register_count}. Scan success rate: {scan_success_rate}. Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Continue with this configuration?",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -35,12 +35,6 @@
       "timeout": "Urządzenie nie odpowiedziało na czas. Sprawdź połączenie sieciowe i adres.",
       "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
     },
-      "timeout": "Przekroczono czas połączenia. Sprawdź host i port.",
-      "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły.",
-        "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1-16.",
-        "timeout": "Urządzenie nie odpowiedziało na czas. Sprawdź połączenie sieciowe i adres.",
-        "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
-      },
     "step": {
       "confirm": {
         "description": "Wykryto urządzenie ThesslaGreen {device_name} (numer seryjny {serial_number}) pod adresem {host}:{port}. ID urządzenia: {slave_id}. Wersja oprogramowania: {firmware_version}. Znalezione rejestry: {register_count}. Skuteczność skanowania: {scan_success_rate}. Możliwości ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Kontynuować z tą konfiguracją?",


### PR DESCRIPTION
## Summary
- remove duplicated timeout/unknown/max_registers_range keys from config error section
- keep translations and strings.json consistent

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/translations/en.json`
- `python -m json.tool custom_components/thessla_green_modbus/translations/pl.json`
- `python -m json.tool custom_components/thessla_green_modbus/strings.json`
- `python tools/check_translations.py`
- `pytest` *(fails: ImportError: cannot import name '_REGISTERS_PATH' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_68ac0e3010d883268733ffe8b20804d3