### PR TITLE
fix: consolidate duplicate error translations

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -35,12 +35,6 @@
       "timeout": "Device did not respond in time. Verify network connectivity and address.",
       "unknown": "Unexpected error. Check logs for details."
     },
-      "timeout": "Connection timed out. Verify host and port.",
-      "unknown": "Unexpected error. Check logs for details.",
-        "max_registers_range": "Max registers per request must be between 1 and 16.",
-        "timeout": "Device did not respond in time. Verify network connectivity and address.",
-        "unknown": "Unexpected error. Check logs for details."
-      },
     "step": {
       "confirm": {
         "description": "Detected ThesslaGreen device {device_name} (serial {serial_number}) at {host}:{port}. Device ID: {slave_id}. Firmware version: {firmware_version}. Registers found: {register_count}. Scan success rate: {scan_success_rate}. Capabilities ({capabilities_count}): {capabilities_list}. {auto_detected_note}. Continue with this configuration?",


### PR DESCRIPTION
## Summary
- remove duplicate error entries from strings.json

## Testing
- `python -m json.tool custom_components/thessla_green_modbus/strings.json`
- `pre-commit run --files custom_components/thessla_green_modbus/strings.json` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoxax2_tey/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: json.decoder.JSONDecodeError: Extra data: line 70 column 4 (char 3846))*

------
https://chatgpt.com/codex/tasks/task_e_68ac0e2dd7508326b2583e4efb1f9396