### PR TITLE
Use MAX_BATCH_REGISTERS for register grouping

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -508,8 +508,13 @@ class ReadPlan:
     length: int
 
 
-def plan_group_reads(max_block_size: int = 64) -> list[ReadPlan]:
+def plan_group_reads(max_block_size: int | None = None) -> list[ReadPlan]:
     """Group registers into contiguous blocks for efficient reading."""
+
+    if max_block_size is None:
+        from ..const import MAX_BATCH_REGISTERS
+
+        max_block_size = MAX_BATCH_REGISTERS
 
     regs_by_fn: dict[int, list[int]] = {}
     for reg in load_registers():

--- a/tests/test_group_reads.py
+++ b/tests/test_group_reads.py
@@ -49,7 +49,7 @@ def test_plan_group_reads_respects_max_block_size(monkeypatch):
         "custom_components.thessla_green_modbus.registers.loader.load_registers",
         lambda: regs,
     )
-    assert plan_group_reads(max_block_size=MAX_BATCH_REGISTERS) == [
+    assert plan_group_reads() == [
         ReadPlan("input", 0, MAX_BATCH_REGISTERS),
         ReadPlan("input", MAX_BATCH_REGISTERS, 6),
     ]

--- a/tests/test_register_grouping.py
+++ b/tests/test_register_grouping.py
@@ -53,8 +53,8 @@ def test_plan_group_reads_from_json():
     addresses: list[int] = []
     for reg in regs:
         addresses.extend(range(reg.address, reg.address + reg.length))
-    expected = group_reads(addresses, max_block_size=64)
-    plans = [p for p in plan_group_reads(max_block_size=64) if p.function == 4]
+    expected = group_reads(addresses, max_block_size=MAX_BATCH_REGISTERS)
+    plans = [p for p in plan_group_reads() if p.function == 4]
     assert [(p.address, p.length) for p in plans] == expected
 
 

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -18,7 +18,7 @@ sys.modules.setdefault("custom_components.thessla_green_modbus", pkg)
 
 # Provide a minimal const module required by modbus_helpers
 const_module = types.ModuleType("custom_components.thessla_green_modbus.const")
-const_module.MAX_BATCH_REGISTERS = 64
+const_module.MAX_BATCH_REGISTERS = 16
 sys.modules.setdefault("custom_components.thessla_green_modbus.const", const_module)
 
 from custom_components.thessla_green_modbus.registers.loader import (


### PR DESCRIPTION
## Summary
- default register grouping to `MAX_BATCH_REGISTERS`
- adjust register grouping tests for 16-register batch default

## Testing
- `pytest tests/test_group_reads.py tests/test_register_grouping.py tests/test_register_loader.py -q`
- `pytest -q` *(fails: cannot import name 'get_register_definition' ...; json.decoder.JSONDecodeError: Extra data: line 70 column 4 (char 4161))*

------
https://chatgpt.com/codex/tasks/task_e_68ac0e36fdec83268930709d8306f8d3