### PR TITLE
Use constant for batch size

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -163,12 +163,19 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if entry is not None:
             try:
                 self.effective_batch = min(
-                    int(entry.options.get(CONF_MAX_REGISTERS_PER_REQUEST, 16)), 16
+                    int(
+                        entry.options.get(
+                            CONF_MAX_REGISTERS_PER_REQUEST, MAX_BATCH_REGISTERS
+                        )
+                    ),
+                    MAX_BATCH_REGISTERS,
                 )
             except (TypeError, ValueError):
-                self.effective_batch = 16
+                self.effective_batch = MAX_BATCH_REGISTERS
         else:
-            self.effective_batch = min(int(max_registers_per_request), 16)
+            self.effective_batch = min(
+                int(max_registers_per_request), MAX_BATCH_REGISTERS
+            )
         if self.effective_batch < 1:
             self.effective_batch = 1
         self.max_registers_per_request = self.effective_batch

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.thessla_green_modbus.const import (
+    CONF_MAX_REGISTERS_PER_REQUEST,
     MAX_BATCH_REGISTERS,
     SENSOR_UNAVAILABLE,
     SENSOR_UNAVAILABLE_REGISTERS,
@@ -227,6 +228,25 @@ def coordinator():
     )
     coordinator.available_registers = available_registers
     return coordinator
+
+
+def test_coordinator_clamps_effective_batch():
+    """Coordinator clamps batch size to ``MAX_BATCH_REGISTERS``."""
+    hass = MagicMock()
+    entry = ConfigEntry(
+        data={},
+        options={CONF_MAX_REGISTERS_PER_REQUEST: MAX_BATCH_REGISTERS + 8},
+    )
+    coord = ThesslaGreenModbusCoordinator(
+        hass=hass,
+        host="localhost",
+        port=502,
+        slave_id=1,
+        name="test",
+        entry=entry,
+    )
+    assert coord.effective_batch == MAX_BATCH_REGISTERS
+    assert coord.max_registers_per_request == MAX_BATCH_REGISTERS
 
 
 @pytest.mark.asyncio

--- a/tests/test_group_reads_max_size.py
+++ b/tests/test_group_reads_max_size.py
@@ -33,3 +33,6 @@ def test_group_reads_respects_max_block_size(limit: int) -> None:
         assert groups == scanner._group_registers_for_batch_read(
             addresses, max_batch=MAX_BATCH_REGISTERS
         )
+
+    # The scanner itself clamps the requested batch size to ``MAX_BATCH_REGISTERS``.
+    assert scanner.effective_batch == min(limit, MAX_BATCH_REGISTERS)


### PR DESCRIPTION
## Summary
- replace magic number with MAX_BATCH_REGISTERS in coordinator
- add test coverage for batch-size clamping

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_coordinator.py::test_coordinator_clamps_effective_batch tests/test_group_reads_max_size.py::test_group_reads_respects_max_block_size -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ac128b80b0832681e0422d465a2274