### PR TITLE
Remove builtins.patch injection and import patch directly

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -8,14 +8,6 @@ from datetime import timedelta
 from importlib import import_module
 from typing import TYPE_CHECKING, cast
 
-# Provide ``patch`` from ``unittest.mock`` for test modules that use it without
-# importing. This mirrors the behaviour provided by the Home Assistant test
-# harness and keeps the standalone tests lightweight.
-import builtins
-from unittest.mock import patch as _patch
-
-builtins.patch = _patch
-
 try:  # Home Assistant may not be installed for external tooling
     from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 except ModuleNotFoundError:  # pragma: no cover - fallback for testing tools

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -3,7 +3,7 @@
 import sys
 import types
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 


### PR DESCRIPTION
## Summary
- remove global `builtins.patch` alias from integration init
- import `patch` explicitly in binary sensor tests

## Testing
- `python -m py_compile custom_components/thessla_green_modbus/__init__.py tests/test_binary_sensor.py`
- `pre-commit run --files custom_components/thessla_green_modbus/__init__.py tests/test_binary_sensor.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repo19qg7dc9/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 25 errors during collection)*
- `pytest tests/test_binary_sensor.py` *(fails: ModuleNotFoundError: No module named 'voluptuous')*

------
https://chatgpt.com/codex/tasks/task_e_68ac1bbe254c8326a162242f07eb81af