### PR TITLE
Add register map accessor and refactor entity platforms

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
         register_type = sensor_def["register_type"]
         register_name = sensor_def.get("register", key)
 
-        register_map = coordinator._register_maps.get(register_type, {})
+        register_map = coordinator.get_register_map(register_type)
         available = coordinator.available_registers.get(register_type, set())
         force_create = coordinator.force_full_register_list and register_name in register_map
 

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
 
     # Create climate entity if basic control is available or if the full
     # register list is forced and required registers exist in the map.
-    holding_map = coordinator._register_maps.get("holding_registers", {})
+    holding_map = coordinator.get_register_map("holding_registers")
     has_basic = coordinator.capabilities.basic_control or (
         coordinator.force_full_register_list and {"mode", "on_off_panel_mode"} <= holding_map.keys()
     )

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -241,6 +241,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_power_timestamp = dt_util.utcnow()
         self._total_energy = 0.0
 
+    def get_register_map(self, register_type: str) -> dict[str, int]:
+        """Return the register map for the given register type."""
+        return self._register_maps.get(register_type, {})
+
     async def _call_modbus(
         self, func: Callable[..., Any], *args: Any, attempt: int = 1, **kwargs: Any
     ) -> Any:

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
 
     # Create number entities for discovered registers, or all known registers
     # when ``force_full_register_list`` is enabled.
-    holding_map = coordinator._register_maps.get("holding_registers", {})
+    holding_map = coordinator.get_register_map("holding_registers")
     available = coordinator.available_registers.get("holding_registers", set())
 
     for register_name, entity_config in number_mappings.items():
@@ -108,7 +108,7 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
         register_type: str | None = None,
     ) -> None:
         """Initialize the number entity."""
-        register_map = coordinator._register_maps.get("holding_registers", {})
+        register_map = coordinator.get_register_map("holding_registers")
         if register_name not in register_map:
             raise KeyError(f"Register {register_name} not found in holding registers")
         address = register_map[register_name]

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
     # ``force_full_register_list`` is enabled.
     for register_name, select_def in ENTITY_MAPPINGS["select"].items():
         register_type = select_def["register_type"]
-        register_map = coordinator._register_maps.get(register_type, {})
+        register_map = coordinator.get_register_map(register_type)
         available = coordinator.available_registers.get(register_type, set())
         force_create = coordinator.force_full_register_list and register_name in register_map
         if register_name in available or force_create:

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
         register_type = sensor_def["register_type"]
         is_temp = sensor_def.get("device_class") == SensorDeviceClass.TEMPERATURE
 
-        register_map = coordinator._register_maps.get(register_type, {})
+        register_map = coordinator.get_register_map(register_type)
         available = coordinator.available_registers.get(register_type, set())
         force_create = coordinator.force_full_register_list and register_name in register_map
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,6 +396,10 @@ DOMAIN = "thessla_green_modbus"
 class CoordinatorMock(MagicMock):
     """MagicMock subclass with device_scan_result property."""
 
+    def get_register_map(self, register_type: str) -> dict[str, int]:
+        """Return register map for the given type."""
+        return self._register_maps.get(register_type, {})
+
     @property
     def device_scan_result(self):  # type: ignore[override]
         return {

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -101,6 +101,9 @@ class ThesslaGreenModbusCoordinator:  # pragma: no cover - simple stub
         self.slave_id = args[3] if len(args) > 3 else kwargs.get("slave_id", 0)
         self._register_maps = {"holding_registers": HOLDING_REGISTERS}
 
+    def get_register_map(self, register_type: str) -> dict[str, int]:
+        return self._register_maps.get(register_type, {})
+
     async def _ensure_connection(self):
         return None
 


### PR DESCRIPTION
## Summary
- expose register maps via `ThesslaGreenModbusCoordinator.get_register_map`
- use `get_register_map` in sensor, binary_sensor, select, number and climate platforms
- update tests and fixtures for new accessor

## Testing
- `pytest tests/test_sensor_platform.py::test_force_full_register_list_adds_missing_entities tests/test_binary_sensor.py::test_async_setup_creates_all_binary_sensors tests/test_number.py::test_async_setup_creates_new_numbers tests/test_select.py::test_select_creation_and_state tests/test_climate.py::test_target_temperature_none_when_unavailable -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac1bc05294832682eb7af241a6973e