### PR TITLE
Use debug level for normal entity setup logs

### DIFF
--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -78,7 +78,7 @@ async def async_setup_entry(
             )
             async_add_entities(entities, False)
             return
-        _LOGGER.info(
+        _LOGGER.debug(
             "Created %d binary sensor entities for %s", len(entities), coordinator.device_name
         )
     else:

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
             _LOGGER.warning("Cancelled while adding climate entity, retrying without initial state")
             async_add_entities(entities, False)
             return
-        _LOGGER.info("Climate entity created for %s", coordinator.device_name)
+        _LOGGER.debug("Climate entity created for %s", coordinator.device_name)
     else:
         _LOGGER.warning("Basic control not available, climate entity not created")
 

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -71,7 +71,7 @@ async def async_setup_entry(
             _LOGGER.warning("Cancelled while adding fan entity, retrying without initial state")
             async_add_entities(entities, False)
             return
-        _LOGGER.info("Added fan entity")
+        _LOGGER.debug("Added fan entity")
     else:
         _LOGGER.debug("No fan control registers available - skipping fan entity")
 
@@ -170,7 +170,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                 # Default to 50% if no percentage specified
                 await self.async_set_percentage(50)
 
-            _LOGGER.info("Turned on fan")
+            _LOGGER.debug("Turned on fan")
 
         except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to turn on fan: %s", exc)
@@ -196,7 +196,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                     await self._write_register(register, 0)
                     self.coordinator.data[register] = 0
 
-            _LOGGER.info("Turned off fan")
+            _LOGGER.debug("Turned off fan")
 
         except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to turn off fan: %s", exc)
@@ -211,7 +211,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         try:
             if percentage == 0:
                 await self.async_turn_off()
-                _LOGGER.info("Set fan speed to 0%")
+                _LOGGER.debug("Set fan speed to 0%")
                 return
 
             # Ensure minimum flow rate (ThesslaGreen typically requires 10% minimum)
@@ -238,7 +238,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                 ):
                     await self._write_register("air_flow_rate_temporary_2", actual_percentage)
 
-            _LOGGER.info("Set fan speed to %d%%", actual_percentage)
+            _LOGGER.debug("Set fan speed to %d%%", actual_percentage)
 
         except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to set fan speed to %d%%: %s", percentage, exc)

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
             )
             async_add_entities(entities, False)
             return
-        _LOGGER.info("Added %d number entities", len(entities))
+        _LOGGER.debug("Added %d number entities", len(entities))
     else:
         _LOGGER.debug("No number entities were created")
 
@@ -199,7 +199,7 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
             )
             if success:
                 await self.coordinator.async_request_refresh()
-                _LOGGER.info("Set %s to %.2f", self.register_name, value)
+                _LOGGER.debug("Set %s to %.2f", self.register_name, value)
             else:
                 _LOGGER.error("Failed to set %s to %.2f", self.register_name, value)
                 raise RuntimeError(f"Failed to write register {self.register_name}")

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -57,7 +57,7 @@ async def async_setup_entry(
             )
             async_add_entities(entities, False)
             return
-        _LOGGER.info("Created %d select entities", len(entities))
+        _LOGGER.debug("Created %d select entities", len(entities))
 
 
 class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
         except asyncio.CancelledError:
             _LOGGER.warning("Entity addition cancelled, adding without initial update")
             async_add_entities(entities, False)
-        _LOGGER.info(
+        _LOGGER.debug(
             "Created %d sensor entities for %s",
             len(entities),
             coordinator.device_name,
@@ -96,7 +96,7 @@ async def async_setup_entry(
     else:
         _LOGGER.warning("No sensor entities created - no compatible registers found")
 
-    _LOGGER.info(
+    _LOGGER.debug(
         "Temperature sensors: %d instantiated, %d skipped",
         temp_created,
         temp_skipped,

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
             )
             async_add_entities(entities, False)
             return
-        _LOGGER.info("Added %d switch entities", len(entities))
+        _LOGGER.debug("Added %d switch entities", len(entities))
     else:
         _LOGGER.debug("No switch entities were created")
 
@@ -155,7 +155,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
             else:
                 value = 1
             await self._write_register(self.register_name, value)
-            _LOGGER.info("Turned on %s", self.register_name)
+            _LOGGER.debug("Turned on %s", self.register_name)
 
         except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to turn on %s: %s", self.register_name, exc)
@@ -170,7 +170,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
             else:
                 value = 0
             await self._write_register(self.register_name, value)
-            _LOGGER.info("Turned off %s", self.register_name)
+            _LOGGER.debug("Turned off %s", self.register_name)
 
         except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to turn off %s: %s", self.register_name, exc)


### PR DESCRIPTION
## Summary
- reduce normal entity setup logging from `info` to `debug` across entity platforms

## Testing
- `pytest tests/test_logging.py -q`
- `pytest tests/test_sensor_platform.py::test_force_full_register_list_adds_missing_entities --log-cli-level DEBUG -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac1bc2f8a48326acc69ca35ba0259e