### PR TITLE
Guard builtins patch in ThesslaGreen integration

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -14,7 +14,9 @@ from typing import TYPE_CHECKING, cast
 import builtins
 from unittest.mock import patch as _patch
 
-builtins.patch = _patch
+# Only provide ``patch`` if it hasn't already been supplied by the test harness
+if not hasattr(builtins, "patch"):
+    builtins.patch = _patch
 
 try:  # Home Assistant may not be installed for external tooling
     from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT


### PR DESCRIPTION
## Summary
- Avoid unconditionally assigning `patch` into `builtins` in integration init
- Provide `patch` only if it hasn't already been supplied by the test harness

## Testing
- `pytest tests/test_number.py tests/test_register_loader.py`
- `pytest` *(fails: ImportError: cannot import name 'get_register_definition' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_68ac1bcab8848326b1a53911f9ef00b3