### PR TITLE
Refactor register maps to lazy cached access

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -17,17 +17,11 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.thessla_green_modbus.registers.loader import (
-    get_registers_by_function,
-)
-
-from .const import DOMAIN, SPECIAL_FUNCTION_MAP
+from .const import DOMAIN, SPECIAL_FUNCTION_MAP, holding_registers
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 
 _LOGGER = logging.getLogger(__name__)
-
-HOLDING_REGISTERS = {r.name for r in get_registers_by_function("03")}
 
 # HVAC mode mappings (from device mode register)
 HVAC_MODE_MAP = {
@@ -319,7 +313,7 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
         _LOGGER.debug("Setting target temperature to %s°C", temperature)
 
         success = True
-        if "comfort_temperature" in HOLDING_REGISTERS:
+        if "comfort_temperature" in holding_registers():
             success = await self.coordinator.async_write_register(
                 "comfort_temperature", temperature, refresh=False
             )

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -80,7 +80,6 @@ from pymodbus.client import AsyncModbusTcpClient
 
 from custom_components.thessla_green_modbus.registers.loader import (
     get_all_registers,
-    get_registers_by_function,
 )
 
 from .config_flow import CannotConnect
@@ -95,6 +94,10 @@ from .const import (
     MAX_BATCH_REGISTERS,
     SENSOR_UNAVAILABLE,
     UNKNOWN_MODEL,
+    coil_registers,
+    discrete_input_registers,
+    holding_registers,
+    input_registers,
 )
 from .modbus_helpers import _call_modbus, group_reads
 from .scanner_core import DeviceCapabilities, ThesslaGreenDeviceScanner
@@ -204,10 +207,10 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         }
         # Register maps and reverse lookup maps
         self._register_maps = {
-            "input_registers": {r.name: r.address for r in get_registers_by_function("04")},
-            "holding_registers": {r.name: r.address for r in get_registers_by_function("03")},
-            "coil_registers": {r.name: r.address for r in get_registers_by_function("01")},
-            "discrete_inputs": {r.name: r.address for r in get_registers_by_function("02")},
+            "input_registers": input_registers().copy(),
+            "holding_registers": holding_registers().copy(),
+            "coil_registers": coil_registers().copy(),
+            "discrete_inputs": discrete_input_registers().copy(),
         }
         self._reverse_maps = {
             key: {addr: name for name, addr in mapping.items()}
@@ -468,7 +471,7 @@ class ThesslaGreenModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             try:
                 await self._ensure_connection()
 
-                test_addresses = [reg.address for reg in get_registers_by_function("04")][:3]
+                test_addresses = list(input_registers().values())[:3]
 
                 for addr in test_addresses:
                     response = await self.client.read_input_registers(

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -85,9 +85,9 @@ from custom_components.thessla_green_modbus.registers.loader import (
 )
 
 from .const import (
-    COIL_REGISTERS,
-    DISCRETE_INPUT_REGISTERS,
-    HOLDING_REGISTERS,
+    coil_registers,
+    discrete_input_registers,
+    holding_registers,
     SPECIAL_FUNCTION_MAP,
 )
 from .utils import _to_snake_case
@@ -328,14 +328,14 @@ def _load_discrete_mappings() -> tuple[
     select_keys = translations["select"]
 
     # Coil and discrete input registers are always binary sensors
-    for reg in COIL_REGISTERS:
+    for reg in coil_registers():
         if reg not in binary_keys:
             continue
         binary_configs[reg] = {
             "translation_key": reg,
             "register_type": "coil_registers",
         }
-    for reg in DISCRETE_INPUT_REGISTERS:
+    for reg in discrete_input_registers():
         if reg not in binary_keys:
             continue
         binary_configs[reg] = {
@@ -344,7 +344,7 @@ def _load_discrete_mappings() -> tuple[
         }
 
     # Holding registers with enumerated states
-    for reg in HOLDING_REGISTERS:
+    for reg in holding_registers():
         info = _get_register_info(reg)
         if not info:
             continue
@@ -373,10 +373,10 @@ def _load_discrete_mappings() -> tuple[
     # any previously generated switch/select configurations.
     diag_registers = {"alarm", "error"}
     diag_registers.update(
-        reg for reg in HOLDING_REGISTERS if re.match(r"[se](?:_|\d)", reg)
+        reg for reg in holding_registers() if re.match(r"[se](?:_|\d)", reg)
     )
     for reg in diag_registers:
-        if reg not in HOLDING_REGISTERS and reg not in {"alarm", "error"}:
+        if reg not in holding_registers() and reg not in {"alarm", "error"}:
             continue
         if reg not in binary_keys:
             continue

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -11,22 +11,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.thessla_green_modbus.registers.loader import (
-    get_registers_by_function,
-)
-
-from .const import DOMAIN
+from .const import DOMAIN, coil_registers, holding_registers
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity
 from .entity_mappings import ENTITY_MAPPINGS
 from .modbus_exceptions import ConnectionException, ModbusException
 
 _LOGGER = logging.getLogger(__name__)
-
-# Register address lookups for modbus writes
-HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
-COIL_REGISTERS = {r.name: r.address for r in get_registers_by_function("01")}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -43,6 +34,8 @@ async def async_setup_entry(
 
     # Create switch entities only for writable registers discovered by
     # ThesslaGreenDeviceScanner.scan_device()
+    holding_map = holding_registers()
+    coil_map = coil_registers()
     for key, config in ENTITY_MAPPINGS["switch"].items():
         register_name = config["register"]
 
@@ -52,19 +45,20 @@ async def async_setup_entry(
         if config["register_type"] == "holding_registers":
             if register_name in coordinator.available_registers.get("holding_registers", set()):
                 is_available = True
-            elif coordinator.force_full_register_list and register_name in HOLDING_REGISTERS:
+            elif coordinator.force_full_register_list and register_name in holding_map:
                 is_available = True
         elif config["register_type"] == "coil_registers":
             if register_name in coordinator.available_registers.get("coil_registers", set()):
                 is_available = True
-            elif coordinator.force_full_register_list and register_name in COIL_REGISTERS:
+            elif coordinator.force_full_register_list and register_name in coil_map:
                 is_available = True
 
         if is_available:
-            if config["register_type"] == "holding_registers":
-                address = HOLDING_REGISTERS[register_name]
-            else:
-                address = COIL_REGISTERS[register_name]
+            address = (
+                holding_map[register_name]
+                if config["register_type"] == "holding_registers"
+                else coil_map[register_name]
+            )
             entities.append(
                 ThesslaGreenSwitch(
                     coordinator=coordinator,
@@ -107,11 +101,6 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
     ) -> None:
         """Initialize the switch entity."""
         register_name = entity_config["register"]
-        register_type = entity_config["register_type"]
-        if register_type == "holding_registers":
-            address = HOLDING_REGISTERS.get(register_name, 0)
-        else:
-            address = COIL_REGISTERS.get(register_name, 0)
         super().__init__(coordinator, key, address, bit=entity_config.get("bit"))
 
         self.entity_config = entity_config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -439,10 +439,10 @@ def mock_config_entry():
 def mock_coordinator():
     """Return a mock coordinator."""
     from custom_components.thessla_green_modbus.const import (
-        COIL_REGISTERS,
-        DISCRETE_INPUT_REGISTERS,
-        HOLDING_REGISTERS,
-        INPUT_REGISTERS,
+        coil_registers,
+        discrete_input_registers,
+        holding_registers,
+        input_registers,
     )
 
     coordinator = CoordinatorMock()
@@ -478,10 +478,10 @@ def mock_coordinator():
         "calculated": {"estimated_power", "total_energy"},
     }
     coordinator._register_maps = {
-        "input_registers": INPUT_REGISTERS,
-        "holding_registers": HOLDING_REGISTERS,
-        "coil_registers": COIL_REGISTERS,
-        "discrete_inputs": DISCRETE_INPUT_REGISTERS,
+        "input_registers": input_registers(),
+        "holding_registers": holding_registers(),
+        "coil_registers": coil_registers(),
+        "discrete_inputs": discrete_input_registers(),
     }
     coordinator.force_full_register_list = False
     coordinator.async_write_register = AsyncMock(return_value=True)

--- a/tests/test_optimized_integration.py
+++ b/tests/test_optimized_integration.py
@@ -12,10 +12,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from custom_components.thessla_green_modbus.const import (
-    COIL_REGISTERS,
-    DISCRETE_INPUT_REGISTERS,
-    HOLDING_REGISTERS,
-    INPUT_REGISTERS,
+    coil_registers,
+    discrete_input_registers,
+    holding_registers,
+    input_registers,
     SENSOR_UNAVAILABLE,
 )
 
@@ -131,10 +131,10 @@ class TestThesslaGreenIntegration:
             "discrete_inputs": {"expansion", "contamination_sensor"},
         }
         coordinator._register_maps = {
-            "input_registers": INPUT_REGISTERS,
-            "holding_registers": HOLDING_REGISTERS,
-            "coil_registers": COIL_REGISTERS,
-            "discrete_inputs": DISCRETE_INPUT_REGISTERS,
+            "input_registers": input_registers(),
+            "holding_registers": holding_registers(),
+            "coil_registers": coil_registers(),
+            "discrete_inputs": discrete_input_registers(),
         }
 
         return coordinator
@@ -591,10 +591,10 @@ class TestThesslaGreenClimate:
         }
         coordinator.async_write_register = AsyncMock(return_value=True)
         coordinator._register_maps = {
-            "input_registers": INPUT_REGISTERS,
-            "holding_registers": HOLDING_REGISTERS,
-            "coil_registers": COIL_REGISTERS,
-            "discrete_inputs": DISCRETE_INPUT_REGISTERS,
+            "input_registers": input_registers(),
+            "holding_registers": holding_registers(),
+            "coil_registers": coil_registers(),
+            "discrete_inputs": discrete_input_registers(),
         }
         coordinator.async_request_refresh = AsyncMock()
         return coordinator


### PR DESCRIPTION
## Summary
- refactor register maps to load lazily with caching
- update entities and coordinator to request cached register maps
- adjust tests for new lazy interface

## Testing
- `pip install pre-commit`
- `pre-commit run --files custom_components/thessla_green_modbus/const.py custom_components/thessla_green_modbus/entity_mappings.py custom_components/thessla_green_modbus/fan.py custom_components/thessla_green_modbus/climate.py custom_components/thessla_green_modbus/switch.py custom_components/thessla_green_modbus/coordinator.py tests/conftest.py tests/test_optimized_integration.py` *(failed: InvalidManifestError: /root/.cache/pre-commit/repo426rk_rn/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1bcd204c8326bf74d01a73f00927