### PR TITLE
refactor: centralize register JSON path

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -40,6 +40,12 @@ _LOGGER = logging.getLogger(__name__)
 _REGISTERS_PATH = Path(
     str(resources.files(__package__).joinpath("thessla_green_registers_full.json"))
 )
+
+
+def get_registers_path() -> Path:
+    """Return resolved path to the bundled register definitions JSON file."""
+    return _REGISTERS_PATH.resolve()
+
 # Cache for file metadata keyed by path. Each entry stores ``(mtime, sha256)``
 # for the most recently seen state of that file.  A second cache keyed by
 # ``(sha256, mtime)`` stores the parsed register definitions so repeated loads of

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -10,8 +10,8 @@ from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Optional, Self, Tuple, cast
 
 from custom_components.thessla_green_modbus.registers.loader import (
-    _REGISTERS_PATH,
     get_all_registers,
+    get_registers_path,
     registers_sha256,
 )
 
@@ -58,7 +58,7 @@ def _build_register_maps() -> None:
     """Populate register lookup maps from current register definitions."""
     global REGISTER_HASH
     regs = get_all_registers()
-    REGISTER_HASH = registers_sha256(_REGISTERS_PATH)
+    REGISTER_HASH = registers_sha256(get_registers_path())
 
     REGISTER_DEFINITIONS.clear()
     REGISTER_DEFINITIONS.update({r.name: r for r in regs})
@@ -96,7 +96,7 @@ def _build_register_maps() -> None:
 # Ensure register lookup maps are available before use
 def _ensure_register_maps() -> None:
     """Ensure register lookup maps are populated."""
-    current_hash = registers_sha256(_REGISTERS_PATH)
+    current_hash = registers_sha256(get_registers_path())
     if not REGISTER_DEFINITIONS or current_hash != REGISTER_HASH:
         _build_register_maps()
 


### PR DESCRIPTION
## Summary
- add `get_registers_path` helper for register definitions
- use `get_registers_path` in scanner core instead of accessing `_REGISTERS_PATH` directly

## Testing
- `pytest` *(fails: ImportError cannot import name 'get_register_definition' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_68ac1bcea8a88326bf569fc085f9d939