### PR TITLE
refactor: use relative imports within package

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ urządzenie – używaj jej tylko do diagnostyki.
 Funkcja `group_reads` dzieli listę adresów na ciągłe bloki ograniczone parametrem `max_block_size` (domyślnie 16). Własne skrypty powinny z niej korzystać, aby minimalizować liczbę zapytań i nie przekraczać zalecanego rozmiaru bloku.
 
 ```python
-from custom_components.thessla_green_modbus.modbus_helpers import group_reads
+from .modbus_helpers import group_reads
 
 for start, size in group_reads(range(100), max_block_size=16):
     print(start, size)

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -17,7 +17,7 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.thessla_green_modbus.registers.loader import (
+from .registers.loader import (
     get_registers_by_function,
 )
 

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, cast
 
-from custom_components.thessla_green_modbus.registers.loader import (
+from .registers.loader import (
     get_registers_by_function,
 )
 

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -78,7 +78,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 from pymodbus.client import AsyncModbusTcpClient
 
-from custom_components.thessla_green_modbus.registers.loader import (
+from .registers.loader import (
     get_all_registers,
     get_registers_by_function,
 )

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import translation
 
-from custom_components.thessla_green_modbus.registers.loader import (
+from .registers.loader import (
     _REGISTERS_PATH,
     get_all_registers,
     registers_sha256,

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -80,7 +80,7 @@ try:  # pragma: no cover - fallback for tests without full HA constants
 except (ModuleNotFoundError, ImportError):  # pragma: no cover - executed only in tests
     PERCENTAGE = "%"
 
-from custom_components.thessla_green_modbus.registers.loader import (
+from .registers.loader import (
     get_all_registers,
 )
 

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -15,7 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.thessla_green_modbus.registers.loader import (
+from .registers.loader import (
     get_registers_by_function,
 )
 

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -9,7 +9,7 @@ import logging
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Optional, Self, Tuple, cast
 
-from custom_components.thessla_green_modbus.registers.loader import (
+from .registers.loader import (
     _REGISTERS_PATH,
     get_all_registers,
     registers_sha256,

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.thessla_green_modbus.registers.loader import (
+from .registers.loader import (
     get_registers_by_function,
 )
 

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import pydantic
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from custom_components.thessla_green_modbus.registers.schema import (
+    from ..custom_components.thessla_green_modbus.registers.schema import (
         RegisterDefinition,
     )
 
@@ -51,7 +51,7 @@ def _coerce_registers(registers: list[dict]) -> list[dict]:
     same coercion here before handing off to the pydantic models.
     """
 
-    from custom_components.thessla_green_modbus.registers.schema import (
+    from ..custom_components.thessla_green_modbus.registers.schema import (
         _normalise_function,
     )
 
@@ -85,7 +85,7 @@ def validate(path: Path) -> list[RegisterDefinition]:
     """Validate ``path`` and return the parsed register definitions."""
 
     _prepare_environment()
-    from custom_components.thessla_green_modbus.registers.schema import (
+    from ..custom_components.thessla_green_modbus.registers.schema import (
         _TYPE_LENGTHS,
         RegisterList,
         RegisterType,
@@ -173,7 +173,7 @@ def main(path: Path | None = None) -> int:
     """Validate registers file, exiting with ``1`` on error."""
 
     _prepare_environment()
-    from custom_components.thessla_green_modbus.registers.loader import (
+    from ..custom_components.thessla_green_modbus.registers.loader import (
         _REGISTERS_PATH,
     )
 


### PR DESCRIPTION
## Summary
- refactor internal modules to use relative imports
- update validator script and README example to match new import style

## Testing
- `pytest tests/test_backoff.py -q`
- `pytest tests/test_modbus_helpers.py -q`
- `pytest tests/test_switch.py -q` *(fails: AssertionError, KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1bd5210c832686c82aab9eee1ac1