### PR TITLE
Add test verifying register loader count matches JSON

### DIFF
--- a/tests/test_register_count.py
+++ b/tests/test_register_count.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from custom_components.thessla_green_modbus.registers.loader import get_all_registers
+from custom_components.thessla_green_modbus.utils import _normalise_name
+
+
+def test_get_all_registers_matches_json() -> None:
+    """Loader should return same number of registers as JSON file."""
+    json_path = Path(
+        "custom_components/thessla_green_modbus/registers/thessla_green_registers_full.json"
+    )
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    registers = data.get("registers", data)
+
+    loaded = get_all_registers(json_path)
+    assert len(loaded) == len(registers)
+
+    json_names = {_normalise_name(r["name"]) for r in registers if r.get("name")}
+    loaded_names = {r.name for r in loaded if r.name}
+    assert json_names == loaded_names


### PR DESCRIPTION
## Summary
- test that `get_all_registers` returns same number of registers as `thessla_green_registers_full.json`
- verify register names normalise to match JSON entries

## Testing
- `pytest tests/test_register_count.py`
- `pre-commit run --files tests/test_register_count.py` *(fails: InvalidManifestError: .pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1bd6e53c83268fe04b1364bc1bad