### PR TITLE
Fix register loader imports

### DIFF
--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -10,8 +10,6 @@ from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Optional, Self, Tuple, cast
 
 from .registers.loader import (
-    _REGISTERS_PATH,
-from custom_components.thessla_green_modbus.registers.loader import (
     get_all_registers,
     get_registers_path,
     registers_sha256,


### PR DESCRIPTION
## Summary
- fix register loader imports

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/scanner_core.py` *(fails: InvalidManifestError: .../.pre-commit-hooks.yaml is not a file)*
- `pytest -q` *(fails: Interrupted: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ae138d5a348326b4d3013b770c9a7f