### PR TITLE
refactor: remove unused register loader import

### DIFF
--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -11,10 +11,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .registers.loader import (
-    get_registers_by_function,
-)
-
 from .const import DOMAIN, coil_registers, holding_registers
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity


### PR DESCRIPTION
## Summary
- clean up switch platform import by dropping unused `get_registers_by_function`

## Testing
- `python tools/py_compile_all.py` (fails: syntax error in scanner_core.py)
- `pre-commit run --files custom_components/thessla_green_modbus/switch.py` (fails: InvalidManifestError: repo `/root/.cache/pre-commit/repok72jz3pf/.pre-commit-hooks.yaml` is not a file)
- `python -m pytest tests` (fails: multiple ImportErrors including missing `pydantic` and syntax error in `scanner_core.py`)


------
https://chatgpt.com/codex/tasks/task_e_68ae138c4d3c832688db05e30857aeaa