### PR TITLE
chore: remove unused import from fan module

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -14,9 +14,6 @@ from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from .registers.loader import (
-    get_registers_by_function,
-)
 
 from .const import DOMAIN, holding_registers
 from .coordinator import ThesslaGreenModbusCoordinator


### PR DESCRIPTION
## Summary
- remove unused get_registers_by_function import from fan module

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/fan.py` *(fails: InvalidManifestError for Home Assistant hooks)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68ae138be2308326b10cf7283dc41859