### PR TITLE
chore: remove unused loader import from climate entity

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -17,10 +17,6 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .registers.loader import (
-    get_registers_by_function,
-)
-
 from .const import DOMAIN, SPECIAL_FUNCTION_MAP, holding_registers
 from .coordinator import ThesslaGreenModbusCoordinator
 from .entity import ThesslaGreenEntity


### PR DESCRIPTION
## Summary
- remove unused `get_registers_by_function` import from climate entity

## Testing
- `ruff check custom_components/thessla_green_modbus/climate.py`
- `pre-commit run --files custom_components/thessla_green_modbus/climate.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/reposeks6emp/.pre-commit-hooks.yaml is not a file)*
- `pytest tests/test_climate.py` *(fails: SyntaxError: '(' was never closed in scanner_core.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ae138abee083269ed4f11504c28022