### PR TITLE
Remove redundant target temperature lookups

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -164,15 +164,6 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
             value = data.get(key)
             if isinstance(value, (int, float)):
                 return float(value)
-
-        value = data.get("comfort_temperature")
-        if isinstance(value, (int, float)):
-            return float(value)
-
-        value = data.get("required_temperature")
-        if isinstance(value, (int, float)):
-            return float(value)
-
         return None
 
     @property


### PR DESCRIPTION
## Summary
- Simplify target temperature retrieval by removing duplicate post-loop lookups

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/climate.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repop0m6gjlx/.pre-commit-hooks.yaml is not a file)*
- `pytest` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ae138a3e148326b773bd31cfa37bc9