### PR TITLE
Remove duplicate HVAC power-on write

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -277,9 +277,6 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
                 "on_off_panel_mode", 0, refresh=False
             )
         else:
-
-            await self.coordinator.async_write_register("on_off_panel_mode", 1, refresh=False)
-
             # Turn on device first and capture result
             power_on_success = await self.coordinator.async_write_register(
                 "on_off_panel_mode", 1, refresh=False


### PR DESCRIPTION
## Summary
- remove extra on_off_panel_mode write when enabling HVAC

## Testing
- `pre-commit run --files custom_components/thessla_green_modbus/climate.py` (fails: InvalidManifestError, /root/.cache/pre-commit/repok1bercv3/.pre-commit-hooks.yaml is not a file)
- `pytest` (fails: ImportError: cannot import name 'AliasChoices' from 'pydantic'; SyntaxError in scanner_core.py)


------
https://chatgpt.com/codex/tasks/task_e_68ae1389660c8326bcee97618653d189