### PR TITLE
Refactor mappings module into submodules with dedicated loaders

### DIFF
--- a/custom_components/thessla_green_modbus/_scanner_capabilities_mixin.py
+++ b/custom_components/thessla_green_modbus/_scanner_capabilities_mixin.py
@@ -1,0 +1,262 @@
+"""Capabilities analysis mixin for ThesslaGreenDeviceScanner."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .capability_rules import CAPABILITY_PATTERNS
+from .const import SENSOR_UNAVAILABLE, SENSOR_UNAVAILABLE_REGISTERS
+from .scanner_device_info import DeviceCapabilities, ScannerDeviceInfo
+from .scanner_helpers import REGISTER_ALLOWED_VALUES
+from .scanner_register_maps import (
+    HOLDING_REGISTERS,
+    INPUT_REGISTERS,
+    REGISTER_DEFINITIONS,
+)
+from .utils import BCD_TIME_PREFIXES, decode_bcd_time
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .modbus_transport import BaseModbusTransport
+
+    class _ScannerCapabilitiesProto:
+        available_registers: dict[str, set[str]]
+        _register_ranges: dict[str, tuple[int | None, int | None]]
+        _client: Any | None
+        _transport: BaseModbusTransport | None
+
+        async def _read_input(self, *args: Any, **kwargs: Any) -> list[int] | None: ...
+        async def _read_holding_block(self, *args: Any, **kwargs: Any) -> list[int] | None: ...
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _ScannerCapabilitiesMixin:
+    """Capability analysis and firmware/device-identity scanning."""
+
+    def _is_valid_register_value(self, name: str, value: int) -> bool:
+        """Validate a register value against known constraints.
+
+        This check is intentionally lightweight – it ensures that obvious
+        placeholder values (like ``SENSOR_UNAVAILABLE``) and values outside the
+        ranges defined in the register metadata are ignored.  The method mirrors
+        behaviour expected by the tests but does not aim to provide exhaustive
+        validation of every register.
+        """
+
+        if value == 65535:
+            return False
+
+        # Registers in SENSOR_UNAVAILABLE_REGISTERS return 0x8000 when a sensor
+        # is not physically connected. The register itself EXISTS and must produce
+        # an entity (shown as "unavailable" in HA). Only EC2 responses mean the
+        # register is truly absent. Accept 0x8000 here — coordinator and sensor.py
+        # already handle it correctly via the SENSOR_UNAVAILABLE sentinel.
+        if name in SENSOR_UNAVAILABLE_REGISTERS and value == SENSOR_UNAVAILABLE:
+            return True
+
+        if "temperature" in name and value == SENSOR_UNAVAILABLE:
+            return True
+
+        allowed = REGISTER_ALLOWED_VALUES.get(name)
+        if allowed is not None and value not in allowed:
+            return False
+
+        if name.startswith(BCD_TIME_PREFIXES) and name != "schedule_start_time":
+            if decode_bcd_time(value) is None:
+                return False
+
+        if range_vals := self._register_ranges.get(name):  # type: ignore[attr-defined]
+            min_val, max_val = range_vals
+            if min_val is not None and value < min_val:
+                return False
+            if max_val is not None and value > max_val:
+                return False
+
+        return True
+
+    def _analyze_capabilities(self) -> DeviceCapabilities:
+        """Derive device capabilities from discovered registers."""
+
+        caps = DeviceCapabilities()
+        inputs = self.available_registers["input_registers"]  # type: ignore[attr-defined]
+        holdings = self.available_registers["holding_registers"]  # type: ignore[attr-defined]
+        coils = self.available_registers["coil_registers"]  # type: ignore[attr-defined]
+        discretes = self.available_registers["discrete_inputs"]  # type: ignore[attr-defined]
+
+        # Temperature sensors
+        temp_map = {
+            "sensor_outside_temperature": "outside_temperature",
+            "sensor_supply_temperature": "supply_temperature",
+            "sensor_exhaust_temperature": "exhaust_temperature",
+            "sensor_fpx_temperature": "fpx_temperature",
+            "sensor_duct_supply_temperature": "duct_supply_temperature",
+            "sensor_gwc_temperature": "gwc_temperature",
+            "sensor_ambient_temperature": "ambient_temperature",
+            "sensor_heating_temperature": "heating_temperature",
+        }
+        for attr, reg in temp_map.items():
+            if reg in inputs:
+                setattr(caps, attr, True)
+                caps.temperature_sensors.add(reg)
+
+        caps.temperature_sensors_count = len(caps.temperature_sensors)  # pragma: no cover
+
+        # Expansion module and GWC detection via discrete inputs/coils
+        if "expansion" in discretes:
+            caps.expansion_module = True  # pragma: no cover
+        if "gwc" in coils or "gwc_temperature" in inputs:
+            caps.gwc_system = True  # pragma: no cover
+
+        if "bypass" in coils:
+            caps.bypass_system = True  # pragma: no cover
+        if any(reg.startswith("schedule_") for reg in holdings):
+            caps.weekly_schedule = True  # pragma: no cover
+
+        if "on_off_panel_mode" in holdings:
+            caps.basic_control = True  # pragma: no cover
+
+        if any(
+            reg in inputs
+            for reg in [
+                "constant_flow_active",
+                "supply_flow_rate",
+                "supply_air_flow",
+                "cf_version",
+            ]
+        ):
+            caps.constant_flow = True  # pragma: no cover
+
+        # Generic capability detection based on register name patterns
+        all_registers = inputs | holdings | coils | discretes
+        for attr, patterns in CAPABILITY_PATTERNS.items():
+            if getattr(caps, attr):
+                continue
+            if any(pat in reg for reg in all_registers for pat in patterns):
+                setattr(caps, attr, True)
+
+        return caps
+
+    async def _scan_firmware_info(self, info_regs: list[int], device: ScannerDeviceInfo) -> None:
+        """Parse firmware version from info_regs and update device."""
+        major: int | None = None
+        minor: int | None = None
+        patch: int | None = None
+        firmware_err: Exception | None = None
+
+        for name in ("version_major", "version_minor", "version_patch"):
+            idx = INPUT_REGISTERS.get(name)
+            if idx is not None and len(info_regs) > idx:
+                try:
+                    value = info_regs[idx]
+                except (TypeError, ValueError, IndexError) as exc:  # pragma: no cover - best effort
+                    firmware_err = exc
+                    continue
+                except (AttributeError, RuntimeError) as exc:  # pragma: no cover - unexpected
+                    _LOGGER.exception("Unexpected firmware value error for %s: %s", name, exc)
+                    firmware_err = exc
+                    continue
+                if name == "version_major":
+                    major = value
+                elif name == "version_minor":
+                    minor = value
+                else:
+                    patch = value
+
+        # Some devices reject larger blocks around register 0 but still allow
+        # individual reads of the firmware registers. Retry missing values as
+        # single-register probes while bypassing failed-range caching.
+        if None in (major, minor, patch):
+            fallback_results: dict[str, int] = {}
+            for name in ("version_major", "version_minor", "version_patch"):
+                current = (
+                    major
+                    if name == "version_major"
+                    else minor
+                    if name == "version_minor"
+                    else patch
+                )
+                if current is not None:
+                    continue
+                probe = None
+                try:
+                    addr = INPUT_REGISTERS.get(name)
+                    if addr is None:
+                        continue
+                    try:
+                        probe = (
+                            await self._read_input(self._client, addr, 1, skip_cache=True)  # type: ignore[attr-defined]
+                            if self._client is not None  # type: ignore[attr-defined]
+                            else await self._read_input(addr, 1, skip_cache=True)  # type: ignore[attr-defined]
+                        )
+                    except TypeError:
+                        probe = await self._read_input(addr, 1, skip_cache=True)  # type: ignore[attr-defined]
+                except (TypeError, ValueError, IndexError) as exc:  # pragma: no cover - best effort
+                    firmware_err = exc
+                    continue
+                except (AttributeError, RuntimeError) as exc:  # pragma: no cover - unexpected
+                    _LOGGER.exception("Unexpected firmware probe error for %s: %s", name, exc)
+                    firmware_err = exc
+                    continue
+                if probe:
+                    fallback_results[name] = probe[0]
+            major = fallback_results.get("version_major", major)
+            minor = fallback_results.get("version_minor", minor)
+            patch = fallback_results.get("version_patch", patch)
+
+        missing_regs: list[str] = []
+        if None in (major, minor, patch):
+            for name, value in (
+                ("version_major", major),
+                ("version_minor", minor),
+                ("version_patch", patch),
+            ):
+                if value is None and name in INPUT_REGISTERS:
+                    missing_regs.append(f"{name} ({INPUT_REGISTERS[name]})")
+
+        if None not in (major, minor, patch):
+            device.firmware = f"{major}.{minor}.{patch}"
+        else:
+            details: list[str] = []
+            if missing_regs:
+                details.append("missing " + ", ".join(missing_regs))
+            if firmware_err is not None:
+                details.append(str(firmware_err))  # pragma: no cover
+            msg = "Failed to read firmware version registers"
+            if details:
+                msg += ": " + "; ".join(details)
+            _LOGGER.warning(msg)
+            device.firmware_available = False  # pragma: no cover
+
+    async def _scan_device_identity(self, info_regs: list[int], device: ScannerDeviceInfo) -> None:
+        """Parse serial number and device name from registers into device."""
+        try:
+            start = INPUT_REGISTERS["serial_number"]
+            parts = info_regs[start : start + REGISTER_DEFINITIONS["serial_number"].length]
+            if parts:
+                device.serial_number = "".join(f"{p:04X}" for p in parts)
+        except (KeyError, IndexError, TypeError, ValueError) as err:  # pragma: no cover
+            _LOGGER.debug("Failed to parse serial number: %s", err)
+        except (AttributeError, RuntimeError) as err:  # pragma: no cover - unexpected
+            _LOGGER.exception("Unexpected error parsing serial number: %s", err)
+        try:
+            start = HOLDING_REGISTERS["device_name"]
+            name_regs = (
+                await self._read_holding_block(start, REGISTER_DEFINITIONS["device_name"].length)  # type: ignore[attr-defined]
+                or []
+            )
+            if name_regs:
+                name_bytes = bytearray()
+                for reg in name_regs:
+                    name_bytes.append((reg >> 8) & 255)
+                    name_bytes.append(reg & 255)
+                device.device_name = name_bytes.decode("ascii", errors="replace").rstrip("\x00")
+        except (KeyError, IndexError, TypeError, ValueError) as err:  # pragma: no cover
+            _LOGGER.debug("Failed to parse device name: %s", err)
+        except (
+            AttributeError,
+            UnicodeDecodeError,
+            RuntimeError,
+        ) as err:  # pragma: no cover - unexpected
+            _LOGGER.exception("Unexpected error parsing device name: %s", err)

--- a/custom_components/thessla_green_modbus/_scanner_registers_mixin.py
+++ b/custom_components/thessla_green_modbus/_scanner_registers_mixin.py
@@ -1,0 +1,748 @@
+"""Raw Modbus read operations mixin for ThesslaGreenDeviceScanner."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
+from .modbus_helpers import chunk_register_range
+from .scanner_helpers import _format_register_value
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pymodbus.client import AsyncModbusTcpClient
+
+    from .modbus_transport import BaseModbusTransport
+
+    class _ScannerRegistersProto:
+        slave_id: int
+        timeout: int | float
+        retry: int
+        backoff: float
+        backoff_jitter: float | tuple[float, float] | None
+        verbose_invalid_values: bool
+        effective_batch: int
+        _client: AsyncModbusTcpClient | None
+        _transport: BaseModbusTransport | None
+        _failed_input: set[int]
+        _failed_holding: set[int]
+        _input_failures: dict[int, int]
+        _holding_failures: dict[int, int]
+        _input_skip_log_ranges: set[tuple[int, int]]
+        _unsupported_input_ranges: dict[tuple[int, int], int]
+        _unsupported_holding_ranges: dict[tuple[int, int], int]
+        _reported_invalid: set[str]
+        failed_addresses: dict[str, dict[str, set[int]]]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _ScannerRegistersMixin:
+    """Raw Modbus read operations for the device scanner."""
+
+    def _filter_unsupported_addresses(self, reg_type: str, addrs: set[int]) -> set[int]:
+        """Return failed addresses that are not already covered by unsupported spans."""
+
+        if reg_type == "input_registers":
+            ranges = self._unsupported_input_ranges  # type: ignore[attr-defined]
+        elif reg_type == "holding_registers":
+            ranges = self._unsupported_holding_ranges  # type: ignore[attr-defined]
+        else:
+            return set(addrs)
+
+        if not ranges:
+            return set(addrs)
+
+        return {addr for addr in addrs if not any(start <= addr <= end for start, end in ranges)}
+
+    def _log_invalid_value(self, name: str, raw: int) -> None:
+        """Log a register value that failed validation."""
+        if name in self._reported_invalid:  # type: ignore[attr-defined]
+            if not self.verbose_invalid_values:  # type: ignore[attr-defined]
+                return
+            level = logging.DEBUG
+        else:
+            level = logging.INFO if self.verbose_invalid_values else logging.DEBUG  # type: ignore[attr-defined]
+            self._reported_invalid.add(name)  # type: ignore[attr-defined]
+        decoded = _format_register_value(name, raw)
+        _LOGGER.log(level, "Invalid value for %s: raw=%d decoded=%s", name, raw, decoded)
+
+    def _mark_input_supported(self, address: int) -> None:
+        """Remove address from cached unsupported input ranges after success."""
+        self._failed_input.discard(address)  # type: ignore[attr-defined]
+        for (start, end), code in list(self._unsupported_input_ranges.items()):  # type: ignore[attr-defined]
+            if start <= address <= end:
+                del self._unsupported_input_ranges[(start, end)]  # type: ignore[attr-defined]
+                if start <= address - 1:
+                    self._unsupported_input_ranges[(start, address - 1)] = code  # type: ignore[attr-defined]
+                if address + 1 <= end:
+                    self._unsupported_input_ranges[(address + 1, end)] = code  # type: ignore[attr-defined]
+
+    def _mark_holding_supported(self, address: int) -> None:
+        """Remove address from cached unsupported holding ranges after success."""
+        self._failed_holding.discard(address)  # type: ignore[attr-defined]
+        for (start, end), code in list(self._unsupported_holding_ranges.items()):  # type: ignore[attr-defined]
+            if start <= address <= end:
+                del self._unsupported_holding_ranges[(start, end)]  # type: ignore[attr-defined]
+                if start <= address - 1:
+                    self._unsupported_holding_ranges[(start, address - 1)] = code  # type: ignore[attr-defined]
+                if address + 1 <= end:
+                    self._unsupported_holding_ranges[(address + 1, end)] = code  # type: ignore[attr-defined]
+
+    def _mark_holding_unsupported(self, start: int, end: int, code: int) -> None:
+        """Track unsupported holding register range without overlaps."""
+        for (exist_start, exist_end), exist_code in list(self._unsupported_holding_ranges.items()):  # type: ignore[attr-defined]
+            if exist_end < start or exist_start > end:
+                continue
+            del self._unsupported_holding_ranges[(exist_start, exist_end)]  # type: ignore[attr-defined]
+            if exist_start < start:
+                self._unsupported_holding_ranges[(exist_start, start - 1)] = exist_code  # type: ignore[attr-defined]
+            if end < exist_end:
+                self._unsupported_holding_ranges[(end + 1, exist_end)] = exist_code  # type: ignore[attr-defined]
+        self._unsupported_holding_ranges[(start, end)] = code  # type: ignore[attr-defined]
+
+    def _mark_input_unsupported(self, start: int, end: int, code: int | None) -> None:
+        """Cache unsupported input register range, merging overlaps."""
+
+        for (old_start, old_end), _ in list(self._unsupported_input_ranges.items()):  # type: ignore[attr-defined]
+            if end < old_start or start > old_end:
+                continue
+            del self._unsupported_input_ranges[(old_start, old_end)]  # type: ignore[attr-defined]
+            start = min(start, old_start)
+            end = max(end, old_end)
+
+        self._unsupported_input_ranges[(start, end)] = code or 0  # type: ignore[attr-defined]
+
+    def _track_input_failure(self, count: int, address: int) -> None:
+        """Increment the failure counter for an input register (only for single-reg reads)."""
+        if count != 1:
+            return
+        failures = self._input_failures.get(address, 0) + 1  # type: ignore[attr-defined]
+        self._input_failures[address] = failures  # type: ignore[attr-defined]
+        if failures >= self.retry and address not in self._failed_input:  # type: ignore[attr-defined]
+            self._failed_input.add(address)  # type: ignore[attr-defined]
+            self.failed_addresses["modbus_exceptions"]["input_registers"].add(address)  # type: ignore[attr-defined]
+            _LOGGER.warning("Device does not expose register %d", address)
+
+    def _track_holding_failure(self, count: int, address: int) -> None:
+        """Increment the failure counter for a holding register (only for single-reg reads)."""
+        if count != 1:
+            return
+        failures = self._holding_failures.get(address, 0) + 1  # type: ignore[attr-defined]
+        self._holding_failures[address] = failures  # type: ignore[attr-defined]
+        if failures >= self.retry and address not in self._failed_holding:  # type: ignore[attr-defined]
+            self._failed_holding.add(address)  # type: ignore[attr-defined]
+            self.failed_addresses["modbus_exceptions"]["holding_registers"].add(address)  # type: ignore[attr-defined]
+            _LOGGER.warning("Device does not expose register %d", address)
+
+    async def _read_input(
+        self,
+        client_or_address: Any,
+        address_or_count: int,
+        count: int | None = None,
+        *,
+        skip_cache: bool = False,
+    ) -> list[int] | None:
+        """Read input registers with retry and backoff.
+
+        ``skip_cache`` is used when probing individual registers after a block
+        read failed. When ``True`` the cached set of failed registers is not
+        checked, allowing each register to be queried once before being cached
+        as missing.
+        """
+        from . import scanner_io as _scanner_io
+        from .modbus_helpers import _call_modbus
+
+        client, address, count = self._unpack_read_args(client_or_address, address_or_count, count)  # type: ignore[attr-defined]
+        start = address
+        end = address + count - 1
+
+        if not skip_cache:
+            for skip_start, skip_end in self._unsupported_input_ranges:  # type: ignore[attr-defined]
+                if skip_start <= start and end <= skip_end:
+                    self.failed_addresses["modbus_exceptions"]["input_registers"].update(  # type: ignore[attr-defined]
+                        range(start, end + 1)
+                    )
+                    return None
+        if not skip_cache and any(reg in self._failed_input for reg in range(start, end + 1)):  # type: ignore[attr-defined]
+            first = next(reg for reg in range(start, end + 1) if reg in self._failed_input)  # type: ignore[attr-defined]
+            skip_start = skip_end = first
+            while skip_start - 1 in self._failed_input:  # type: ignore[attr-defined]
+                skip_start -= 1
+            while skip_end + 1 in self._failed_input:  # type: ignore[attr-defined]
+                skip_end += 1
+            if (skip_start, skip_end) not in self._input_skip_log_ranges:  # type: ignore[attr-defined]
+                _LOGGER.debug(
+                    "Skipping cached failed input registers %d-%d",
+                    skip_start,
+                    skip_end,
+                )
+                self._input_skip_log_ranges.add((skip_start, skip_end))  # type: ignore[attr-defined]
+            self.failed_addresses["modbus_exceptions"]["input_registers"].update(  # type: ignore[attr-defined]
+                range(skip_start, skip_end + 1)
+            )
+            return None
+
+        transport, client = self._resolve_transport_and_client(client)  # type: ignore[attr-defined]
+
+        attempted_reads = 0
+        aborted_transiently = False
+        for attempt in range(1, self.retry + 1):  # type: ignore[attr-defined]
+            attempted_reads = attempt
+            try:
+                if transport is not None:
+                    response = await transport.read_input_registers(
+                        self.slave_id,  # type: ignore[attr-defined]
+                        address,
+                        count=count,
+                    )
+                else:
+                    response = await _scanner_io.call_modbus_compat(
+                        _call_modbus,
+                        client.read_input_registers,
+                        self.slave_id,  # type: ignore[attr-defined]
+                        address,
+                        count=count,
+                        attempt=attempt,
+                        retry=self.retry,  # type: ignore[attr-defined]
+                        timeout=self.timeout,  # type: ignore[attr-defined]
+                        backoff=self.backoff,  # type: ignore[attr-defined]
+                        backoff_jitter=self.backoff_jitter,  # type: ignore[attr-defined]
+                    )
+                if response is not None:
+                    if response.isError():
+                        code = getattr(response, "exception_code", None)
+                        _LOGGER.warning(
+                            "Exception code %s while reading holding registers %d-%d",
+                            code,
+                            start,
+                            end,
+                        )
+                        self._failed_input.update(range(start, end + 1))  # type: ignore[attr-defined]
+                        self._mark_input_unsupported(start, end, code)
+                        self.failed_addresses["modbus_exceptions"]["input_registers"].update(  # type: ignore[attr-defined]
+                            range(start, end + 1)
+                        )
+                        return None
+                    if skip_cache and count == 1:
+                        self._mark_input_supported(address)
+                    registers = cast(list[int], response.registers)
+                    _LOGGER.debug(
+                        "Read input registers %d-%d: %s",
+                        start,
+                        end,
+                        registers,
+                    )
+                    return registers
+                _LOGGER.debug(
+                    "Attempt %d failed to read input %d: %s",
+                    attempt,
+                    address,
+                    response,
+                )
+            except ModbusIOException as exc:
+                _LOGGER.debug(
+                    "Modbus IO error reading input registers %d-%d on attempt %d: %s",
+                    start,
+                    end,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                if _scanner_io.is_request_cancelled_error(exc):
+                    aborted_transiently = True
+                    break  # Treat cancellation like a timeout — stop retrying
+                self._track_input_failure(count, address)
+            except TimeoutError as exc:
+                _LOGGER.warning(
+                    "Timeout reading input registers %d-%d on attempt %d: %s",
+                    start,
+                    end,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                aborted_transiently = True
+                break
+            except OSError as exc:
+                _LOGGER.error(
+                    "Unexpected error reading input %d on attempt %d: %s",
+                    address,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                break
+            except (ModbusException, ConnectionException) as exc:
+                _LOGGER.debug(
+                    "Failed to read input registers %d-%d on attempt %d: %s",
+                    start,
+                    end,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                self._track_input_failure(count, address)
+
+            await _scanner_io.sleep_retry_backoff(
+                calculate_backoff_delay=lambda base, at, jitter: __import__(
+                    "custom_components.thessla_green_modbus.modbus_helpers",
+                    fromlist=["_calculate_backoff_delay"],
+                )._calculate_backoff_delay(base=base, attempt=at, jitter=jitter),
+                backoff=self.backoff,  # type: ignore[attr-defined]
+                backoff_jitter=self.backoff_jitter,  # type: ignore[attr-defined]
+                attempt=attempt,
+                retry=self.retry,  # type: ignore[attr-defined]
+            )
+
+        if aborted_transiently:
+            _LOGGER.warning(
+                (
+                    "Aborted reading input registers %d-%d after %d/%d attempts "
+                    "due to timeout/cancellation"
+                ),
+                start,
+                end,
+                attempted_reads,
+                self.retry,  # type: ignore[attr-defined]
+            )
+            return None
+
+        self.failed_addresses["modbus_exceptions"]["input_registers"].update(range(start, end + 1))  # type: ignore[attr-defined]
+        _LOGGER.error(
+            "Failed to read input registers %d-%d after %d retries",
+            start,
+            end,
+            self.retry,  # type: ignore[attr-defined]
+        )
+        return None
+
+    async def _read_register_block(
+        self,
+        read_fn: Any,
+        client_or_start: Any,
+        start_or_count: int,
+        count: int | None = None,
+    ) -> list[int] | None:
+        """Read a contiguous register block in MAX-sized chunks using read_fn."""
+        if count is None:
+            start = int(client_or_start)
+            count = start_or_count
+            client: Any = None
+        elif isinstance(client_or_start, int):
+            start = client_or_start
+            count = start_or_count
+            client = None
+        else:
+            client = client_or_start
+            start = start_or_count
+
+        results: list[int] = []
+        active_client = client or self._client  # type: ignore[attr-defined]
+        for chunk_start, chunk_count in chunk_register_range(start, count, self.effective_batch):  # type: ignore[attr-defined]
+            block = await (
+                read_fn(chunk_start, chunk_count)
+                if active_client is None
+                else read_fn(active_client, chunk_start, chunk_count)
+            )
+            if block is None:
+                return None
+            results.extend(block)
+        return results
+
+    async def _read_input_block(
+        self,
+        client_or_start: Any,
+        start_or_count: int,
+        count: int | None = None,
+    ) -> list[int] | None:
+        """Read a contiguous input register block in MAX-sized chunks."""
+        return await self._read_register_block(
+            self._read_input, client_or_start, start_or_count, count
+        )
+
+    async def _read_holding_block(
+        self,
+        client_or_start: Any,
+        start_or_count: int,
+        count: int | None = None,
+    ) -> list[int] | None:
+        """Read a contiguous holding register block in MAX-sized chunks."""
+        return await self._read_register_block(
+            self._read_holding, client_or_start, start_or_count, count  # type: ignore[attr-defined]
+        )
+
+    async def _read_holding(
+        self,
+        client_or_address: Any,
+        address_or_count: int,
+        count: int | None = None,
+        *,
+        skip_cache: bool = False,
+    ) -> list[int] | None:
+        """Read holding registers with retry, backoff and failure tracking.
+
+        ``skip_cache`` is used when probing individual registers after a block
+        read failed. When ``True`` the cached sets of unsupported ranges and
+        failed registers are ignored, allowing each register to be queried
+        once before being cached again.
+        """
+        from . import scanner_io as _scanner_io
+        from .modbus_helpers import _call_modbus
+
+        client, address, count = self._unpack_read_args(client_or_address, address_or_count, count)  # type: ignore[attr-defined]
+        start = address
+        end = address + count - 1
+
+        if not skip_cache:
+            for skip_start, skip_end in self._unsupported_holding_ranges:  # type: ignore[attr-defined]
+                if skip_start <= start and end <= skip_end:
+                    self.failed_addresses["modbus_exceptions"]["holding_registers"].update(  # type: ignore[attr-defined]
+                        range(start, end + 1)
+                    )
+                    return None
+
+            if address in self._failed_holding:  # type: ignore[attr-defined]
+                _LOGGER.debug("Skipping cached failed holding register %d", address)
+                self.failed_addresses["modbus_exceptions"]["holding_registers"].add(address)  # type: ignore[attr-defined]
+                return None
+
+        failures = self._holding_failures.get(address, 0)  # type: ignore[attr-defined]
+        if failures >= self.retry:  # type: ignore[attr-defined]
+            _LOGGER.warning("Skipping unsupported holding register %d", address)
+            self.failed_addresses["modbus_exceptions"]["holding_registers"].add(address)  # type: ignore[attr-defined]
+            return None
+
+        transport, client = self._resolve_transport_and_client(client)  # type: ignore[attr-defined]
+
+        attempted_reads = 0
+        aborted_transiently = False
+        for attempt in range(1, self.retry + 1):  # type: ignore[attr-defined]
+            attempted_reads = attempt
+            try:
+                if transport is not None:
+                    response = await transport.read_holding_registers(
+                        self.slave_id,  # type: ignore[attr-defined]
+                        address,
+                        count=count,
+                    )
+                else:
+                    response = await _scanner_io.call_modbus_compat(
+                        _call_modbus,
+                        client.read_holding_registers,
+                        self.slave_id,  # type: ignore[attr-defined]
+                        address,
+                        count=count,
+                        attempt=attempt,
+                        retry=self.retry,  # type: ignore[attr-defined]
+                        timeout=self.timeout,  # type: ignore[attr-defined]
+                        backoff=self.backoff,  # type: ignore[attr-defined]
+                        backoff_jitter=self.backoff_jitter,  # type: ignore[attr-defined]
+                    )
+                if response is not None:
+                    if response.isError():
+                        code = getattr(response, "exception_code", None)
+                        _LOGGER.warning(
+                            "Exception code %s while reading holding registers %d-%d",
+                            code,
+                            start,
+                            end,
+                        )
+                        if code == 2:
+                            self._failed_holding.update(range(start, end + 1))  # type: ignore[attr-defined]
+                            self._mark_holding_unsupported(start, end, code)
+                            self.failed_addresses["modbus_exceptions"]["holding_registers"].update(  # type: ignore[attr-defined]
+                                range(start, end + 1)
+                            )
+                            return None
+                        if count == 1:
+                            failures = self._holding_failures.get(address, 0) + 1  # type: ignore[attr-defined]
+                            self._holding_failures[address] = failures  # type: ignore[attr-defined]
+                            if failures >= self.retry:  # type: ignore[attr-defined]
+                                self._failed_holding.update(range(start, end + 1))  # type: ignore[attr-defined]
+                                self._mark_holding_unsupported(start, end, code or 0)
+                                self.failed_addresses["modbus_exceptions"][  # type: ignore[attr-defined]
+                                    "holding_registers"
+                                ].update(range(start, end + 1))
+                                return None
+                        continue
+                    if skip_cache and count == 1:
+                        self._mark_holding_supported(address)
+                    if address in self._holding_failures:  # type: ignore[attr-defined]
+                        del self._holding_failures[address]  # type: ignore[attr-defined]
+                    registers = cast(list[int], response.registers)
+                    _LOGGER.debug(
+                        "Read holding registers %d-%d: %s",
+                        start,
+                        end,
+                        registers,
+                    )
+                    return registers
+            except TimeoutError as exc:
+                _LOGGER.warning(
+                    "Timeout reading holding %d (attempt %d/%d): %s",
+                    address,
+                    attempt,
+                    self.retry,  # type: ignore[attr-defined]
+                    exc,
+                    exc_info=True,
+                )
+                self._track_holding_failure(count, address)
+                aborted_transiently = True
+            except ModbusIOException as exc:
+                if _scanner_io.is_request_cancelled_error(exc):
+                    _LOGGER.debug(
+                        "Cancelled reading holding registers %d-%d on attempt %d/%d: %s",
+                        start,
+                        end,
+                        attempt,
+                        self.retry,  # type: ignore[attr-defined]
+                        exc,
+                    )
+                    aborted_transiently = True
+                    break
+                _LOGGER.debug(
+                    "Failed to read holding %d (attempt %d/%d): %s",
+                    address,
+                    attempt,
+                    self.retry,  # type: ignore[attr-defined]
+                    exc,
+                    exc_info=True,
+                )
+                self._track_holding_failure(count, address)
+            except (ModbusException, ConnectionException) as exc:
+                _LOGGER.debug(
+                    "Failed to read holding %d (attempt %d/%d): %s",
+                    address,
+                    attempt,
+                    self.retry,  # type: ignore[attr-defined]
+                    exc,
+                    exc_info=True,
+                )
+                self._track_holding_failure(count, address)
+            except asyncio.CancelledError:
+                _LOGGER.debug(
+                    "Cancelled reading holding %d on attempt %d/%d",
+                    address,
+                    attempt,
+                    self.retry,  # type: ignore[attr-defined]
+                )
+                raise
+            except OSError as exc:
+                _LOGGER.error(
+                    "Unexpected error reading holding %d on attempt %d: %s",
+                    address,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                break
+
+            await _scanner_io.sleep_retry_backoff(
+                calculate_backoff_delay=lambda base, at, jitter: __import__(
+                    "custom_components.thessla_green_modbus.modbus_helpers",
+                    fromlist=["_calculate_backoff_delay"],
+                )._calculate_backoff_delay(base=base, attempt=at, jitter=jitter),
+                backoff=self.backoff,  # type: ignore[attr-defined]
+                backoff_jitter=self.backoff_jitter,  # type: ignore[attr-defined]
+                attempt=attempt,
+                retry=self.retry,  # type: ignore[attr-defined]
+            )
+
+        if aborted_transiently:
+            _LOGGER.warning(
+                (
+                    "Aborted reading holding registers %d-%d after %d/%d attempts "
+                    "due to timeout/cancellation"
+                ),
+                start,
+                end,
+                attempted_reads,
+                self.retry,  # type: ignore[attr-defined]
+            )
+            _LOGGER.error(
+                "Failed to read holding registers %d-%d after %d retries",
+                start,
+                end,
+                self.retry,  # type: ignore[attr-defined]
+            )
+            return None
+
+        _LOGGER.error(
+            "Failed to read holding registers %d-%d after %d retries",
+            start,
+            end,
+            self.retry,  # type: ignore[attr-defined]
+        )
+        self.failed_addresses["modbus_exceptions"]["holding_registers"].update(  # type: ignore[attr-defined]
+            range(start, end + 1)
+        )
+        return None
+
+    async def _read_bit_registers(
+        self,
+        method_name: str,
+        failed_key: str,
+        type_name: str,
+        client_or_address: Any,
+        address_or_count: int,
+        count: int | None = None,
+    ) -> list[bool] | None:
+        """Shared implementation for coil and discrete input reads with retry and backoff."""
+        from . import scanner_io as _scanner_io
+        from .modbus_helpers import _call_modbus
+
+        if count is None:
+            address = int(client_or_address)
+            count = address_or_count
+            client = self._client  # type: ignore[attr-defined]
+        elif isinstance(client_or_address, int):
+            address = client_or_address
+            count = address_or_count
+            client = self._client  # type: ignore[attr-defined]
+        else:
+            client = client_or_address
+            address = address_or_count
+
+        if client is None:
+            raise ConnectionException("Modbus client is not connected")
+        # Refresh client from transport in case transport reconnected since scan start
+        if client is self._client and self._transport is not None:  # type: ignore[attr-defined]
+            fresh = getattr(self._transport, "client", None)  # type: ignore[attr-defined]
+            if fresh is not None:
+                client = fresh
+        for attempt in range(1, self.retry + 1):  # type: ignore[attr-defined]
+            try:
+                response: Any = await _scanner_io.call_modbus_compat(
+                    _call_modbus,
+                    getattr(client, method_name),
+                    self.slave_id,  # type: ignore[attr-defined]
+                    address,
+                    count=count,
+                    attempt=attempt,
+                    retry=self.retry,  # type: ignore[attr-defined]
+                    timeout=self.timeout,  # type: ignore[attr-defined]
+                    backoff=self.backoff,  # type: ignore[attr-defined]
+                    backoff_jitter=self.backoff_jitter,  # type: ignore[attr-defined]
+                )
+                if response is not None and not response.isError():
+                    bits = cast(list[bool], response.bits[:count])
+                    _LOGGER.debug(
+                        "Read %s registers %d-%d: %s",
+                        type_name,
+                        address,
+                        address + count - 1,
+                        bits,
+                    )
+                    return bits
+            except TimeoutError as exc:
+                _LOGGER.warning(
+                    "Timeout reading %s %d on attempt %d: %s",
+                    type_name,
+                    address,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+            except (ModbusException, ConnectionException) as exc:
+                _LOGGER.debug(
+                    "Failed to read %s %d on attempt %d: %s",
+                    type_name,
+                    address,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                if self._transport is not None:  # type: ignore[attr-defined]
+                    try:
+                        await self._transport.ensure_connected()  # type: ignore[attr-defined]
+                        transport_client = getattr(self._transport, "client", None)  # type: ignore[attr-defined]
+                        if transport_client is not None:
+                            client = transport_client
+                            self._client = transport_client  # type: ignore[attr-defined]
+                    except (
+                        ModbusException,
+                        ConnectionException,
+                        ModbusIOException,
+                        TimeoutError,
+                        OSError,
+                        AttributeError,
+                    ) as exc:
+                        _LOGGER.debug(
+                            "Transport client refresh failed during %s read: %s", type_name, exc
+                        )
+            except asyncio.CancelledError:
+                _LOGGER.debug(
+                    "Cancelled reading %s %d on attempt %d",
+                    type_name,
+                    address,
+                    attempt,
+                )
+                raise
+            except OSError as exc:
+                _LOGGER.error(
+                    "Unexpected error reading %s %d on attempt %d: %s",
+                    type_name,
+                    address,
+                    attempt,
+                    exc,
+                    exc_info=True,
+                )
+                break
+
+            await _scanner_io.sleep_retry_backoff(
+                calculate_backoff_delay=lambda base, at, jitter: __import__(
+                    "custom_components.thessla_green_modbus.modbus_helpers",
+                    fromlist=["_calculate_backoff_delay"],
+                )._calculate_backoff_delay(base=base, attempt=at, jitter=jitter),
+                backoff=self.backoff,  # type: ignore[attr-defined]
+                backoff_jitter=self.backoff_jitter,  # type: ignore[attr-defined]
+                attempt=attempt,
+                retry=self.retry,  # type: ignore[attr-defined]
+            )
+
+        self.failed_addresses["modbus_exceptions"][failed_key].update(  # type: ignore[attr-defined]
+            range(address, address + count)
+        )
+        _LOGGER.error(
+            "Failed to read %s registers %d-%d after %d retries",
+            type_name,
+            address,
+            address + count - 1,
+            self.retry,  # type: ignore[attr-defined]
+        )
+        return None
+
+    async def _read_coil(
+        self,
+        client_or_address: Any,
+        address_or_count: int,
+        count: int | None = None,
+    ) -> list[bool] | None:
+        """Read coil registers with retry and backoff."""
+        return await self._read_bit_registers(
+            "read_coils",
+            "coil_registers",
+            "coil",
+            client_or_address,
+            address_or_count,
+            count,
+        )
+
+    async def _read_discrete(
+        self,
+        client_or_address: Any,
+        address_or_count: int,
+        count: int | None = None,
+    ) -> list[bool] | None:
+        """Read discrete input registers with retry and backoff."""
+        return await self._read_bit_registers(
+            "read_discrete_inputs",
+            "discrete_inputs",
+            "discrete",
+            client_or_address,
+            address_or_count,
+            count,
+        )

--- a/custom_components/thessla_green_modbus/_scanner_transport_mixin.py
+++ b/custom_components/thessla_green_modbus/_scanner_transport_mixin.py
@@ -1,0 +1,297 @@
+"""Transport / connection-setup mixin for ThesslaGreenDeviceScanner."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .const import (
+    CONNECTION_MODE_AUTO,
+    CONNECTION_MODE_TCP,
+    CONNECTION_MODE_TCP_RTU,
+    CONNECTION_TYPE_RTU,
+    CONNECTION_TYPE_TCP,
+    DEFAULT_MAX_BACKOFF,
+    DEFAULT_PARITY,
+    DEFAULT_PORT,
+    DEFAULT_STOP_BITS,
+    HOLDING_BATCH_BOUNDARIES,
+    SERIAL_PARITY_MAP,
+    SERIAL_STOP_BITS_MAP,
+)
+from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
+from .modbus_helpers import (
+    async_maybe_await_close,
+)
+from .modbus_helpers import (
+    group_reads as _group_reads,
+)
+from .modbus_transport import (
+    BaseModbusTransport,
+    RawRtuOverTcpTransport,
+    RtuModbusTransport,
+    TcpModbusTransport,
+)
+from .scanner_helpers import SAFE_REGISTERS
+from .scanner_register_maps import REGISTER_DEFINITIONS
+from .utils import default_connection_mode
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pymodbus.client import AsyncModbusTcpClient
+
+    class _ScannerTransportProto:
+        host: str
+        port: int
+        slave_id: int
+        timeout: int | float
+        retry: int
+        backoff: float
+        backoff_jitter: float | tuple[float, float] | None
+        connection_type: str
+        connection_mode: str | None
+        serial_port: str
+        baud_rate: int
+        parity: str
+        stop_bits: int
+        effective_batch: int
+        _transport: BaseModbusTransport | None
+        _client: AsyncModbusTcpClient | None
+        _resolved_connection_mode: str | None
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _ScannerTransportMixin:
+    """Connection-setup and transport management for the device scanner."""
+
+    # ------------------------------------------------------------------ #
+    # Connection helpers                                                   #
+    # ------------------------------------------------------------------ #
+
+    async def close(self) -> None:
+        """Close the underlying Modbus client connection."""
+
+        if self._transport is not None:  # type: ignore[attr-defined]
+            try:
+                await self._transport.close()  # type: ignore[attr-defined]
+            except (OSError, ConnectionException, ModbusIOException):
+                _LOGGER.debug("Error closing Modbus transport", exc_info=True)
+            finally:
+                self._transport = None  # type: ignore[attr-defined]
+
+        client = self._client  # type: ignore[attr-defined]
+        if client is None:
+            return
+
+        try:
+            await async_maybe_await_close(client)
+        except (OSError, ConnectionException, ModbusIOException):
+            _LOGGER.debug("Error closing Modbus client", exc_info=True)
+        finally:
+            self._client = None  # type: ignore[attr-defined]
+
+    def _build_tcp_transport(
+        self,
+        mode: str,
+        *,
+        timeout_override: float | None = None,
+    ) -> BaseModbusTransport:
+        timeout = self.timeout if timeout_override is None else timeout_override  # type: ignore[attr-defined]
+        if mode == CONNECTION_MODE_TCP_RTU:
+            return RawRtuOverTcpTransport(
+                host=self.host,  # type: ignore[attr-defined]
+                port=self.port,  # type: ignore[attr-defined]
+                max_retries=self.retry,  # type: ignore[attr-defined]
+                base_backoff=self.backoff,  # type: ignore[attr-defined]
+                max_backoff=DEFAULT_MAX_BACKOFF,
+                timeout=timeout,
+            )
+        return TcpModbusTransport(
+            host=self.host,  # type: ignore[attr-defined]
+            port=self.port,  # type: ignore[attr-defined]
+            connection_type=CONNECTION_TYPE_TCP,
+            max_retries=self.retry,  # type: ignore[attr-defined]
+            base_backoff=self.backoff,  # type: ignore[attr-defined]
+            max_backoff=DEFAULT_MAX_BACKOFF,
+            timeout=timeout,
+        )
+
+    def _build_auto_tcp_attempts(self) -> list[tuple[str, BaseModbusTransport, float]]:
+        rtu_timeout = min(max(self.timeout, 2.0), 5.0)  # type: ignore[attr-defined]
+        tcp_timeout = min(max(self.timeout, 5.0), 10.0)  # type: ignore[attr-defined]
+        prefer_tcp = self.port == DEFAULT_PORT  # type: ignore[attr-defined]
+        mode_order = (
+            [CONNECTION_MODE_TCP, CONNECTION_MODE_TCP_RTU]
+            if prefer_tcp
+            else [
+                CONNECTION_MODE_TCP_RTU,
+                CONNECTION_MODE_TCP,
+            ]
+        )
+        attempts: list[tuple[str, BaseModbusTransport, float]] = []
+        for mode in mode_order:
+            timeout = rtu_timeout if mode == CONNECTION_MODE_TCP_RTU else tcp_timeout
+            attempts.append(
+                (
+                    mode,
+                    self._build_tcp_transport(mode, timeout_override=timeout),
+                    timeout,
+                )
+            )
+        return attempts
+
+    async def verify_connection(self) -> None:
+        """Verify basic Modbus connectivity by reading a few safe registers.
+
+        A handful of well-known registers are read from the device to confirm
+        that the TCP connection and Modbus protocol are functioning. Any
+        failure will raise a ``ModbusException`` or ``ConnectionException`` so
+        callers can surface an appropriate error to the user.
+        """
+
+        safe_input: list[int] = []
+        safe_holding: list[int] = []
+        for func, name in SAFE_REGISTERS:
+            reg = REGISTER_DEFINITIONS.get(name)
+            if reg is None:
+                continue
+            if func == 4:
+                safe_input.append(reg.address)
+            else:
+                safe_holding.append(reg.address)
+
+        attempts: list[tuple[str | None, BaseModbusTransport, float]] = []
+        if self.connection_type == CONNECTION_TYPE_RTU:  # type: ignore[attr-defined]
+            if not self.serial_port:  # type: ignore[attr-defined]
+                raise ConnectionException("Serial port not configured")
+            parity = SERIAL_PARITY_MAP.get(self.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])  # type: ignore[attr-defined]
+            stop_bits = SERIAL_STOP_BITS_MAP.get(
+                self.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]  # type: ignore[attr-defined]
+            )
+            attempts.append(
+                (
+                    None,
+                    RtuModbusTransport(
+                        serial_port=self.serial_port,  # type: ignore[attr-defined]
+                        baudrate=self.baud_rate,  # type: ignore[attr-defined]
+                        parity=parity,
+                        stopbits=stop_bits,
+                        max_retries=self.retry,  # type: ignore[attr-defined]
+                        base_backoff=self.backoff,  # type: ignore[attr-defined]
+                        max_backoff=DEFAULT_MAX_BACKOFF,
+                        timeout=self.timeout,  # type: ignore[attr-defined]
+                    ),
+                    self.timeout,  # type: ignore[attr-defined]
+                )
+            )
+        elif self.connection_mode == CONNECTION_MODE_AUTO:  # type: ignore[attr-defined]
+            attempts.extend(self._build_auto_tcp_attempts())
+        else:
+            mode = self.connection_mode or default_connection_mode(self.port)  # type: ignore[attr-defined]
+            attempts.append((mode, self._build_tcp_transport(mode), self.timeout))  # type: ignore[attr-defined]
+
+        last_error: Exception | None = None
+        closed_transports: set[int] = set()
+        for mode, transport, timeout in attempts:
+            try:
+                _LOGGER.info(
+                    "verify_connection: connecting to %s:%s (mode=%s, timeout=%s)",
+                    self.host,  # type: ignore[attr-defined]
+                    self.port,  # type: ignore[attr-defined]
+                    mode or self.connection_type,  # type: ignore[attr-defined]
+                    timeout,
+                )
+                await asyncio.wait_for(transport.ensure_connected(), timeout=timeout)
+
+                for start, count in _group_reads(safe_input, max_block_size=self.effective_batch):  # type: ignore[attr-defined]
+                    _LOGGER.debug(
+                        "verify_connection: read_input_registers start=%s count=%s",
+                        start,
+                        count,
+                    )
+                    await transport.read_input_registers(
+                        self.slave_id,  # type: ignore[attr-defined]
+                        start,
+                        count=count,
+                    )
+
+                for start, count in _group_reads(
+                    safe_holding,
+                    max_block_size=self.effective_batch,  # type: ignore[attr-defined]
+                    boundaries=HOLDING_BATCH_BOUNDARIES,
+                ):
+                    _LOGGER.debug(
+                        "verify_connection: read_holding_registers start=%s count=%s",
+                        start,
+                        count,
+                    )
+                    await transport.read_holding_registers(
+                        self.slave_id,  # type: ignore[attr-defined]
+                        start,
+                        count=count,
+                    )
+                if mode is not None:
+                    if self.connection_mode == CONNECTION_MODE_AUTO:  # type: ignore[attr-defined]
+                        _LOGGER.info(
+                            "verify_connection: auto-selected Modbus transport %s for %s:%s",
+                            mode,
+                            self.host,  # type: ignore[attr-defined]
+                            self.port,  # type: ignore[attr-defined]
+                        )
+                    self._resolved_connection_mode = mode  # type: ignore[attr-defined]
+                return
+            except asyncio.CancelledError:
+                raise
+            except ModbusIOException as exc:
+                last_error = exc
+                from .scanner_io import is_request_cancelled_error
+
+                if is_request_cancelled_error(exc):
+                    _LOGGER.info("Modbus request cancelled during verify_connection.")
+                    raise TimeoutError("Modbus request cancelled") from exc
+            except TimeoutError as exc:
+                last_error = exc
+                _LOGGER.warning("Timeout during verify_connection: %s", exc)
+            except (ConnectionException, ModbusException, OSError) as exc:
+                last_error = exc
+            finally:
+                try:
+                    transport_id = id(transport)
+                    if transport_id not in closed_transports:
+                        close_result = transport.close()
+                        if inspect.isawaitable(close_result):
+                            await close_result
+                        closed_transports.add(transport_id)
+                except (OSError, ConnectionException, ModbusIOException):
+                    _LOGGER.debug(
+                        "Error closing Modbus transport during verify_connection", exc_info=True
+                    )
+
+        if last_error:
+            raise last_error
+
+    def _unpack_read_args(
+        self,
+        client_or_address: Any,
+        address_or_count: int,
+        count: int | None,
+    ) -> tuple[Any, int, int]:
+        """Unpack the overloaded (client, address, count) / (address, count) signatures."""
+        if count is None or isinstance(client_or_address, int):
+            return None, int(client_or_address), address_or_count
+        return client_or_address, address_or_count, count
+
+    def _resolve_transport_and_client(
+        self,
+        client: Any,
+    ) -> tuple[Any, Any]:
+        """Return (transport, client) ready for reads. Raises if neither available."""
+        transport = self._transport if client is None else None  # type: ignore[attr-defined]
+        if client is None and transport is None:
+            client = self._client  # type: ignore[attr-defined]
+        if client is None and transport is None:
+            raise ConnectionException("Modbus transport is not connected")
+        return transport, client

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -569,7 +569,7 @@ async def validate_input(hass: HomeAssistant | None, data: dict[str, Any]) -> di
         raise CannotConnect("cannot_connect") from exc  # pragma: no cover
     except CannotConnect:
         raise
-    except Exception as exc:
+    except (ValueError, TypeError, RuntimeError, ImportError) as exc:
         _LOGGER.error("Unexpected error during device validation: %s", exc)
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
         raise CannotConnect("cannot_connect") from exc

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -247,7 +247,7 @@ try:  # pragma: no cover - optional during isolated tests
         _Platform.TEXT,
         _Platform.TIME,
     ]
-except (ImportError, Exception):  # pragma: no cover - fallback for test environments
+except (ImportError, AttributeError):  # pragma: no cover - fallback for test environments
     PLATFORMS = [  # type: ignore[assignment]
         "sensor",
         "binary_sensor",

--- a/custom_components/thessla_green_modbus/mappings/__init__.py
+++ b/custom_components/thessla_green_modbus/mappings/__init__.py
@@ -446,7 +446,9 @@ def _number_translation_keys() -> set[str]:
     undocumented registers (e.g. ``reserved_8145``–``reserved_8151``).
     """
     try:
-        with (((_tp := Path(__file__).resolve().with_name("translations")) if (Path(__file__).resolve().with_name("translations")).exists() else Path(__file__).resolve().parents[1] / "translations") / "en.json").open(encoding="utf-8") as f:
+        _t = Path(__file__).resolve().with_name("translations")
+        _translations_dir = _t if _t.exists() else Path(__file__).resolve().parents[1] / "translations"
+        with (_translations_dir / "en.json").open(encoding="utf-8") as f:
             data = json.load(f)
         return set(data.get("entity", {}).get("number", {}).keys())
     except (
@@ -465,7 +467,9 @@ def _load_translation_keys() -> dict[str, set[str]]:
     """Return available translation keys for supported entity types."""
 
     try:
-        with (((_tp := Path(__file__).resolve().with_name("translations")) if (Path(__file__).resolve().with_name("translations")).exists() else Path(__file__).resolve().parents[1] / "translations") / "en.json").open(encoding="utf-8") as f:
+        _t = Path(__file__).resolve().with_name("translations")
+        _translations_dir = _t if _t.exists() else Path(__file__).resolve().parents[1] / "translations"
+        with (_translations_dir / "en.json").open(encoding="utf-8") as f:
             data = json.load(f)
         entity = data.get("entity", {})
         return {

--- a/custom_components/thessla_green_modbus/mappings/__init__.py
+++ b/custom_components/thessla_green_modbus/mappings/__init__.py
@@ -13,10 +13,7 @@ were renamed in newer versions of the integration.
 from __future__ import annotations
 
 import importlib.util
-import json
 import logging
-import re
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .._compat import (
@@ -35,304 +32,104 @@ from .._compat import (
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from homeassistant.core import HomeAssistant
 
-try:  # pragma: no cover - optional during isolated tests
-    from ..registers.loader import get_all_registers
-except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
-
-    def get_all_registers(*_args, **_kwargs):
-        return []
-
-
 from ..const import (
-    SPECIAL_FUNCTION_MAP,
-    coil_registers,
-    discrete_input_registers,
-    holding_registers,
+    coil_registers as coil_registers,
 )
-from ..utils import _to_snake_case
+from ..const import (
+    discrete_input_registers as discrete_input_registers,
+)
+from ..const import (
+    holding_registers as holding_registers,
+)
+
+# ---------------------------------------------------------------------------
+# Submodule imports — each submodule owns its code; __init__ is the controller
+# ---------------------------------------------------------------------------
+from ._helpers import (
+    _REGISTER_INFO_CACHE as _REGISTER_INFO_CACHE,
+)
+from ._helpers import (
+    _get_register_info as _get_register_info,
+)
+from ._helpers import (
+    _infer_icon as _infer_icon,
+)
+from ._helpers import (
+    _load_translation_keys as _load_translation_keys,
+)
+from ._helpers import (
+    _number_translation_keys as _number_translation_keys,
+)
+from ._helpers import (
+    _parse_states as _parse_states,
+)
+from ._helpers import (
+    get_all_registers as get_all_registers,
+)
+from ._loaders import (
+    _build_entity_mappings as _build_entity_mappings,
+)
+from ._loaders import (
+    _extend_entity_mappings_from_registers as _extend_entity_mappings_from_registers,
+)
+from ._loaders import (
+    _load_discrete_mappings as _load_discrete_mappings,
+)
+from ._loaders import (
+    _load_number_mappings as _load_number_mappings,
+)
+from .legacy import (
+    LEGACY_ENTITY_ID_ALIASES as LEGACY_ENTITY_ID_ALIASES,
+)
+from .legacy import (
+    LEGACY_ENTITY_ID_OBJECT_ALIASES as LEGACY_ENTITY_ID_OBJECT_ALIASES,
+)
+from .legacy import _alias_warning_logged as _alias_warning_logged
+from .legacy import (
+    map_legacy_entity_id as map_legacy_entity_id,
+)
+from .special_modes import SPECIAL_MODE_ICONS as SPECIAL_MODE_ICONS
 
 _LOGGER = logging.getLogger(__name__)
-_REGISTER_INFO_CACHE: dict[str, dict[str, Any]] | None = None
 
-
-# ---------------------------------------------------------------------------
-# Legacy entity ID mapping
-# ---------------------------------------------------------------------------
-# Map legacy entity suffixes to new domain and suffix pairs. Only a small
-# subset of legacy names existed in early versions of the integration. These
-# mappings allow services to transparently use the new entity IDs while warning
-# users to update their automations.
-LEGACY_ENTITY_ID_ALIASES: dict[str, tuple[str, str]] = {
-    # Keys are suffixes of legacy entity_ids.
-    # "number.rekuperator_predkosc" / "number.rekuperator_speed" → fan entity
-    "predkosc": ("fan", "fan"),
-    "speed": ("fan", "fan"),
-}
-
-# Exact object_id aliases used by earlier releases. These are matched before
-# ``LEGACY_ENTITY_ID_ALIASES`` to avoid ambiguity for names ending with
-# common suffixes like ``_mode``.
-LEGACY_ENTITY_ID_OBJECT_ALIASES: dict[str, tuple[str, str]] = {
-    # Legacy number entities migrated to read-only sensors.
-    "rekuperator_antifreeze_mode": ("binary_sensor", "rekuperator_antifreeze_mode"),
-    "rekuperator_comfort_mode": ("sensor", "rekuperator_comfort_mode"),
-    "rekuperator_dac_supply": ("sensor", "rekuperator_dac_supply"),
-    "rekuperator_dac_exhaust": ("sensor", "rekuperator_dac_exhaust"),
-    "rekuperator_dac_heater": ("sensor", "rekuperator_dac_heater"),
-    "rekuperator_dac_cooler": ("sensor", "rekuperator_dac_cooler"),
-    "rekuperator_supply_air_flow": ("sensor", "rekuperator_supply_air_flow"),
-    "rekuperator_exhaust_air_flow": ("sensor", "rekuperator_exhaust_air_flow"),
-    "rekuperator_hood_supply_coef": ("number", "rekuperator_hood_supply_coef"),
-    "rekuperator_hood_exhaust_coef": ("number", "rekuperator_hood_exhaust_coef"),
-    "rekuperator_fan_speed_1_coef": ("number", "rekuperator_fan_speed_1_coef"),
-    "rekuperator_fan_speed_2_coef": ("number", "rekuperator_fan_speed_2_coef"),
-    "rekuperator_fan_speed_3_coef": ("number", "rekuperator_fan_speed_3_coef"),
-    # Legacy status sensors migrated to select/switch controls.
-    "rekuperator_mode": ("select", "rekuperator_mode"),
-    "rekuperator_gwc_mode": ("sensor", "rekuperator_gwc_mode"),
-    "rekuperator_season_mode": ("select", "rekuperator_season_mode"),
-    "rekuperator_bypass_mode_status": ("sensor", "rekuperator_bypass_mode"),
-    "rekuperator_on_off_panel_mode": ("switch", "rekuperator_on_off_panel_mode"),
-    # Typo fix: antifreez_stage → antifreeze_stage (version 2.3.0)
-    "rekuperator_antifreez_stage": ("sensor", "rekuperator_antifreeze_stage"),
-    # Binary sensor renames (dp_ prefix added, key made more precise)
-    "rekuperator_ahu_filter_overflow": ("binary_sensor", "rekuperator_dp_ahu_filter_overflow"),
-    "rekuperator_duct_filter_overflow": ("binary_sensor", "rekuperator_dp_duct_filter_overflow"),
-    "rekuperator_gwc_regeneration_active": ("binary_sensor", "rekuperator_gwc_regen_flag"),
-    "rekuperator_central_heater_overprotection": ("binary_sensor", "rekuperator_post_heater_on"),
-    "rekuperator_unit_operation_confirmation": ("binary_sensor", "rekuperator_info"),
-    "rekuperator_water_heater_pump": ("binary_sensor", "rekuperator_duct_water_heater_pump"),
-    # Sensor renames
-    "rekuperator_maximum_percentage": ("sensor", "rekuperator_max_percentage"),
-    "rekuperator_minimum_percentage": ("sensor", "rekuperator_min_percentage"),
-    "rekuperator_time_period": ("sensor", "rekuperator_period"),
-    "rekuperator_supply_flow_rate_m3_h": ("sensor", "rekuperator_supply_flow_rate"),
-    "rekuperator_exhaust_flow_rate_m3_h": ("sensor", "rekuperator_exhaust_flow_rate"),
-    "rekuperator_ahu_stop_alarm_code": ("sensor", "rekuperator_stop_ahu_code"),
-    "rekuperator_active_errors": ("sensor", "rekuperator_stop_ahu_code"),
-    "rekuperator_product_key_lock_date_day": ("sensor", "rekuperator_lock_date_00dd"),
-    "rekuperator_comfort_mode_status": ("sensor", "rekuperator_comfort_mode"),
-    # Switch renames
-    "rekuperator_bypass_active": ("switch", "rekuperator_bypass_off"),
-    "rekuperator_gwc_active": ("switch", "rekuperator_gwc_off"),
-    "rekuperator_lock": ("switch", "rekuperator_lock_flag"),
-    # Select renames
-    "rekuperator_filter_check_day_of_week": ("select", "rekuperator_pres_check_day"),
-    "rekuperator_filter_check_day_of_week_ext": ("select", "rekuperator_pres_check_day_4432"),
-    "rekuperator_gwc_regeneration": ("select", "rekuperator_gwc_regen"),
-    "rekuperator_filter_type": ("select", "rekuperator_filter_change"),
-    # Time entity renames
-    "rekuperator_filter_check_start_time": ("time", "rekuperator_pres_check_time"),
-    "rekuperator_filter_check_start_time_ext": ("time", "rekuperator_pres_check_time_ggmm"),
-    # Polish-language entity IDs (installations with HA language set to pl before 2026)
-    "rekuperator_moc_odzysku_ciepla": ("sensor", "rekuperator_heat_recovery_power"),
-    "rekuperator_sprawnosc_rekuperatora": ("sensor", "rekuperator_heat_recovery_efficiency"),
-    "rekuperator_pobor_mocy_elektrycznej": ("sensor", "rekuperator_electrical_power"),
-    "rekuperator_nazwa_urzadzenia": ("text", "rekuperator_device_name"),
-    "rekuperator_predkosc_1": ("fan", "rekuperator_ventilation"),
-    # Legacy split aliases for e_196_e_199 bitmask register
-    "rekuperator_error_e196": ("binary_sensor", "rekuperator_e_196_e_199_e_196"),
-    "rekuperator_error_e197": ("binary_sensor", "rekuperator_e_196_e_199_e_197"),
-    "rekuperator_error_e198": ("binary_sensor", "rekuperator_e_196_e_199_e_198"),
-    "rekuperator_error_e199": ("binary_sensor", "rekuperator_e_196_e_199_e_199"),
-    # Product key lock date split fields
-    "rekuperator_product_key_lock_date_month": ("sensor", "rekuperator_lock_date_00mm"),
-}
-
-_alias_warning_logged = False
-
-
-def map_legacy_entity_id(entity_id: str) -> str:
-    """Map a legacy entity ID to the new format.
-
-    If the provided ``entity_id`` matches one of the known legacy aliases, the
-    corresponding new entity ID is returned and a warning is logged exactly
-    once to inform the user about the change.
-    """
-
-    global _alias_warning_logged
-
-    if "." not in entity_id:
-        return entity_id
-
-    _domain, object_id = entity_id.split(".", 1)
-    if object_id in LEGACY_ENTITY_ID_OBJECT_ALIASES:
-        new_domain, new_object_id = LEGACY_ENTITY_ID_OBJECT_ALIASES[object_id]
-        new_entity_id = f"{new_domain}.{new_object_id}"
-        if not _alias_warning_logged:
-            _LOGGER.warning(
-                "Legacy entity ID '%s' detected. Please update automations to use '%s'.",
-                entity_id,
-                new_entity_id,
-            )
-            _alias_warning_logged = True
-        return new_entity_id
-
-    suffix = object_id.rsplit("_", 1)[-1]
-    if suffix not in LEGACY_ENTITY_ID_ALIASES:
-        return entity_id
-
-    new_domain, new_suffix = LEGACY_ENTITY_ID_ALIASES[suffix]
-    parts = object_id.split("_")
-    new_object_id = "_".join([*parts[:-1], new_suffix]) if len(parts) > 1 else new_suffix
-    new_entity_id = f"{new_domain}.{new_object_id}"
-
-    if not _alias_warning_logged:
-        _LOGGER.warning(
-            "Legacy entity ID '%s' detected. Please update automations to use '%s'.",
-            entity_id,
-            new_entity_id,
-        )
-        _alias_warning_logged = True
-
-    return new_entity_id
-
-
-def _infer_icon(name: str, unit: str | None) -> str:
-    """Return a default icon based on register name and unit."""
-    if unit == "°C" or "temperature" in name:
-        return "mdi:thermometer"
-    if unit in {"m³/h", "m3/h"} or "flow" in name or "fan" in name:
-        return "mdi:fan"
-    if unit == PERCENTAGE or "percentage" in name:
-        return "mdi:percent-outline"
-    if unit in {"s", "min", "h", "d"} or "time" in name:
-        return "mdi:timer"
-    if unit == "V":
-        return "mdi:sine-wave"
-    return "mdi:numeric"
-
-
-def _get_register_info(name: str) -> dict[str, Any] | None:
-    """Return register metadata, handling numeric suffixes."""
-    global _REGISTER_INFO_CACHE
-    if _REGISTER_INFO_CACHE is None:
-        _REGISTER_INFO_CACHE = {}
-        for reg in get_all_registers():
-            if not reg.name:
-                continue
-            scale = reg.multiplier or 1
-            step = reg.resolution or scale
-            _REGISTER_INFO_CACHE[reg.name] = {
-                "access": reg.access,
-                "min": reg.min,
-                "max": reg.max,
-                "unit": reg.unit,
-                "information": reg.information,
-                "scale": scale,
-                "step": step,
-            }
-    info = _REGISTER_INFO_CACHE.get(name)
-    if info is None and (suffix := name.rsplit("_", 1)) and len(suffix) > 1 and suffix[1].isdigit():
-        info = _REGISTER_INFO_CACHE.get(suffix[0])
-    return info
-
-
-def _parse_states(value: str | None) -> dict[str, int] | None:
-    """Parse ``"0 - off; 1 - on"`` style state strings into a mapping."""
-    if not value or "-" not in value:
-        return None
-    states: dict[str, int] = {}
-    for part in value.split(";"):
-        part = part.strip()
-        if not part:
-            continue
-        try:
-            num_str, label = part.split("-", 1)
-            number = int(num_str.strip())
-        except ValueError:
-            continue
-        states[_to_snake_case(label.strip())] = number
-    return states or None
-
-
-def _load_number_mappings() -> dict[str, dict[str, Any]]:
-    """Build number entity configurations from register metadata."""
-
-    number_configs: dict[str, dict[str, Any]] = {}
-
-    for reg in get_all_registers():
-        if reg.function != 3 or not reg.name:
-            continue
-        # String-type registers span multiple registers and store ASCII data.
-        # They cannot be meaningfully represented as a single numeric value,
-        # so skip them here (e.g. ``device_name`` at holding address 8144).
-        if reg.extra and reg.extra.get("type") == "string":
-            continue
-        register = reg.name
-        info = _get_register_info(register)
-        if not info:
-            continue
-
-        # Some writable holding registers are also exposed as sensors for
-        # display/diagnostics. Keep creating number entities for writable
-        # registers so users can still edit configuration values. For
-        # read-only sensor registers we skip number creation to avoid dead
-        # controls.
-        if register in SENSOR_ENTITY_MAPPINGS and "W" not in (info.get("access") or ""):
-            continue
-
-        # Skip registers already handled by select/switch platforms to avoid
-        # creating a duplicate Number entity alongside the correct entity type.
-        if register in SELECT_ENTITY_MAPPINGS:
-            continue
-        if register in SWITCH_ENTITY_MAPPINGS:
-            continue
-
-        # Skip BCD date/time registers — they store encoded year/month/day
-        # fields with format-descriptor "units" (e.g. "RRMM", "DDTT") that
-        # are not valid measurement units and must not be editable numbers.
-        if register.startswith("date_time"):
-            continue
-
-        # Skip diagnostic/error/fault registers (E/S/F codes and alarm/error flags)
-        if re.match(r"[sef](?:_|\d)", register) or register in {"alarm", "error"}:
-            continue
-
-        # Skip BCD time registers (schedule/airing/GWC-regen timeslots) – they
-        # decode to "HH:MM" strings, not floats, and are exposed as sensors.
-        from ..utils import BCD_TIME_PREFIXES
-
-        if any(register.startswith(prefix) for prefix in BCD_TIME_PREFIXES):
-            continue
-
-        # Skip schedule intensity/airflow setting registers — they store AATT
-        # packed values and are exposed as select entities (0–100 % in 10 %
-        # increments), not editable number inputs.
-        if register.startswith(("setting_summer_", "setting_winter_")):
-            continue
-
-        # Skip registers with enumerated states – handled as binary/select
-        if _parse_states(info.get("unit")):
-            continue
-
-        # Skip registers with JSON enum field — handled as select/switch/binary_sensor
-        if reg.enum and not (reg.extra and reg.extra.get("bitmask")):
-            continue
-
-        # Only expose registers that have a Number translation entry.
-        # This mirrors the whitelist approach used by binary_sensor/switch/select
-        # and prevents unnamed "Rekuperator" entities for reserved or
-        # undocumented registers (e.g. reserved_8145–reserved_8151, lock_pass_2).
-        if register not in _number_translation_keys():
-            continue
-
-        cfg: dict[str, Any] = {
-            "unit": info.get("unit"),
-            "step": info.get("step", 1),
-            "scale": info.get("scale", 1),
-        }
-        if info.get("min") is not None:
-            cfg["min"] = info["min"]
-        if info.get("max") is not None:
-            cfg["max"] = info["max"]
-
-        number_configs[register] = cfg
-
-    for register, override in NUMBER_OVERRIDES.items():
-        number_configs.setdefault(register, {}).update(override)
-
-    return number_configs
+__all__ = [
+    "BINARY_SENSOR_ENTITY_MAPPINGS",
+    # entity mappings
+    "ENTITY_MAPPINGS",
+    # legacy
+    "LEGACY_ENTITY_ID_ALIASES",
+    "LEGACY_ENTITY_ID_OBJECT_ALIASES",
+    "NUMBER_ENTITY_MAPPINGS",
+    "NUMBER_OVERRIDES",
+    "SELECT_ENTITY_MAPPINGS",
+    "SENSOR_ENTITY_MAPPINGS",
+    # special modes
+    "SPECIAL_MODE_ICONS",
+    "SWITCH_ENTITY_MAPPINGS",
+    "TEXT_ENTITY_MAPPINGS",
+    "TIME_ENTITY_MAPPINGS",
+    # helpers
+    "_REGISTER_INFO_CACHE",
+    "_alias_warning_logged",
+    # loaders
+    "_build_entity_mappings",
+    "_extend_entity_mappings_from_registers",
+    "_get_register_info",
+    "_infer_icon",
+    "_load_discrete_mappings",
+    "_load_number_mappings",
+    "_load_translation_keys",
+    "_number_translation_keys",
+    "_parse_states",
+    # setup
+    "async_setup_entity_mappings",
+    # const register accessors (re-exported so tests can monkeypatch via this module)
+    "coil_registers",
+    "discrete_input_registers",
+    "get_all_registers",
+    "holding_registers",
+    "map_legacy_entity_id",
+]
 
 
 # Manual overrides for number entities (icons, custom units, etc.)
@@ -436,189 +233,6 @@ NUMBER_OVERRIDES: dict[str, dict[str, Any]] = {
     # lock_pass — product key passphrase, first 16-bit word (0–0x423f = 16959)
     "lock_pass": {"icon": "mdi:lock", "min": 0, "max": 16959, "step": 1},
 }
-
-
-def _number_translation_keys() -> set[str]:
-    """Return register names that have a Number translation entry in en.json.
-
-    Used as a whitelist: only registers present here will produce a Number
-    entity, preventing unnamed "Rekuperator" fallback entries for reserved or
-    undocumented registers (e.g. ``reserved_8145``–``reserved_8151``).
-    """
-    try:
-        _t = Path(__file__).resolve().with_name("translations")
-        _translations_dir = _t if _t.exists() else Path(__file__).resolve().parents[1] / "translations"
-        with (_translations_dir / "en.json").open(encoding="utf-8") as f:
-            data = json.load(f)
-        return set(data.get("entity", {}).get("number", {}).keys())
-    except (
-        OSError,
-        json.JSONDecodeError,
-        ValueError,
-    ) as err:  # pragma: no cover - fallback when translations missing
-        _LOGGER.debug("Failed to load number translation keys: %s", err)
-        return set()
-    except (AttributeError, TypeError) as err:  # pragma: no cover - unexpected
-        _LOGGER.exception("Unexpected error loading number translation keys: %s", err)
-        return set()
-
-
-def _load_translation_keys() -> dict[str, set[str]]:
-    """Return available translation keys for supported entity types."""
-
-    try:
-        _t = Path(__file__).resolve().with_name("translations")
-        _translations_dir = _t if _t.exists() else Path(__file__).resolve().parents[1] / "translations"
-        with (_translations_dir / "en.json").open(encoding="utf-8") as f:
-            data = json.load(f)
-        entity = data.get("entity", {})
-        return {
-            "binary_sensor": set(entity.get("binary_sensor", {}).keys()),
-            "switch": set(entity.get("switch", {}).keys()),
-            "select": set(entity.get("select", {}).keys()),
-        }
-    except (
-        OSError,
-        json.JSONDecodeError,
-        ValueError,
-    ) as err:  # pragma: no cover - fallback when translations missing
-        _LOGGER.debug("Failed to load translation keys: %s", err)
-        return {"binary_sensor": set(), "switch": set(), "select": set()}
-    except (AttributeError, TypeError) as err:  # pragma: no cover - unexpected
-        _LOGGER.exception("Unexpected error loading translation keys: %s", err)
-        return {"binary_sensor": set(), "switch": set(), "select": set()}
-
-
-def _load_discrete_mappings() -> tuple[
-    dict[str, dict[str, Any]],
-    dict[str, dict[str, Any]],
-    dict[str, dict[str, Any]],
-]:
-    """Generate mappings for binary_sensor, switch and select entities."""
-
-    binary_configs: dict[str, dict[str, Any]] = {}
-    switch_configs: dict[str, dict[str, Any]] = {}
-    select_configs: dict[str, dict[str, Any]] = {}
-
-    translations = _load_translation_keys()
-    binary_keys = translations["binary_sensor"]
-    switch_keys = translations["switch"]
-    select_keys = translations["select"]
-
-    # Coil and discrete input registers are always binary sensors
-    for reg in coil_registers():
-        if reg not in binary_keys:
-            continue
-        binary_configs[reg] = {
-            "translation_key": reg,
-            "register_type": "coil_registers",
-        }
-    for reg in discrete_input_registers():
-        if reg not in binary_keys:
-            continue
-        binary_configs[reg] = {
-            "translation_key": reg,
-            "register_type": "discrete_inputs",
-        }
-
-    # Holding registers with enumerated states
-    for reg in holding_registers():
-        info = _get_register_info(reg)
-        if not info:
-            continue
-        states = _parse_states(info.get("unit"))
-        if not states:
-            continue
-        access = (info.get("access") or "").upper()
-        cfg: dict[str, Any] = {"translation_key": reg, "register_type": "holding_registers"}
-        if len(states) == 2 and set(states.values()) == {0, 1}:
-            if "W" in access:
-                if reg in switch_keys:
-                    cfg["register"] = reg
-                    cfg.setdefault("icon", "mdi:toggle-switch")
-                    switch_configs[reg] = cfg
-                else:
-                    if reg in binary_keys:
-                        binary_configs[reg] = cfg
-        else:
-            if reg in select_keys:
-                cfg["states"] = states
-                select_configs[reg] = cfg
-
-    # Alarm/error registers and diagnostic S_/E_ codes should always be
-    # exposed as binary sensors so they are created even if the register
-    # metadata marks them as writable or enumerated. We therefore override
-    # any previously generated switch/select configurations.
-    diag_registers = {"alarm", "error"}
-    diag_registers.update(reg for reg in holding_registers() if re.match(r"[se](?:_|\d)", reg))
-    for reg in diag_registers:
-        if reg not in holding_registers() and reg not in {"alarm", "error"}:
-            continue
-        if reg not in binary_keys:
-            continue
-        binary_configs[reg] = {
-            "translation_key": reg,
-            "register_type": "holding_registers",
-            "entity_category": EntityCategory.DIAGNOSTIC,
-        }
-        switch_configs.pop(reg, None)
-        select_configs.pop(reg, None)
-
-    # Registers exposing bitmask flags
-    func_map = {
-        1: "coil_registers",
-        2: "discrete_inputs",
-        3: "holding_registers",
-        4: "input_registers",
-    }
-    for reg in get_all_registers():
-        if not reg.name:
-            continue
-        if not reg.extra or not reg.extra.get("bitmask"):
-            continue
-        register_type = func_map.get(reg.function)
-        if not register_type:
-            continue
-        bits = reg.bits or []
-        if bits:
-            unnamed_bit = False
-            for idx, bit_def in enumerate(bits):
-                if isinstance(bit_def, dict):
-                    bit_name = bit_def.get("name")
-                else:
-                    bit_name = str(bit_def) if bit_def is not None else None
-
-                if bit_name:
-                    key = f"{reg.name}_{_to_snake_case(bit_name)}"
-                    binary_configs[key] = {
-                        "translation_key": key,
-                        "register_type": register_type,
-                        "register": reg.name,
-                        "bit": 1 << idx,
-                    }
-                else:
-                    unnamed_bit = True
-
-            if unnamed_bit:
-                binary_configs.setdefault(
-                    reg.name,
-                    {
-                        "translation_key": reg.name,
-                        "register_type": register_type,
-                        "bitmask": True,
-                    },
-                )
-        else:
-            binary_configs.setdefault(
-                reg.name,
-                {
-                    "translation_key": reg.name,
-                    "register_type": register_type,
-                    "bitmask": True,
-                },
-            )
-
-    return binary_configs, switch_configs, select_configs
 
 
 # ---------------------------------------------------------------------------
@@ -1433,20 +1047,6 @@ BINARY_SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     },
 }
 
-SPECIAL_MODE_ICONS = {
-    "boost": "mdi:rocket-launch",
-    "eco": "mdi:leaf",
-    "away": "mdi:airplane",
-    "fireplace": "mdi:fireplace",
-    "hood": "mdi:range-hood",
-    "sleep": "mdi:weather-night",
-    "party": "mdi:party-popper",
-    "bathroom": "mdi:shower",
-    "kitchen": "mdi:chef-hat",
-    "summer": "mdi:white-balance-sunny",
-    "winter": "mdi:snowflake",
-}
-
 SWITCH_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     # System control switches from holding registers
     "on_off_panel_mode": {
@@ -1533,321 +1133,18 @@ TEXT_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
 ENTITY_MAPPINGS: dict[str, dict[str, dict[str, Any]]] = {}
 
 
-def _extend_entity_mappings_from_registers() -> None:
-    """Populate entity mappings for registers not explicitly defined.
-
-    Only registers that have a corresponding translation entry are added to
-    avoid creating unnamed "Rekuperator" fallback entities for reserved or
-    undocumented registers.
-    """
-
-    translations = _load_translation_keys()
-    binary_keys = translations["binary_sensor"]
-    switch_keys = translations["switch"]
-    select_keys = translations["select"]
-    number_keys = _number_translation_keys()
-
-    for reg in get_all_registers():
-        if reg.function != 3 or not reg.name:
-            continue
-        register = reg.name
-        if register in NUMBER_ENTITY_MAPPINGS:
-            continue
-        if register in SENSOR_ENTITY_MAPPINGS:
-            continue
-        if register in BINARY_SENSOR_ENTITY_MAPPINGS:
-            continue
-        # Skip if bit-level entities already cover this register (bitmask registers).
-        # Adding a whole-register entity on top of bit entities would create a
-        # redundant duplicate that reads the raw bitmask value.
-        if any(v.get("register") == register for v in BINARY_SENSOR_ENTITY_MAPPINGS.values()):
-            continue
-        if register in SWITCH_ENTITY_MAPPINGS:
-            continue
-        if register in SELECT_ENTITY_MAPPINGS:
-            continue
-        if register in TEXT_ENTITY_MAPPINGS:
-            continue
-        if register in TIME_ENTITY_MAPPINGS:
-            continue
-
-        if (
-            register in {"alarm", "error"}
-            or register.startswith("s_")
-            or register.startswith("e_")
-            or register.startswith("f_")
-        ):
-            if register not in binary_keys:
-                continue
-            BINARY_SENSOR_ENTITY_MAPPINGS.setdefault(
-                register,
-                {
-                    "translation_key": register,
-                    "icon": "mdi:alert-circle",
-                    "register_type": "holding_registers",
-                    "device_class": BinarySensorDeviceClass.PROBLEM,
-                },
-            )
-            continue
-
-        # BCD date/time encoding registers — raw BCD year/month/day values with
-        # format-descriptor "units" (e.g. "RRMM", "DDTT"); not plain numbers.
-        if register.startswith("date_time"):
-            continue
-
-        # BCD time registers (schedule/airing/GWC timeslots).
-        # RW schedule_* registers → select entity (time-slot picker).
-        # RW start_gwc_regen* / stop_gwc_regen* → select entity (preset times).
-        # RW pres_check_time*, airing_summer_*, airing_winter_*,
-        #   manual_airing_time_to_start → native HA time entity (HH:MM picker).
-        # Read-only BCD time registers remain sensors.
-        from ..utils import BCD_TIME_PREFIXES
-
-        _TIME_ENTITY_PREFIXES = (
-            "schedule_",
-            "pres_check_time",
-            "airing_summer_",
-            "airing_winter_",
-            "manual_airing_time_to_start",
-            "start_gwc_regen",
-            "stop_gwc_regen",
-        )
-
-        if any(register.startswith(prefix) for prefix in BCD_TIME_PREFIXES):
-            reg_access = (reg.access or "").upper()
-            if register.startswith(_TIME_ENTITY_PREFIXES) and "W" in reg_access:
-                TIME_ENTITY_MAPPINGS.setdefault(
-                    register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:clock-outline",
-                        "register_type": "holding_registers",
-                    },
-                )
-            else:
-                SENSOR_ENTITY_MAPPINGS.setdefault(
-                    register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:clock-outline",
-                        "register_type": "holding_registers",
-                    },
-                )
-            continue
-
-        # Schedule intensity/airflow setting registers (setting_summer_* and
-        # setting_winter_*).  These store a 0–100 % airflow value paired with
-        # each BCD time slot and are exposed as select entities with 10 %
-        # increment steps so that users can easily pick a preset level.
-        if register.startswith(("setting_summer_", "setting_winter_")):
-            reg_access = (reg.access or "").upper()
-            if "W" in reg_access:
-                from ..schedule_helpers import PERCENT_10_SELECT_STATES
-
-                SELECT_ENTITY_MAPPINGS.setdefault(
-                    register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:fan",
-                        "register_type": "holding_registers",
-                        "states": PERCENT_10_SELECT_STATES,
-                    },
-                )
-            else:
-                SENSOR_ENTITY_MAPPINGS.setdefault(
-                    register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:fan",
-                        "register_type": "holding_registers",
-                    },
-                )
-            continue
-
-        access = (reg.access or "").upper()
-        min_val = reg.min
-        max_val = reg.max
-        unit = reg.unit
-        info_text = reg.information or ""
-        scale = reg.multiplier or 1
-        step = reg.resolution or scale
-
-        # Registers with JSON enum field — classify as switch/binary_sensor/select
-        if reg.enum and not (reg.extra and reg.extra.get("bitmask")):
-            enum_states = {_to_snake_case(str(v)): int(k) for k, v in reg.enum.items()}
-            if len(reg.enum) == 2 and set(int(k) for k in reg.enum) == {0, 1}:
-                if "W" in access:
-                    if register not in switch_keys:
-                        continue
-                    SWITCH_ENTITY_MAPPINGS.setdefault(
-                        register,
-                        {
-                            "icon": "mdi:toggle-switch",
-                            "register": register,
-                            "register_type": "holding_registers",
-                            "category": None,
-                            "translation_key": register,
-                        },
-                    )
-                else:
-                    if register not in binary_keys:
-                        continue
-                    BINARY_SENSOR_ENTITY_MAPPINGS.setdefault(
-                        register,
-                        {
-                            "translation_key": register,
-                            "icon": "mdi:checkbox-marked-circle-outline",
-                            "register_type": "holding_registers",
-                        },
-                    )
-            elif "W" in access:
-                if register not in select_keys:
-                    continue
-                SELECT_ENTITY_MAPPINGS.setdefault(
-                    register,
-                    {
-                        "icon": "mdi:format-list-bulleted",
-                        "translation_key": register,
-                        "states": enum_states,
-                        "register_type": "holding_registers",
-                    },
-                )
-            else:
-                # Read-only enum sensor — no translation key check needed since
-                # sensor.py skips entities without a recognised translation_key
-                # and these are rarely present in the register spec.
-                SENSOR_ENTITY_MAPPINGS.setdefault(
-                    register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:information-outline",
-                        "register_type": "holding_registers",
-                    },
-                )
-            continue
-
-        if min_val is not None and max_val is not None:
-            if max_val <= 1:
-                if "W" in access:
-                    if register not in switch_keys:
-                        continue
-                    SWITCH_ENTITY_MAPPINGS.setdefault(
-                        register,
-                        {
-                            "icon": "mdi:toggle-switch",
-                            "register": register,
-                            "register_type": "holding_registers",
-                            "category": None,
-                            "translation_key": register,
-                        },
-                    )
-                else:
-                    if register not in binary_keys:
-                        continue
-                    BINARY_SENSOR_ENTITY_MAPPINGS.setdefault(
-                        register,
-                        {
-                            "translation_key": register,
-                            "icon": "mdi:checkbox-marked-circle-outline",
-                            "register_type": "holding_registers",
-                        },
-                    )
-                continue
-
-            if "W" in access and info_text and ";" in info_text and max_val <= 10:
-                states: dict[str, int] = {}
-                for part in info_text.split(";"):
-                    part = part.strip()
-                    if " - " not in part:
-                        continue
-                    val_str, label = part.split(" - ", 1)
-                    try:
-                        states[_to_snake_case(label)] = int(val_str.strip())
-                    except ValueError:
-                        continue
-                if states:
-                    if register not in select_keys:
-                        continue
-                    SELECT_ENTITY_MAPPINGS.setdefault(
-                        register,
-                        {
-                            "icon": "mdi:format-list-bulleted",
-                            "translation_key": register,
-                            "states": states,
-                            "register_type": "holding_registers",
-                        },
-                    )
-                    continue
-
-            if "W" in access:
-                if register not in number_keys:
-                    continue
-                NUMBER_ENTITY_MAPPINGS.setdefault(
-                    register,
-                    {
-                        "unit": unit,
-                        "icon": _infer_icon(register, unit),
-                        "min": min_val,
-                        "max": max_val,
-                        "step": step,
-                        "scale": scale,
-                    },
-                )
-
-
-def _build_entity_mappings() -> None:
-    """Populate entity mapping dictionaries."""
-
-    global NUMBER_ENTITY_MAPPINGS, TIME_ENTITY_MAPPINGS, ENTITY_MAPPINGS
-
-    NUMBER_ENTITY_MAPPINGS = _load_number_mappings()
-    TIME_ENTITY_MAPPINGS = {}
-
-    _gen_binary, _gen_switch, _gen_select = _load_discrete_mappings()
-    for key in BINARY_SENSOR_ENTITY_MAPPINGS:
-        _gen_binary.pop(key, None)
-        _gen_switch.pop(key, None)
-        _gen_select.pop(key, None)
-    for key in SWITCH_ENTITY_MAPPINGS:
-        _gen_binary.pop(key, None)
-        _gen_select.pop(key, None)
-    for key in SELECT_ENTITY_MAPPINGS:
-        _gen_binary.pop(key, None)
-        _gen_switch.pop(key, None)
-    BINARY_SENSOR_ENTITY_MAPPINGS.update(_gen_binary)
-    SWITCH_ENTITY_MAPPINGS.update(_gen_switch)
-    SELECT_ENTITY_MAPPINGS.update(_gen_select)
-
-    for mode, bit in SPECIAL_FUNCTION_MAP.items():
-        SWITCH_ENTITY_MAPPINGS[mode] = {
-            "icon": SPECIAL_MODE_ICONS.get(mode, "mdi:toggle-switch"),
-            "register": "special_mode",
-            "register_type": "holding_registers",
-            "category": None,
-            "translation_key": mode,
-            "bit": bit,
-        }
-
-    _extend_entity_mappings_from_registers()
-
-    ENTITY_MAPPINGS = {
-        "number": NUMBER_ENTITY_MAPPINGS,
-        "sensor": SENSOR_ENTITY_MAPPINGS,
-        "binary_sensor": BINARY_SENSOR_ENTITY_MAPPINGS,
-        "switch": SWITCH_ENTITY_MAPPINGS,
-        "select": SELECT_ENTITY_MAPPINGS,
-        "text": TEXT_ENTITY_MAPPINGS,
-        "time": TIME_ENTITY_MAPPINGS,
-    }
+def _run_build_entity_mappings() -> None:
+    """Build entity mappings; delegates to _loaders._build_entity_mappings."""
+    _build_entity_mappings()
 
 
 async def async_setup_entity_mappings(hass: HomeAssistant | None = None) -> None:
     """Asynchronously build entity mappings."""
 
     if hass is not None:
-        await hass.async_add_executor_job(_build_entity_mappings)
+        await hass.async_add_executor_job(_run_build_entity_mappings)
     else:
-        _build_entity_mappings()
+        _run_build_entity_mappings()
 
 
 try:  # pragma: no cover - handle partially initialized module
@@ -1855,4 +1152,4 @@ try:  # pragma: no cover - handle partially initialized module
 except (ImportError, ValueError):
     _HAS_HA = False
 
-_build_entity_mappings()
+_run_build_entity_mappings()

--- a/custom_components/thessla_green_modbus/mappings/_helpers.py
+++ b/custom_components/thessla_green_modbus/mappings/_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -38,16 +39,31 @@ def _infer_icon(name: str, unit: str | None) -> str:
 
 
 def _get_register_info(name: str) -> dict[str, Any] | None:
-    """Return register metadata, handling numeric suffixes."""
+    """Return register metadata, handling numeric suffixes.
+
+    Looks up ``_REGISTER_INFO_CACHE`` through the parent ``mappings`` package
+    module so that test monkeypatching on ``em._REGISTER_INFO_CACHE`` is
+    respected at call time.
+    """
     global _REGISTER_INFO_CACHE
-    if _REGISTER_INFO_CACHE is None:
-        _REGISTER_INFO_CACHE = {}
-        for reg in get_all_registers():
+
+    # Prefer the cache stored on the parent module so monkeypatch works.
+    _parent = sys.modules.get(__package__)
+    cache: dict[str, Any] | None = (
+        getattr(_parent, "_REGISTER_INFO_CACHE", None) if _parent is not None else _REGISTER_INFO_CACHE
+    )
+
+    if cache is None:
+        _fn = (
+            getattr(_parent, "get_all_registers", None) if _parent is not None else None
+        ) or get_all_registers
+        cache = {}
+        for reg in _fn():
             if not reg.name:
                 continue
             scale = reg.multiplier or 1
             step = reg.resolution or scale
-            _REGISTER_INFO_CACHE[reg.name] = {
+            cache[reg.name] = {
                 "access": reg.access,
                 "min": reg.min,
                 "max": reg.max,
@@ -56,9 +72,13 @@ def _get_register_info(name: str) -> dict[str, Any] | None:
                 "scale": scale,
                 "step": step,
             }
-    info = _REGISTER_INFO_CACHE.get(name)
+        _REGISTER_INFO_CACHE = cache
+        if _parent is not None:
+            _parent._REGISTER_INFO_CACHE = cache  # type: ignore[union-attr]
+
+    info = cache.get(name)
     if info is None and (suffix := name.rsplit("_", 1)) and len(suffix) > 1 and suffix[1].isdigit():
-        info = _REGISTER_INFO_CACHE.get(suffix[0])
+        info = cache.get(suffix[0])
     return info
 
 
@@ -136,4 +156,5 @@ __all__ = [
     "_load_translation_keys",
     "_number_translation_keys",
     "_parse_states",
+    "get_all_registers",
 ]

--- a/custom_components/thessla_green_modbus/mappings/_helpers.py
+++ b/custom_components/thessla_green_modbus/mappings/_helpers.py
@@ -1,16 +1,136 @@
-"""Helper function exports for mapping generation."""
+"""Helper functions for mapping generation."""
 
 from __future__ import annotations
 
-from . import (
-    _get_register_info,
-    _infer_icon,
-    _load_translation_keys,
-    _number_translation_keys,
-    _parse_states,
-)
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .._compat import PERCENTAGE
+from ..utils import _to_snake_case
+
+try:  # pragma: no cover - optional during isolated tests
+    from ..registers.loader import get_all_registers
+except (ImportError, AttributeError):  # pragma: no cover
+
+    def get_all_registers(*_args, **_kwargs):
+        return []
+
+
+_LOGGER = logging.getLogger(__name__)
+_REGISTER_INFO_CACHE: dict[str, dict[str, Any]] | None = None
+
+
+def _infer_icon(name: str, unit: str | None) -> str:
+    """Return a default icon based on register name and unit."""
+    if unit == "°C" or "temperature" in name:
+        return "mdi:thermometer"
+    if unit in {"m³/h", "m3/h"} or "flow" in name or "fan" in name:
+        return "mdi:fan"
+    if unit == PERCENTAGE or "percentage" in name:
+        return "mdi:percent-outline"
+    if unit in {"s", "min", "h", "d"} or "time" in name:
+        return "mdi:timer"
+    if unit == "V":
+        return "mdi:sine-wave"
+    return "mdi:numeric"
+
+
+def _get_register_info(name: str) -> dict[str, Any] | None:
+    """Return register metadata, handling numeric suffixes."""
+    global _REGISTER_INFO_CACHE
+    if _REGISTER_INFO_CACHE is None:
+        _REGISTER_INFO_CACHE = {}
+        for reg in get_all_registers():
+            if not reg.name:
+                continue
+            scale = reg.multiplier or 1
+            step = reg.resolution or scale
+            _REGISTER_INFO_CACHE[reg.name] = {
+                "access": reg.access,
+                "min": reg.min,
+                "max": reg.max,
+                "unit": reg.unit,
+                "information": reg.information,
+                "scale": scale,
+                "step": step,
+            }
+    info = _REGISTER_INFO_CACHE.get(name)
+    if info is None and (suffix := name.rsplit("_", 1)) and len(suffix) > 1 and suffix[1].isdigit():
+        info = _REGISTER_INFO_CACHE.get(suffix[0])
+    return info
+
+
+def _parse_states(value: str | None) -> dict[str, int] | None:
+    """Parse ``"0 - off; 1 - on"`` style state strings into a mapping."""
+    if not value or "-" not in value:
+        return None
+    states: dict[str, int] = {}
+    for part in value.split(";"):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            num_str, label = part.split("-", 1)
+            number = int(num_str.strip())
+        except ValueError:
+            continue
+        states[_to_snake_case(label.strip())] = number
+    return states or None
+
+
+def _number_translation_keys() -> set[str]:
+    """Return register names that have a Number translation entry in en.json.
+
+    Used as a whitelist: only registers present here will produce a Number
+    entity, preventing unnamed "Rekuperator" fallback entries for reserved or
+    undocumented registers (e.g. ``reserved_8145``–``reserved_8151``).
+    """
+    try:
+        _translations_dir = Path(__file__).resolve().parents[1] / "translations"
+        with (_translations_dir / "en.json").open(encoding="utf-8") as f:
+            data = json.load(f)
+        return set(data.get("entity", {}).get("number", {}).keys())
+    except (
+        OSError,
+        json.JSONDecodeError,
+        ValueError,
+    ) as err:  # pragma: no cover - fallback when translations missing
+        _LOGGER.debug("Failed to load number translation keys: %s", err)
+        return set()
+    except (AttributeError, TypeError) as err:  # pragma: no cover - unexpected
+        _LOGGER.exception("Unexpected error loading number translation keys: %s", err)
+        return set()
+
+
+def _load_translation_keys() -> dict[str, set[str]]:
+    """Return available translation keys for supported entity types."""
+
+    try:
+        _translations_dir = Path(__file__).resolve().parents[1] / "translations"
+        with (_translations_dir / "en.json").open(encoding="utf-8") as f:
+            data = json.load(f)
+        entity = data.get("entity", {})
+        return {
+            "binary_sensor": set(entity.get("binary_sensor", {}).keys()),
+            "switch": set(entity.get("switch", {}).keys()),
+            "select": set(entity.get("select", {}).keys()),
+        }
+    except (
+        OSError,
+        json.JSONDecodeError,
+        ValueError,
+    ) as err:  # pragma: no cover - fallback when translations missing
+        _LOGGER.debug("Failed to load translation keys: %s", err)
+        return {"binary_sensor": set(), "switch": set(), "select": set()}
+    except (AttributeError, TypeError) as err:  # pragma: no cover - unexpected
+        _LOGGER.exception("Unexpected error loading translation keys: %s", err)
+        return {"binary_sensor": set(), "switch": set(), "select": set()}
+
 
 __all__ = [
+    "_REGISTER_INFO_CACHE",
     "_get_register_info",
     "_infer_icon",
     "_load_translation_keys",

--- a/custom_components/thessla_green_modbus/mappings/_loaders.py
+++ b/custom_components/thessla_green_modbus/mappings/_loaders.py
@@ -1,13 +1,556 @@
-"""Loader function exports for mapping generation."""
+"""Loader functions for entity mapping generation."""
 
 from __future__ import annotations
 
-from . import (
-    _build_entity_mappings,
-    _extend_entity_mappings_from_registers,
-    _load_discrete_mappings,
-    _load_number_mappings,
+import re
+import sys
+from typing import Any
+
+from .._compat import BinarySensorDeviceClass, EntityCategory
+from ..const import (
+    SPECIAL_FUNCTION_MAP,
+    coil_registers,
+    discrete_input_registers,
+    holding_registers,
 )
+from ..utils import BCD_TIME_PREFIXES, _to_snake_case
+from ._helpers import (
+    _get_register_info,
+    _infer_icon,
+    _load_translation_keys,
+    _number_translation_keys,
+    _parse_states,
+)
+
+try:  # pragma: no cover - optional during isolated tests
+    from ..registers.loader import get_all_registers
+except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
+
+    def get_all_registers(*_args, **_kwargs):  # type: ignore[misc]
+        return []
+
+
+_TIME_ENTITY_PREFIXES = (
+    "schedule_",
+    "pres_check_time",
+    "airing_summer_",
+    "airing_winter_",
+    "manual_airing_time_to_start",
+    "start_gwc_regen",
+    "stop_gwc_regen",
+)
+
+
+def _get_parent() -> Any:
+    """Return the parent mappings package module.
+
+    Using ``sys.modules`` lookup allows test monkeypatching on the parent
+    module (e.g. ``monkeypatch.setattr(em, "get_all_registers", ...)``) to
+    transparently propagate into the functions below.
+    """
+    return sys.modules.get(__package__)
+
+
+def _resolve(attr: str, fallback: Any) -> Any:
+    """Look up *attr* on the parent mappings module, falling back to *fallback*."""
+    parent = _get_parent()
+    if parent is not None:
+        val = getattr(parent, attr, None)
+        if val is not None:
+            return val
+    return fallback
+
+
+def _load_number_mappings() -> dict[str, dict[str, Any]]:
+    """Build number entity configurations from register metadata."""
+
+    _get_all = _resolve("get_all_registers", get_all_registers)
+    _get_info = _resolve("_get_register_info", _get_register_info)
+    _parse = _resolve("_parse_states", _parse_states)
+    _num_trans = _resolve("_number_translation_keys", _number_translation_keys)
+
+    parent = _get_parent()
+    sensor_maps: dict[str, Any] = getattr(parent, "SENSOR_ENTITY_MAPPINGS", {}) if parent else {}
+    select_maps: dict[str, Any] = getattr(parent, "SELECT_ENTITY_MAPPINGS", {}) if parent else {}
+    switch_maps: dict[str, Any] = getattr(parent, "SWITCH_ENTITY_MAPPINGS", {}) if parent else {}
+    num_overrides: dict[str, Any] = getattr(parent, "NUMBER_OVERRIDES", {}) if parent else {}
+
+    number_configs: dict[str, dict[str, Any]] = {}
+
+    for reg in _get_all():
+        if reg.function != 3 or not reg.name:
+            continue
+        if reg.extra and reg.extra.get("type") == "string":
+            continue
+        register = reg.name
+        info = _get_info(register)
+        if not info:
+            continue
+
+        if register in sensor_maps and "W" not in (info.get("access") or ""):
+            continue
+        if register in select_maps:
+            continue
+        if register in switch_maps:
+            continue
+        if register.startswith("date_time"):
+            continue
+        if re.match(r"[sef](?:_|\d)", register) or register in {"alarm", "error"}:
+            continue
+        if any(register.startswith(prefix) for prefix in BCD_TIME_PREFIXES):
+            continue
+        if register.startswith(("setting_summer_", "setting_winter_")):
+            continue
+        if _parse(info.get("unit")):
+            continue
+        if reg.enum and not (reg.extra and reg.extra.get("bitmask")):
+            continue
+        if register not in _num_trans():
+            continue
+
+        cfg: dict[str, Any] = {
+            "unit": info.get("unit"),
+            "step": info.get("step", 1),
+            "scale": info.get("scale", 1),
+        }
+        if info.get("min") is not None:
+            cfg["min"] = info["min"]
+        if info.get("max") is not None:
+            cfg["max"] = info["max"]
+
+        number_configs[register] = cfg
+
+    for register, override in num_overrides.items():
+        number_configs.setdefault(register, {}).update(override)
+
+    return number_configs
+
+
+def _load_discrete_mappings() -> tuple[
+    dict[str, dict[str, Any]],
+    dict[str, dict[str, Any]],
+    dict[str, dict[str, Any]],
+]:
+    """Generate mappings for binary_sensor, switch and select entities."""
+
+    _get_all = _resolve("get_all_registers", get_all_registers)
+    _get_info = _resolve("_get_register_info", _get_register_info)
+    _parse = _resolve("_parse_states", _parse_states)
+    _tkeys = _resolve("_load_translation_keys", _load_translation_keys)
+    _coil_regs = _resolve("coil_registers", coil_registers)
+    _discrete_regs = _resolve("discrete_input_registers", discrete_input_registers)
+    _holding_regs = _resolve("holding_registers", holding_registers)
+
+    binary_configs: dict[str, dict[str, Any]] = {}
+    switch_configs: dict[str, dict[str, Any]] = {}
+    select_configs: dict[str, dict[str, Any]] = {}
+
+    translations = _tkeys()
+    binary_keys = translations["binary_sensor"]
+    switch_keys = translations["switch"]
+    select_keys = translations["select"]
+
+    for reg in _coil_regs():
+        if reg not in binary_keys:
+            continue
+        binary_configs[reg] = {"translation_key": reg, "register_type": "coil_registers"}
+    for reg in _discrete_regs():
+        if reg not in binary_keys:
+            continue
+        binary_configs[reg] = {"translation_key": reg, "register_type": "discrete_inputs"}
+
+    for reg in _holding_regs():
+        info = _get_info(reg)
+        if not info:
+            continue
+        states = _parse(info.get("unit"))
+        if not states:
+            continue
+        access = (info.get("access") or "").upper()
+        cfg: dict[str, Any] = {"translation_key": reg, "register_type": "holding_registers"}
+        if len(states) == 2 and set(states.values()) == {0, 1}:
+            if "W" in access:
+                if reg in switch_keys:
+                    cfg["register"] = reg
+                    cfg.setdefault("icon", "mdi:toggle-switch")
+                    switch_configs[reg] = cfg
+                else:
+                    if reg in binary_keys:
+                        binary_configs[reg] = cfg
+        else:
+            if reg in select_keys:
+                cfg["states"] = states
+                select_configs[reg] = cfg
+
+    diag_registers = {"alarm", "error"}
+    diag_registers.update(reg for reg in _holding_regs() if re.match(r"[se](?:_|\d)", reg))
+    for reg in diag_registers:
+        if reg not in _holding_regs() and reg not in {"alarm", "error"}:
+            continue
+        if reg not in binary_keys:
+            continue
+        binary_configs[reg] = {
+            "translation_key": reg,
+            "register_type": "holding_registers",
+            "entity_category": EntityCategory.DIAGNOSTIC,
+        }
+        switch_configs.pop(reg, None)
+        select_configs.pop(reg, None)
+
+    func_map = {
+        1: "coil_registers",
+        2: "discrete_inputs",
+        3: "holding_registers",
+        4: "input_registers",
+    }
+    for reg in _get_all():
+        if not reg.name:
+            continue
+        if not reg.extra or not reg.extra.get("bitmask"):
+            continue
+        register_type = func_map.get(reg.function)
+        if not register_type:
+            continue
+        bits = reg.bits or []
+        if bits:
+            unnamed_bit = False
+            for idx, bit_def in enumerate(bits):
+                bit_name = bit_def.get("name") if isinstance(bit_def, dict) else (
+                    str(bit_def) if bit_def is not None else None
+                )
+                if bit_name:
+                    key = f"{reg.name}_{_to_snake_case(bit_name)}"
+                    binary_configs[key] = {
+                        "translation_key": key,
+                        "register_type": register_type,
+                        "register": reg.name,
+                        "bit": 1 << idx,
+                    }
+                else:
+                    unnamed_bit = True
+            if unnamed_bit:
+                binary_configs.setdefault(
+                    reg.name,
+                    {"translation_key": reg.name, "register_type": register_type, "bitmask": True},
+                )
+        else:
+            binary_configs.setdefault(
+                reg.name,
+                {"translation_key": reg.name, "register_type": register_type, "bitmask": True},
+            )
+
+    return binary_configs, switch_configs, select_configs
+
+
+def _extend_entity_mappings_from_registers() -> None:
+    """Populate entity mappings for registers not explicitly defined.
+
+    Only registers that have a corresponding translation entry are added to
+    avoid creating unnamed "Rekuperator" fallback entities for reserved or
+    undocumented registers.
+    """
+    from ..schedule_helpers import PERCENT_10_SELECT_STATES
+
+    _get_all = _resolve("get_all_registers", get_all_registers)
+    _tkeys = _resolve("_load_translation_keys", _load_translation_keys)
+    _num_tkeys = _resolve("_number_translation_keys", _number_translation_keys)
+
+    parent = _get_parent()
+
+    def _maps(name: str) -> dict[str, Any]:
+        return getattr(parent, name, {}) if parent else {}
+
+    number_mappings = _maps("NUMBER_ENTITY_MAPPINGS")
+    sensor_mappings = _maps("SENSOR_ENTITY_MAPPINGS")
+    binary_mappings = _maps("BINARY_SENSOR_ENTITY_MAPPINGS")
+    switch_mappings = _maps("SWITCH_ENTITY_MAPPINGS")
+    select_mappings = _maps("SELECT_ENTITY_MAPPINGS")
+    text_mappings = _maps("TEXT_ENTITY_MAPPINGS")
+    time_mappings = _maps("TIME_ENTITY_MAPPINGS")
+
+    translations = _tkeys()
+    binary_keys = translations["binary_sensor"]
+    switch_keys = translations["switch"]
+    select_keys = translations["select"]
+    number_keys = _num_tkeys()
+
+    for reg in _get_all():
+        if reg.function != 3 or not reg.name:
+            continue
+        register = reg.name
+        if register in number_mappings:
+            continue
+        if register in sensor_mappings:
+            continue
+        if register in binary_mappings:
+            continue
+        if any(v.get("register") == register for v in binary_mappings.values()):
+            continue
+        if register in switch_mappings:
+            continue
+        if register in select_mappings:
+            continue
+        if register in text_mappings:
+            continue
+        if register in time_mappings:
+            continue
+
+        if (
+            register in {"alarm", "error"}
+            or register.startswith("s_")
+            or register.startswith("e_")
+            or register.startswith("f_")
+        ):
+            if register not in binary_keys:
+                continue
+            binary_mappings.setdefault(
+                register,
+                {
+                    "translation_key": register,
+                    "icon": "mdi:alert-circle",
+                    "register_type": "holding_registers",
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+            )
+            continue
+
+        if register.startswith("date_time"):
+            continue
+
+        if any(register.startswith(prefix) for prefix in BCD_TIME_PREFIXES):
+            reg_access = (reg.access or "").upper()
+            if register.startswith(_TIME_ENTITY_PREFIXES) and "W" in reg_access:
+                time_mappings.setdefault(
+                    register,
+                    {
+                        "translation_key": register,
+                        "icon": "mdi:clock-outline",
+                        "register_type": "holding_registers",
+                    },
+                )
+            else:
+                sensor_mappings.setdefault(
+                    register,
+                    {
+                        "translation_key": register,
+                        "icon": "mdi:clock-outline",
+                        "register_type": "holding_registers",
+                    },
+                )
+            continue
+
+        if register.startswith(("setting_summer_", "setting_winter_")):
+            reg_access = (reg.access or "").upper()
+            if "W" in reg_access:
+                select_mappings.setdefault(
+                    register,
+                    {
+                        "translation_key": register,
+                        "icon": "mdi:fan",
+                        "register_type": "holding_registers",
+                        "states": PERCENT_10_SELECT_STATES,
+                    },
+                )
+            else:
+                sensor_mappings.setdefault(
+                    register,
+                    {
+                        "translation_key": register,
+                        "icon": "mdi:fan",
+                        "register_type": "holding_registers",
+                    },
+                )
+            continue
+
+        access = (reg.access or "").upper()
+        min_val = reg.min
+        max_val = reg.max
+        unit = reg.unit
+        info_text = reg.information or ""
+        scale = reg.multiplier or 1
+        step = reg.resolution or scale
+
+        if reg.enum and not (reg.extra and reg.extra.get("bitmask")):
+            enum_states = {_to_snake_case(str(v)): int(k) for k, v in reg.enum.items()}
+            if len(reg.enum) == 2 and set(int(k) for k in reg.enum) == {0, 1}:
+                if "W" in access:
+                    if register not in switch_keys:
+                        continue
+                    switch_mappings.setdefault(
+                        register,
+                        {
+                            "icon": "mdi:toggle-switch",
+                            "register": register,
+                            "register_type": "holding_registers",
+                            "category": None,
+                            "translation_key": register,
+                        },
+                    )
+                else:
+                    if register not in binary_keys:
+                        continue
+                    binary_mappings.setdefault(
+                        register,
+                        {
+                            "translation_key": register,
+                            "icon": "mdi:checkbox-marked-circle-outline",
+                            "register_type": "holding_registers",
+                        },
+                    )
+            elif "W" in access:
+                if register not in select_keys:
+                    continue
+                select_mappings.setdefault(
+                    register,
+                    {
+                        "icon": "mdi:format-list-bulleted",
+                        "translation_key": register,
+                        "states": enum_states,
+                        "register_type": "holding_registers",
+                    },
+                )
+            else:
+                sensor_mappings.setdefault(
+                    register,
+                    {
+                        "translation_key": register,
+                        "icon": "mdi:information-outline",
+                        "register_type": "holding_registers",
+                    },
+                )
+            continue
+
+        if min_val is not None and max_val is not None:
+            if max_val <= 1:
+                if "W" in access:
+                    if register not in switch_keys:
+                        continue
+                    switch_mappings.setdefault(
+                        register,
+                        {
+                            "icon": "mdi:toggle-switch",
+                            "register": register,
+                            "register_type": "holding_registers",
+                            "category": None,
+                            "translation_key": register,
+                        },
+                    )
+                else:
+                    if register not in binary_keys:
+                        continue
+                    binary_mappings.setdefault(
+                        register,
+                        {
+                            "translation_key": register,
+                            "icon": "mdi:checkbox-marked-circle-outline",
+                            "register_type": "holding_registers",
+                        },
+                    )
+                continue
+
+            if "W" in access and info_text and ";" in info_text and max_val <= 10:
+                states: dict[str, int] = {}
+                for part in info_text.split(";"):
+                    part = part.strip()
+                    if " - " not in part:
+                        continue
+                    val_str, label = part.split(" - ", 1)
+                    try:
+                        states[_to_snake_case(label)] = int(val_str.strip())
+                    except ValueError:
+                        continue
+                if states:
+                    if register not in select_keys:
+                        continue
+                    select_mappings.setdefault(
+                        register,
+                        {
+                            "icon": "mdi:format-list-bulleted",
+                            "translation_key": register,
+                            "states": states,
+                            "register_type": "holding_registers",
+                        },
+                    )
+                    continue
+
+            if "W" in access:
+                if register not in number_keys:
+                    continue
+                number_mappings.setdefault(
+                    register,
+                    {
+                        "unit": unit,
+                        "icon": _infer_icon(register, unit),
+                        "min": min_val,
+                        "max": max_val,
+                        "step": step,
+                        "scale": scale,
+                    },
+                )
+
+
+def _build_entity_mappings() -> None:
+    """Populate entity mapping dictionaries (module-global side-effects)."""
+
+    parent = _get_parent()
+
+    def _maps(name: str) -> dict[str, Any]:
+        return getattr(parent, name, {}) if parent else {}
+
+    sensor_mappings = _maps("SENSOR_ENTITY_MAPPINGS")
+    select_mappings = _maps("SELECT_ENTITY_MAPPINGS")
+    binary_mappings = _maps("BINARY_SENSOR_ENTITY_MAPPINGS")
+    switch_mappings = _maps("SWITCH_ENTITY_MAPPINGS")
+    text_mappings = _maps("TEXT_ENTITY_MAPPINGS")
+    special_mode_icons: dict[str, str] = _maps("SPECIAL_MODE_ICONS")
+
+    number_mappings = _load_number_mappings()
+    time_mappings: dict[str, dict[str, Any]] = {}
+
+    _gen_binary, _gen_switch, _gen_select = _load_discrete_mappings()
+    for key in binary_mappings:
+        _gen_binary.pop(key, None)
+        _gen_switch.pop(key, None)
+        _gen_select.pop(key, None)
+    for key in switch_mappings:
+        _gen_binary.pop(key, None)
+        _gen_select.pop(key, None)
+    for key in select_mappings:
+        _gen_binary.pop(key, None)
+        _gen_switch.pop(key, None)
+    binary_mappings.update(_gen_binary)
+    switch_mappings.update(_gen_switch)
+    select_mappings.update(_gen_select)
+
+    for mode, bit in SPECIAL_FUNCTION_MAP.items():
+        switch_mappings[mode] = {
+            "icon": special_mode_icons.get(mode, "mdi:toggle-switch"),
+            "register": "special_mode",
+            "register_type": "holding_registers",
+            "category": None,
+            "translation_key": mode,
+            "bit": bit,
+        }
+
+    # Temporarily inject number_mappings and time_mappings into parent so
+    # _extend_entity_mappings_from_registers can see them via _get_parent().
+    if parent is not None:
+        parent.NUMBER_ENTITY_MAPPINGS = number_mappings
+        parent.TIME_ENTITY_MAPPINGS = time_mappings
+
+    _extend_entity_mappings_from_registers()
+
+    if parent is not None:
+        parent.ENTITY_MAPPINGS = {
+            "number": number_mappings,
+            "sensor": sensor_mappings,
+            "binary_sensor": binary_mappings,
+            "switch": switch_mappings,
+            "select": select_mappings,
+            "text": text_mappings,
+            "time": time_mappings,
+        }
+
 
 __all__ = [
     "_build_entity_mappings",

--- a/custom_components/thessla_green_modbus/mappings/legacy.py
+++ b/custom_components/thessla_green_modbus/mappings/legacy.py
@@ -1,7 +1,156 @@
-"""Legacy entity-id alias exports."""
+"""Legacy entity-id alias definitions."""
 
 from __future__ import annotations
 
-from . import LEGACY_ENTITY_ID_ALIASES, map_legacy_entity_id
+import logging
+import sys
 
-__all__ = ["LEGACY_ENTITY_ID_ALIASES", "map_legacy_entity_id"]
+_LOGGER = logging.getLogger(__name__)
+
+# Map legacy entity suffixes to new domain and suffix pairs. Only a small
+# subset of legacy names existed in early versions of the integration. These
+# mappings allow services to transparently use the new entity IDs while warning
+# users to update their automations.
+LEGACY_ENTITY_ID_ALIASES: dict[str, tuple[str, str]] = {
+    # Keys are suffixes of legacy entity_ids.
+    # "number.rekuperator_predkosc" / "number.rekuperator_speed" → fan entity
+    "predkosc": ("fan", "fan"),
+    "speed": ("fan", "fan"),
+}
+
+# Exact object_id aliases used by earlier releases. These are matched before
+# ``LEGACY_ENTITY_ID_ALIASES`` to avoid ambiguity for names ending with
+# common suffixes like ``_mode``.
+LEGACY_ENTITY_ID_OBJECT_ALIASES: dict[str, tuple[str, str]] = {
+    # Legacy number entities migrated to read-only sensors.
+    "rekuperator_antifreeze_mode": ("binary_sensor", "rekuperator_antifreeze_mode"),
+    "rekuperator_comfort_mode": ("sensor", "rekuperator_comfort_mode"),
+    "rekuperator_dac_supply": ("sensor", "rekuperator_dac_supply"),
+    "rekuperator_dac_exhaust": ("sensor", "rekuperator_dac_exhaust"),
+    "rekuperator_dac_heater": ("sensor", "rekuperator_dac_heater"),
+    "rekuperator_dac_cooler": ("sensor", "rekuperator_dac_cooler"),
+    "rekuperator_supply_air_flow": ("sensor", "rekuperator_supply_air_flow"),
+    "rekuperator_exhaust_air_flow": ("sensor", "rekuperator_exhaust_air_flow"),
+    "rekuperator_hood_supply_coef": ("number", "rekuperator_hood_supply_coef"),
+    "rekuperator_hood_exhaust_coef": ("number", "rekuperator_hood_exhaust_coef"),
+    "rekuperator_fan_speed_1_coef": ("number", "rekuperator_fan_speed_1_coef"),
+    "rekuperator_fan_speed_2_coef": ("number", "rekuperator_fan_speed_2_coef"),
+    "rekuperator_fan_speed_3_coef": ("number", "rekuperator_fan_speed_3_coef"),
+    # Legacy status sensors migrated to select/switch controls.
+    "rekuperator_mode": ("select", "rekuperator_mode"),
+    "rekuperator_gwc_mode": ("sensor", "rekuperator_gwc_mode"),
+    "rekuperator_season_mode": ("select", "rekuperator_season_mode"),
+    "rekuperator_bypass_mode_status": ("sensor", "rekuperator_bypass_mode"),
+    "rekuperator_on_off_panel_mode": ("switch", "rekuperator_on_off_panel_mode"),
+    # Typo fix: antifreez_stage → antifreeze_stage (version 2.3.0)
+    "rekuperator_antifreez_stage": ("sensor", "rekuperator_antifreeze_stage"),
+    # Binary sensor renames (dp_ prefix added, key made more precise)
+    "rekuperator_ahu_filter_overflow": ("binary_sensor", "rekuperator_dp_ahu_filter_overflow"),
+    "rekuperator_duct_filter_overflow": ("binary_sensor", "rekuperator_dp_duct_filter_overflow"),
+    "rekuperator_gwc_regeneration_active": ("binary_sensor", "rekuperator_gwc_regen_flag"),
+    "rekuperator_central_heater_overprotection": ("binary_sensor", "rekuperator_post_heater_on"),
+    "rekuperator_unit_operation_confirmation": ("binary_sensor", "rekuperator_info"),
+    "rekuperator_water_heater_pump": ("binary_sensor", "rekuperator_duct_water_heater_pump"),
+    # Sensor renames
+    "rekuperator_maximum_percentage": ("sensor", "rekuperator_max_percentage"),
+    "rekuperator_minimum_percentage": ("sensor", "rekuperator_min_percentage"),
+    "rekuperator_time_period": ("sensor", "rekuperator_period"),
+    "rekuperator_supply_flow_rate_m3_h": ("sensor", "rekuperator_supply_flow_rate"),
+    "rekuperator_exhaust_flow_rate_m3_h": ("sensor", "rekuperator_exhaust_flow_rate"),
+    "rekuperator_ahu_stop_alarm_code": ("sensor", "rekuperator_stop_ahu_code"),
+    "rekuperator_active_errors": ("sensor", "rekuperator_stop_ahu_code"),
+    "rekuperator_product_key_lock_date_day": ("sensor", "rekuperator_lock_date_00dd"),
+    "rekuperator_comfort_mode_status": ("sensor", "rekuperator_comfort_mode"),
+    # Switch renames
+    "rekuperator_bypass_active": ("switch", "rekuperator_bypass_off"),
+    "rekuperator_gwc_active": ("switch", "rekuperator_gwc_off"),
+    "rekuperator_lock": ("switch", "rekuperator_lock_flag"),
+    # Select renames
+    "rekuperator_filter_check_day_of_week": ("select", "rekuperator_pres_check_day"),
+    "rekuperator_filter_check_day_of_week_ext": ("select", "rekuperator_pres_check_day_4432"),
+    "rekuperator_gwc_regeneration": ("select", "rekuperator_gwc_regen"),
+    "rekuperator_filter_type": ("select", "rekuperator_filter_change"),
+    # Time entity renames
+    "rekuperator_filter_check_start_time": ("time", "rekuperator_pres_check_time"),
+    "rekuperator_filter_check_start_time_ext": ("time", "rekuperator_pres_check_time_ggmm"),
+    # Polish-language entity IDs (installations with HA language set to pl before 2026)
+    "rekuperator_moc_odzysku_ciepla": ("sensor", "rekuperator_heat_recovery_power"),
+    "rekuperator_sprawnosc_rekuperatora": ("sensor", "rekuperator_heat_recovery_efficiency"),
+    "rekuperator_pobor_mocy_elektrycznej": ("sensor", "rekuperator_electrical_power"),
+    "rekuperator_nazwa_urzadzenia": ("text", "rekuperator_device_name"),
+    "rekuperator_predkosc_1": ("fan", "rekuperator_ventilation"),
+    # Legacy split aliases for e_196_e_199 bitmask register
+    "rekuperator_error_e196": ("binary_sensor", "rekuperator_e_196_e_199_e_196"),
+    "rekuperator_error_e197": ("binary_sensor", "rekuperator_e_196_e_199_e_197"),
+    "rekuperator_error_e198": ("binary_sensor", "rekuperator_e_196_e_199_e_198"),
+    "rekuperator_error_e199": ("binary_sensor", "rekuperator_e_196_e_199_e_199"),
+    # Product key lock date split fields
+    "rekuperator_product_key_lock_date_month": ("sensor", "rekuperator_lock_date_00mm"),
+}
+
+_alias_warning_logged = False
+
+
+def map_legacy_entity_id(entity_id: str) -> str:
+    """Map a legacy entity ID to the new format.
+
+    If the provided ``entity_id`` matches one of the known legacy aliases, the
+    corresponding new entity ID is returned and a warning is logged exactly
+    once to inform the user about the change.
+    """
+
+    global _alias_warning_logged
+
+    if "." not in entity_id:
+        return entity_id
+
+    # Read the warning flag through the parent module so that test
+    # monkeypatching on the parent (e.g. ``monkeypatch.setattr(em, ...)``)
+    # propagates here at call time.
+    _parent = sys.modules.get(__package__)
+    _already_logged: bool = (
+        getattr(_parent, "_alias_warning_logged", False) if _parent is not None else _alias_warning_logged
+    )
+
+    _domain, object_id = entity_id.split(".", 1)
+    if object_id in LEGACY_ENTITY_ID_OBJECT_ALIASES:
+        new_domain, new_object_id = LEGACY_ENTITY_ID_OBJECT_ALIASES[object_id]
+        new_entity_id = f"{new_domain}.{new_object_id}"
+        if not _already_logged:
+            _LOGGER.warning(
+                "Legacy entity ID '%s' detected. Please update automations to use '%s'.",
+                entity_id,
+                new_entity_id,
+            )
+            _alias_warning_logged = True
+            if _parent is not None:
+                _parent._alias_warning_logged = True  # type: ignore[union-attr]
+        return new_entity_id
+
+    suffix = object_id.rsplit("_", 1)[-1]
+    if suffix not in LEGACY_ENTITY_ID_ALIASES:
+        return entity_id
+
+    new_domain, new_suffix = LEGACY_ENTITY_ID_ALIASES[suffix]
+    parts = object_id.split("_")
+    new_object_id = "_".join([*parts[:-1], new_suffix]) if len(parts) > 1 else new_suffix
+    new_entity_id = f"{new_domain}.{new_object_id}"
+
+    if not _already_logged:
+        _LOGGER.warning(
+            "Legacy entity ID '%s' detected. Please update automations to use '%s'.",
+            entity_id,
+            new_entity_id,
+        )
+        _alias_warning_logged = True
+        if _parent is not None:
+            _parent._alias_warning_logged = True  # type: ignore[union-attr]
+
+    return new_entity_id
+
+
+__all__ = [
+    "LEGACY_ENTITY_ID_ALIASES",
+    "LEGACY_ENTITY_ID_OBJECT_ALIASES",
+    "map_legacy_entity_id",
+]

--- a/custom_components/thessla_green_modbus/mappings/special_modes.py
+++ b/custom_components/thessla_green_modbus/mappings/special_modes.py
@@ -1,7 +1,19 @@
-"""Special mode constants exports."""
+"""Special-mode icon constants for ThesslaGreen Modbus integration."""
 
 from __future__ import annotations
 
-from . import SPECIAL_MODE_ICONS
+SPECIAL_MODE_ICONS: dict[str, str] = {
+    "boost": "mdi:rocket-launch",
+    "eco": "mdi:leaf",
+    "away": "mdi:airplane",
+    "fireplace": "mdi:fireplace",
+    "hood": "mdi:range-hood",
+    "sleep": "mdi:weather-night",
+    "party": "mdi:party-popper",
+    "bathroom": "mdi:shower",
+    "kitchen": "mdi:chef-hat",
+    "summer": "mdi:white-balance-sunny",
+    "winter": "mdi:snowflake",
+}
 
 __all__ = ["SPECIAL_MODE_ICONS"]

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -7,7 +7,7 @@ import importlib
 import inspect
 import logging
 import time
-from dataclasses import asdict  # noqa: F401
+from dataclasses import asdict as _dataclasses_asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -100,6 +100,8 @@ except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs 
     def registers_sha256(*_args, **_kwargs) -> str:
         return ""
 
+
+asdict = _dataclasses_asdict  # re-exported for test monkeypatching
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/scanner_device_info.py
+++ b/custom_components/thessla_green_modbus/scanner_device_info.py
@@ -17,7 +17,7 @@ def _compat_asdict(obj: Any) -> dict[str, Any]:
         from . import scanner_core as _scanner_core
 
         return _scanner_core.asdict(obj)
-    except Exception:  # pragma: no cover - fallback
+    except (ImportError, AttributeError, TypeError):  # pragma: no cover - fallback
         return dataclasses.asdict(obj)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ ignore = [
     "SIM102",
 ]
 extend-safe-fixes = ["ANN"]
-per-file-ignores = {"tests/*" = ["E402", "RUF001", "SIM117"], "tools/translate_register_descriptions.py" = ["RUF001"]}
+per-file-ignores = {"tests/*" = ["BLE001", "E402", "RUF001", "SIM117"], "tools/translate_register_descriptions.py" = ["RUF001"]}
 
 [tool.ruff.format]
 line-ending = "lf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ target-version = "py312"
 src = ["custom_components", "tests", "tools"]
 
 [tool.ruff.lint]
-select = ["F", "E", "W", "B", "SIM", "RUF", "UP", "I", "PERF"]
+select = ["F", "E", "W", "B", "SIM", "RUF", "UP", "I", "PERF", "BLE"]
 ignore = [
     "E501",
     "RUF002",

--- a/tools/validate_registers.py
+++ b/tools/validate_registers.py
@@ -132,7 +132,7 @@ def validate(path: Path) -> list[RegisterDefinition]:
             for key, val in reg.enum.items():
                 try:
                     int(key)
-                except Exception:  # pragma: no cover - defensive
+                except (ValueError, TypeError):  # pragma: no cover - defensive
                     raise ValueError(f"{reg.name}: enum keys must be numeric") from None
                 if not isinstance(val, str):
                     raise ValueError(f"{reg.name}: enum values must be strings")
@@ -179,7 +179,7 @@ def main(path: Path | None = None) -> int:
 
     try:
         validate(Path(target))
-    except Exception as err:  # pragma: no cover - error path
+    except (ValueError, OSError, TypeError) as err:  # pragma: no cover - error path
         print(err)
         raise SystemExit(1) from None
     return 0


### PR DESCRIPTION
## Summary

This PR refactors the `mappings` module from a monolithic `__init__.py` into a modular architecture with dedicated submodules for different concerns. The changes improve code organization, maintainability, and testability by separating entity mapping generation logic from the main module initialization.

## Key Changes

- **Module restructuring**: Split `mappings/__init__.py` into focused submodules:
  - `_helpers.py`: Helper functions for register metadata and icon inference
  - `_loaders.py`: Entity mapping generation logic (numbers, discrete entities, sensors, etc.)
  - `legacy.py`: Legacy entity ID alias definitions and mapping functions
  - `special_modes.py`: Special mode icon constants

- **Removed from `__init__.py`**: 
  - Large mapping generation functions (`_load_number_mappings`, `_load_discrete_mappings`, etc.)
  - Legacy entity ID mapping logic and constants
  - Helper functions (`_infer_icon`, `_get_register_info`, `_parse_states`)
  - Register info caching and translation key loading

- **Added new scanner mixins** for better separation of concerns:
  - `_scanner_registers_mixin.py`: Raw Modbus read operations
  - `_scanner_transport_mixin.py`: Connection setup and transport management
  - `_scanner_capabilities_mixin.py`: Capability analysis and device scanning

- **Improved testability**: Loader functions now use `sys.modules` lookup to resolve dependencies, allowing test monkeypatching to work transparently across module boundaries

- **Linting improvements**: Added `BLE` to ruff lint rules and fixed bare exception handling patterns

## Implementation Details

- The `_loaders.py` module uses a `_resolve()` helper function to look up parent module attributes, enabling proper test isolation while maintaining runtime functionality
- Legacy mapping functions are now in `legacy.py` but maintain the same public API
- Helper functions in `_helpers.py` cache register metadata globally while respecting parent module overrides for testing
- Scanner mixins follow a protocol-based approach with `TYPE_CHECKING` guards for type safety without runtime overhead

https://claude.ai/code/session_014jHZK1bwrPCWNGrvAuBeek