### PR TITLE
Add compatibility fallbacks for UTC and StrEnum; unify timeout exception handling

### DIFF
--- a/custom_components/thessla_green_modbus/_compat.py
+++ b/custom_components/thessla_green_modbus/_compat.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 from typing import Any
 
-UTC = dt.UTC
+UTC = getattr(dt, "UTC", dt.timezone.utc)
 
 try:
     from homeassistant.util import dt as dt_util

--- a/custom_components/thessla_green_modbus/_coordinator_capabilities.py
+++ b/custom_components/thessla_green_modbus/_coordinator_capabilities.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = datetime.UTC if hasattr(datetime, "UTC") else timezone.utc
 from types import MappingProxyType
 from typing import Any, ClassVar
 

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -95,6 +95,7 @@ from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOExc
 from .utils import resolve_connection_settings
 
 _LOGGER = logging.getLogger(__name__)
+TIMEOUT_EXCEPTIONS = (TimeoutError, asyncio.TimeoutError)
 
 
 class _FallbackFlowBase:  # pragma: no cover
@@ -303,7 +304,7 @@ async def _run_with_retry(
             delay = backoff * 2 ** (attempt - 1)
             if delay:
                 await asyncio.sleep(delay)
-        except (TimeoutError, ConnectionException, ModbusException, OSError):
+        except (*TIMEOUT_EXCEPTIONS, ConnectionException, ModbusException, OSError):
             if attempt >= retries:
                 raise
             delay = backoff * 2 ** (attempt - 1)
@@ -540,7 +541,7 @@ async def validate_input(hass: HomeAssistant | None, data: dict[str, Any]) -> di
         _LOGGER.error("Modbus IO error during device validation: %s", exc)
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
         raise CannotConnect("io_error") from exc
-    except TimeoutError as exc:
+    except TIMEOUT_EXCEPTIONS as exc:
         _LOGGER.warning("Timeout during device validation: %s", exc)
         if "modbus request cancelled" not in str(exc).lower():
             _LOGGER.debug("Traceback:\n%s", traceback.format_exc())

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -79,7 +79,7 @@ from .scanner_core import (
 from .utils import resolve_connection_settings
 
 __all__ = ["ThesslaGreenModbusCoordinator", "_PermanentModbusError"]
-UTC = dt.UTC
+UTC = getattr(dt, "UTC", dt.timezone.utc)
 
 
 class _SafeDTUtil:

--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -20,7 +20,13 @@ from __future__ import annotations
 
 import logging
 import re
-from enum import StrEnum
+from enum import Enum
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - Python < 3.11
+    class StrEnum(str, Enum):
+        """Fallback StrEnum for older Python versions."""
 from typing import Any, Literal, cast
 
 import pydantic

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = datetime.UTC if hasattr(datetime, "UTC") else timezone.utc
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest


### PR DESCRIPTION
### Motivation

- Ensure the integration runs across Python versions and in environments without Home Assistant by providing safe fallbacks for timezone and enum features.
- Avoid `AttributeError` and inconsistent timezone-aware datetimes by normalising UTC handling when `datetime.UTC` is not available.
- Make timeout handling robust by treating `asyncio.TimeoutError` and `TimeoutError` uniformly in retry and validation paths.
- Provide a `StrEnum` fallback for Python < 3.11 so register schema parsing works on older interpreters.

### Description

- Added UTC fallbacks using `getattr(..., "UTC", timezone.utc)` in `custom_components/thessla_green_modbus/_compat.py` and `custom_components/thessla_green_modbus/coordinator.py`, and introduced a similar `UTC` definition in `custom_components/thessla_green_modbus/_coordinator_capabilities.py` and tests.
- Introduced `TIMEOUT_EXCEPTIONS = (TimeoutError, asyncio.TimeoutError)` in `custom_components/thessla_green_modbus/config_flow.py` and replaced direct `TimeoutError` handling with `TIMEOUT_EXCEPTIONS` in retry and validation exception blocks, and updated the retry `except` to use the tuple unpacking form for clarity.
- Added a compatibility fallback for `StrEnum` in `custom_components/thessla_green_modbus/registers/schema.py` so older Python versions get a `StrEnum`-like class implemented with `Enum`.
- Updated `tests/test_coordinator_coverage.py` to use the same UTC fallback so tests are timezone-aware across Python versions.

### Testing

- Ran the unit test suite with `pytest`, including `tests/test_coordinator_coverage.py`, and all tests completed successfully.
- Verified exception paths in `config_flow` by exercising retry and timeout branches through the existing test coverage, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb2a19e6883269ceb9d70c93fbb8c)