### PR TITLE
Improve typing/mypy compatibility, replace dynamic HA fallbacks, and bump version to 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the ThesslaGreen Modbus Integration will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.3.2
+
+### Changed
+- Replaced runtime `getattr(...)` dispatch in `climate.py` with direct imports from `homeassistant.components.climate`, removing dead fallback paths and restoring strict typing support.
+- Added explicit mixin attribute and stub-method declarations in coordinator/scanner mixins so mypy can validate cross-mixin contracts without runtime changes.
+- Added `assert self.client is not None` after transport reconnection in Modbus transport read/write methods to make `None` narrowing explicit for static typing.
+- Aligned conditional fallback shim signatures in register loader adapters (`scanner_register_maps.py`, `scanner_core.py`, `const.py`, `mappings/_helpers.py`, `mappings/_loaders.py`) with real loader APIs.
+- Refactored BCD clock decode in `_coordinator_capabilities.py` from `all(...)` generator checks to explicit `is not None` guards for mypy narrowing.
+
+### Fixed
+- Removed stale/incorrect `# type: ignore[...]` tags that no longer matched emitted mypy error codes.
+- Added stricter typing/guard fixes in scanner and register helpers to reduce strict-mode typing failures.
+
 ## 2.3.1
 
 ### Fixed

--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -75,9 +75,9 @@ from .modbus_exceptions import ConnectionException, ModbusException
 from .utils import resolve_connection_settings
 
 try:  # pragma: no cover - optional in tests
-    from homeassistant.helpers import entity_registry as er  # type: ignore
+    from homeassistant.helpers import entity_registry as er
 except (ImportError, ModuleNotFoundError, AttributeError):  # pragma: no cover
-    er = None  # type: ignore
+    er = None
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,8 +86,10 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 # Compatibility shim for tests patching "custom_components.thessla_green_modbus.__init__.er".
 _init_alias = sys.modules.setdefault(f"{__name__}.__init__", sys.modules[__name__])
-_init_alias.er = er
-sys.modules[__name__].__init__ = _init_alias
+_init_alias_any: Any = _init_alias
+_init_alias_any.er = er
+module_self: Any = sys.modules[__name__]
+module_self.__init__ = _init_alias
 
 # Legacy default port used before version 2 when explicit port was optional
 LEGACY_DEFAULT_PORT = 8899
@@ -115,7 +117,7 @@ def _get_platforms() -> list[object]:
         return _platform_cache
 
     try:  # Import only when running inside Home Assistant
-        from homeassistant.const import Platform  # type: ignore
+        from homeassistant.const import Platform
     except (
         ImportError,
         ModuleNotFoundError,
@@ -297,8 +299,8 @@ async def _async_start_coordinator(
     Returns False if a reauth flow was triggered (caller should return False).
     Raises ConfigEntryNotReady on other connection failures.
     """
-    from homeassistant.exceptions import ConfigEntryNotReady  # type: ignore
-    from homeassistant.helpers.update_coordinator import UpdateFailed  # type: ignore
+    from homeassistant.exceptions import ConfigEntryNotReady
+    from homeassistant.helpers.update_coordinator import UpdateFailed
 
     try:
         setup_cb = getattr(coordinator, "async_setup", None)
@@ -325,8 +327,10 @@ async def _async_start_coordinator(
         # exception classes (including test-local subclasses of UpdateFailed).
         # We convert all such failures into ConfigEntryNotReady/reauth flow.
         if (
-            isinstance(exc, UpdateFailed) or exc.__class__.__name__ == "UpdateFailed"
-        ) and is_invalid_auth_error(exc):
+            isinstance(exc, Exception)
+            and (isinstance(exc, UpdateFailed) or exc.__class__.__name__ == "UpdateFailed")
+            and is_invalid_auth_error(exc)
+        ):
             _LOGGER.error("Authentication failed during setup: %s", exc)
             await entry.async_start_reauth(hass)
             return False
@@ -364,8 +368,10 @@ async def _async_start_coordinator(
         # exception classes (including test-local subclasses of UpdateFailed).
         # We convert all such failures into ConfigEntryNotReady/reauth flow.
         if (
-            isinstance(exc, UpdateFailed) or exc.__class__.__name__ == "UpdateFailed"
-        ) and is_invalid_auth_error(exc):
+            isinstance(exc, Exception)
+            and (isinstance(exc, UpdateFailed) or exc.__class__.__name__ == "UpdateFailed")
+            and is_invalid_auth_error(exc)
+        ):
             _LOGGER.error("Authentication failed during initial refresh: %s", exc)
             await entry.async_start_reauth(hass)
             return False
@@ -388,7 +394,7 @@ def _async_patch_coordinator_compat(
         coordinator.capabilities = _PermissiveCapabilities()
 
     if not hasattr(coordinator, "get_register_map"):
-        empty_maps = {
+        empty_maps: dict[str, dict[str, Any]] = {
             "input_registers": {},
             "holding_registers": {},
             "coil_registers": {},
@@ -668,9 +674,9 @@ async def _async_migrate_entity_ids(
     unreachable ghost.
     """
     try:
-        from homeassistant.helpers import device_registry as dr  # type: ignore
-        from homeassistant.helpers import entity_registry as er  # type: ignore
-        from homeassistant.util import slugify  # type: ignore
+        from homeassistant.helpers import device_registry as dr
+        from homeassistant.helpers import entity_registry as er
+        from homeassistant.util import slugify
     except (ImportError, ModuleNotFoundError, AttributeError):
         return
 
@@ -955,14 +961,14 @@ async def _async_migrate_entity_ids(
         )
 
 
-async def _async_cleanup_legacy_fan_entity(hass: HomeAssistant, coordinator) -> None:
+async def _async_cleanup_legacy_fan_entity(hass: HomeAssistant, coordinator: Any) -> None:
     """Remove legacy number entity IDs replaced by the fan entity.
 
     HA's entity registry does not allow changing domains via async_update_entity,
     so old number.* entities cannot be renamed to fan.*. They are simply removed;
     the fan.rekuperator_fan entity is created by the fan platform setup.
     """
-    from homeassistant.helpers import entity_registry as er  # type: ignore
+    from homeassistant.helpers import entity_registry as er
 
     registry = er.async_get(hass)
     if registry is None:
@@ -993,7 +999,7 @@ async def _async_cleanup_legacy_fan_entity(hass: HomeAssistant, coordinator) -> 
 
 async def _async_migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Migrate entity unique IDs stored in the entity registry."""
-    from homeassistant.helpers import entity_registry as er  # type: ignore
+    from homeassistant.helpers import entity_registry as er
 
     registry = er.async_get(hass)
     coordinator = entry.runtime_data

--- a/custom_components/thessla_green_modbus/_compat.py
+++ b/custom_components/thessla_green_modbus/_compat.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import datetime as dt
-from datetime import UTC
 from typing import Any
+
+UTC = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017 - Python < 3.11 fallback
 
 try:
     from homeassistant.util import dt as dt_util
@@ -67,7 +68,7 @@ try:
     from homeassistant.helpers.device_registry import DeviceInfo
 except (ModuleNotFoundError, ImportError):
 
-    class DeviceInfo:
+    class DeviceInfo:  # type: ignore[no-redef]
         """Minimal fallback DeviceInfo for tests."""
 
         def __init__(self, **kwargs: Any) -> None:

--- a/custom_components/thessla_green_modbus/_coordinator_capabilities.py
+++ b/custom_components/thessla_green_modbus/_coordinator_capabilities.py
@@ -18,6 +18,10 @@ def _utcnow() -> datetime:
 class _CoordinatorCapabilitiesMixin:
     """Capability and derived-value logic for the coordinator."""
 
+    device_info: dict[str, Any]
+    _last_power_timestamp: datetime | None
+    _total_energy: float
+
     _STANDBY_POWER_W: float = 10.0
     _MODEL_POWER_DATA: ClassVar[Mapping[int, tuple[float, float]]] = MappingProxyType(
         {
@@ -223,7 +227,12 @@ class _CoordinatorCapabilitiesMixin:
             raw_ddtt = data.get("date_time_ddtt")
             raw_ggmm = data.get("date_time_ggmm")
             raw_sscc = data.get("date_time_sscc")
-            if all(v is not None for v in (raw_yymm, raw_ddtt, raw_ggmm, raw_sscc)):
+            if (
+                raw_yymm is not None
+                and raw_ddtt is not None
+                and raw_ggmm is not None
+                and raw_sscc is not None
+            ):
 
                 def _bcd(b: int) -> int:
                     return ((b >> 4) & 0xF) * 10 + (b & 0xF)

--- a/custom_components/thessla_green_modbus/_coordinator_io.py
+++ b/custom_components/thessla_green_modbus/_coordinator_io.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
@@ -22,15 +22,40 @@ class _PermanentModbusError(ModbusException):
 
 
 class _ModbusIOMixin:
-    """Read-path Modbus methods used by the coordinator."""
+    """Read-path Modbus methods used by the coordinator.
 
+    Attributes and stub methods declared below are provided by
+    ``ThesslaGreenModbusCoordinator`` and sibling mixins at runtime.
+    They allow mypy to type-check this mixin in isolation.
+    """
+
+    # Transport / connection
     _transport: BaseModbusTransport | None
     client: Any | None
+    slave_id: int
+    timeout: float
+    retry: int
+    backoff: float
+    backoff_jitter: float | tuple[float, float] | None
+
+    # Runtime state
     statistics: dict[str, Any]
     available_registers: dict[str, set[str]]
     _register_groups: dict[str, list[tuple[int, int]]]
     effective_batch: int
     _failed_registers: set[str]
+
+    async def _ensure_connection(self) -> None: ...
+    def _find_register_name(self, register_type: str, address: int) -> str | None: ...
+    def _process_register_value(self, register_name: str, value: int) -> Any: ...
+    def _clear_register_failure(self, name: str) -> None: ...
+    def _mark_registers_failed(self, names: Iterable[str | None]) -> None: ...
+    async def _read_coils_transport(
+        self, slave_id: int, address: int, *, count: int, attempt: int = 1
+    ) -> Any: ...
+    async def _read_discrete_inputs_transport(
+        self, slave_id: int, address: int, *, count: int, attempt: int = 1
+    ) -> Any: ...
 
     async def _call_modbus(
         self, func: Callable[..., Any], *args: Any, attempt: int = 1, **kwargs: Any
@@ -231,7 +256,9 @@ class _ModbusIOMixin:
             read_method = transport.read_input_registers
         elif client is not None and getattr(client, "connected", True):
 
-            async def read_method(slave_id: int, address: int, *, count: int, attempt: int = 1):
+            async def read_method(
+                slave_id: int, address: int, *, count: int, attempt: int = 1
+            ) -> Any:
                 return await self._call_modbus(
                     client.read_input_registers,
                     address,
@@ -384,7 +411,9 @@ class _ModbusIOMixin:
             read_method = transport.read_holding_registers
         elif client is not None and getattr(client, "connected", True):
 
-            async def read_method(slave_id: int, address: int, *, count: int, attempt: int = 1):
+            async def read_method(
+                slave_id: int, address: int, *, count: int, attempt: int = 1
+            ) -> Any:
                 return await self._call_modbus(
                     client.read_holding_registers,
                     address,

--- a/custom_components/thessla_green_modbus/_coordinator_schedule.py
+++ b/custom_components/thessla_green_modbus/_coordinator_schedule.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .const import MAX_REGS_PER_REQUEST
 from .modbus_exceptions import ConnectionException, ModbusException
 from .modbus_helpers import chunk_register_values
 from .register_addresses import REG_TEMPORARY_FLOW_START, REG_TEMPORARY_TEMP_START
+
+if TYPE_CHECKING:
+    from .modbus_transport import BaseModbusTransport
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,11 +28,26 @@ def _get_register_definition(register_name: str) -> Any:
 class _CoordinatorScheduleMixin:
     """Write-path and schedule helpers for the coordinator."""
 
+    _transport: BaseModbusTransport | None
+    client: Any | None
+    slave_id: int
+    retry: int
+    effective_batch: int
+    _write_lock: asyncio.Lock
+
+    async def _call_modbus(
+        self, func: Any, *args: Any, attempt: int = 1, **kwargs: Any
+    ) -> Any: ...
+    def _get_client_method(self, name: str) -> Any: ...
+    async def _ensure_connection(self) -> None: ...
+    async def _disconnect(self) -> None: ...
+    def _clear_register_failure(self, name: str) -> None: ...
+
     def _encode_write_value(
         self,
         register_name: str,
         definition: Any,
-        value: float | list[int] | tuple[int, ...],
+        value: float | str | list[int] | tuple[int, ...],
         offset: int,
     ) -> tuple[list[int] | None, Any]:
         """Encode *value* for writing. Returns (encoded_values, scalar_value).
@@ -130,7 +149,7 @@ class _CoordinatorScheduleMixin:
     async def async_write_register(
         self,
         register_name: str,
-        value: float | list[int] | tuple[int, ...],
+        value: float | str | list[int] | tuple[int, ...],
         refresh: bool = True,
         *,
         offset: int = 0,

--- a/custom_components/thessla_green_modbus/_scanner_capabilities_mixin.py
+++ b/custom_components/thessla_green_modbus/_scanner_capabilities_mixin.py
@@ -207,12 +207,12 @@ class _ScannerCapabilitiesMixin:
 
         missing_regs: list[str] = []
         if None in (major, minor, patch):
-            for name, value in (
+            for name, missing_value in (
                 ("version_major", major),
                 ("version_minor", minor),
                 ("version_patch", patch),
             ):
-                if value is None and name in INPUT_REGISTERS:
+                if missing_value is None and name in INPUT_REGISTERS:
                     missing_regs.append(f"{name} ({INPUT_REGISTERS[name]})")
 
         if None not in (major, minor, patch):

--- a/custom_components/thessla_green_modbus/_scanner_registers_mixin.py
+++ b/custom_components/thessla_green_modbus/_scanner_registers_mixin.py
@@ -42,6 +42,8 @@ _LOGGER = logging.getLogger(__name__)
 class _ScannerRegistersMixin:
     """Raw Modbus read operations for the device scanner."""
 
+    _client: AsyncModbusTcpClient | None
+
     def _filter_unsupported_addresses(self, reg_type: str, addrs: set[int]) -> set[int]:
         """Return failed addresses that are not already covered by unsupported spans."""
 
@@ -340,7 +342,7 @@ class _ScannerRegistersMixin:
             start = start_or_count
 
         results: list[int] = []
-        active_client = client or self._client  # type: ignore[attr-defined]
+        active_client = client or self._client
         for chunk_start, chunk_count in chunk_register_range(start, count, self.effective_batch):  # type: ignore[attr-defined]
             block = await (
                 read_fn(chunk_start, chunk_count)
@@ -371,7 +373,7 @@ class _ScannerRegistersMixin:
     ) -> list[int] | None:
         """Read a contiguous holding register block in MAX-sized chunks."""
         return await self._read_register_block(
-            self._read_holding, client_or_start, start_or_count, count  # type: ignore[attr-defined]
+            self._read_holding, client_or_start, start_or_count, count
         )
 
     async def _read_holding(
@@ -597,11 +599,11 @@ class _ScannerRegistersMixin:
         if count is None:
             address = int(client_or_address)
             count = address_or_count
-            client = self._client  # type: ignore[attr-defined]
+            client = self._client
         elif isinstance(client_or_address, int):
             address = client_or_address
             count = address_or_count
-            client = self._client  # type: ignore[attr-defined]
+            client = self._client
         else:
             client = client_or_address
             address = address_or_count
@@ -661,7 +663,7 @@ class _ScannerRegistersMixin:
                         transport_client = getattr(self._transport, "client", None)  # type: ignore[attr-defined]
                         if transport_client is not None:
                             client = transport_client
-                            self._client = transport_client  # type: ignore[attr-defined]
+                            self._client = transport_client
                     except (
                         ModbusException,
                         ConnectionException,

--- a/custom_components/thessla_green_modbus/_scanner_transport_mixin.py
+++ b/custom_components/thessla_green_modbus/_scanner_transport_mixin.py
@@ -67,6 +67,9 @@ _LOGGER = logging.getLogger(__name__)
 class _ScannerTransportMixin:
     """Connection-setup and transport management for the device scanner."""
 
+    _transport: BaseModbusTransport | None
+    _client: AsyncModbusTcpClient | None
+
     # ------------------------------------------------------------------ #
     # Connection helpers                                                   #
     # ------------------------------------------------------------------ #
@@ -74,15 +77,15 @@ class _ScannerTransportMixin:
     async def close(self) -> None:
         """Close the underlying Modbus client connection."""
 
-        if self._transport is not None:  # type: ignore[attr-defined]
+        if self._transport is not None:
             try:
-                await self._transport.close()  # type: ignore[attr-defined]
+                await self._transport.close()
             except (OSError, ConnectionException, ModbusIOException):
                 _LOGGER.debug("Error closing Modbus transport", exc_info=True)
             finally:
-                self._transport = None  # type: ignore[attr-defined]
+                self._transport = None
 
-        client = self._client  # type: ignore[attr-defined]
+        client = self._client
         if client is None:
             return
 
@@ -91,7 +94,7 @@ class _ScannerTransportMixin:
         except (OSError, ConnectionException, ModbusIOException):
             _LOGGER.debug("Error closing Modbus client", exc_info=True)
         finally:
-            self._client = None  # type: ignore[attr-defined]
+            self._client = None
 
     def _build_tcp_transport(
         self,
@@ -241,7 +244,7 @@ class _ScannerTransportMixin:
                             self.host,  # type: ignore[attr-defined]
                             self.port,  # type: ignore[attr-defined]
                         )
-                    self._resolved_connection_mode = mode  # type: ignore[attr-defined]
+                    self._resolved_connection_mode = mode
                 return
             except asyncio.CancelledError:
                 raise
@@ -289,9 +292,9 @@ class _ScannerTransportMixin:
         client: Any,
     ) -> tuple[Any, Any]:
         """Return (transport, client) ready for reads. Raises if neither available."""
-        transport = self._transport if client is None else None  # type: ignore[attr-defined]
+        transport = self._transport if client is None else None
         if client is None and transport is None:
-            client = self._client  # type: ignore[attr-defined]
+            client = self._client
         if client is None and transport is None:
             raise ConnectionException("Modbus transport is not connected")
         return transport, client

--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -161,7 +161,7 @@ class ThesslaGreenBinarySensor(ThesslaGreenEntity, BinarySensorEntity):
         """
         tk = self._attr_translation_key
         if tk and tk != self._key:
-            return tk
+            return str(tk)
         return super().suggested_object_id
 
     # Prefixes that identify diagnostic alarm/error/status registers.

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -6,50 +6,33 @@ import asyncio
 import logging
 from typing import Any
 
-import homeassistant.components as ha_components
-from homeassistant import const as ha_const
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-climate_component = getattr(ha_components, "climate", None)
-ClimateEntity = getattr(climate_component, "ClimateEntity", object)
-ClimateEntityFeature = getattr(climate_component, "ClimateEntityFeature", int)
-HVACAction = getattr(
-    climate_component,
-    "HVACAction",
-    type(
-        "HVACAction",
-        (),
-        {"OFF": "off", "FAN": "fan", "HEATING": "heating", "COOLING": "cooling", "IDLE": "idle"},
-    ),
-)
-HVACMode = getattr(
-    climate_component,
-    "HVACMode",
-    type("HVACMode", (), {"OFF": "off", "AUTO": "auto", "FAN_ONLY": "fan_only"}),
-)
-
-ATTR_TEMPERATURE = getattr(ha_const, "ATTR_TEMPERATURE", "temperature")
-UnitOfTemperature = getattr(
-    ha_const, "UnitOfTemperature", type("UnitOfTemperature", (), {"CELSIUS": "°C"})
-)
-
-from .const import (  # noqa: E402
+from .const import (
     SPECIAL_FUNCTION_MAP,
     TEMPERATURE_MAX_C,
     TEMPERATURE_MIN_C,
     TEMPERATURE_STEP_C,
     holding_registers,
 )
-from .coordinator import ThesslaGreenModbusCoordinator  # noqa: E402
-from .entity import ThesslaGreenEntity  # noqa: E402
+from .coordinator import ThesslaGreenModbusCoordinator
+from .entity import ThesslaGreenEntity
 
-_FEATURE_TARGET_TEMPERATURE = getattr(ClimateEntityFeature, "TARGET_TEMPERATURE", 1)
-_FEATURE_FAN_MODE = getattr(ClimateEntityFeature, "FAN_MODE", 2)
-_FEATURE_PRESET_MODE = getattr(ClimateEntityFeature, "PRESET_MODE", 4)
-_FEATURE_TURN_ON = getattr(ClimateEntityFeature, "TURN_ON", 0)
-_FEATURE_TURN_OFF = getattr(ClimateEntityFeature, "TURN_OFF", 0)
+# ClimateEntityFeature.TURN_ON / TURN_OFF are guaranteed in required HA versions.
+_FEATURE_TARGET_TEMPERATURE = ClimateEntityFeature.TARGET_TEMPERATURE
+_FEATURE_FAN_MODE = ClimateEntityFeature.FAN_MODE
+_FEATURE_PRESET_MODE = ClimateEntityFeature.PRESET_MODE
+_FEATURE_TURN_ON = ClimateEntityFeature.TURN_ON
+_FEATURE_TURN_OFF = ClimateEntityFeature.TURN_OFF
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -253,7 +236,7 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
         # Check for active special function
         for preset, bit_value in SPECIAL_FUNCTION_MAP.items():
             if special_mode == bit_value:
-                return preset
+                return str(preset)
 
         return "none"
 

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -11,27 +11,42 @@ import socket
 import traceback
 from collections.abc import Awaitable, Callable
 from importlib import import_module
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 
-try:  # pragma: no cover - optional HA component
+if TYPE_CHECKING:
     from homeassistant.components.dhcp import DhcpServiceInfo
-except (ImportError, ModuleNotFoundError):  # pragma: no cover
-    DhcpServiceInfo = None  # type: ignore[assignment,misc]
-
-try:  # pragma: no cover - optional HA component
     from homeassistant.components.zeroconf import ZeroconfServiceInfo
-except (ImportError, ModuleNotFoundError):  # pragma: no cover
-    ZeroconfServiceInfo = None  # type: ignore[assignment,misc]
+else:
+    try:  # pragma: no cover - optional HA component
+        from homeassistant.components.dhcp import DhcpServiceInfo
+    except (ImportError, ModuleNotFoundError):  # pragma: no cover
+
+        @dataclasses.dataclass
+        class DhcpServiceInfo:  # pragma: no cover
+            """Fallback DHCP service info for minimal test environments."""
+
+            macaddress: str | None = None
+            ip: str | None = None
+
+    try:  # pragma: no cover - optional HA component
+        from homeassistant.components.zeroconf import ZeroconfServiceInfo
+    except (ImportError, ModuleNotFoundError):  # pragma: no cover
+
+        @dataclasses.dataclass
+        class ZeroconfServiceInfo:  # pragma: no cover
+            """Fallback Zeroconf service info for minimal test environments."""
+
+            host: str | None = None
 from homeassistant.core import HomeAssistant
 
 try:  # pragma: no cover - available since HA 2023.9
     from homeassistant.config_entries import ConfigFlowResult
 except (ImportError, ModuleNotFoundError):  # pragma: no cover
-    ConfigFlowResult = dict  # type: ignore[assignment,misc]
+    ConfigFlowResult = dict[str, Any]
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import translation
 from homeassistant.util.network import is_host_valid
@@ -97,31 +112,34 @@ from .utils import resolve_connection_settings
 _LOGGER = logging.getLogger(__name__)
 TIMEOUT_EXCEPTIONS = (TimeoutError, asyncio.TimeoutError)
 
+if TYPE_CHECKING:
+    class _ConfigFlowBase(config_entries.ConfigFlow):
+        def __init_subclass__(cls, *, domain: str, **kwargs: Any) -> None: ...
+
+else:
+    _ConfigFlowBase = config_entries.ConfigFlow
+
 
 class _FallbackFlowBase:  # pragma: no cover
     """Fallback flow base for minimal test environments."""
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         return None
 
-    async def async_set_unique_id(self, *args, **kwargs):
+    async def async_set_unique_id(self, *args: Any, **kwargs: Any) -> None:
         return None
 
-    def _abort_if_unique_id_configured(self):
+    def _abort_if_unique_id_configured(self) -> None:
         return None
 
-    def async_show_form(self, **kwargs):
+    def async_show_form(self, **kwargs: Any) -> dict[str, Any]:
         return {"type": "form", **kwargs}
 
-    def async_create_entry(self, **kwargs):
+    def async_create_entry(self, **kwargs: Any) -> dict[str, Any]:
         return {"type": "create_entry", **kwargs}
 
-    def async_abort(self, **kwargs):
+    def async_abort(self, **kwargs: Any) -> dict[str, Any]:
         return {"type": "abort", **kwargs}
-
-
-_BASE_CONFIG_FLOW = getattr(config_entries, "ConfigFlow", _FallbackFlowBase)
-_BASE_OPTIONS_FLOW = getattr(config_entries, "OptionsFlow", _FallbackFlowBase)
 
 
 def _is_request_cancelled_error(exc: ModbusIOException) -> bool:
@@ -325,7 +343,7 @@ async def _call_with_optional_timeout(func: Callable[[], Any], timeout: float) -
 
 def _caps_to_dict(obj: Any) -> dict[str, Any]:
     """Return a JSON-serializable dict from a capabilities object."""
-    if dataclasses.is_dataclass(obj):
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
         data = dict(obj.as_dict()) if hasattr(obj, "as_dict") else dataclasses.asdict(obj)
     elif hasattr(obj, "as_dict"):
         data = obj.as_dict()
@@ -575,13 +593,13 @@ async def validate_input(hass: HomeAssistant | None, data: dict[str, Any]) -> di
         _LOGGER.debug("Traceback:\n%s", traceback.format_exc())
         raise CannotConnect("cannot_connect") from exc
     finally:
-        if hasattr(scanner, "close"):
+        if scanner is not None and hasattr(scanner, "close"):
             close_result = scanner.close()
             if inspect.isawaitable(close_result):
                 await close_result
 
 
-class ConfigFlow(_BASE_CONFIG_FLOW, domain=DOMAIN):  # type: ignore[call-arg]
+class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
     """Handle a config flow for ThesslaGreen Modbus."""
 
     VERSION = 4  # pragma: no cover
@@ -631,7 +649,7 @@ class ConfigFlow(_BASE_CONFIG_FLOW, domain=DOMAIN):  # type: ignore[call-arg]
             ),
         )
 
-    async def async_set_unique_id(self, *args, **kwargs):  # pragma: no cover
+    async def async_set_unique_id(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover
         base = getattr(super(), "async_set_unique_id", None)
         if callable(base):
             result = base(*args, **kwargs)
@@ -640,25 +658,25 @@ class ConfigFlow(_BASE_CONFIG_FLOW, domain=DOMAIN):  # type: ignore[call-arg]
             return result
         return None
 
-    def _abort_if_unique_id_configured(self, **kwargs):  # pragma: no cover
+    def _abort_if_unique_id_configured(self, **kwargs: Any) -> Any:  # pragma: no cover
         base = getattr(super(), "_abort_if_unique_id_configured", None)
         if callable(base):
             return base(**kwargs)
         return None
 
-    def async_show_form(self, **kwargs):  # pragma: no cover
+    def async_show_form(self, **kwargs: Any) -> Any:  # pragma: no cover
         base = getattr(super(), "async_show_form", None)
         if callable(base):
             return base(**kwargs)
         return {"type": "form", **kwargs}
 
-    def async_create_entry(self, **kwargs):  # pragma: no cover
+    def async_create_entry(self, **kwargs: Any) -> Any:  # pragma: no cover
         base = getattr(super(), "async_create_entry", None)
         if callable(base):
             return base(**kwargs)
         return {"type": "create_entry", **kwargs}
 
-    def async_abort(self, **kwargs):  # pragma: no cover
+    def async_abort(self, **kwargs: Any) -> Any:  # pragma: no cover
         base = getattr(super(), "async_abort", None)
         if callable(base):
             return base(**kwargs)
@@ -1179,7 +1197,7 @@ class ConfigFlow(_BASE_CONFIG_FLOW, domain=DOMAIN):  # type: ignore[call-arg]
         return OptionsFlow(config_entry)
 
 
-class OptionsFlow(_BASE_OPTIONS_FLOW):
+class OptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for ThesslaGreen Modbus."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:  # pragma: no cover
@@ -1187,23 +1205,23 @@ class OptionsFlow(_BASE_OPTIONS_FLOW):
         self._stored_config_entry = config_entry
 
     @property
-    def config_entry(self):  # type: ignore[override]  # pragma: no cover
+    def config_entry(self) -> config_entries.ConfigEntry:  # pragma: no cover
         """Return the config entry for this options flow."""
         return self._stored_config_entry
 
-    def async_show_form(self, **kwargs):  # pragma: no cover
+    def async_show_form(self, **kwargs: Any) -> Any:  # pragma: no cover
         base = getattr(super(), "async_show_form", None)
         if callable(base):
             return base(**kwargs)
         return {"type": "form", **kwargs}
 
-    def async_create_entry(self, **kwargs):  # pragma: no cover
+    def async_create_entry(self, **kwargs: Any) -> Any:  # pragma: no cover
         base = getattr(super(), "async_create_entry", None)
         if callable(base):
             return base(**kwargs)
         return {"type": "create_entry", **kwargs}
 
-    def async_abort(self, **kwargs):  # pragma: no cover
+    def async_abort(self, **kwargs: Any) -> Any:  # pragma: no cover
         base = getattr(super(), "async_abort", None)
         if callable(base):
             return base(**kwargs)

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -14,12 +14,16 @@ try:  # pragma: no cover - optional during isolated tests
     from .registers.loader import get_registers_by_function
 except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
 
-    def get_registers_by_function(fn: str):
+    def get_registers_by_function(
+        fn: str, json_path: Path | str | None = None
+    ) -> list[RegisterDef]:
         return []
 
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from homeassistant.core import HomeAssistant
+
+    from .registers.loader import RegisterDef
 
 # Maximum number of registers that can be read in a single request.
 # The registers loader previously created a circular dependency with
@@ -248,7 +252,7 @@ try:  # pragma: no cover - optional during isolated tests
         _Platform.TIME,
     ]
 except (ImportError, AttributeError):  # pragma: no cover - fallback for test environments
-    PLATFORMS = [  # type: ignore[assignment]
+    PLATFORMS = [
         "sensor",
         "binary_sensor",
         "climate",
@@ -357,12 +361,12 @@ def migrate_unique_id(
     reverse_by_address: dict[tuple[int, int | None], str] = {}
     register_to_key: dict[str, str] = {}
 
-    for key, (register_name, register_type, bit) in lookup.items():
-        register_to_key.setdefault(register_name, key)
-        address = _register_address(register_name, register_type)
+    for mapping_key, (mapped_register_name, mapped_register_type, bit) in lookup.items():
+        register_to_key.setdefault(mapped_register_name, mapping_key)
+        address = _register_address(mapped_register_name, mapped_register_type)
         if address is None:
             continue
-        reverse_by_address.setdefault((address, _bit_index(bit)), key)
+        reverse_by_address.setdefault((address, _bit_index(bit)), mapping_key)
 
     match = re.match(rf".*_{slave_id}_(.+)", uid_no_domain)
     remainder = match.group(1) if match else None
@@ -374,31 +378,34 @@ def migrate_unique_id(
         if match_address:
             address = int(match_address.group(1))
             bit_index = int(match_address.group(2)) if match_address.group(2) else None
-            key = reverse_by_address.get((address, bit_index)) or reverse_by_address.get(
+            resolved_key = reverse_by_address.get((address, bit_index)) or reverse_by_address.get(
                 (address, None)
             )
-            if key:
+            if resolved_key:
                 bit_suffix = f"_bit{bit_index}" if bit_index is not None else ""
-                base_uid = f"{slave_id}_{key}_{address}{bit_suffix}"
+                base_uid = f"{slave_id}_{resolved_key}_{address}{bit_suffix}"
         else:
-            key = None
-            register_name: str | None = None
-            bit_index: int | None = None
+            resolved_key = None
+            matched_register_name: str | None = None
+            matched_register_type: str | None = None
+            matched_bit_index: int | None = None
 
             if remainder in lookup:
-                key = remainder
-                register_name, register_type, bit = lookup[key]
-                bit_index = _bit_index(bit)
+                resolved_key = remainder
+                matched_register_name, matched_register_type, bit = lookup[resolved_key]
+                matched_bit_index = _bit_index(bit)
             elif remainder in register_to_key:
-                key = register_to_key[remainder]
-                register_name, register_type, bit = lookup[key]
-                bit_index = _bit_index(bit)
+                resolved_key = register_to_key[remainder]
+                matched_register_name, matched_register_type, bit = lookup[resolved_key]
+                matched_bit_index = _bit_index(bit)
 
-            if register_name:
-                address = _register_address(register_name, register_type)
+            if matched_register_name:
+                address = _register_address(matched_register_name, matched_register_type)
                 if address is not None:
-                    bit_suffix = f"_bit{bit_index}" if bit_index is not None else ""
-                    base_uid = f"{slave_id}_{key}_{address}{bit_suffix}"
+                    bit_suffix = (
+                        f"_bit{matched_bit_index}" if matched_bit_index is not None else ""
+                    )
+                    base_uid = f"{slave_id}_{resolved_key}_{address}{bit_suffix}"
             elif remainder == "fan":
                 base_uid = f"{slave_id}_fan_0"
 

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -69,7 +69,7 @@ from .modbus_transport import (
     TcpModbusTransport,
 )
 from .register_map import REGISTER_MAP_VERSION
-from .registers.loader import get_all_registers
+from .registers.loader import RegisterDef, get_all_registers
 from .scanner_core import (
     DeviceCapabilities,
     ThesslaGreenDeviceScanner,
@@ -123,7 +123,7 @@ _ORIGINAL_ASYNC_MODBUS_TCP_CLIENT = AsyncModbusTcpClient
 REGISTER_DEFS = {r.name: r for r in get_all_registers()}
 
 
-def get_register_definition(name: str):
+def get_register_definition(name: str) -> RegisterDef:
     return REGISTER_DEFS[name]
 
 
@@ -143,7 +143,7 @@ def _update_failed_exception(message: str) -> Exception:
     if len(classes) == 1:
         return classes[0](message)  # pragma: no cover
 
-    compat_cls = type("CompatUpdateFailed", tuple(classes), {})
+    compat_cls = cast(type[Exception], type("CompatUpdateFailed", tuple(classes), {}))
     return compat_cls(message)
 
 
@@ -398,13 +398,13 @@ class ThesslaGreenModbusCoordinator(
         transport = self._transport
         transport_method = getattr(transport, name, None) if transport is not None else None
         if callable(transport_method):
-            return transport_method
+            return cast(Callable[..., Any], transport_method)
         """Return a Modbus client method or a no-op async placeholder."""
 
         client = self.client
         method = getattr(client, name, None) if client is not None else None
         if callable(method):
-            return method
+            return cast(Callable[..., Any], method)
 
         async def _missing_method(*_args: Any, **_kwargs: Any) -> Any:
             return None
@@ -488,7 +488,7 @@ class ThesslaGreenModbusCoordinator(
 
     def _apply_scan_result(self, scan_result: dict[str, Any]) -> None:  # pragma: no cover
         """Store and process a completed device scan result."""
-        self.device_scan_result = cast(dict[str, Any], scan_result)
+        self.device_scan_result = scan_result
         if self.connection_mode == CONNECTION_MODE_AUTO:
             if resolved := self.device_scan_result.get("resolved_connection_mode"):
                 self._resolved_connection_mode = resolved
@@ -619,7 +619,9 @@ class ThesslaGreenModbusCoordinator(
         elif not self.enable_device_scan:
             cache: dict[str, Any] = {}
             if self.entry is not None:
-                cache = self.entry.options.get("device_scan_cache", {})  # type: ignore[assignment]
+                raw_cache = self.entry.options.get("device_scan_cache", {})
+                if isinstance(raw_cache, dict):
+                    cache = raw_cache
             if cache and self._apply_scan_cache(cache):
                 _LOGGER.info("Using cached device scan results")
             else:
@@ -1543,4 +1545,4 @@ class ThesslaGreenModbusCoordinator(
     @property
     def device_info_dict(self) -> dict[str, Any]:  # pragma: no cover
         """Return device information as a plain dictionary for legacy use."""
-        return cast(dict[str, Any], self.get_device_info())
+        return self.get_device_info()

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -10,6 +10,7 @@ import copy
 import ipaddress
 import logging
 import re
+from collections.abc import Callable
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -24,7 +25,9 @@ from .registers.loader import _REGISTERS_PATH, get_all_registers, registers_sha2
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _run_executor_job(hass: HomeAssistant, func, *args):
+async def _run_executor_job(
+    hass: HomeAssistant, func: Callable[..., Any], *args: Any
+) -> Any:
     """Run a callable using HA executor when available, fallback inline in tests."""
 
     if hasattr(hass, "async_add_executor_job"):

--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -6,12 +6,10 @@ import inspect
 import logging
 from typing import Any
 
-from homeassistant.helpers import update_coordinator as update_coordinator_helper
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-CoordinatorEntity = getattr(update_coordinator_helper, "CoordinatorEntity", object)
-
-from .const import MAX_VENTILATION_PERCENT, device_unique_id_prefix  # noqa: E402
-from .coordinator import ThesslaGreenModbusCoordinator  # noqa: E402
+from .const import MAX_VENTILATION_PERCENT, device_unique_id_prefix
+from .coordinator import ThesslaGreenModbusCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +23,7 @@ class ThesslaGreenEntity(CoordinatorEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         key: str,
-        address: int,
+        address: int | None,
         *,
         bit: int | None = None,
     ) -> None:

--- a/custom_components/thessla_green_modbus/entity_mappings.py
+++ b/custom_components/thessla_green_modbus/entity_mappings.py
@@ -1,12 +1,37 @@
-"""Backward-compatible shim for entity mappings package."""
+"""Backward-compatible shim for the ``mappings`` package."""
 
 from __future__ import annotations
 
 import sys
 
 from . import mappings as _m
+from .mappings import (
+    BINARY_SENSOR_ENTITY_MAPPINGS,
+    ENTITY_MAPPINGS,
+    NUMBER_ENTITY_MAPPINGS,
+    SELECT_ENTITY_MAPPINGS,
+    SENSOR_ENTITY_MAPPINGS,
+    SWITCH_ENTITY_MAPPINGS,
+    TEXT_ENTITY_MAPPINGS,
+    TIME_ENTITY_MAPPINGS,
+    async_setup_entity_mappings,
+    map_legacy_entity_id,
+)
 
 # Keep ``entity_mappings`` as an alias of ``mappings`` so existing tests and
 # monkeypatches that mutate module globals continue to affect runtime behavior.
 _m.__file__ = __file__
 sys.modules[__name__] = _m
+
+__all__ = [
+    "BINARY_SENSOR_ENTITY_MAPPINGS",
+    "ENTITY_MAPPINGS",
+    "NUMBER_ENTITY_MAPPINGS",
+    "SELECT_ENTITY_MAPPINGS",
+    "SENSOR_ENTITY_MAPPINGS",
+    "SWITCH_ENTITY_MAPPINGS",
+    "TEXT_ENTITY_MAPPINGS",
+    "TIME_ENTITY_MAPPINGS",
+    "async_setup_entity_mappings",
+    "map_legacy_entity_id",
+]

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -252,7 +252,15 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
             return self._MODE_MAP.get(self.coordinator.data["mode"])
         return None
 
-    async def _write_register(self, register_name: str, value: int) -> None:
+    async def _write_register(
+        self,
+        register_name: str,
+        value: Any,
+        *,
+        offset: int = 0,
+        refresh: bool = True,
+        include_offset: bool = False,
+    ) -> None:
         """Write value to holding register when present on the device."""
         if register_name not in holding_registers():
             raise ValueError(f"Register {register_name} is not writable")
@@ -262,7 +270,13 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
             _LOGGER.debug("Register %s unavailable, skipping write", register_name)
             return
 
-        await super()._write_register(register_name, value)
+        await super()._write_register(
+            register_name,
+            int(value),
+            offset=offset,
+            refresh=refresh,
+            include_offset=include_offset,
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:  # pragma: no cover

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -14,7 +14,7 @@
   "requirements": [
     "pymodbus>=3.6.0"
   ],
-  "version": "2.3.1",
+  "version": "2.3.2",
   "integration_type": "hub",
   "after_dependencies": [
     "modbus"

--- a/custom_components/thessla_green_modbus/mappings/_helpers.py
+++ b/custom_components/thessla_green_modbus/mappings/_helpers.py
@@ -6,7 +6,10 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..registers.loader import RegisterDef
 
 from .._compat import PERCENTAGE
 from ..utils import _to_snake_case
@@ -15,7 +18,7 @@ try:  # pragma: no cover - optional during isolated tests
     from ..registers.loader import get_all_registers
 except (ImportError, AttributeError):  # pragma: no cover
 
-    def get_all_registers(*_args, **_kwargs):
+    def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
         return []
 
 
@@ -74,7 +77,7 @@ def _get_register_info(name: str) -> dict[str, Any] | None:
             }
         _REGISTER_INFO_CACHE = cache
         if _parent is not None:
-            _parent._REGISTER_INFO_CACHE = cache  # type: ignore[union-attr]
+            _parent._REGISTER_INFO_CACHE = cache  # type: ignore[attr-defined]
 
     info = cache.get(name)
     if info is None and (suffix := name.rsplit("_", 1)) and len(suffix) > 1 and suffix[1].isdigit():

--- a/custom_components/thessla_green_modbus/mappings/_loaders.py
+++ b/custom_components/thessla_green_modbus/mappings/_loaders.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..registers.loader import RegisterDef
 
 from .._compat import BinarySensorDeviceClass, EntityCategory
 from ..const import (
@@ -26,7 +30,7 @@ try:  # pragma: no cover - optional during isolated tests
     from ..registers.loader import get_all_registers
 except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
 
-    def get_all_registers(*_args, **_kwargs):  # type: ignore[misc]
+    def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
         return []
 
 

--- a/custom_components/thessla_green_modbus/mappings/legacy.py
+++ b/custom_components/thessla_green_modbus/mappings/legacy.py
@@ -124,7 +124,7 @@ def map_legacy_entity_id(entity_id: str) -> str:
             )
             _alias_warning_logged = True
             if _parent is not None:
-                _parent._alias_warning_logged = True  # type: ignore[union-attr]
+                _parent._alias_warning_logged = True  # type: ignore[attr-defined]
         return new_entity_id
 
     suffix = object_id.rsplit("_", 1)[-1]
@@ -144,7 +144,7 @@ def map_legacy_entity_id(entity_id: str) -> str:
         )
         _alias_warning_logged = True
         if _parent is not None:
-            _parent._alias_warning_logged = True  # type: ignore[union-attr]
+            _parent._alias_warning_logged = True  # type: ignore[attr-defined]
 
     return new_entity_id
 

--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -222,7 +222,7 @@ def _calculate_backoff_delay(
             jitter_min, jitter_max = jitter_max, jitter_min
         delay += random.uniform(jitter_min, jitter_max)
 
-    return max(delay, 0.0)
+    return float(max(delay, 0.0))
 
 
 async def _call_modbus(

--- a/custom_components/thessla_green_modbus/modbus_transport.py
+++ b/custom_components/thessla_green_modbus/modbus_transport.py
@@ -402,6 +402,7 @@ class TcpModbusTransport(BaseModbusTransport):
     ) -> Any:
         if self.client is None:
             await self.ensure_connected()
+        assert self.client is not None
         return await self.call(
             self.client.read_input_registers,
             slave_id,
@@ -420,6 +421,7 @@ class TcpModbusTransport(BaseModbusTransport):
     ) -> Any:
         if self.client is None:
             await self.ensure_connected()
+        assert self.client is not None
         return await self.call(
             self.client.read_holding_registers,
             slave_id,
@@ -438,6 +440,7 @@ class TcpModbusTransport(BaseModbusTransport):
     ) -> Any:
         if self.client is None:
             await self.ensure_connected()
+        assert self.client is not None
         return await self.call(
             self.client.write_register,
             slave_id,
@@ -456,6 +459,7 @@ class TcpModbusTransport(BaseModbusTransport):
     ) -> Any:
         if self.client is None:
             await self.ensure_connected()
+        assert self.client is not None
         return await self.call(
             self.client.write_registers,
             slave_id,
@@ -545,6 +549,7 @@ class RtuModbusTransport(BaseModbusTransport):
     ) -> Any:
         if self.client is None:
             await self.ensure_connected()
+        assert self.client is not None
         return await self.call(
             self.client.read_input_registers,
             slave_id,
@@ -563,6 +568,7 @@ class RtuModbusTransport(BaseModbusTransport):
     ) -> Any:
         if self.client is None:
             await self.ensure_connected()
+        assert self.client is not None
         return await self.call(
             self.client.read_holding_registers,
             slave_id,
@@ -581,6 +587,7 @@ class RtuModbusTransport(BaseModbusTransport):
     ) -> Any:
         if self.client is None:
             await self.ensure_connected()
+        assert self.client is not None
         return await self.call(
             self.client.write_register,
             slave_id,
@@ -599,6 +606,7 @@ class RtuModbusTransport(BaseModbusTransport):
     ) -> Any:
         if self.client is None:
             await self.ensure_connected()
+        assert self.client is not None
         return await self.call(
             self.client.write_registers,
             slave_id,

--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -349,6 +349,8 @@ class RegisterDef:
                 airflow, temp = value
             else:
                 airflow, temp = value, 0
+            if airflow is None or temp is None:
+                raise ValueError(f"Invalid AATT value for {self.name}: {value!r}")
             return (int(airflow) << 8) | (round(float(temp) * 2) & 255)
 
         raw: Any = value
@@ -383,6 +385,8 @@ class RegisterDef:
                 scaled = (scaled / mult).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
             raw = scaled
         typ = self.extra.get("type") if self.extra else None
+        if raw is None:
+            raise ValueError(f"Invalid value None for {self.name}")
         if typ == "i16":
             return int(raw) & 65535
         return int(raw)
@@ -703,7 +707,7 @@ def group_registers(
 
     from ..modbus_helpers import group_reads
 
-    return cast(list[tuple[int, int]], group_reads(addresses, max_block_size=max_block_size))
+    return group_reads(addresses, max_block_size=max_block_size)
 
 
 # Public exports for import * use in tests and helpers

--- a/custom_components/thessla_green_modbus/registers/schema.py
+++ b/custom_components/thessla_green_modbus/registers/schema.py
@@ -20,7 +20,15 @@ from __future__ import annotations
 
 import logging
 import re
-from enum import StrEnum
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - Python < 3.11
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # type: ignore[no-redef]
+        """Compatibility StrEnum fallback for Python < 3.11."""
+
 from typing import Any, Literal, cast
 
 import pydantic

--- a/custom_components/thessla_green_modbus/scanner_core.py
+++ b/custom_components/thessla_green_modbus/scanner_core.py
@@ -7,6 +7,7 @@ import importlib
 import inspect
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict as _dataclasses_asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -85,19 +86,21 @@ try:  # pragma: no cover - optional during isolated tests
     )
 except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
 
-    async def async_get_all_registers(*_args, **_kwargs):
+    async def async_get_all_registers(
+        hass: Any | None, json_path: Path | str | None = None
+    ) -> list[RegisterDef]:
         return []
 
-    async def async_registers_sha256(*_args, **_kwargs) -> str:
+    async def async_registers_sha256(hass: Any | None, json_path: Path | str) -> str:
         return ""
 
-    def get_all_registers(*_args, **_kwargs):
+    def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
         return []
 
-    def get_registers_path(*_args, **_kwargs) -> Path:
+    def get_registers_path() -> Path:
         return Path(".")
 
-    def registers_sha256(*_args, **_kwargs) -> str:
+    def registers_sha256(json_path: Path | str) -> str:
         return ""
 
 
@@ -106,8 +109,8 @@ asdict = _dataclasses_asdict  # re-exported for test monkeypatching
 _LOGGER = logging.getLogger(__name__)
 
 try:
-    _pymodbus = importlib.import_module("pymodbus")
-    _pymodbus_client = importlib.import_module("pymodbus.client")
+    _pymodbus: Any = importlib.import_module("pymodbus")
+    _pymodbus_client: Any = importlib.import_module("pymodbus.client")
     if not hasattr(_pymodbus, "client"):
         _pymodbus.client = _pymodbus_client  # pragma: no cover
 except (ImportError, AttributeError) as _exc:  # pragma: no cover
@@ -115,6 +118,8 @@ except (ImportError, AttributeError) as _exc:  # pragma: no cover
 
 if TYPE_CHECKING:  # pragma: no cover - typing helper only
     from pymodbus.client import AsyncModbusSerialClient as AsyncModbusSerialClientType
+
+    from .registers.loader import RegisterDef
 else:
     AsyncModbusSerialClientType = Any
 
@@ -129,7 +134,7 @@ def _ensure_pymodbus_client_module() -> None:
 
 def is_request_cancelled_error(exc: ModbusIOException) -> bool:
     """Return True when a modbus IO error indicates a cancelled request."""
-    return _scanner_io.is_request_cancelled_error(exc)
+    return bool(_scanner_io.is_request_cancelled_error(exc))
 
 
 async def _maybe_retry_yield(backoff: float, attempt: int, retry: int) -> None:
@@ -347,7 +352,7 @@ class ThesslaGreenDeviceScanner:
 
         # Placeholder for register map and value ranges loaded asynchronously
         self._registers: dict[int, dict[int, str]] = {}
-        self._register_ranges: dict[str, tuple[int | None, int | None]] = {}
+        self._register_ranges: dict[str, tuple[float | None, float | None]] = {}
         self._names_by_address: dict[int, dict[int, set[str]]] = {4: {}, 3: {}, 1: {}, 2: {}}
 
         # Track holding registers that consistently fail to respond so we
@@ -421,14 +426,12 @@ class ThesslaGreenDeviceScanner:
         await _async_ensure_register_maps(self._hass)
         loaded = await self._load_registers()
         if isinstance(loaded, tuple):
-            self._registers = cast(dict[int, dict[int, str]], loaded[0])
+            self._registers = loaded[0]
             self._register_ranges = (
-                cast(dict[str, tuple[int | None, int | None]], loaded[1])
-                if len(loaded) > 1 and isinstance(loaded[1], dict)
-                else {}
+                loaded[1] if len(loaded) > 1 and isinstance(loaded[1], dict) else {}
             )
         else:
-            self._registers = cast(dict[int, dict[int, str]], loaded)
+            self._registers = loaded
             self._register_ranges = {}
         self._names_by_address = {
             4: self._build_names_by_address(
@@ -648,13 +651,13 @@ class ThesslaGreenDeviceScanner:
 
         last_error: Exception | None = None
         closed_transports: set[int] = set()
-        for mode, transport, timeout in attempts:
+        for mode_name, transport, timeout in attempts:
             try:
                 _LOGGER.info(
                     "verify_connection: connecting to %s:%s (mode=%s, timeout=%s)",
                     self.host,
                     self.port,
-                    mode or self.connection_type,
+                    mode_name or self.connection_type,
                     timeout,
                 )
                 await asyncio.wait_for(transport.ensure_connected(), timeout=timeout)
@@ -686,15 +689,15 @@ class ThesslaGreenDeviceScanner:
                         start,
                         count=count,
                     )
-                if mode is not None:
+                if mode_name is not None:
                     if self.connection_mode == CONNECTION_MODE_AUTO:
                         _LOGGER.info(
                             "verify_connection: auto-selected Modbus transport %s for %s:%s",
-                            mode,
+                            mode_name,
                             self.host,
                             self.port,
                         )
-                    self._resolved_connection_mode = mode
+                    self._resolved_connection_mode = mode_name
                 return
             except asyncio.CancelledError:
                 raise
@@ -953,12 +956,12 @@ class ThesslaGreenDeviceScanner:
 
         missing_regs: list[str] = []
         if None in (major, minor, patch):
-            for name, value in (
+            for name, missing_value in (
                 ("version_major", major),
                 ("version_minor", minor),
                 ("version_patch", patch),
             ):
-                if value is None and name in INPUT_REGISTERS:
+                if missing_value is None and name in INPUT_REGISTERS:
                     missing_regs.append(f"{name} ({INPUT_REGISTERS[name]})")
 
         if None not in (major, minor, patch):
@@ -1204,7 +1207,7 @@ class ThesslaGreenDeviceScanner:
         reg_type: str,
         addr_to_names: dict[int, set[str]],
         addresses: list[int],
-        read_fn,
+        read_fn: Callable[..., Awaitable[list[int] | None]],
         *,
         boundaries: frozenset[int] | None = None,
     ) -> None:
@@ -1263,7 +1266,7 @@ class ThesslaGreenDeviceScanner:
             addr_to_names.setdefault(addr, set()).add(name)
             addresses.append(addr)
 
-        async def _read(start: int, count: int, *, skip_cache: bool = False):
+        async def _read(start: int, count: int, *, skip_cache: bool = False) -> list[int] | None:
             try:
                 return (
                     await self._read_input(self._client, start, count, skip_cache=skip_cache)
@@ -1294,7 +1297,7 @@ class ThesslaGreenDeviceScanner:
 
         addr_to_names = {addr: names for addr, (names, _) in holding_info.items()}
 
-        async def _read(start: int, count: int, *, skip_cache: bool = False):
+        async def _read(start: int, count: int, *, skip_cache: bool = False) -> list[int] | None:
             try:
                 return (
                     await self._read_holding(self._client, start, count, skip_cache=skip_cache)
@@ -1625,17 +1628,21 @@ class ThesslaGreenDeviceScanner:
         scan_method = self.scan
         if getattr(scan_method, "__func__", None) is not ThesslaGreenDeviceScanner.scan:
             try:
-                result = scan_method()
-                if inspect.isawaitable(result):
-                    result = await result
+                scan_result: Any = scan_method()
+                if inspect.isawaitable(scan_result):
+                    scan_result = await scan_result
                 if (
-                    isinstance(result, tuple)
-                    and len(result) >= 2
-                    and isinstance(result[0], ScannerDeviceInfo)
-                    and isinstance(result[1], DeviceCapabilities)
+                    isinstance(scan_result, tuple)
+                    and len(scan_result) >= 2
+                    and isinstance(scan_result[0], ScannerDeviceInfo)
+                    and isinstance(scan_result[1], DeviceCapabilities)
                 ):
-                    device, caps = result[0], result[1]
-                    unknown = result[2] if len(result) > 2 and isinstance(result[2], dict) else {}
+                    device, caps = scan_result[0], scan_result[1]
+                    unknown = (
+                        scan_result[2]
+                        if len(scan_result) > 2 and isinstance(scan_result[2], dict)
+                        else {}
+                    )
                     return {
                         "available_registers": {
                             k: sorted(v) for k, v in self.available_registers.items()
@@ -1645,7 +1652,11 @@ class ThesslaGreenDeviceScanner:
                         "register_count": sum(len(v) for v in self.available_registers.values()),
                         "unknown_registers": unknown,
                     }
-                return cast(dict[str, Any], result)
+                if isinstance(scan_result, dict):
+                    return scan_result
+                raise TypeError(
+                    "Overridden scan() must return dict or (ScannerDeviceInfo, DeviceCapabilities)"
+                )
             finally:
                 await self.close()
 
@@ -1724,10 +1735,10 @@ class ThesslaGreenDeviceScanner:
             raise ConnectionException(f"Failed to connect to {self.host}:{self.port}") from exc
 
         try:
-            result = await self.scan()
-            if not isinstance(result, dict):
+            scan_data = await self.scan()
+            if not isinstance(scan_data, dict):
                 raise TypeError("scan() must return a dict")
-            return result
+            return scan_data
         finally:
             await self.close()
 
@@ -1735,11 +1746,11 @@ class ThesslaGreenDeviceScanner:
         self,
     ) -> tuple[
         dict[int, dict[int, str]],
-        dict[str, tuple[int | None, int | None]],
+        dict[str, tuple[float | None, float | None]],
     ]:
         """Load Modbus register definitions and value ranges."""
         register_map: dict[int, dict[int, str]] = {3: {}, 4: {}, 1: {}, 2: {}}
-        register_ranges: dict[str, tuple[int | None, int | None]] = {}
+        register_ranges: dict[str, tuple[float | None, float | None]] = {}
         for reg in await async_get_all_registers(self._hass):
             if not reg.name:
                 continue
@@ -1878,7 +1889,7 @@ class ThesslaGreenDeviceScanner:
         """Unpack the overloaded (client, address, count) / (address, count) signatures."""
         if count is None or isinstance(client_or_address, int):
             return None, int(client_or_address), address_or_count
-        return client_or_address, address_or_count, count  # type: ignore[return-value]
+        return client_or_address, address_or_count, count
 
     def _resolve_transport_and_client(
         self,

--- a/custom_components/thessla_green_modbus/scanner_device_info.py
+++ b/custom_components/thessla_green_modbus/scanner_device_info.py
@@ -20,8 +20,6 @@ def _compat_asdict(obj: Any) -> dict[str, Any]:
     except (ImportError, AttributeError, TypeError):  # pragma: no cover - fallback
         return dataclasses.asdict(obj)
 
-
-
 @dataclass(slots=True)
 class ScannerDeviceInfo(collections.abc.Mapping):  # pragma: no cover
     """Basic identifying information about a ThesslaGreen unit.
@@ -46,24 +44,23 @@ class ScannerDeviceInfo(collections.abc.Mapping):  # pragma: no cover
     def as_dict(self) -> dict[str, Any]:
         return _compat_asdict(self)
 
-    def items(self):
+    def items(self) -> Any:
         return self.as_dict().items()
 
-    def keys(self):
+    def keys(self) -> Any:
         return self.as_dict().keys()
 
-    def values(self):
+    def values(self) -> Any:
         return self.as_dict().values()
 
     def __getitem__(self, key: str) -> Any:
         return self.as_dict()[key]
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         return iter(self.as_dict())
 
     def __len__(self) -> int:
         return len(self.as_dict())
-
 @dataclass(slots=True)
 class DeviceCapabilities(collections.abc.Mapping):  # pragma: no cover
     """Feature flags and sensor availability detected on the device.
@@ -121,21 +118,24 @@ class DeviceCapabilities(collections.abc.Mapping):  # pragma: no cover
                 if isinstance(value, set):
                     data[key] = sorted(value)
             object.__setattr__(self, "_as_dict_cache", data)
-        return self._as_dict_cache
+        cache = self._as_dict_cache
+        if cache is None:
+            return {}
+        return cache
 
-    def items(self):
+    def items(self) -> Any:
         return self.as_dict().items()
 
-    def keys(self):
+    def keys(self) -> Any:
         return self.as_dict().keys()
 
-    def values(self):
+    def values(self) -> Any:
         return self.as_dict().values()
 
     def __getitem__(self, key: str) -> Any:
         return self.as_dict()[key]
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         return iter(self.as_dict())
 
     def __len__(self) -> int:

--- a/custom_components/thessla_green_modbus/scanner_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner_helpers.py
@@ -34,8 +34,8 @@ def _format_register_value(name: str, value: int) -> int | str | None:
     """Return a human-readable representation of a register value."""
     if name == "manual_airing_time_to_start":
         raw_value = value
-        value = ((value & 255) << 8) | ((value >> 8) & 255)
-        decoded = _decode_register_time(value)
+        swapped_value = ((value & 255) << 8) | ((value >> 8) & 255)
+        decoded = _decode_register_time(swapped_value)
         if decoded is None:
             return None if raw_value == SENSOR_UNAVAILABLE else f"{raw_value} (invalid)"
         return f"{decoded // 60:02d}:{decoded % 60:02d}"
@@ -43,23 +43,25 @@ def _format_register_value(name: str, value: int) -> int | str | None:
     if name.startswith(BCD_TIME_PREFIXES):
         if value > 0x2359:
             return None if value == SENSOR_UNAVAILABLE else f"{value} (invalid)"
-        decoded = decode_bcd_time(value)
-        if decoded is None:
+        bcd_decoded = decode_bcd_time(value)
+        if bcd_decoded is None:
             return None if value == SENSOR_UNAVAILABLE else f"{value} (invalid)"
-        return decoded
+        return bcd_decoded
 
     if name.startswith(TIME_REGISTER_PREFIXES):
-        decoded = _decode_register_time(value)
-        if decoded is None:
+        time_decoded = _decode_register_time(value)
+        if time_decoded is None:
             return None if value == SENSOR_UNAVAILABLE else f"{value} (invalid)"
-        return f"{decoded // 60:02d}:{decoded % 60:02d}"
+        return f"{time_decoded // 60:02d}:{time_decoded % 60:02d}"
 
     if name.startswith(SETTING_PREFIX):
-        decoded = _decode_aatt(value)
-        if decoded is None:
+        aatt_decoded: dict[str, float | int] | None = _decode_aatt(value)
+        if aatt_decoded is None:
             return None if value == SENSOR_UNAVAILABLE else value
-        airflow = decoded["airflow_pct"]
-        temp = decoded["temp_c"]
+        airflow = aatt_decoded.get("airflow_pct")
+        temp = aatt_decoded.get("temp_c")
+        if airflow is None or temp is None:
+            return None if value == SENSOR_UNAVAILABLE else value
         temp_str = f"{temp:g}"
         return f"{airflow}% @ {temp_str}°C"
 

--- a/custom_components/thessla_green_modbus/scanner_io.py
+++ b/custom_components/thessla_green_modbus/scanner_io.py
@@ -19,8 +19,8 @@ def ensure_pymodbus_client_module() -> None:
     """Ensure ``pymodbus.client`` is importable and attached to ``pymodbus``."""
 
     try:
-        pymodbus_mod = importlib.import_module("pymodbus")
-        client_mod = importlib.import_module("pymodbus.client")
+        pymodbus_mod: Any = importlib.import_module("pymodbus")
+        client_mod: Any = importlib.import_module("pymodbus.client")
     except (ImportError, ModuleNotFoundError, AttributeError):
         return
     if not hasattr(pymodbus_mod, "client"):

--- a/custom_components/thessla_green_modbus/scanner_register_maps.py
+++ b/custom_components/thessla_green_modbus/scanner_register_maps.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .registers.loader import RegisterDef
 
 try:  # pragma: no cover - optional during isolated tests
     from .registers.loader import (
@@ -15,19 +18,21 @@ try:  # pragma: no cover - optional during isolated tests
     )
 except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
 
-    async def async_get_all_registers(*_args, **_kwargs):
+    async def async_get_all_registers(
+        hass: Any | None, json_path: Path | str | None = None
+    ) -> list[RegisterDef]:
         return []
 
-    async def async_registers_sha256(*_args, **_kwargs) -> str:
+    async def async_registers_sha256(hass: Any | None, json_path: Path | str) -> str:
         return ""
 
-    def get_all_registers(*_args, **_kwargs):
+    def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
         return []
 
-    def get_registers_path(*_args, **_kwargs) -> Path:
+    def get_registers_path() -> Path:
         return Path(".")
 
-    def registers_sha256(*_args, **_kwargs) -> str:
+    def registers_sha256(json_path: Path | str) -> str:
         return ""
 
 

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -176,7 +176,7 @@ class ThesslaGreenSensor(ThesslaGreenEntity, SensorEntity):
         self,
         coordinator: ThesslaGreenModbusCoordinator,
         register_name: str,
-        address: int,
+        address: int | None,
         sensor_definition: dict[str, Any],
     ) -> None:
         """Initialize the sensor."""
@@ -307,7 +307,7 @@ class ThesslaGreenSerialNumberSensor(ThesslaGreenSensor):
         """Return the serial number string assembled during device scan."""
         sn = (self.coordinator.device_info or {}).get("serial_number")
         if sn and sn != "Unknown":
-            return sn
+            return str(sn)
         return None
 
     @property

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -981,22 +981,24 @@ def _register_data_services(hass: HomeAssistant) -> None:
             if not coordinator:
                 continue
 
-            scanner = await ThesslaGreenDeviceScanner.create(
-                host=coordinator.host,
-                port=coordinator.port,
-                slave_id=coordinator.slave_id,
-                timeout=coordinator.timeout,
-                retry=coordinator.retry,
-                scan_uart_settings=coordinator.scan_uart_settings,
-                skip_known_missing=False,
-                full_register_scan=True,
-                max_registers_per_request=coordinator.effective_batch,
-                hass=hass,
-            )
+            scanner: ThesslaGreenDeviceScanner | None = None
             try:
+                scanner = await ThesslaGreenDeviceScanner.create(
+                    host=coordinator.host,
+                    port=coordinator.port,
+                    slave_id=coordinator.slave_id,
+                    timeout=int(coordinator.timeout),
+                    retry=coordinator.retry,
+                    scan_uart_settings=coordinator.scan_uart_settings,
+                    skip_known_missing=False,
+                    full_register_scan=True,
+                    max_registers_per_request=coordinator.effective_batch,
+                    hass=hass,
+                )
                 scan_result = await scanner.scan_device()
             finally:
-                await scanner.close()
+                if scanner is not None:
+                    await scanner.close()
 
             coordinator.device_scan_result = scan_result
 

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -140,7 +140,7 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
 
         if self.bit is not None:
             if self.register_name == "special_mode":
-                return raw_value == self.bit
+                return bool(raw_value == self.bit)
             return bool(raw_value & self.bit)
 
         # Convert to boolean
@@ -182,10 +182,24 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
             _LOGGER.error("Failed to turn off %s: %s", self.register_name, exc)
             raise
 
-    async def _write_register(self, register_name: str, value: int) -> None:
+    async def _write_register(
+        self,
+        register_name: str,
+        value: Any,
+        *,
+        offset: int = 0,
+        refresh: bool = True,
+        include_offset: bool = False,
+    ) -> None:
         """Write value to register."""
-        offset = self.entity_config.get("offset", 0)
-        await super()._write_register(register_name, value, offset=offset, include_offset=True)
+        entity_offset = self.entity_config.get("offset", 0)
+        await super()._write_register(
+            register_name,
+            int(value),
+            offset=entity_offset if offset == 0 else offset,
+            refresh=refresh,
+            include_offset=True if offset == 0 else include_offset,
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:  # pragma: no cover
@@ -231,4 +245,4 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
         """Return if entity is available."""
         # For switch entities, we don't require the register to be in current data
         # as they are primarily for control, not just display.
-        return self.coordinator.last_update_success
+        return bool(self.coordinator.last_update_success)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thessla-green-modbus"
-version = "2.3.1"
+version = "2.3.2"
 description = "ThesslaGreen Modbus integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}
@@ -131,6 +131,7 @@ follow_imports = "skip"
 module = [
     "homeassistant.*",
     "pymodbus.*",
+    "pydantic.*",
     "voluptuous.*",
 ]
 ignore_missing_imports = true

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -46,7 +46,11 @@ class HVACMode:  # pragma: no cover - simple stub
 
 
 class HVACAction:  # pragma: no cover - simple stub
-    pass
+    OFF = "off"
+    FAN = "fan"
+    HEATING = "heating"
+    COOLING = "cooling"
+    IDLE = "idle"
 
 
 climate_mod.ClimateEntity = ClimateEntity
@@ -380,3 +384,13 @@ def test_preset_mode_unknown_bits_returns_none():
     # Patch SPECIAL_FUNCTION_MAP to empty so no preset matches
     with patch.dict(climate_mod.SPECIAL_FUNCTION_MAP, {}, clear=True):
         assert climate_entity.preset_mode == "none"  # nosec B101
+
+
+def test_climate_imports_real_ha_symbols() -> None:
+    """Ensure climate module uses direct Home Assistant symbols."""
+    from custom_components.thessla_green_modbus import climate
+
+    assert hasattr(climate.HVACMode, "AUTO")
+    assert hasattr(climate.HVACMode, "OFF")
+    assert hasattr(climate.HVACAction, "HEATING")
+    assert climate.ClimateEntity is climate_mod.ClimateEntity


### PR DESCRIPTION
### Motivation
- Remove runtime `getattr(...)` import fallbacks and stale `# type: ignore` annotations to restore strict typing and make mypy validation meaningful. 
- Declare explicit mixin attributes and stub-methods so mixins can be type-checked in isolation without changing runtime behaviour. 
- Make small defensive runtime guards (e.g. `assert self.client is not None` after transport reconnect) to make `None`-narrowing explicit for static checkers.

### Description
- Replaced dynamic dispatch and fallback imports in `climate.py` with direct imports from `homeassistant.components.climate` and `homeassistant.const`, removing dead fallback paths and restoring strict typing support for climate symbols. 
- Added/expanded explicit type annotations, declared mixin attributes and stub method signatures across coordinator, scanner, transport, IO and schedule mixins (files including `_coordinator_io.py`, `_coordinator_schedule.py`, `_scanner_*`, `modbus_transport.py`, `registers/loader.py`, etc.) so mypy can validate cross-mixin contracts. 
- Inserted `assert self.client is not None` after `ensure_connected()` in transport read/write methods to narrow `None` for static typing and avoid false positives. 
- Aligned signatures of loader/adapter fallbacks (in `mappings/*`, `registers/loader.py`, `scanner_core.py`, `scanner_register_maps.py`, `_helpers.py`) with real APIs and tightened various decoding/validation branches (e.g. BCD clock decode and AATT handling) to use explicit `is not None` checks. 
- Removed or adjusted stale `# type: ignore[...]` tags and improved return/collection typing, and added a couple of small compat fallbacks for older Python/pydantic where required. 
- Bumped package and manifest versions to `2.3.2` and updated `CHANGELOG.md` with the changes.

### Testing
- Ran unit tests with `pytest` (including the newly added `tests/test_climate.py::test_climate_imports_real_ha_symbols`) and all tests passed. 
- Ran static checks/type validation (`mypy` using the repository `tool.mypy` config) as part of CI and the type-check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12dfd05088326ac7ab82e9737b9a0)