### PR TITLE
Remove defensive compatibility code for HA 2022+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the ThesslaGreen Modbus Integration will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.1 — Config flow cleanup
+
+### Removed
+- 5 defensive `getattr(super(), ...)` method wrappers in `ConfigFlow`
+  (`async_set_unique_id`, `_abort_if_unique_id_configured`, `async_show_form`,
+  `async_create_entry`, `async_abort`). These methods exist in
+  `homeassistant.config_entries.ConfigFlow` since HA 2022; the fallbacks
+  were test-compat code for SimpleNamespace stubs.
+- `try/except ImportError` guard around `homeassistant.helpers` imports in
+  `_entity_registry_migrations.py`. HA helpers are always available given
+  manifest requirement >=2026.1.0.
+- Defensive `getattr(super(), "async_shutdown", None)` in
+  `ThesslaGreenModbusCoordinator.async_shutdown`; replaced with direct
+  `await super().async_shutdown()`.
+
+### Changed
+- `_load_scanner_module` in `config_flow.py` simplified: removed
+  `getattr(hass, "async_add_executor_job", None)` fallback and
+  `inspect.isawaitable` check; now uses `hass.async_add_executor_job` directly.
+  Parameter type narrowed from `Any` to `HomeAssistant | None`.
+- `BIT_ENTITY_KEYS` in `_legacy.py` comment updated to match canonical
+  "NOT LEGACY — active functional requirement" format.
+- `VERSION = 4` class attribute in `ConfigFlow` no longer has spurious
+  `# pragma: no cover - defensive` annotation.
+
+---
+
 ## 2.5.0 — Legacy cleanup (BREAKING)
 
 ### ⚠️ Breaking changes

--- a/custom_components/thessla_green_modbus/_entity_registry_migrations.py
+++ b/custom_components/thessla_green_modbus/_entity_registry_migrations.py
@@ -8,11 +8,9 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import CONF_HOST, CONF_PORT
-
-try:  # pragma: no cover - optional in tests
-    from homeassistant.helpers import entity_registry as er
-except (ImportError, ModuleNotFoundError, AttributeError):  # pragma: no cover - defensive
-    er = None
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
 
 from ._legacy import (
     BIT_ENTITY_KEYS,
@@ -31,13 +29,6 @@ _LOGGER = logging.getLogger(__name__.rsplit(".", maxsplit=1)[0])
 
 async def async_migrate_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:  # pragma: no cover - defensive
     """Rename entity IDs from translation-based to register-key-based naming."""
-    try:
-        from homeassistant.helpers import device_registry as dr
-        from homeassistant.helpers import entity_registry as er
-        from homeassistant.util import slugify
-    except (ImportError, ModuleNotFoundError, AttributeError):
-        return
-
     entity_reg = er.async_get(hass)
     device_reg = dr.async_get(hass)
     if entity_reg is None or device_reg is None:
@@ -214,8 +205,6 @@ async def async_migrate_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> N
 
 async def async_migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Migrate entity unique IDs stored in the entity registry."""
-    if er is None:
-        return
     registry = er.async_get(hass)
     coordinator = entry.runtime_data
     device_info = getattr(coordinator, "device_info", None)

--- a/custom_components/thessla_green_modbus/_legacy.py
+++ b/custom_components/thessla_green_modbus/_legacy.py
@@ -39,14 +39,11 @@ LEGACY_KEY_RENAMES: dict[str, str] = {
     "filter_type": "filter_change",
 }
 
-# Mapping from (register_key, bit_value) → bit-specific entity key.
-#
-# NOT LEGACY — this is an active functional requirement. The e_196_e_199
-# register is a 4-bit bitmask; each bit maps to a separate binary_sensor
-# entity (E196..E199). Without this map all 4 bits would collide on the
-# same entity_id. Do not remove.
+# NOT LEGACY — active functional requirement. The e_196_e_199 register is a
+# 4-bit bitmask; each bit maps to a separate binary_sensor entity (E196-E199).
+# Without this map all 4 bits would collide on the same entity_id.
+# Do not remove unless the underlying hardware/protocol changes.
 BIT_ENTITY_KEYS: dict[tuple[str, int], str] = {
-    # e_196_e_199 is a bitmask register; each bit gets its own entity key.
     # Key format: _to_snake_case(bit_name) inserts underscore before digits,
     # so "e196" → "e_196", giving "e_196_e_199_e_196".
     ("e_196_e_199", 1): "e_196_e_199_e_196",

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -105,18 +105,11 @@ ThesslaGreenDeviceScanner: Any | None = None
 DeviceCapabilities: Any | None = None
 
 
-async def _load_scanner_module(hass: Any) -> Any:
-    """Import scanner.core using the HA executor when available.
-
-    Falls back to a direct synchronous import when *hass* is ``None`` or does
-    not expose ``async_add_executor_job`` (e.g. SimpleNamespace test stubs).
-    """
+async def _load_scanner_module(hass: HomeAssistant | None) -> Any:
+    """Import scanner.core via the HA executor to avoid blocking the event loop."""
     module_name = "custom_components.thessla_green_modbus.scanner.core"
-    _aej = getattr(hass, "async_add_executor_job", None)
-    if _aej is not None:
-        result = _aej(import_module, module_name)
-        if inspect.isawaitable(result):
-            return await result
+    if hass is not None:
+        return await hass.async_add_executor_job(import_module, module_name)
     return import_module(module_name)
 
 
@@ -515,7 +508,7 @@ async def validate_input(hass: HomeAssistant | None, data: dict[str, Any]) -> di
 class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
     """Handle a config flow for ThesslaGreen Modbus."""
 
-    VERSION = 4  # pragma: no cover - defensive
+    VERSION = 4
 
     def __init__(self) -> None:
         """Initialize config flow."""
@@ -561,39 +554,6 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
                 }
             ),
         )
-
-    async def async_set_unique_id(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - defensive
-        base = getattr(super(), "async_set_unique_id", None)
-        if callable(base):
-            result = base(*args, **kwargs)
-            if asyncio.iscoroutine(result):
-                return await result
-            return result
-        return None
-
-    def _abort_if_unique_id_configured(self, **kwargs: Any) -> Any:  # pragma: no cover - defensive
-        base = getattr(super(), "_abort_if_unique_id_configured", None)
-        if callable(base):
-            return base(**kwargs)
-        return None
-
-    def async_show_form(self, **kwargs: Any) -> Any:  # pragma: no cover - defensive
-        base = getattr(super(), "async_show_form", None)
-        if callable(base):
-            return base(**kwargs)
-        return {"type": "form", **kwargs}
-
-    def async_create_entry(self, **kwargs: Any) -> Any:  # pragma: no cover - defensive
-        base = getattr(super(), "async_create_entry", None)
-        if callable(base):
-            return base(**kwargs)
-        return {"type": "create_entry", **kwargs}
-
-    def async_abort(self, **kwargs: Any) -> Any:  # pragma: no cover - defensive
-        base = getattr(super(), "async_abort", None)
-        if callable(base):
-            return base(**kwargs)
-        return {"type": "abort", **kwargs}
 
     def _build_connection_schema(self, defaults: dict[str, Any]) -> vol.Schema:
         """Return schema for connection details with provided defaults."""

--- a/custom_components/thessla_green_modbus/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator.py
@@ -1402,9 +1402,7 @@ class ThesslaGreenModbusCoordinator(
         if self._stop_listener is not None:
             self._stop_listener()
             self._stop_listener = None
-        shutdown = getattr(super(), "async_shutdown", None)
-        if shutdown is not None:
-            await shutdown()
+        await super().async_shutdown()
         await self._disconnect()
 
     @property

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -14,7 +14,7 @@
   "requirements": [
     "pymodbus>=3.6.0"
   ],
-  "version": "2.5.0",
+  "version": "2.5.1",
   "integration_type": "hub",
   "after_dependencies": [
     "modbus"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thessla-green-modbus"
-version = "2.5.0"
+version = "2.5.1"
 description = "ThesslaGreen Modbus integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
This PR removes defensive fallback code that was added for compatibility with older Home Assistant versions and test stubs. Since the manifest now requires HA >=2026.1.0, these compatibility layers are no longer needed.

## Key Changes

- **config_flow.py**: Simplified `_load_scanner_module()` by removing `getattr()` fallback for `async_add_executor_job` and `inspect.isawaitable()` check. Parameter type narrowed from `Any` to `HomeAssistant | None`.

- **config_flow.py**: Removed 5 defensive method wrappers from `ConfigFlow` class:
  - `async_set_unique_id()`
  - `_abort_if_unique_id_configured()`
  - `async_show_form()`
  - `async_create_entry()`
  - `async_abort()`
  
  These methods exist in `homeassistant.config_entries.ConfigFlow` since HA 2022; the wrappers were only needed for SimpleNamespace test stubs.

- **_entity_registry_migrations.py**: Removed `try/except ImportError` guard around `homeassistant.helpers` imports. These helpers are guaranteed to be available given the HA >=2026.1.0 requirement.

- **coordinator.py**: Simplified `async_shutdown()` by replacing `getattr(super(), "async_shutdown", None)` with direct `await super().async_shutdown()` call.

- **_legacy.py**: Updated `BIT_ENTITY_KEYS` comment to match canonical "NOT LEGACY — active functional requirement" format and improved clarity.

- **Version bumped** to 2.5.1 in manifest.json and pyproject.toml.

## Implementation Details

All changes maintain backward compatibility with the integration's functionality while reducing code complexity. The removal of these defensive patterns makes the codebase cleaner and easier to maintain, as it no longer needs to account for missing or incomplete Home Assistant APIs.

https://claude.ai/code/session_01Mb4Uaa17kHok6a5KfA1Zhy