### PR TITLE
chore: 2.6.0 dead fallback cleanup — remove all try/except ImportErro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to the ThesslaGreen Modbus Integration will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.6.0 — Dead fallback cleanup
+
+### Removed
+- `OptionsFlow` defensive `getattr(super(), ...)` wrappers for `async_show_form`,
+  `async_create_entry`, `async_abort` — HA guarantees these since 2022.
+- `try/except ImportError` fallbacks for `entity_registry` in `__init__.py`,
+  `get_registers_by_function` in `const.py`, `get_all_registers` in
+  `mappings/_helpers.py` and `mappings/_loaders.py`, and 5 loader stubs in
+  `scanner/core.py` — all guarding symbols always present given
+  `homeassistant>=2026.1.0`.
+- `try/except (ImportError, AttributeError)` dead path in
+  `register_map._resolve_entity_domain`; ENTITY_MAPPINGS is always available.
+- `hass is not None` guard in `_load_scanner_module`; `validate_input` now
+  requires `HomeAssistant` (not `None`).
+- `# re-exported for test monkeypatching` comment on `scanner/core.asdict`.
+- Unused `RegisterDef` TYPE_CHECKING imports in `const.py`, `mappings/_helpers.py`,
+  `mappings/_loaders.py`, `scanner/core.py` (were only needed for fallback stubs).
+
+### Changed
+- `_entity_registry_migrations`: uses `er.async_entries_for_config_entry` directly
+  in both `async_migrate_entity_ids` and `async_migrate_unique_ids` instead of
+  `getattr(er, "async_entries_for_config_entry", None)` + `callable()` guard.
+- `list[object]` annotation in `async_migrate_entity_ids` replaced with `list[Any]`.
+- `scanner/core.py` now imports only `async_get_all_registers` from `registers.loader`
+  (the other 4 symbols were only present as fallback re-exports).
+
+---
+
 ## 2.5.1 — Config flow cleanup
 
 ### Removed

--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -57,11 +57,6 @@ from .const import (
 )
 from .const import PLATFORMS as PLATFORM_DOMAINS
 
-try:  # pragma: no cover - optional in tests
-    from homeassistant.helpers import entity_registry as er
-except (ImportError, ModuleNotFoundError, AttributeError):  # pragma: no cover - defensive
-    er = None
-
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only

--- a/custom_components/thessla_green_modbus/_entity_registry_migrations.py
+++ b/custom_components/thessla_green_modbus/_entity_registry_migrations.py
@@ -36,12 +36,9 @@ async def async_migrate_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> N
 
     coordinator = entry.runtime_data
     slave_id = getattr(coordinator, "slave_id", 1)
-    entries_for_config = getattr(er, "async_entries_for_config_entry", None)
-    config_entry_list: list[object] = (
-        list(entries_for_config(entity_reg, entry.entry_id)) if callable(entries_for_config) else []
-    )
+    config_entry_list = list(er.async_entries_for_config_entry(entity_reg, entry.entry_id))
 
-    all_platform_entries: list[object] = []
+    all_platform_entries: list[Any] = []
     entities_dict = getattr(entity_reg, "entities", None)
     if entities_dict is not None:
         try:
@@ -223,10 +220,7 @@ async def async_migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> N
     host = getattr(coordinator, "host", None) or entry.data.get(CONF_HOST)
     port = getattr(coordinator, "port", None) or entry.data.get(CONF_PORT)
     slave_id = getattr(coordinator, "slave_id", None) or entry.data.get(CONF_SLAVE_ID)
-    entries_for_config = getattr(er, "async_entries_for_config_entry", None)
-    if not callable(entries_for_config):
-        return
-    for reg_entry in entries_for_config(registry, entry.entry_id):
+    for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
         if registry.async_get(reg_entry.entity_id) is None:
             continue
         if reg_entry.entity_id == "fan.rekuperator_fan":

--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -105,12 +105,11 @@ ThesslaGreenDeviceScanner: Any | None = None
 DeviceCapabilities: Any | None = None
 
 
-async def _load_scanner_module(hass: HomeAssistant | None) -> Any:
+async def _load_scanner_module(hass: HomeAssistant) -> Any:
     """Import scanner.core via the HA executor to avoid blocking the event loop."""
-    module_name = "custom_components.thessla_green_modbus.scanner.core"
-    if hass is not None:
-        return await hass.async_add_executor_job(import_module, module_name)
-    return import_module(module_name)
+    return await hass.async_add_executor_job(
+        import_module, "custom_components.thessla_green_modbus.scanner.core"
+    )
 
 
 # Delay between retries when establishing the connection during the config flow.
@@ -380,7 +379,7 @@ def _process_scan_capabilities(
     return caps_dict
 
 
-async def validate_input(hass: HomeAssistant | None, data: dict[str, Any]) -> dict[str, Any]:
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
     connection_type = _normalize_connection_type(data)
     slave_id = _validate_slave_id(data)
@@ -1081,24 +1080,6 @@ class OptionsFlow(config_entries.OptionsFlow):
     def config_entry(self) -> config_entries.ConfigEntry:  # pragma: no cover - defensive
         """Return the config entry for this options flow."""
         return self._stored_config_entry
-
-    def async_show_form(self, **kwargs: Any) -> Any:  # pragma: no cover - defensive
-        base = getattr(super(), "async_show_form", None)
-        if callable(base):
-            return base(**kwargs)
-        return {"type": "form", **kwargs}
-
-    def async_create_entry(self, **kwargs: Any) -> Any:  # pragma: no cover - defensive
-        base = getattr(super(), "async_create_entry", None)
-        if callable(base):
-            return base(**kwargs)
-        return {"type": "create_entry", **kwargs}
-
-    def async_abort(self, **kwargs: Any) -> Any:  # pragma: no cover - defensive
-        base = getattr(super(), "async_abort", None)
-        if callable(base):
-            return base(**kwargs)
-        return {"type": "abort", **kwargs}
 
     async def async_step_init(  # pragma: no cover - defensive
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -10,20 +10,10 @@ from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.const import Platform
 
-try:  # pragma: no cover - optional during isolated tests
-    from .registers.loader import get_registers_by_function
-except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
-
-    def get_registers_by_function(
-        fn: str, json_path: Path | str | None = None
-    ) -> list[RegisterDef]:
-        return []
-
+from .registers.loader import get_registers_by_function
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from homeassistant.core import HomeAssistant
-
-    from .registers.loader import RegisterDef
 
 # Maximum number of registers that can be read in a single request.
 # The registers loader previously created a circular dependency with

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -14,7 +14,7 @@
   "requirements": [
     "pymodbus>=3.6.0"
   ],
-  "version": "2.5.1",
+  "version": "2.6.0",
   "integration_type": "hub",
   "after_dependencies": [
     "modbus"

--- a/custom_components/thessla_green_modbus/mappings/_helpers.py
+++ b/custom_components/thessla_green_modbus/mappings/_helpers.py
@@ -6,21 +6,11 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from ..registers.loader import RegisterDef
+from typing import Any
 
 from .._compat import PERCENTAGE
+from ..registers.loader import get_all_registers
 from ..utils import _to_snake_case
-
-try:  # pragma: no cover - optional during isolated tests
-    from ..registers.loader import get_all_registers
-except (ImportError, AttributeError):  # pragma: no cover - defensive
-
-    def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
-        return []
-
 
 _LOGGER = logging.getLogger(__name__)
 _REGISTER_INFO_CACHE: dict[str, dict[str, Any]] | None = None

--- a/custom_components/thessla_green_modbus/mappings/_loaders.py
+++ b/custom_components/thessla_green_modbus/mappings/_loaders.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 import re
 import sys
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from ..registers.loader import RegisterDef
+from typing import Any
 
 from .._compat import BinarySensorDeviceClass, EntityCategory
 from ..const import (
@@ -17,6 +13,7 @@ from ..const import (
     discrete_input_registers,
     holding_registers,
 )
+from ..registers.loader import get_all_registers
 from ..utils import BCD_TIME_PREFIXES, _to_snake_case
 from ._helpers import (
     _get_register_info,
@@ -25,14 +22,6 @@ from ._helpers import (
     _number_translation_keys,
     _parse_states,
 )
-
-try:  # pragma: no cover - optional during isolated tests
-    from ..registers.loader import get_all_registers
-except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
-
-    def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
-        return []
-
 
 _TIME_ENTITY_PREFIXES = (
     "schedule_",

--- a/custom_components/thessla_green_modbus/register_map.py
+++ b/custom_components/thessla_green_modbus/register_map.py
@@ -161,14 +161,11 @@ def _infer_data_type(definition: RegisterDef) -> str:
 
 
 def _resolve_entity_domain(register_name: str) -> str | None:
-    try:
-        from .mappings import ENTITY_MAPPINGS
+    from .mappings import ENTITY_MAPPINGS
 
-        for domain, mapping in ENTITY_MAPPINGS.items():
-            if register_name in mapping:
-                return domain
-    except (ImportError, AttributeError):  # pragma: no cover - defensive during bootstrap
-        return None
+    for domain, mapping in ENTITY_MAPPINGS.items():
+        if register_name in mapping:
+            return domain
     return None
 
 

--- a/custom_components/thessla_green_modbus/scanner/core.py
+++ b/custom_components/thessla_green_modbus/scanner/core.py
@@ -6,7 +6,6 @@ import importlib
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict as _dataclasses_asdict
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pymodbus.client import AsyncModbusTcpClient
@@ -44,6 +43,9 @@ from ..modbus_transport import (
     RtuModbusTransport,
     TcpModbusTransport,
 )
+from ..registers.loader import (
+    async_get_all_registers,
+)
 from ..scanner_device_info import DeviceCapabilities, ScannerDeviceInfo
 from ..scanner_helpers import (
     MAX_BATCH_REGISTERS,
@@ -69,35 +71,7 @@ from . import orchestration as scanner_orchestration
 from . import registers as scanner_registers
 from . import setup as scanner_setup
 
-try:  # pragma: no cover - optional during isolated tests
-    from ..registers.loader import (
-        async_get_all_registers,
-        async_registers_sha256,
-        get_all_registers,
-        get_registers_path,
-        registers_sha256,
-    )
-except (ImportError, AttributeError):  # pragma: no cover - fallback when stubs incomplete
-
-    async def async_get_all_registers(
-        hass: Any | None, json_path: Path | str | None = None
-    ) -> list[RegisterDef]:
-        return []
-
-    async def async_registers_sha256(hass: Any | None, json_path: Path | str) -> str:
-        return ""
-
-    def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
-        return []
-
-    def get_registers_path() -> Path:
-        return Path(".")
-
-    def registers_sha256(json_path: Path | str) -> str:
-        return ""
-
-
-asdict = _dataclasses_asdict  # re-exported for test monkeypatching
+asdict = _dataclasses_asdict
 
 _LOGGER = logging.getLogger(__name__)
 REGISTER_DEFINITIONS = _register_maps.REGISTER_DEFINITIONS
@@ -113,8 +87,6 @@ except (ImportError, AttributeError) as _exc:  # pragma: no cover - defensive
 
 if TYPE_CHECKING:  # pragma: no cover - typing helper only
     from pymodbus.client import AsyncModbusSerialClient as AsyncModbusSerialClientType
-
-    from ..registers.loader import RegisterDef
 else:
     AsyncModbusSerialClientType = Any
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thessla-green-modbus"
-version = "2.5.1"
+version = "2.6.0"
 description = "ThesslaGreen Modbus integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
…r stubs

- Remove 3 getattr(super(),...) wrappers from OptionsFlow (async_show_form, async_create_entry, async_abort) — Fix #1
- Remove try/except ImportError for entity_registry in __init__.py — Fix #2
- Remove get_registers_by_function fallback stub in const.py — Fix #3
- Remove get_all_registers fallback stubs in mappings/_helpers.py, mappings/_loaders.py — Fix #4, #5
- Remove 5 loader fallback stubs in scanner/core.py; keep only async_get_all_registers that is actually used — Fix #6
- Remove try/except in register_map._resolve_entity_domain — Fix #7
- Simplify _load_scanner_module to HomeAssistant (drop None guard); validate_input signature narrowed accordingly — Fix #8
- Remove re-exported comment on scanner/core.asdict — Fix #9
- Use er.async_entries_for_config_entry directly in both migration helpers; replace list[object] with list[Any] — Fix #10
- Remove unused RegisterDef TYPE_CHECKING imports from const.py, _helpers.py, _loaders.py, scanner/core.py
- Bump 2.5.1 → 2.6.0, update CHANGELOG

ruff: 0 | mypy: 0 (58 files)

https://claude.ai/code/session_01Mb4Uaa17kHok6a5KfA1Zhy