### PR TITLE
tests: remove per-test platform stubs and delete empty coordinator scaffold

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/__init__.py
+++ b/custom_components/thessla_green_modbus/coordinator/__init__.py
@@ -1,1 +1,0 @@
-"""TODO: module scaffold for branch test refactor."""

--- a/tests/test_airflow_unit.py
+++ b/tests/test_airflow_unit.py
@@ -1,9 +1,5 @@
 from unittest.mock import MagicMock
 
-from tests.platform_stubs import install_common_ha_stubs
-
-install_common_ha_stubs()
-
 from custom_components.thessla_green_modbus.const import (
     AIRFLOW_UNIT_M3H,
     AIRFLOW_UNIT_PERCENTAGE,

--- a/tests/test_all_entity_creation.py
+++ b/tests/test_all_entity_creation.py
@@ -20,31 +20,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from tests.platform_stubs import (
-    install_binary_sensor_stubs,
-    install_fan_stubs,
-    install_number_stubs,
-    install_select_stubs,
-    install_switch_stubs,
-    install_time_stubs,
-)
-
-# ---------------------------------------------------------------------------
-# Required HA component stubs
-# ---------------------------------------------------------------------------
-
-install_binary_sensor_stubs()
-install_fan_stubs()
-install_switch_stubs()
-install_number_stubs()
-install_select_stubs()
-install_time_stubs()
-
-# ---------------------------------------------------------------------------
-# Now it is safe to import the integration domain constant
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus.const import DOMAIN
 
 # ---------------------------------------------------------------------------

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -3,15 +3,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from tests.platform_stubs import install_binary_sensor_stubs
-
-install_binary_sensor_stubs()
-
-# ---------------------------------------------------------------------------
-# Actual tests
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus.binary_sensor import (
     BINARY_SENSOR_DEFINITIONS,
     LEGACY_PROBLEM_KEY_PATTERN,

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -5,14 +5,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-from tests.platform_stubs import install_climate_stubs
-
-install_climate_stubs()
-
-# ---------------------------------------------------------------------------
-# Actual imports after stubbing
-# ---------------------------------------------------------------------------
 from custom_components.thessla_green_modbus.climate import (
     HVAC_MODE_MAP,
     HVAC_MODE_REVERSE_MAP,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,13 +9,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import voluptuous as vol
-from homeassistant.const import CONF_HOST, CONF_PORT
-
-from tests.platform_stubs import install_network_validation_stub
-
-# Stub network validation module — config_flow uses is_host_valid at import time.
-install_network_validation_stub()
-
 from custom_components.thessla_green_modbus.config_flow import (
     CannotConnect,
     ConfigFlow,
@@ -48,6 +41,7 @@ from custom_components.thessla_green_modbus.modbus_exceptions import (
     ModbusException,
     ModbusIOException,
 )
+from homeassistant.const import CONF_HOST, CONF_PORT
 
 CONF_NAME = "name"
 

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -1,19 +1,9 @@
 """Tests for config_flow helper functions that don't require HA."""
 
 import asyncio
-import sys
-from pathlib import Path
 
 import pytest
 import voluptuous as vol
-
-from tests.platform_stubs import install_network_validation_stub, install_registers_stub
-
-install_network_validation_stub()
-_original_registers = sys.modules.get("custom_components.thessla_green_modbus.registers")
-_original_loader = sys.modules.get("custom_components.thessla_green_modbus.registers.loader")
-install_registers_stub(Path("dummy"))
-
 from custom_components.thessla_green_modbus.config_flow import (
     ConfigFlow,
     _normalize_baud_rate,
@@ -22,15 +12,6 @@ from custom_components.thessla_green_modbus.config_flow import (
     _run_with_retry,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
-
-if _original_registers is not None:
-    sys.modules["custom_components.thessla_green_modbus.registers"] = _original_registers
-else:  # pragma: no cover - defensive cleanup
-    sys.modules.pop("custom_components.thessla_green_modbus.registers", None)
-if _original_loader is not None:
-    sys.modules["custom_components.thessla_green_modbus.registers.loader"] = _original_loader
-else:  # pragma: no cover - defensive cleanup
-    sys.modules.pop("custom_components.thessla_green_modbus.registers.loader", None)
 
 # ---------------------------------------------------------------------------
 # _normalize_baud_rate

--- a/tests/test_entity_data_correctness.py
+++ b/tests/test_entity_data_correctness.py
@@ -9,25 +9,6 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-
-from tests.platform_stubs import (
-    install_binary_sensor_stubs,
-    install_number_stubs,
-    install_select_stubs,
-)
-
-# ---------------------------------------------------------------------------
-# HA component stubs
-# ---------------------------------------------------------------------------
-
-install_binary_sensor_stubs()
-install_number_stubs()
-install_select_stubs()
-
-# ---------------------------------------------------------------------------
-# Imports (after stubs are in place)
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus.binary_sensor import ThesslaGreenBinarySensor
 from custom_components.thessla_green_modbus.mappings import (
     BINARY_SENSOR_ENTITY_MAPPINGS,

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -4,17 +4,8 @@ import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
-from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
-
-from tests.platform_stubs import install_fan_stubs
-
-install_fan_stubs()
-
-# ---------------------------------------------------------------------------
-# Actual tests
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus.fan import ThesslaGreenFan
+from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 
 
 def test_fan_creation_and_state(mock_coordinator):

--- a/tests/test_fan_percentage_limits.py
+++ b/tests/test_fan_percentage_limits.py
@@ -3,11 +3,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-
-from tests.platform_stubs import install_fan_stubs
-
-install_fan_stubs()
-
 from custom_components.thessla_green_modbus.coordinator import (
     ThesslaGreenModbusCoordinator,
 )

--- a/tests/test_force_full_register_list_integration.py
+++ b/tests/test_force_full_register_list_integration.py
@@ -3,13 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.thessla_green_modbus import async_setup_entry
 from custom_components.thessla_green_modbus.const import CONF_FORCE_FULL_REGISTER_LIST, DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
-
-from tests.platform_stubs import install_binary_sensor_stubs
-
-install_binary_sensor_stubs()
-
 from homeassistant import const as ha_const
+from homeassistant.const import CONF_HOST, CONF_PORT
 
 ha_const.STATE_UNAVAILABLE = "unavailable"
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -4,20 +4,11 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
-
-from tests.platform_stubs import install_number_stubs
-
-install_number_stubs()
-
-# ---------------------------------------------------------------------------
-# Actual tests
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus.const import DOMAIN
 from custom_components.thessla_green_modbus.mappings import (
     SENSOR_ENTITY_MAPPINGS,
 )
+from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 from custom_components.thessla_green_modbus.number import (
     ENTITY_MAPPINGS,
     ThesslaGreenNumber,

--- a/tests/test_register_coverage.py
+++ b/tests/test_register_coverage.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 from custom_components.thessla_green_modbus.utils import _to_snake_case
 
-from tests.platform_stubs import install_common_ha_stubs
-
 INTENTIONAL_OMISSIONS = {
     "serial_number_2",
     "serial_number_3",
@@ -31,9 +29,6 @@ INTENTIONAL_OMISSIONS = {
     "device_name_8",
     "lock_pass_2",
 }
-
-# Minimal Home Assistant stubs required to import entity mappings
-install_common_ha_stubs()
 
 
 def test_all_registers_covered() -> None:

--- a/tests/test_register_loader.py
+++ b/tests/test_register_loader.py
@@ -4,15 +4,6 @@ import json
 from pathlib import Path
 
 import pytest
-
-from tests.platform_stubs import install_integration_package_stub
-
-# Stub the integration package to avoid executing its heavy __init__
-install_integration_package_stub(
-    Path(__file__).resolve().parents[1] / "custom_components" / "thessla_green_modbus",
-    max_batch_registers=16,
-)
-
 from custom_components.thessla_green_modbus.registers.loader import (
     _REGISTERS_PATH,
     _SPECIAL_MODES_PATH,

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -4,15 +4,6 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-from tests.platform_stubs import install_select_stubs
-
-install_select_stubs()
-
-# ---------------------------------------------------------------------------
-# Actual tests
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus import select
 from custom_components.thessla_green_modbus.mappings import ENTITY_MAPPINGS
 from custom_components.thessla_green_modbus.modbus_exceptions import (

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -4,17 +4,8 @@ import asyncio
 import types
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-from tests.platform_stubs import install_sensor_platform_stubs
-
-install_sensor_platform_stubs()
-
-# ---------------------------------------------------------------------------
-# Actual tests
-# ---------------------------------------------------------------------------
-
 import custom_components.thessla_green_modbus.select as select_module
+import pytest
 from custom_components.thessla_green_modbus.const import (
     AIRFLOW_UNIT_PERCENTAGE,
     CONF_AIRFLOW_UNIT,

--- a/tests/test_sensor_register_mapping.py
+++ b/tests/test_sensor_register_mapping.py
@@ -1,15 +1,6 @@
 """Validate SENSOR_DEFINITIONS register mapping."""
 
 import pytest
-
-from tests.platform_stubs import install_common_ha_stubs
-
-install_common_ha_stubs()
-
-# ---------------------------------------------------------------------------
-# Actual test
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus.mappings import ENTITY_MAPPINGS
 from custom_components.thessla_green_modbus.registers.loader import (
     get_registers_by_function,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -4,19 +4,10 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
-
-from tests.platform_stubs import install_switch_stubs
-
-install_switch_stubs()
-
-# ---------------------------------------------------------------------------
-# Actual tests
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus import switch
 from custom_components.thessla_green_modbus.const import DOMAIN
 from custom_components.thessla_green_modbus.mappings import ENTITY_MAPPINGS
+from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 from custom_components.thessla_green_modbus.switch import ThesslaGreenSwitch
 
 # Ensure required test mapping is present when dynamic generation is unavailable

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,21 +4,12 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
-
-from tests.platform_stubs import install_text_stubs
-
-install_text_stubs()
-
-# ---------------------------------------------------------------------------
-# Imports under test
-# ---------------------------------------------------------------------------
-
 from custom_components.thessla_green_modbus.const import DOMAIN
 from custom_components.thessla_green_modbus.mappings import (
     ENTITY_MAPPINGS,
     TEXT_ENTITY_MAPPINGS,
 )
+from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 from custom_components.thessla_green_modbus.registers.loader import (
     get_registers_by_function,
 )

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 import yaml
 
-from tests.platform_stubs import install_sensor_platform_stubs
-
 ROOT = Path(__file__).resolve().parent.parent / "custom_components" / "thessla_green_modbus"
 
 with open(ROOT / "translations" / "en.json", encoding="utf-8") as f:
@@ -55,7 +53,6 @@ def _load_keys(file: Path, var_name: str) -> list[str]:
 
 
 # Import sensor module to obtain translation keys
-install_sensor_platform_stubs()
 
 SENSOR_KEYS = [*_load_runtime_translation_keys("SENSOR_ENTITY_MAPPINGS"), "error_codes"]
 BINARY_KEYS = _load_runtime_translation_keys("BINARY_SENSOR_ENTITY_MAPPINGS")


### PR DESCRIPTION
### Motivation

- Remove repeated per-test HA platform stub installation and import-time stubbing to rely on the central/global test fixtures, simplifying test modules.
- Clean up an unused scaffold file in the coordinator package that served no purpose.
- Reduce import-time side effects by reordering and consolidating imports in tests that previously depended on module-level stubbing.

### Description

- Deleted the empty scaffold file `custom_components/thessla_green_modbus/coordinator/__init__.py` which contained only a TODO comment.
- Removed calls to `install_*_stubs()` and `install_common_ha_stubs()` from many test modules and cleaned up related import stubs to rely on centralized test fixtures instead of per-file setup.
- Adjusted import ordering and locations across tests (for example moving `CONF_HOST`/`CONF_PORT` imports) to avoid import-time dependencies on stubbing helpers and network/register validation stubs.
- Reorganized a few test imports (such as moving `ConnectionException` and other exception imports) so tests remain self-contained after removing the per-file stubs.

### Testing

- Ran the integration's pytest suite (`pytest`) against the updated tests; the test run completed successfully with all tests passing.
- Verified unit tests exercised by `tests/` (including sensor, binary_sensor, fan, climate, select, number, switch, text, and register loader tests) passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ad3d66e88326a681de7bb6c83877)