### PR TITLE
docs: document current refactor status and constraints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This project adheres to a simple code of conduct:
 
 ### Prerequisites
 
-- Python 3.12+
+- Python 3.13+
 - Home Assistant 2026.1.0+ (managed outside `requirements.txt`)
 - Git
 - A ThesslaGreen AirPack device (for testing)
@@ -117,7 +117,7 @@ The test suite ensures the JSON definitions remain valid.
 ### Branch Strategy
 
 - `main` - stable releases
-- `develop` - development branch
+- `dev` - development branch
 - `feature/your-feature-name` - feature branches
 - `bugfix/issue-description` - bug fix branches
 
@@ -150,6 +150,19 @@ We follow these conventions:
 - Implement retry logic
 - Use efficient batch reading
 - Validate register values
+
+### Refactor guardrails
+
+When touching architecture-related code/docs, keep these constraints:
+
+- No legacy modules.
+- No compatibility shims.
+- No re-export shims.
+- No proxy modules.
+- `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant.
+- `coordinator.py` must not be moved yet.
+
+See also: [`docs/refactor_status.md`](docs/refactor_status.md).
 
 ### File Structure
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ logger:
 
 - [Architektura docelowa](docs/thesslagreen_architecture.md)
 - [Wytyczne refaktoryzacji](docs/thesslagreen_guidelines.md)
+- [Status refaktoryzacji](docs/refactor_status.md)
 - [Changelog](CHANGELOG.md)
 
 ## Rozwój i testy
@@ -112,3 +113,5 @@ pytest tests/ -x -q
 > (Python 3.11+). Running `pytest` in a container with Python < 3.13 will
 > fail at import with `ImportError: cannot import name 'StrEnum' from 'enum'`.
 > This is expected — the test environment must use Python 3.13.
+
+> **Refactor constraints (must keep):** no legacy modules, no compatibility/re-export/proxy shims; `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant; and `coordinator.py` must stay in place for now. See [`docs/refactor_status.md`](docs/refactor_status.md).

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,0 +1,40 @@
+# Refactor status (current)
+
+Last reviewed: 2026-04-28.
+
+## Scope and direction
+
+The project is in an incremental refactor toward layered architecture:
+
+- HA layer (platforms, flows, services, diagnostics)
+- coordinator (HA adapter)
+- core (device/domain logic)
+- registers (definitions + codec + planning)
+- scanner (capability discovery)
+- transport (Modbus I/O)
+
+## Hard constraints
+
+The following constraints are active and must be preserved:
+
+1. No legacy modules.
+2. No compatibility shims.
+3. No re-export shims.
+4. No proxy modules.
+5. `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant.
+6. `coordinator.py` must not be moved yet.
+
+## Current transitional note
+
+Both forms currently exist in the repository:
+
+- `custom_components/thessla_green_modbus/coordinator.py`
+- `custom_components/thessla_green_modbus/coordinator/`
+
+This is a temporary refactor stage. Until migration is complete, `coordinator.py` remains in place and should not be relocated.
+
+## Documentation policy for refactor work
+
+- Keep architecture docs aligned with real repository state.
+- Do not document unsupported devices or speculative features.
+- Do not create migration guides unless real migration code exists.

--- a/docs/thesslagreen_architecture.md
+++ b/docs/thesslagreen_architecture.md
@@ -29,6 +29,35 @@ Logika domenowa urządzenia nie zależy od Home Assistant.
 
 ---
 
+
+## Stan bieżący (2026-04-28)
+
+Repozytorium jest w trakcie etapowej refaktoryzacji. Obok struktury docelowej współistnieją jeszcze elementy przejściowe.
+
+Wymóg bieżący:
+
+```text
+coordinator.py nie może być na razie przenoszony
+```
+
+Dopuszczalny stan przejściowy:
+
+```text
+custom_components/thessla_green_modbus/coordinator.py
+custom_components/thessla_green_modbus/coordinator/
+```
+
+Niezmiennie obowiązuje zakaz tworzenia:
+
+```text
+- legacy modules,
+- compatibility shims,
+- re-export shims,
+- proxy modules.
+```
+
+---
+
 ## Warstwy
 
 ### 1. HA Layer

--- a/docs/thesslagreen_guidelines.md
+++ b/docs/thesslagreen_guidelines.md
@@ -56,6 +56,21 @@ pymodbus / raw socket
 10. Nie optymalizować pod liczbę plików, tylko pod odpowiedzialność modułów.
 11. Nie tworzyć legacy modules, compatibility shims ani re-export shimów.
 12. Po przepisaniu kodu na nową warstwę usunąć stary odpowiednik.
+13. coordinator.py nie może być jeszcze przenoszony.
+```
+
+---
+
+
+## Stan przejściowy (aktualny)
+
+Do czasu domknięcia migracji coordinatora obowiązuje:
+
+```text
+- coordinator.py pozostaje na miejscu,
+- równoległy katalog coordinator/ może współistnieć,
+- nie tworzymy shimów ani proxy modułów,
+- nie dokumentujemy migracji, jeśli nie ma realnego kodu migracyjnego.
 ```
 
 ---


### PR DESCRIPTION
### Motivation
- Capture the current incremental refactor state and hard guardrails so contributors and automated checks have an explicit, repo-aligned reference. 
- Ensure documentation accurately describes architecture direction and enforces no legacy/shim/proxy modules and no Home Assistant imports in core/transport/registers/scanner. 
- Preserve repository safety by documenting that `coordinator.py` must remain in place during the transitional migration phase.

### Description
- Add `docs/refactor_status.md` with the current status, scope, and hard constraints (no legacy modules, no compatibility/re-export/proxy shims, and no HA imports in `core/transport/registers/scanner`).
- Update `README.md` to link the new `docs/refactor_status.md` and add a short refactor constraints note. 
- Update `CONTRIBUTING.md` to require `Python 3.13+`, set the development branch to `dev`, and add a `Refactor guardrails` section. 
- Update `docs/thesslagreen_architecture.md` and `docs/thesslagreen_guidelines.md` to include an explicit transitional-state section and the rule that `coordinator.py` must not be moved yet; no production or scanner files were changed.

### Testing
- Ran `ruff check custom_components tests tools` and the linting checks passed. 
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` and byte-compile checks passed. 
- Verified local markdown links in `README.md`, `CONTRIBUTING.md`, and `docs/*.md` resolve to existing files (link validation passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11f0c58948326950b08bd5fff435c)