### PR TITLE
refactor: clean scanner.core facade and delegate helpers to canonical scanner modules

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/__init__.py
+++ b/custom_components/thessla_green_modbus/scanner/__init__.py
@@ -1,5 +1,6 @@
 """Scanner package public exports."""
 
-from .core import DeviceCapabilities, ThesslaGreenDeviceScanner, is_request_cancelled_error
+from .core import DeviceCapabilities, ThesslaGreenDeviceScanner
+from .io import is_request_cancelled_error
 
 __all__ = ["DeviceCapabilities", "ThesslaGreenDeviceScanner", "is_request_cancelled_error"]

--- a/custom_components/thessla_green_modbus/scanner/core.py
+++ b/custom_components/thessla_green_modbus/scanner/core.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib  # noqa: F401 - kept for tests patching scanner.core.importlib
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict as _dataclasses_asdict
@@ -23,8 +22,7 @@ from ..const import (
     SERIAL_PARITY_MAP,
     SERIAL_STOP_BITS_MAP,
 )
-from ..modbus_exceptions import ModbusIOException
-from ..modbus_helpers import _call_modbus, async_maybe_await_close
+from ..modbus_helpers import async_maybe_await_close
 from ..modbus_helpers import group_reads as _group_reads
 from ..modbus_transport import (
     BaseModbusTransport,
@@ -52,8 +50,6 @@ from ..utils import (
 )
 from . import capabilities_facade as scanner_capabilities_facade
 from . import firmware as scanner_firmware
-from . import io as _scanner_io_impl
-from . import io_runtime as scanner_io_runtime
 from . import orchestration as scanner_orchestration
 from . import read_facade as scanner_read_facade
 from . import register_map_runtime as scanner_register_map_runtime
@@ -67,25 +63,9 @@ _LOGGER = logging.getLogger(__name__)
 REGISTER_DEFINITIONS = _register_maps.REGISTER_DEFINITIONS
 SAFE_REGISTERS = _SAFE_REGISTERS
 __all__ = [
-    "REGISTER_HASH",
     "DeviceCapabilities",
     "ThesslaGreenDeviceScanner",
-    "_async_build_register_maps",
-    "_async_ensure_register_maps",
-    "_build_register_maps",
-    "_build_register_maps_from",
-    "_ensure_register_maps",
-    "async_ensure_register_maps",
-    "is_request_cancelled_error",
 ]
-
-
-def _attach_pymodbus_client_module() -> None:
-    """Ensure `pymodbus.client` is importable and attached to `pymodbus`."""
-    scanner_io_runtime.attach_pymodbus_client_module()
-
-
-_attach_pymodbus_client_module()
 
 
 if TYPE_CHECKING:  # pragma: no cover - typing helper only
@@ -93,114 +73,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing helper only
 else:
     AsyncModbusSerialClientType = Any
 
-
-def ensure_pymodbus_client_module() -> None:
-    """Ensure `pymodbus.client` is importable and attached to `pymodbus`."""
-    _attach_pymodbus_client_module()
-
-
-# Register definition caches - populated lazily
-
-
-def is_request_cancelled_error(exc: ModbusIOException) -> bool:
-    """Return True when a modbus IO error indicates a cancelled request."""
-    return bool(_scanner_io_impl.is_request_cancelled_error(exc))
-
-
-async def _maybe_retry_yield(backoff: float, attempt: int, retry: int) -> None:
-    """Yield control between retries to allow cancellation to propagate."""
-    await scanner_io_runtime.maybe_retry_yield(backoff=backoff, attempt=attempt, retry=retry)
-
-
-async def _call_modbus_with_fallback(
-    func: Any,
-    slave_id: int,
-    address: int,
-    *,
-    count: int,
-    attempt: int,
-    retry: int,
-    timeout: int,
-    backoff: float,
-    backoff_jitter: float | tuple[float, float] | None,
-    apply_backoff: bool = True,
-) -> Any:
-    """Call `_call_modbus` with rich kwargs, fallback to minimal mock signatures."""
-    return await scanner_io_runtime.call_modbus_with_fallback(
-        _call_modbus,
-        func,
-        slave_id,
-        address,
-        count=count,
-        attempt=attempt,
-        retry=retry,
-        timeout=timeout,
-        backoff=backoff,
-        backoff_jitter=backoff_jitter,
-        apply_backoff=apply_backoff,
-    )
-
-
-async def _sleep_retry_backoff(
-    *, backoff: float, backoff_jitter: float | tuple[float, float] | None, attempt: int, retry: int
-) -> None:
-    """Sleep between retries using modbus_helpers timing semantics."""
-    await scanner_io_runtime.sleep_retry_backoff(
-        backoff=backoff,
-        backoff_jitter=backoff_jitter,
-        attempt=attempt,
-        retry=retry,
-    )
-
-
-# Register-map wrappers re-exported from scanner core.
-REGISTER_HASH = scanner_register_map_runtime.initial_register_hash()
-
-
-def _sync_register_hash_from_maps() -> None:
-    """Synchronize locally re-exported register hash from scanner_register_maps."""
-    global REGISTER_HASH
-    REGISTER_HASH = scanner_register_map_runtime.sync_register_hash_from_maps()
-
-
-def _build_register_maps_from(regs: list[Any], register_hash: str) -> None:
-    """Populate register lookup maps from provided register definitions."""
-    global REGISTER_HASH
-    REGISTER_HASH = scanner_register_map_runtime.build_register_maps_from(regs, register_hash)
-
-
-def _build_register_maps() -> None:
-    """Populate register lookup maps from current register definitions."""
-    global REGISTER_HASH
-    REGISTER_HASH = scanner_register_map_runtime.build_register_maps()
-
-
-async def _async_build_register_maps(hass: Any | None) -> None:
-    """Populate register lookup maps from current definitions asynchronously."""
-    global REGISTER_HASH
-    REGISTER_HASH = await scanner_register_map_runtime.async_build_register_maps(hass)
-
-
-def _ensure_register_maps() -> None:
-    """Ensure register lookup maps are populated."""
-    global REGISTER_HASH
-    REGISTER_HASH = scanner_register_map_runtime.ensure_register_maps(REGISTER_HASH)
-
-
-async def _async_ensure_register_maps(hass: Any | None) -> None:
-    """Ensure register lookup maps are populated without blocking the event loop."""
-    global REGISTER_HASH
-    REGISTER_HASH = await scanner_register_map_runtime.async_ensure_register_maps(
-        REGISTER_HASH, hass
-    )
-
-
-async def async_ensure_register_maps(hass: Any | None = None) -> None:
-    """Ensure register lookup maps are populated without blocking the event loop."""
-    await _async_ensure_register_maps(hass)
-
-
-# Ensure register lookup maps are available before use
 
 
 class ThesslaGreenDeviceScanner(
@@ -259,7 +131,9 @@ class ThesslaGreenDeviceScanner(
         1-16 registers per request.
         """
         if not registers_ready:
-            _ensure_register_maps()
+            scanner_register_map_runtime.ensure_register_maps(
+                scanner_register_map_runtime.initial_register_hash()
+            )
         # Avoid sticky logger levels from previous tests/services.
         _LOGGER.setLevel(logging.DEBUG)
         self.host = host
@@ -312,8 +186,6 @@ class ThesslaGreenDeviceScanner(
         self._hass = hass
 
         scanner_setup.initialize_runtime_collections(self, DeviceCapabilities)
-        # Keep overridable register metadata on the scanner instance so tests
-        # patching scanner.core symbols remain effective after helper extraction.
         self._input_register_map = INPUT_REGISTERS
         self._holding_register_map = HOLDING_REGISTERS
         self._coil_register_map = COIL_REGISTERS
@@ -342,7 +214,7 @@ class ThesslaGreenDeviceScanner(
 
     async def _async_setup(self) -> None:
         """Asynchronously load register definitions."""
-        await scanner_setup.async_setup_register_maps(self, _async_ensure_register_maps)
+        await scanner_setup.async_setup_register_maps(self)
         self._names_by_address = {
             4: self._build_names_by_address(
                 {name: addr for addr, name in self._registers.get(4, {}).items()}
@@ -424,8 +296,6 @@ class ThesslaGreenDeviceScanner(
             parity=parity,
             stop_bits=stop_bits,
             hass=hass,
-            ensure_client_module_fn=ensure_pymodbus_client_module,
-            async_ensure_register_maps_fn=async_ensure_register_maps,
             ),
         )
 
@@ -504,15 +374,6 @@ class ThesslaGreenDeviceScanner(
         self,
     ) -> tuple[dict[int, str], dict[int, str], dict[int, str], dict[int, str], int, int, int, int]:
         """Select which registers to scan and compute address ranges."""
-        # Refresh maps from module-level symbols so tests patching scanner.core.*
-        # remain effective even after helper extraction.
-        self._input_register_map = INPUT_REGISTERS
-        self._holding_register_map = HOLDING_REGISTERS
-        self._coil_register_map = COIL_REGISTERS
-        self._discrete_input_register_map = DISCRETE_INPUT_REGISTERS
-        self._known_missing_registers = KNOWN_MISSING_REGISTERS
-        self._multi_register_sizes = MULTI_REGISTER_SIZES
-        self._update_known_missing_addresses()
         return scanner_selection.select_scan_registers(self)
 
     async def _run_full_scan(

--- a/custom_components/thessla_green_modbus/scanner/io.py
+++ b/custom_components/thessla_green_modbus/scanner/io.py
@@ -1,4 +1,4 @@
-"""Backward-compatible scanner I/O exports."""
+"""Scanner I/O exports."""
 
 from .io_core import (
     _call_modbus_with_fallback_fn,

--- a/custom_components/thessla_green_modbus/scanner/register_map_cache.py
+++ b/custom_components/thessla_green_modbus/scanner/register_map_cache.py
@@ -10,7 +10,7 @@ REGISTER_HASH = _register_maps.REGISTER_HASH
 
 
 def sync_register_hash_from_maps() -> str:
-    """Synchronize locally re-exported register hash from scanner_register_maps."""
+    """Synchronize cached register hash from scanner_register_maps."""
     global REGISTER_HASH
     REGISTER_HASH = _register_maps.REGISTER_HASH
     return REGISTER_HASH or ""

--- a/custom_components/thessla_green_modbus/scanner/setup.py
+++ b/custom_components/thessla_green_modbus/scanner/setup.py
@@ -33,6 +33,8 @@ from ..scanner_helpers import SAFE_REGISTERS
 from ..scanner_register_maps import REGISTER_DEFINITIONS
 from ..utils import default_connection_mode
 from .io import is_request_cancelled_error
+from .io_runtime import attach_pymodbus_client_module
+from .register_map_runtime import async_ensure_register_maps, initial_register_hash
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,9 +135,9 @@ def update_known_missing_addresses(
             scanner._known_missing_addresses.update(range(addr, addr + size))
 
 
-async def async_setup_register_maps(scanner: Any, async_ensure_register_maps: Any) -> None:
+async def async_setup_register_maps(scanner: Any) -> None:
     """Asynchronously load register definitions and build address/name maps."""
-    await async_ensure_register_maps(scanner._hass)
+    await async_ensure_register_maps(initial_register_hash(), scanner._hass)
     loaded = await scanner._load_registers()
     if isinstance(loaded, tuple):
         scanner._registers = loaded[0]
@@ -371,12 +373,10 @@ async def async_create_scanner_instance(
     parity: str,
     stop_bits: int,
     hass: Any | None,
-    ensure_client_module_fn: Any,
-    async_ensure_register_maps_fn: Any,
 ) -> Any:
     """Create and initialize scanner instance with bound read helper methods."""
-    ensure_client_module_fn()
-    await async_ensure_register_maps_fn(hass)
+    attach_pymodbus_client_module()
+    await async_ensure_register_maps(initial_register_hash(), hass)
     scanner = scanner_cls(
         host,
         port,

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -17,16 +17,11 @@ def test_coordinator_exports_permanent_modbus_error() -> None:
     assert "_PermanentModbusError" in coordinator.__all__
 
 
-def test_scanner_core_public_api_contains_register_cache_wrappers() -> None:
-    """Scanner core should expose register cache wrappers in its public API."""
+def test_scanner_core_public_api_is_minimal() -> None:
+    """Scanner core should expose only true scanner class API."""
     expected_exports = {
-        "REGISTER_HASH",
-        "_build_register_maps",
-        "_build_register_maps_from",
-        "_ensure_register_maps",
-        "_async_build_register_maps",
-        "_async_ensure_register_maps",
-        "async_ensure_register_maps",
+        "DeviceCapabilities",
+        "ThesslaGreenDeviceScanner",
     }
     assert expected_exports.issubset(set(scanner_core.__all__))
     for export_name in expected_exports:
@@ -67,6 +62,8 @@ def test_config_flow_keeps_helper_surface() -> None:
         assert hasattr(config_flow, helper_name)
 
 
-def test_scanner_core_exports_init_helper() -> None:
-    """Scanner helper name should be available."""
-    assert hasattr(scanner_core, "ensure_pymodbus_client_module")
+def test_scanner_package_exports_cancelled_error_helper() -> None:
+    """Scanner package should expose cancelled-request classifier from scanner.io."""
+    import custom_components.thessla_green_modbus.scanner as scanner_pkg
+
+    assert hasattr(scanner_pkg, "is_request_cancelled_error")

--- a/tests/test_scanner_coverage.py
+++ b/tests/test_scanner_coverage.py
@@ -19,7 +19,6 @@ from custom_components.thessla_green_modbus.modbus_exceptions import (
 )
 from custom_components.thessla_green_modbus.scanner.core import (
     ThesslaGreenDeviceScanner,
-    _build_register_maps,
 )
 
 # ---------------------------------------------------------------------------
@@ -78,8 +77,12 @@ def _make_transport(
 
 
 def test_build_register_maps_direct():
-    """Call _build_register_maps() directly to cover lines 245-247."""
-    _build_register_maps()
+    """Build register maps via scanner register-map runtime module."""
+    from custom_components.thessla_green_modbus.scanner.register_map_runtime import (
+        build_register_maps,
+    )
+
+    build_register_maps()
     from custom_components.thessla_green_modbus.scanner.core import REGISTER_DEFINITIONS
 
     assert isinstance(REGISTER_DEFINITIONS, dict)
@@ -88,30 +91,32 @@ def test_build_register_maps_direct():
 @pytest.mark.asyncio
 async def test_maybe_retry_yield_backoff_positive():
     """Cover line 145: backoff > 0 causes early return without sleeping."""
-    from custom_components.thessla_green_modbus.scanner.core import _maybe_retry_yield
+    from custom_components.thessla_green_modbus.scanner.io_runtime import maybe_retry_yield
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
         # backoff > 0 → early return, no sleep
-        await _maybe_retry_yield(backoff=0.1, attempt=0, retry=3)
+        await maybe_retry_yield(backoff=0.1, attempt=0, retry=3)
         mock_sleep.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_call_modbus_with_fallback_type_error_reraise():
     """Cover line 182: TypeError with non-'unexpected keyword' message is re-raised."""
-    from custom_components.thessla_green_modbus.scanner.core import _call_modbus_with_fallback
+    from custom_components.thessla_green_modbus.modbus_helpers import _call_modbus
+    from custom_components.thessla_green_modbus.scanner.io_runtime import call_modbus_with_fallback
 
     async def raise_other_type_error(*args, **kwargs):
         raise TypeError("something unrelated to keyword")
 
     with (
         patch(
-            "custom_components.thessla_green_modbus.scanner.core._call_modbus",
+            "custom_components.thessla_green_modbus.modbus_helpers._call_modbus",
             side_effect=raise_other_type_error,
         ),
         pytest.raises(TypeError, match="something unrelated"),
     ):
-        await _call_modbus_with_fallback(
+        await call_modbus_with_fallback(
+            _call_modbus,
             MagicMock(),
             1,
             0,
@@ -1379,36 +1384,22 @@ async def test_scan_device_auto_detect_all_fail():
 
 
 # ---------------------------------------------------------------------------
-# Group R: scan_device legacy compat path (line 1663)
+# Group R: scan_device non-dict return path
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_scan_device_scan_returns_non_dict_raises():
-    """Line 1663: scan() returning non-dict raises TypeError (legacy compat path)."""
+    """scan() returning non-dict should raise TypeError."""
     scanner = await _make_scanner()
 
     # Patch scan at class level with a regular coroutine function so that
     # scan_method.__func__ IS ThesslaGreenDeviceScanner.scan (bypassing first branch).
-    # Then in the legacy compat path, scan() returns non-dict → TypeError.
+    # scan() returns non-dict → TypeError.
     async def fake_scan(self_arg):
         return "not_a_dict"
 
-    mock_ctor = MagicMock()
-    mock_client = MagicMock()
-    mock_client.connect.return_value = True
-    mock_ctor.return_value = mock_client
-
-    with (
-        patch.object(ThesslaGreenDeviceScanner, "scan", fake_scan),
-        patch(
-            "custom_components.thessla_green_modbus.scanner.core.importlib.import_module"
-        ) as mock_import,
-    ):
-        mock_mod = MagicMock()
-        mock_mod.ModbusTcpClient = mock_ctor
-        mock_import.return_value = mock_mod
-
+    with patch.object(ThesslaGreenDeviceScanner, "scan", fake_scan):
         with patch.object(scanner, "close", AsyncMock()):
             with pytest.raises(TypeError, match="scan\\(\\) must return a dict"):
                 await scanner.scan_device()
@@ -1460,20 +1451,19 @@ async def test_close_client_async_maybe_await_raises():
 
 
 def test_ensure_register_maps_rebuilds_on_hash_mismatch():
-    """Line 262: rebuilds when hash differs from REGISTER_HASH."""
-    import custom_components.thessla_green_modbus.scanner.core as sc
+    """register_map_runtime.ensure_register_maps should rebuild mismatched cache hash."""
+    import custom_components.thessla_green_modbus.scanner.register_map_cache as cache
+    from custom_components.thessla_green_modbus.scanner.register_map_runtime import (
+        ensure_register_maps,
+    )
 
-    original_hash = sc.REGISTER_HASH
+    original_hash = cache.REGISTER_HASH
     try:
-        # Force a mismatch so _build_register_maps is called
-        sc.REGISTER_HASH = "stale_hash"
-        from custom_components.thessla_green_modbus.scanner.core import _ensure_register_maps
-
-        _ensure_register_maps()
-        # After rebuild, hash should be updated
-        assert sc.REGISTER_HASH != "stale_hash"
+        cache.REGISTER_HASH = "stale_hash"
+        updated_hash = ensure_register_maps("stale_hash")
+        assert updated_hash != "stale_hash"
     finally:
-        sc.REGISTER_HASH = original_hash
+        cache.REGISTER_HASH = original_hash
 
 
 # ---------------------------------------------------------------------------
@@ -1961,17 +1951,13 @@ async def test_scan_device_legacy_returns_dict():
 
 @pytest.mark.asyncio
 async def test_scan_device_importlib_fails():
-    """Lines 1643-1644: importlib.import_module raises → legacy_ctor = None."""
+    """scan_device should continue via transport path when setup probes fail."""
     scanner = await _make_scanner()
     mock_transport = _make_transport()
     mock_transport.client = AsyncMock()
 
     with (
         patch.object(scanner, "_build_tcp_transport", return_value=mock_transport),
-        patch(
-            "custom_components.thessla_green_modbus.scanner.core.importlib.import_module",
-            side_effect=Exception("import failed"),
-        ),
         patch.object(scanner, "_read_input_block", AsyncMock(return_value=[])),
         patch.object(scanner, "_read_holding_block", AsyncMock(return_value=[])),
         patch.object(scanner, "_read_input", AsyncMock(return_value=None)),
@@ -2257,14 +2243,16 @@ async def test_mark_holding_unsupported_partial_overlap():
 
 def test_ensure_pymodbus_import_fails():
     """Lines 119-120: except Exception: return when importlib raises."""
-    from custom_components.thessla_green_modbus.scanner.core import ensure_pymodbus_client_module
+    from custom_components.thessla_green_modbus.scanner.io_runtime import (
+        attach_pymodbus_client_module,
+    )
 
     with patch(
-        "custom_components.thessla_green_modbus.scanner.core.importlib.import_module",
+        "custom_components.thessla_green_modbus.scanner.io_runtime.importlib.import_module",
         side_effect=ImportError("no pymodbus"),
     ):
         # Must not raise
-        ensure_pymodbus_client_module()
+        attach_pymodbus_client_module()
 
 
 # ---------------------------------------------------------------------------
@@ -2319,7 +2307,7 @@ async def test_async_setup_load_registers_returns_plain_dict():
 
     with (
         patch(
-            "custom_components.thessla_green_modbus.scanner.core._async_ensure_register_maps",
+            "custom_components.thessla_green_modbus.scanner.setup.async_ensure_register_maps",
             AsyncMock(),
         ),
         patch.object(scanner, "_load_registers", AsyncMock(return_value=plain_dict)),

--- a/tests/test_scanner_register_cache_invalidation.py
+++ b/tests/test_scanner_register_cache_invalidation.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import custom_components.thessla_green_modbus.scanner.core as sc
 import pytest
 from custom_components.thessla_green_modbus.registers.loader import clear_cache, get_registers_path
+from custom_components.thessla_green_modbus.scanner import register_map_cache
 
 
 def test_scanner_register_cache_invalidation(tmp_path: Path, monkeypatch) -> None:
@@ -22,7 +23,7 @@ def test_scanner_register_cache_invalidation(tmp_path: Path, monkeypatch) -> Non
     sc.COIL_REGISTERS.clear()
     sc.DISCRETE_INPUT_REGISTERS.clear()
     sc.MULTI_REGISTER_SIZES.clear()
-    sc.REGISTER_HASH = None
+    register_map_cache.REGISTER_HASH = None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Reduce the bloated test-driven facade surface in `scanner/core.py` by moving responsibilities and helpers to the canonical scanner modules so the scanner class exposes only its true production API.  
- Keep scanner behaviour and tests intact while removing wrappers that existed mainly for tests or legacy compatibility.

### Description
- Removed non-class helper wrappers and re-exports from `custom_components/thessla_green_modbus/scanner/core.py`, narrowing `__all__` to the true scanner API (`DeviceCapabilities`, `ThesslaGreenDeviceScanner`).
- Delegated bootstrap/runtime helpers to canonical modules: moved pymodbus client attachment and register-map initialization to `scanner/io_runtime.py` and `scanner/register_map_runtime.py` and wired `scanner/setup.py` to call them directly (`attach_pymodbus_client_module`, `async_ensure_register_maps`, `initial_register_hash`).
- Exported the cancelled-request classifier from `scanner.io` (package `__init__` now re-exports `is_request_cancelled_error` from `scanner.io`) instead of `scanner.core`.
- Updated tests to import and assert the canonical modules and symbols (modified `tests/test_api_contracts.py`, `tests/test_scanner_coverage.py`, and `tests/test_scanner_register_cache_invalidation.py`) so tests no longer patch or depend on removed `scanner.core` wrappers.
- Small doc/comment cleanups in `scanner/io.py` and `scanner/register_map_cache.py` to reflect the clarified ownership.

Files changed (key):
- custom_components/thessla_green_modbus/scanner/core.py (trim facade, remove wrappers)
- custom_components/thessla_green_modbus/scanner/setup.py (call canonical bootstrap helpers)
- custom_components/thessla_green_modbus/scanner/__init__.py (re-export cancelled classifier from `io`)
- custom_components/thessla_green_modbus/scanner/io.py, scanner/register_map_cache.py (minor wording/cleanups)
- tests/test_api_contracts.py, tests/test_scanner_coverage.py, tests/test_scanner_register_cache_invalidation.py (adapted to canonical imports/assertions)

### Testing
- Ran linting: `ruff check custom_components tests tools` — passed.  
- Ran static compile: `python -m compileall -q custom_components/thessla_green_modbus tests tools` — passed.  
- Ran full test suite: `pytest tests/ -q` — failed to start due to an environment dependency issue: `ModuleNotFoundError: No module named 'pydantic'` raised while importing `tests/conftest.py`, which prevented pytest from executing the updated tests; this is an environment-level missing dependency and not caused by the refactor.  
- Updated/covered tests: `tests/test_api_contracts.py`, `tests/test_scanner_coverage.py`, and `tests/test_scanner_register_cache_invalidation.py` were adapted to target `scanner.io_runtime` / `scanner.register_map_runtime` / `scanner.register_map_cache` where appropriate (these test edits compile cleanly but could not be executed here due to the missing `pydantic` dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11ec5b0f8832681aedfe0fe39d27c)