### PR TITLE
docs: correct coordinator transition status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,7 @@ When touching architecture-related code/docs, keep these constraints:
 - No proxy modules.
 - `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant.
 - `coordinator.py` must not be moved yet.
+- `coordinator/` must not be recreated before a dedicated migration PR.
 
 See also: [`docs/refactor_status.md`](docs/refactor_status.md).
 

--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ pytest tests/ -x -q
 > fail at import with `ImportError: cannot import name 'StrEnum' from 'enum'`.
 > This is expected — the test environment must use Python 3.13.
 
-> **Refactor constraints (must keep):** no legacy modules, no compatibility/re-export/proxy shims; `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant; and `coordinator.py` must stay in place for now. See [`docs/refactor_status.md`](docs/refactor_status.md).
+> **Refactor constraints (must keep):** no legacy modules, no compatibility/re-export/proxy shims; `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant; `coordinator.py` must stay in place for now, and `coordinator/` must not be recreated. See [`docs/refactor_status.md`](docs/refactor_status.md).

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -26,12 +26,20 @@ The following constraints are active and must be preserved:
 
 ## Current transitional note
 
-Both forms currently exist in the repository:
+Current active coordinator location:
 
 - `custom_components/thessla_green_modbus/coordinator.py`
-- `custom_components/thessla_green_modbus/coordinator/`
 
-This is a temporary refactor stage. Until migration is complete, `coordinator.py` remains in place and should not be relocated.
+Current repository state:
+
+- `custom_components/thessla_green_modbus/coordinator/` is **not present**.
+- The old empty `coordinator/` scaffold was removed because it shadowed `coordinator.py` and broke imports.
+
+Transition rule (current):
+
+- `coordinator.py` remains in place and must not be moved in this stage.
+- `coordinator/` must not be recreated until a dedicated future PR performs a real migration to a package layout.
+- That future migration must update imports directly and must not use compatibility shims, re-export shims, or proxy modules.
 
 ## Documentation policy for refactor work
 

--- a/docs/thesslagreen_architecture.md
+++ b/docs/thesslagreen_architecture.md
@@ -40,12 +40,15 @@ Wymóg bieżący:
 coordinator.py nie może być na razie przenoszony
 ```
 
-Dopuszczalny stan przejściowy:
+Stan przejściowy (aktualny):
 
 ```text
-custom_components/thessla_green_modbus/coordinator.py
-custom_components/thessla_green_modbus/coordinator/
+custom_components/thessla_green_modbus/coordinator.py      # obecna aktywna lokalizacja
+custom_components/thessla_green_modbus/coordinator/         # NIE występuje i nie może być odtwarzany
 ```
+
+Migracja do docelowego katalogu `coordinator/` jest planem przyszłym i wymaga osobnego PR.
+W takim PR importy muszą zostać zaktualizowane bezpośrednio, bez shimów kompatybilności i bez modułów proxy.
 
 Niezmiennie obowiązuje zakaz tworzenia:
 

--- a/docs/thesslagreen_guidelines.md
+++ b/docs/thesslagreen_guidelines.md
@@ -57,6 +57,7 @@ pymodbus / raw socket
 11. Nie tworzyć legacy modules, compatibility shims ani re-export shimów.
 12. Po przepisaniu kodu na nową warstwę usunąć stary odpowiednik.
 13. coordinator.py nie może być jeszcze przenoszony.
+14. coordinator/ nie może być odtwarzany przed dedykowaną migracją.
 ```
 
 ---
@@ -67,11 +68,14 @@ pymodbus / raw socket
 Do czasu domknięcia migracji coordinatora obowiązuje:
 
 ```text
-- coordinator.py pozostaje na miejscu,
-- równoległy katalog coordinator/ może współistnieć,
+- coordinator.py pozostaje na miejscu (aktywna lokalizacja),
+- katalog coordinator/ nie istnieje i nie może być odtwarzany na tym etapie,
 - nie tworzymy shimów ani proxy modułów,
 - nie dokumentujemy migracji, jeśli nie ma realnego kodu migracyjnego.
 ```
+
+Migracja `coordinator.py` -> `coordinator/` jest wyłącznie celem przyszłym i wymaga dedykowanego PR.
+W tej przyszłej migracji należy zaktualizować importy bezpośrednio (bez compatibility/re-export shimów).
 
 ---
 


### PR DESCRIPTION
### Motivation
- Fix incorrect documentation that implied both `coordinator.py` and a `coordinator/` package currently coexist, which does not match the repository state and caused confusion. 
- Ensure all architecture/guidelines/contributing/README references consistently state the active coordinator location and the rule forbidding recreation of a `coordinator/` package. 
- Prevent accidental recreation of a `coordinator/` scaffold that previously shadowed `coordinator.py` and broke imports by making the current constraint explicit in docs. 

### Description
- Updated `docs/refactor_status.md` to state the exact current coordinator status: the active coordinator file is `custom_components/thessla_green_modbus/coordinator.py`, `custom_components/thessla_green_modbus/coordinator/` is **not present** and must not be recreated, and any future migration must update imports directly without compatibility/re-export/proxy shims. 
- Aligned `docs/thesslagreen_architecture.md` and `docs/thesslagreen_guidelines.md` to mark `coordinator.py` as the current active location, specify that `coordinator/` is a future target (not currently present), and add the rule forbidding recreation until a dedicated PR performs the migration with direct import updates. 
- Updated top-level docs `README.md` and `CONTRIBUTING.md` to reflect the same rule (that `coordinator.py` stays in place for now and `coordinator/` must not be recreated). 
- Files changed: `docs/refactor_status.md`, `docs/thesslagreen_architecture.md`, `docs/thesslagreen_guidelines.md`, `README.md`, and `CONTRIBUTING.md`. 

### Testing
- Ran a markdown link validation script that checked links in `README.md`, `CONTRIBUTING.md`, and `docs/*.md`, and all local file links resolved successfully. 
- Ran `ruff check custom_components tests tools` and it completed with no issues. 
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` and compilation succeeded with no errors. 
- No production code, tests, or scanner files were modified during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1211d657483269e96624823c5e4b8)