### PR TITLE
chore: validate scanner cleanup (docstring fix)

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/core.py
+++ b/custom_components/thessla_green_modbus/scanner/core.py
@@ -345,8 +345,7 @@ class ThesslaGreenDeviceScanner(
     ) -> list[tuple[int, int]]:
         """Group consecutive register addresses for efficient batch reads.
 
-        The grouping implementation delegates to the shared ``group_reads`` helper.
-        delegates grouping to the shared ``group_reads`` helper so that the
+        The grouping implementation delegates to the shared ``group_reads`` helper so that the
         scanner benefits from the same optimisation logic used elsewhere in the
         project.  Any registers that have previously been marked as missing are
         split into their own single-register groups to avoid unnecessary


### PR DESCRIPTION
### Motivation
- Finalise post-merge validation after recent scanner refactors and remove a duplicated sentence in the `_group_registers_for_batch_read` docstring to keep documentation clear without changing behavior or public API.

### Description
- Removed the duplicated sentence in the `_group_registers_for_batch_read` docstring in `custom_components/thessla_green_modbus/scanner/core.py`, preserving the original meaning and making no behavioral or API changes.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `ruff check custom_components tests tools`, `pytest tests/ -q`, and the requested `rg` searches; all checks completed successfully, `pytest` passed with a few skipped tests (one due to missing optional `pypdf`), and no dependency updates were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f124f4ced4832696c6ee856e41de3d)