### PR TITLE
test: split coordinator tests by behavior

### DIFF
--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -42,58 +42,6 @@ def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
 # ---------------------------------------------------------------------------
 
 
-def test_utcnow_returns_timezone_aware_datetime():
-    """_utcnow should always return timezone-aware datetime."""
-    result = _utcnow()
-    assert isinstance(result, datetime)
-    assert result.tzinfo is not None
-
-
-# ---------------------------------------------------------------------------
-# Group B — __init__ invalid parameter values (lines 310-376)
-# ---------------------------------------------------------------------------
-
-
-def test_coordinator_init_bad_backoff_falls_back():
-    """ValueError in float(backoff) is caught; self.backoff = DEFAULT_BACKOFF (lines 310-313)."""
-    coord = _make_coordinator(backoff="not_a_float")
-    from custom_components.thessla_green_modbus.const import DEFAULT_BACKOFF
-
-    assert coord.backoff == DEFAULT_BACKOFF
-
-
-def test_coordinator_init_bad_baud_rate_falls_back():
-    """ValueError in int(baud_rate) is caught; self.baud_rate = DEFAULT_BAUD_RATE (lines 348-351)."""
-    coord = _make_coordinator(baud_rate="not_an_int")
-    from custom_components.thessla_green_modbus.const import DEFAULT_BAUD_RATE
-
-    assert coord.baud_rate == DEFAULT_BAUD_RATE
-
-
-def test_coordinator_init_jitter_list_two_floats():
-    """backoff_jitter as list with 2 elements creates tuple jitter (lines 323-327)."""
-    coord = _make_coordinator(backoff_jitter=[0.1, 0.5])
-    assert coord.backoff_jitter == (0.1, 0.5)
-
-
-def test_coordinator_init_jitter_string_float():
-    """backoff_jitter as string float is parsed to float (lines 318-322)."""
-    coord = _make_coordinator(backoff_jitter="0.3")
-    assert coord.backoff_jitter == 0.3
-
-
-def test_coordinator_init_jitter_bad_string():
-    """backoff_jitter as bad string falls back to None (lines 319-322)."""
-    coord = _make_coordinator(backoff_jitter="bad")
-    assert coord.backoff_jitter is None
-
-
-def test_coordinator_init_jitter_zero():
-    """backoff_jitter = 0 is stored as 0.0 (line 331-332)."""
-    coord = _make_coordinator(backoff_jitter=0)
-    assert coord.backoff_jitter == 0.0
-
-
 # ---------------------------------------------------------------------------
 # Group C — _get_client_method fallback no-op (lines 509-527)
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator_setup.py
+++ b/tests/test_coordinator_setup.py
@@ -1,0 +1,81 @@
+"""Coordinator setup/init focused tests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+    _utcnow,
+)
+
+
+def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
+    hass = MagicMock()
+    hass.async_add_executor_job = None
+    return ThesslaGreenModbusCoordinator.from_params(
+        hass=hass,
+        host="192.168.1.1",
+        port=502,
+        slave_id=1,
+        name="test",
+        scan_interval=30,
+        timeout=3,
+        retry=2,
+        **kwargs,
+    )
+
+
+def test_utcnow_returns_timezone_aware_datetime():
+    """_utcnow should always return timezone-aware datetime."""
+    result = _utcnow()
+    assert isinstance(result, datetime)
+    assert result.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# Group B — __init__ invalid parameter values (lines 310-376)
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_init_bad_backoff_falls_back():
+    """ValueError in float(backoff) is caught; self.backoff = DEFAULT_BACKOFF (lines 310-313)."""
+    coord = _make_coordinator(backoff="not_a_float")
+    from custom_components.thessla_green_modbus.const import DEFAULT_BACKOFF
+
+    assert coord.backoff == DEFAULT_BACKOFF
+
+
+def test_coordinator_init_bad_baud_rate_falls_back():
+    """ValueError in int(baud_rate) is caught; self.baud_rate = DEFAULT_BAUD_RATE (lines 348-351)."""
+    coord = _make_coordinator(baud_rate="not_an_int")
+    from custom_components.thessla_green_modbus.const import DEFAULT_BAUD_RATE
+
+    assert coord.baud_rate == DEFAULT_BAUD_RATE
+
+
+def test_coordinator_init_jitter_list_two_floats():
+    """backoff_jitter as list with 2 elements creates tuple jitter (lines 323-327)."""
+    coord = _make_coordinator(backoff_jitter=[0.1, 0.5])
+    assert coord.backoff_jitter == (0.1, 0.5)
+
+
+def test_coordinator_init_jitter_string_float():
+    """backoff_jitter as string float is parsed to float (lines 318-322)."""
+    coord = _make_coordinator(backoff_jitter="0.3")
+    assert coord.backoff_jitter == 0.3
+
+
+def test_coordinator_init_jitter_bad_string():
+    """backoff_jitter as bad string falls back to None (lines 319-322)."""
+    coord = _make_coordinator(backoff_jitter="bad")
+    assert coord.backoff_jitter is None
+
+
+def test_coordinator_init_jitter_zero():
+    """backoff_jitter = 0 is stored as 0.0 (line 331-332)."""
+    coord = _make_coordinator(backoff_jitter=0)
+    assert coord.backoff_jitter == 0.0
+
+


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibility of the large coordinator coverage file by extracting setup/init-focused tests into a focused module to improve maintainability and readability.
- Preserve all coordinator behavior and assertions while preparing for further focused splits per the preferred target structure.
- Avoid any changes to production code or coordinator module layout during the test reorganization.

### Description
- Added `tests/test_coordinator_setup.py` containing the `_utcnow` and __init__-parameter fallback/jitter tests plus a local `_make_coordinator` helper, moved verbatim from the coverage file.
- Removed those moved tests from `tests/test_coordinator_coverage.py` so the remaining coverage file keeps the other targeted tests intact.
- Ensured imports and formatting satisfy linters (applied `ruff --fix` to the new file) and did not modify any production modules or coordinator location.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` successfully.
- Ran `ruff check custom_components tests tools` and fixed import ordering; lint check passed after the fix.
- Executed `pytest` on the affected coordinator tests (`tests/test_coordinator_setup.py` and `tests/test_coordinator_coverage.py`), the coordinator test pattern (`tests/test_coordinator*.py`), selected unit tests (`tests/unit/test_errors.py`, `tests/unit/test_transport_retry.py`), and the full suite (`pytest tests/ -q`), and all runs passed with the same expected skips noted in the baseline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12dd88998832699c9353643119bb5)