### PR TITLE
refactor(mappings): extract pure mapping builder helpers

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -35,6 +35,36 @@ _TIME_ENTITY_PREFIXES = (
 )
 
 
+def _is_already_mapped(register: str, mappings: dict[str, dict[str, Any]]) -> bool:
+    """Return True if *register* already exists in direct mapping keys."""
+    return register in mappings
+
+
+def _is_mapped_as_binary_source(register: str, binary_mappings: dict[str, dict[str, Any]]) -> bool:
+    """Return True if a binary mapping references *register* as its source register."""
+    return any(v.get("register") == register for v in binary_mappings.values())
+
+
+def _is_problem_register(register: str) -> bool:
+    """Return True for diagnostic/problem registers handled as binary sensors."""
+    return register in {"alarm", "error"} or register.startswith(("s_", "e_", "f_"))
+
+
+def _parse_info_states(info_text: str) -> dict[str, int]:
+    """Parse '0 - foo; 1 - bar' style info text into state mapping."""
+    states: dict[str, int] = {}
+    for part in info_text.split(";"):
+        part = part.strip()
+        if " - " not in part:
+            continue
+        val_str, label = part.split(" - ", 1)
+        try:
+            states[_to_snake_case(label)] = int(val_str.strip())
+        except ValueError:
+            continue
+    return states
+
+
 def _get_parent() -> Any:
     """Return the parent mappings package module for attribute resolution.
 
@@ -279,29 +309,23 @@ def _extend_entity_mappings_from_registers() -> None:
         if reg.function != 3 or not reg.name:
             continue
         register = reg.name
-        if register in number_mappings:
+        if any(
+            _is_already_mapped(register, current_map)
+            for current_map in (
+                number_mappings,
+                sensor_mappings,
+                binary_mappings,
+                switch_mappings,
+                select_mappings,
+                text_mappings,
+                time_mappings,
+            )
+        ):
             continue
-        if register in sensor_mappings:
-            continue
-        if register in binary_mappings:
-            continue
-        if any(v.get("register") == register for v in binary_mappings.values()):
-            continue
-        if register in switch_mappings:
-            continue
-        if register in select_mappings:
-            continue
-        if register in text_mappings:
-            continue
-        if register in time_mappings:
+        if _is_mapped_as_binary_source(register, binary_mappings):
             continue
 
-        if (
-            register in {"alarm", "error"}
-            or register.startswith("s_")
-            or register.startswith("e_")
-            or register.startswith("f_")
-        ):
+        if _is_problem_register(register):
             if register not in binary_keys:
                 continue
             binary_mappings.setdefault(
@@ -450,16 +474,7 @@ def _extend_entity_mappings_from_registers() -> None:
                 continue
 
             if "W" in access and info_text and ";" in info_text and max_val <= 10:
-                states: dict[str, int] = {}
-                for part in info_text.split(";"):
-                    part = part.strip()
-                    if " - " not in part:
-                        continue
-                    val_str, label = part.split(" - ", 1)
-                    try:
-                        states[_to_snake_case(label)] = int(val_str.strip())
-                    except ValueError:
-                        continue
+                states = _parse_info_states(info_text)
                 if states:
                     if register not in select_keys:
                         continue
@@ -495,7 +510,11 @@ __all__ = [
     "_TIME_ENTITY_PREFIXES",
     "_extend_entity_mappings_from_registers",
     "_get_parent",
+    "_is_already_mapped",
+    "_is_mapped_as_binary_source",
+    "_is_problem_register",
     "_load_discrete_mappings",
     "_load_number_mappings",
+    "_parse_info_states",
     "_resolve",
 ]

--- a/tests/test_entity_mappings_helpers.py
+++ b/tests/test_entity_mappings_helpers.py
@@ -1,0 +1,37 @@
+"""Direct tests for pure mapping-builder helper functions."""
+
+from custom_components.thessla_green_modbus.mappings._mapping_builders import (
+    _is_already_mapped,
+    _is_mapped_as_binary_source,
+    _is_problem_register,
+    _parse_info_states,
+)
+
+
+def test_is_already_mapped_true_and_false() -> None:
+    mappings = {"reg_a": {"translation_key": "reg_a"}}
+    assert _is_already_mapped("reg_a", mappings) is True
+    assert _is_already_mapped("reg_b", mappings) is False
+
+
+def test_is_mapped_as_binary_source() -> None:
+    binary = {
+        "source_reg_bit_0": {"register": "source_reg", "bit": 1},
+        "simple_reg": {"translation_key": "simple_reg"},
+    }
+    assert _is_mapped_as_binary_source("source_reg", binary) is True
+    assert _is_mapped_as_binary_source("other_reg", binary) is False
+
+
+def test_is_problem_register_variants() -> None:
+    assert _is_problem_register("alarm") is True
+    assert _is_problem_register("error") is True
+    assert _is_problem_register("s_status") is True
+    assert _is_problem_register("e_12") is True
+    assert _is_problem_register("f_fault") is True
+    assert _is_problem_register("normal_register") is False
+
+
+def test_parse_info_states_parses_and_skips_invalid_parts() -> None:
+    parsed = _parse_info_states("0 - off; x - broken;1 - on;ignored")
+    assert parsed == {"off": 0, "on": 1}


### PR DESCRIPTION
### Motivation
- Reduce complexity of `_extend_entity_mappings_from_registers` by extracting small pure helpers so decision logic is easier to read and unit-test without changing mapping behavior.
- Keep the change surface minimal and confined to mapping generation helpers and focused tests to avoid touching coordinator/scanner/transport areas.

### Description
- Modified `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` to extract four pure helper functions: `_is_already_mapped`, `_is_mapped_as_binary_source`, `_is_problem_register`, and `_parse_info_states`, and replaced the original inline checks with calls to these helpers.
- Added unit tests in `tests/test_entity_mappings_helpers.py` that exercise the new helper functions directly (`_is_already_mapped`, `_is_mapped_as_binary_source`, `_is_problem_register`, `_parse_info_states`).
- No mapping output, register JSON, platform behavior, or forbidden paths were changed; this is a pure refactor/substitution to preserve runtime behavior.

### Testing
- Installed dev requirements and ran compile check with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which succeeded.
- Ran lint with `ruff check custom_components tests tools` which passed (auto-fixed `__all__` ordering during the run).
- Ran targeted tests and full suite with `pytest tests/test_entity_mappings.py`, `pytest tests/ -q`, and the additional platform-focused test runs; all tests passed (with existing expected skips for optional extras such as `pypdf`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12dee02ac8326a4b580c12364312c)