### PR TITLE
Split scanner setup/init tests into separate module and remove unused import

### DIFF
--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -10,7 +10,6 @@ from custom_components.thessla_green_modbus.const import (
     SENSOR_UNAVAILABLE,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import (
-    ConnectionException,
     ModbusException,
     ModbusIOException,
 )
@@ -33,66 +32,6 @@ HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function(3)}
 INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function(4)}
 
 pytestmark = pytest.mark.asyncio
-
-
-async def test_scanner_core_initialization():
-    """Test device scanner initialization."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
-
-    assert hasattr(scanner, "_read_coil")
-    assert hasattr(scanner, "_read_holding")
-    assert hasattr(scanner, "_read_discrete")
-
-    assert scanner.host == "192.168.3.17"
-    assert scanner.port == 8899
-    assert scanner.slave_id == 10
-    assert scanner.retry == 3
-    assert scanner.backoff == 0
-
-
-async def test_verify_connection_close_non_awaitable_on_failure():
-    """Verify close() handles non-awaitable result on connection failure."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
-    fake_transport = MagicMock()
-    fake_transport.ensure_connected = AsyncMock(side_effect=ConnectionException("fail"))
-    fake_transport.read_input_registers = AsyncMock()
-    fake_transport.read_holding_registers = AsyncMock()
-    fake_transport.close = MagicMock(return_value=None)
-
-    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
-        with pytest.raises(ConnectionException):
-            await scanner.verify_connection()
-
-    fake_transport.close.assert_called_once()
-
-
-async def test_verify_connection_close_non_awaitable_on_success():
-    """Verify close() handles non-awaitable result on success."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
-    fake_transport = MagicMock()
-    fake_transport.ensure_connected = AsyncMock(return_value=True)
-    fake_transport.read_input_registers = AsyncMock()
-    fake_transport.read_holding_registers = AsyncMock()
-    fake_transport.close = MagicMock(return_value=None)
-
-    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
-        await scanner.verify_connection()
-
-    fake_transport.close.assert_called_once()
-
-
-async def test_create_binds_read_helpers():
-    """Scanner.create binds read helper methods to the instance."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
-    assert hasattr(scanner, "_read_holding")
-    assert hasattr(scanner, "_read_coil")
-    assert hasattr(scanner, "_read_discrete")
-
-
-async def test_scanner_has_read_coil_method():
-    """Ensure scanner exposes coil reading helper."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
-    assert hasattr(scanner, "_read_coil")
 
 
 async def test_read_holding_skips_after_failure():

--- a/tests/test_device_scanner_setup.py
+++ b/tests/test_device_scanner_setup.py
@@ -1,0 +1,69 @@
+"""Setup and initialization tests for device scanner."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
+from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_scanner_core_initialization():
+    """Test device scanner initialization."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+
+    assert hasattr(scanner, "_read_coil")
+    assert hasattr(scanner, "_read_holding")
+    assert hasattr(scanner, "_read_discrete")
+
+    assert scanner.host == "192.168.3.17"
+    assert scanner.port == 8899
+    assert scanner.slave_id == 10
+    assert scanner.retry == 3
+    assert scanner.backoff == 0
+
+
+async def test_verify_connection_close_non_awaitable_on_failure():
+    """Verify close() handles non-awaitable result on connection failure."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+    fake_transport = MagicMock()
+    fake_transport.ensure_connected = AsyncMock(side_effect=ConnectionException("fail"))
+    fake_transport.read_input_registers = AsyncMock()
+    fake_transport.read_holding_registers = AsyncMock()
+    fake_transport.close = MagicMock(return_value=None)
+
+    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
+        with pytest.raises(ConnectionException):
+            await scanner.verify_connection()
+
+    fake_transport.close.assert_called_once()
+
+
+async def test_verify_connection_close_non_awaitable_on_success():
+    """Verify close() handles non-awaitable result on success."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+    fake_transport = MagicMock()
+    fake_transport.ensure_connected = AsyncMock(return_value=True)
+    fake_transport.read_input_registers = AsyncMock()
+    fake_transport.read_holding_registers = AsyncMock()
+    fake_transport.close = MagicMock(return_value=None)
+
+    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
+        await scanner.verify_connection()
+
+    fake_transport.close.assert_called_once()
+
+
+async def test_create_binds_read_helpers():
+    """Scanner.create binds read helper methods to the instance."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+    assert hasattr(scanner, "_read_holding")
+    assert hasattr(scanner, "_read_coil")
+    assert hasattr(scanner, "_read_discrete")
+
+
+async def test_scanner_has_read_coil_method():
+    """Ensure scanner exposes coil reading helper."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
+    assert hasattr(scanner, "_read_coil")


### PR DESCRIPTION
### Motivation

- Separate initialization and connection-related tests from behavioural scanner tests to improve test organization and readability.
- Remove an unused `ConnectionException` import from `tests/test_device_scanner.py` after relocating tests that referenced it.

### Description

- Moved setup and initialization tests into a new file `tests/test_device_scanner_setup.py` containing `test_scanner_core_initialization`, `test_verify_connection_close_non_awaitable_on_failure`, `test_verify_connection_close_non_awaitable_on_success`, `test_create_binds_read_helpers`, and `test_scanner_has_read_coil_method`.
- Removed those tests from `tests/test_device_scanner.py`, leaving the read-holding failure caching test `test_read_holding_skips_after_failure` in place.
- Removed the now-unused `ConnectionException` import from `tests/test_device_scanner.py`.

### Testing

- Ran the related unit tests with `pytest tests/test_device_scanner_setup.py tests/test_device_scanner.py -q` and they completed successfully.
- All modified test files executed without failures under the test run mentioned above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12dd1d0d883268898b83ff869ef30)