### PR TITLE
test: continue splitting coordinator tests by behavior

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -212,59 +212,6 @@ async def test_read_input_registers_reconnect_on_error(coordinator):
 
 
 @pytest.mark.asyncio
-async def test_disconnect_retry_transportless_restores_client(coordinator):
-    """Transport-less retry restores client when disconnect clears it."""
-    client = MagicMock()
-    coordinator.client = client
-    coordinator._transport = None
-    coordinator._disconnect = _disconnect_clear_client(coordinator)
-    coordinator._ensure_connection = AsyncMock()
-
-    reconnect_error = await coordinator._disconnect_and_reconnect_for_retry(
-        register_type="input",
-        start_address=0,
-        attempt=1,
-    )
-
-    assert reconnect_error is None
-    assert coordinator.client is client
-    coordinator._ensure_connection.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_disconnect_retry_transportless_returns_disconnect_error(coordinator):
-    """Transport-less retry returns disconnect error and skips reconnect."""
-    client = MagicMock()
-    coordinator.client = client
-    coordinator._transport = None
-    coordinator._disconnect = _disconnect_raise_oserror()
-    coordinator._ensure_connection = AsyncMock()
-
-    reconnect_error = await coordinator._disconnect_and_reconnect_for_retry(
-        register_type="input",
-        start_address=0,
-        attempt=1,
-    )
-
-    assert isinstance(reconnect_error, OSError)
-    coordinator._ensure_connection.assert_not_awaited()
-
-
-def _disconnect_clear_client(coordinator):
-    async def _disconnect() -> None:
-        coordinator.client = None
-
-    return _disconnect
-
-
-def _disconnect_raise_oserror():
-    async def _disconnect() -> None:
-        raise OSError("disconnect failed")
-
-    return _disconnect
-
-
-@pytest.mark.asyncio
 async def test_async_write_multi_register_start(coordinator, monkeypatch):
     """Writing multi-register from start address succeeds."""
     coordinator.async_request_refresh = AsyncMock()

--- a/tests/test_coordinator_connection.py
+++ b/tests/test_coordinator_connection.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+
+
+@pytest.fixture
+def coordinator() -> ThesslaGreenModbusCoordinator:
+    coord = ThesslaGreenModbusCoordinator.from_params(
+        hass=MagicMock(),
+        host="localhost",
+        port=502,
+        slave_id=1,
+        name="test",
+        scan_interval=30,
+        timeout=10,
+        retry=3,
+    )
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_disconnect_retry_transportless_restores_client(coordinator):
+    """Transport-less retry restores client when disconnect clears it."""
+    client = MagicMock()
+    coordinator.client = client
+    coordinator._transport = None
+    coordinator._disconnect = _disconnect_clear_client(coordinator)
+    coordinator._ensure_connection = AsyncMock()
+
+    reconnect_error = await coordinator._disconnect_and_reconnect_for_retry(
+        register_type="input",
+        start_address=0,
+        attempt=1,
+    )
+
+    assert reconnect_error is None
+    assert coordinator.client is client
+    coordinator._ensure_connection.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_retry_transportless_returns_disconnect_error(coordinator):
+    """Transport-less retry returns disconnect error and skips reconnect."""
+    client = MagicMock()
+    coordinator.client = client
+    coordinator._transport = None
+    coordinator._disconnect = _disconnect_raise_oserror()
+    coordinator._ensure_connection = AsyncMock()
+
+    reconnect_error = await coordinator._disconnect_and_reconnect_for_retry(
+        register_type="input",
+        start_address=0,
+        attempt=1,
+    )
+
+    assert isinstance(reconnect_error, OSError)
+    coordinator._ensure_connection.assert_not_awaited()
+
+
+def _disconnect_clear_client(coordinator):
+    async def _disconnect() -> None:
+        coordinator.client = None
+
+    return _disconnect
+
+
+def _disconnect_raise_oserror():
+    async def _disconnect() -> None:
+        raise OSError("disconnect failed")
+
+    return _disconnect


### PR DESCRIPTION
### Motivation
- Continue decomposing the large coordinator test surface into focused modules to improve maintainability by extracting a coherent transport/reconnect behavior group into its own file.

### Description
- Added `tests/test_coordinator_connection.py` which contains a local `coordinator` fixture plus the two transport-less reconnect tests: `test_disconnect_retry_transportless_restores_client` and `test_disconnect_retry_transportless_returns_disconnect_error`, and the two local helpers `_disconnect_clear_client` and `_disconnect_raise_oserror`.
- Removed the exact complete decorated test blocks and their local helpers from `tests/test_coordinator.py` without changing assertions, decorators, parametrization, or any production code or coordinator behavior.

### Testing
- Performed environment/setup and static checks with `python -m pip install -q -r requirements-dev.txt`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, and `ruff check custom_components tests tools` which passed.
- Ran focused and full test commands including `pytest -q tests/test_coordinator.py tests/test_coordinator_connection.py tests/test_coordinator_coverage.py tests/test_coordinator_setup.py`, `pytest -q tests/test_coordinator*.py`, and `pytest tests/ -q`; all tests passed (with the repository's pre-existing expected skips for optional extras).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f133b4a51083268881020f769e3da5)