### PR TITLE
refactor: continue mapping builder decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -65,6 +65,42 @@ def _parse_info_states(info_text: str) -> dict[str, int]:
     return states
 
 
+def _is_register_mapped_anywhere(register: str, mappings: tuple[dict[str, Any], ...]) -> bool:
+    """Return True when *register* exists in any mapping dictionary."""
+    return any(_is_already_mapped(register, current_map) for current_map in mappings)
+
+
+def _build_problem_binary_mapping(register: str) -> dict[str, Any]:
+    """Return standard mapping payload for problem-style binary sensors."""
+    return {
+        "translation_key": register,
+        "icon": "mdi:alert-circle",
+        "register_type": "holding_registers",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+    }
+
+
+def _build_time_like_mapping(register: str) -> dict[str, Any]:
+    """Return standard mapping payload for time-like register entities."""
+    return {
+        "translation_key": register,
+        "icon": "mdi:clock-outline",
+        "register_type": "holding_registers",
+    }
+
+
+def _build_season_setting_mapping(register: str) -> dict[str, Any]:
+    """Return standard mapping payload for seasonal settings."""
+    from ..schedule_helpers import PERCENT_10_SELECT_STATES
+
+    return {
+        "translation_key": register,
+        "icon": "mdi:fan",
+        "register_type": "holding_registers",
+        "states": PERCENT_10_SELECT_STATES,
+    }
+
+
 def _get_parent() -> Any:
     """Return the parent mappings package module for attribute resolution.
 
@@ -280,8 +316,6 @@ def _extend_entity_mappings_from_registers() -> None:
     avoid creating unnamed "Rekuperator" fallback entities for reserved or
     undocumented registers.
     """
-    from ..schedule_helpers import PERCENT_10_SELECT_STATES
-
     _get_all = _resolve("get_all_registers", get_all_registers)
     _tkeys = _resolve("_load_translation_keys", _load_translation_keys)
     _num_tkeys = _resolve("_number_translation_keys", _number_translation_keys)
@@ -309,9 +343,9 @@ def _extend_entity_mappings_from_registers() -> None:
         if reg.function != 3 or not reg.name:
             continue
         register = reg.name
-        if any(
-            _is_already_mapped(register, current_map)
-            for current_map in (
+        if _is_register_mapped_anywhere(
+            register,
+            (
                 number_mappings,
                 sensor_mappings,
                 binary_mappings,
@@ -319,7 +353,7 @@ def _extend_entity_mappings_from_registers() -> None:
                 select_mappings,
                 text_mappings,
                 time_mappings,
-            )
+            ),
         ):
             continue
         if _is_mapped_as_binary_source(register, binary_mappings):
@@ -330,12 +364,7 @@ def _extend_entity_mappings_from_registers() -> None:
                 continue
             binary_mappings.setdefault(
                 register,
-                {
-                    "translation_key": register,
-                    "icon": "mdi:alert-circle",
-                    "register_type": "holding_registers",
-                    "device_class": BinarySensorDeviceClass.PROBLEM,
-                },
+                _build_problem_binary_mapping(register),
             )
             continue
 
@@ -347,20 +376,12 @@ def _extend_entity_mappings_from_registers() -> None:
             if register.startswith(_TIME_ENTITY_PREFIXES) and "W" in reg_access:
                 time_mappings.setdefault(
                     register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:clock-outline",
-                        "register_type": "holding_registers",
-                    },
+                    _build_time_like_mapping(register),
                 )
             else:
                 sensor_mappings.setdefault(
                     register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:clock-outline",
-                        "register_type": "holding_registers",
-                    },
+                    _build_time_like_mapping(register),
                 )
             continue
 
@@ -369,12 +390,7 @@ def _extend_entity_mappings_from_registers() -> None:
             if "W" in reg_access:
                 select_mappings.setdefault(
                     register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:fan",
-                        "register_type": "holding_registers",
-                        "states": PERCENT_10_SELECT_STATES,
-                    },
+                    _build_season_setting_mapping(register),
                 )
             else:
                 sensor_mappings.setdefault(
@@ -508,11 +524,15 @@ def _extend_entity_mappings_from_registers() -> None:
 
 __all__ = [
     "_TIME_ENTITY_PREFIXES",
+    "_build_problem_binary_mapping",
+    "_build_season_setting_mapping",
+    "_build_time_like_mapping",
     "_extend_entity_mappings_from_registers",
     "_get_parent",
     "_is_already_mapped",
     "_is_mapped_as_binary_source",
     "_is_problem_register",
+    "_is_register_mapped_anywhere",
     "_load_discrete_mappings",
     "_load_number_mappings",
     "_parse_info_states",

--- a/tests/test_entity_mappings_helpers.py
+++ b/tests/test_entity_mappings_helpers.py
@@ -1,11 +1,15 @@
 """Direct tests for pure mapping-builder helper functions."""
 
 from custom_components.thessla_green_modbus.mappings._mapping_builders import (
+    _build_problem_binary_mapping,
+    _build_time_like_mapping,
     _is_already_mapped,
     _is_mapped_as_binary_source,
     _is_problem_register,
+    _is_register_mapped_anywhere,
     _parse_info_states,
 )
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
 
 def test_is_already_mapped_true_and_false() -> None:
@@ -35,3 +39,25 @@ def test_is_problem_register_variants() -> None:
 def test_parse_info_states_parses_and_skips_invalid_parts() -> None:
     parsed = _parse_info_states("0 - off; x - broken;1 - on;ignored")
     assert parsed == {"off": 0, "on": 1}
+
+
+def test_is_register_mapped_anywhere() -> None:
+    assert _is_register_mapped_anywhere("reg_a", ({"reg_a": {}}, {"reg_b": {}})) is True
+    assert _is_register_mapped_anywhere("reg_x", ({"reg_a": {}}, {"reg_b": {}})) is False
+
+
+def test_build_problem_binary_mapping_shape() -> None:
+    assert _build_problem_binary_mapping("alarm") == {
+        "translation_key": "alarm",
+        "icon": "mdi:alert-circle",
+        "register_type": "holding_registers",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+    }
+
+
+def test_build_time_like_mapping_shape() -> None:
+    assert _build_time_like_mapping("schedule_slot") == {
+        "translation_key": "schedule_slot",
+        "icon": "mdi:clock-outline",
+        "register_type": "holding_registers",
+    }


### PR DESCRIPTION
### Motivation

- Reduce duplication and complexity in the mapping builder by extracting small pure helpers for repeated payload construction and membership checks while preserving mapping output exactly.

### Description

- Added pure helper functions: `_is_register_mapped_anywhere`, `_build_problem_binary_mapping`, `_build_time_like_mapping`, and `_build_season_setting_mapping` and updated `__all__` to export them.
- Replaced repeated inline mapping dicts and `any(...)` membership checks inside `_extend_entity_mappings_from_registers` with the new helper calls to simplify the function without changing decision logic.
- Added focused unit tests for the new helpers in `tests/test_entity_mappings_helpers.py` to cover shapes and membership behavior.
- Changes are limited to `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` and `tests/test_entity_mappings_helpers.py` only.

### Testing

- Ran `python -m pip install -q -r requirements-dev.txt` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` which succeeded.
- Ran `ruff check custom_components tests tools` which succeeded after an auto-fix, and ran targeted tests `pytest -q tests/test_entity_mappings*.py` and related platform tests which all passed.
- Ran the full test suite with `pytest tests/ -q` which passed in this environment with the existing, expected skips reported by the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19c3ea7e083269e377d37f221af15)