### PR TITLE
refactor: extract config flow validation helpers

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -59,18 +59,18 @@ from .config_flow_runtime import (
 )
 from .config_flow_runtime import run_with_retry as _run_with_retry_impl
 from .config_flow_schema import build_connection_schema as _build_connection_schema_impl
+from .config_flow_steps import merge_options_payload as _merge_options_payload_impl
+from .config_flow_steps import validate_options_submission as _validate_options_submission_impl
 from .config_flow_user_submit import process_user_submission as _process_user_submission_impl
 from .config_flow_validation import process_scan_capabilities as _process_scan_capabilities_impl
 from .config_flow_validation import validate_rtu_config as _validate_rtu_config_impl
 from .config_flow_validation import validate_slave_id as _validate_slave_id_impl
 from .config_flow_validation import validate_tcp_config as _validate_tcp_config_impl
 from .const import (
-    CONF_MAX_REGISTERS_PER_REQUEST,
     CONF_SLAVE_ID,
     CONF_TIMEOUT,
     CONNECTION_TYPE_TCP,
     DEFAULT_DEEP_SCAN,
-    DEFAULT_MAX_REGISTERS_PER_REQUEST,
     DEFAULT_NAME,
     DEFAULT_PARITY,
     DEFAULT_PORT,
@@ -494,16 +494,16 @@ class OptionsFlow(config_entries.OptionsFlow):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            max_regs = user_input.get(
-                CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
+            errors.update(
+                _validate_options_submission_impl(
+                    user_input,
+                    max_batch_registers=MAX_BATCH_REGISTERS,
+                )
             )
-            if not 1 <= max_regs <= MAX_BATCH_REGISTERS:
-                errors[CONF_MAX_REGISTERS_PER_REQUEST] = "max_registers_range"
-            else:
+            if not errors:
                 # Merge into existing options (do not wipe other keys)
                 entry_options = getattr(self.config_entry, "options", {}) or {}
-                merged = dict(entry_options)
-                merged.update(dict(user_input))
+                merged = _merge_options_payload_impl(entry_options, user_input)
                 return self.async_create_entry(title="", data=merged)
 
         entry_data = getattr(self.config_entry, "data", {}) or {}

--- a/custom_components/thessla_green_modbus/config_flow_steps.py
+++ b/custom_components/thessla_green_modbus/config_flow_steps.py
@@ -1,1 +1,30 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Pure step helpers for config flow orchestration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .const import CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
+
+
+def validate_options_submission(
+    user_input: dict[str, Any],
+    *,
+    max_batch_registers: int,
+) -> dict[str, str]:
+    """Validate options form submission and return field errors."""
+    errors: dict[str, str] = {}
+    max_regs = user_input.get(CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST)
+    if not 1 <= max_regs <= max_batch_registers:
+        errors[CONF_MAX_REGISTERS_PER_REQUEST] = "max_registers_range"
+    return errors
+
+
+def merge_options_payload(
+    existing_options: dict[str, Any] | None,
+    user_input: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge user input into existing options without dropping keys."""
+    merged = dict(existing_options or {})
+    merged.update(dict(user_input))
+    return merged


### PR DESCRIPTION
### Motivation
- Reduce complexity in the config flow by extracting pure validation and payload-normalization helpers from step orchestration so the options step remains focused and easier to maintain.

### Description
- Added `custom_components/thessla_green_modbus/config_flow_steps.py` with `validate_options_submission()` to centralize max-registers validation and `merge_options_payload()` to safely merge new options into existing options.
- Updated `custom_components/thessla_green_modbus/config_flow.py` to delegate options-step validation and merging to the new helpers and removed the now-unused inline constants, preserving UI schemas and flow behavior.
- No behavior, schema, or coordinator changes were made and only allowed config-flow files were modified.

### Testing
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which succeeded.
- Ran `pytest -q tests/test_config_flow_*.py` and `pytest -q tests/test_integration.py tests/test_migration.py` which succeeded.
- Ran `ruff check custom_components tests tools` and `pytest tests/ -q` which both succeeded (test suite passed with expected skips for optional extras).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19c34a3f483269ad23c1371f21806)