### PR TITLE
refactor: continue service handler cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -54,6 +54,15 @@ async def _write_device_name(coordinator: object, device_name: str, batch: int) 
     return True
 
 
+
+
+async def _refresh_and_log(
+    coordinator: object, deps: ServiceHandlerDeps, message: str, *args: object
+) -> None:
+    await coordinator.async_request_refresh()
+    deps.logger.info(message, *args)
+
+
 def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
     """Register maintenance services."""
 
@@ -67,8 +76,7 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
             ):
                 deps.logger.error("Failed to reset filters for %s", entity_id)
                 continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Reset filters for %s", entity_id)
+            await _refresh_and_log(coordinator, deps, "Reset filters for %s", entity_id)
 
     async def reset_settings(call: ServiceCall) -> None:
         reset_type = deps.normalize_option(call.data["reset_type"])
@@ -85,8 +93,9 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                 ):
                     deps.logger.error("Failed to reset schedule settings for %s", entity_id)
                     continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Reset settings (%s) for %s", reset_type, entity_id)
+            await _refresh_and_log(
+                coordinator, deps, "Reset settings (%s) for %s", reset_type, entity_id
+            )
 
     async def start_pressure_test(call: ServiceCall) -> None:
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
@@ -103,8 +112,7 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
             ):
                 deps.logger.error("Failed to start pressure test for %s", entity_id)
                 continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Started pressure test for %s", entity_id)
+            await _refresh_and_log(coordinator, deps, "Started pressure test for %s", entity_id)
 
     async def set_modbus_parameters(call: ServiceCall) -> None:
         port, baud_rate, parity, stop_bits = _normalize_modbus_options(deps, call)
@@ -141,8 +149,9 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                 ):
                     deps.logger.error("Failed to set stop bits for %s", entity_id)
                     continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Set Modbus parameters for %s", entity_id)
+            await _refresh_and_log(
+                coordinator, deps, "Set Modbus parameters for %s", entity_id
+            )
 
     async def set_device_name(call: ServiceCall) -> None:
         device_name = call.data["device_name"]
@@ -166,8 +175,9 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                 except (ModbusException, ConnectionException) as err:
                     deps.logger.error("Failed to set device name for %s: %s", entity_id, err)
                     continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Set device name to '%s' for %s", device_name, entity_id)
+            await _refresh_and_log(
+                coordinator, deps, "Set device name to '%s' for %s", device_name, entity_id
+            )
 
     async def sync_time(call: ServiceCall) -> None:
         from datetime import datetime as _dt

--- a/custom_components/thessla_green_modbus/services_handlers_mode.py
+++ b/custom_components/thessla_green_modbus/services_handlers_mode.py
@@ -8,6 +8,13 @@ from .services_handler_deps import ServiceHandlerDeps
 from .services_schema import SET_SPECIAL_MODE_SCHEMA
 
 
+async def _refresh_and_log_mode_success(
+    coordinator: object, deps: ServiceHandlerDeps, mode: str, entity_id: str
+) -> None:
+    await coordinator.async_request_refresh()
+    deps.logger.info("Set special mode %s for %s", mode, entity_id)
+
+
 def register_mode_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
     """Register mode-related services."""
 
@@ -34,8 +41,7 @@ def register_mode_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> Non
                         deps.logger.error("Failed to set duration for %s on %s", mode, entity_id)
                         continue
 
-            await coordinator.async_request_refresh()
-            deps.logger.info("Set special mode %s for %s", mode, entity_id)
+            await _refresh_and_log_mode_success(coordinator, deps, mode, entity_id)
 
     hass.services.async_register(
         deps.domain, "set_special_mode", set_special_mode, SET_SPECIAL_MODE_SCHEMA

--- a/custom_components/thessla_green_modbus/services_handlers_parameters.py
+++ b/custom_components/thessla_green_modbus/services_handlers_parameters.py
@@ -30,6 +30,18 @@ async def _write_optional_register(
     return True
 
 
+
+
+async def _refresh_and_log_success(
+    coordinator: object,
+    deps: ServiceHandlerDeps,
+    message: str,
+    entity_id: str,
+) -> None:
+    await coordinator.async_request_refresh()
+    deps.logger.info(message, entity_id)
+
+
 def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
     """Register parameter/configuration services."""
 
@@ -55,8 +67,9 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
                     "Failed to set bypass min temperature for %s",
                 ):
                     continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Set bypass parameters for %s", entity_id)
+            await _refresh_and_log_success(
+                coordinator, deps, "Set bypass parameters for %s", entity_id
+            )
 
     async def set_gwc_parameters(call: ServiceCall) -> None:
         mode = deps.normalize_option(call.data["mode"])
@@ -90,8 +103,9 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
                 "Failed to set GWC max air temperature for %s",
             ):
                 continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Set GWC parameters for %s", entity_id)
+            await _refresh_and_log_success(
+                coordinator, deps, "Set GWC parameters for %s", entity_id
+            )
 
     async def set_air_quality_thresholds(call: ServiceCall) -> None:
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
@@ -112,8 +126,9 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
                         break
             if not success:
                 continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Set air quality thresholds for %s", entity_id)
+            await _refresh_and_log_success(
+                coordinator, deps, "Set air quality thresholds for %s", entity_id
+            )
 
     async def set_temperature_curve(call: ServiceCall) -> None:
         slope = call.data["slope"]
@@ -152,8 +167,9 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
                 "Failed to set min supply temperature for %s",
             ):
                 continue
-            await coordinator.async_request_refresh()
-            deps.logger.info("Set temperature curve for %s", entity_id)
+            await _refresh_and_log_success(
+                coordinator, deps, "Set temperature curve for %s", entity_id
+            )
 
     hass.services.async_register(
         deps.domain, "set_bypass_parameters", set_bypass_parameters, SET_BYPASS_PARAMETERS_SCHEMA

--- a/custom_components/thessla_green_modbus/services_handlers_schedule.py
+++ b/custom_components/thessla_green_modbus/services_handlers_schedule.py
@@ -8,6 +8,16 @@ from .services_handler_deps import ServiceHandlerDeps
 from .services_schema import SET_AIRFLOW_SCHEDULE_SCHEMA
 
 
+def _resolve_schedule_temperature_byte(
+    coordinator: object, setting_register: str, temperature: float | None
+) -> int:
+    if temperature is not None:
+        return max(0, min(39, round((temperature - 16.0) * 2)))
+
+    current = coordinator.data.get(setting_register) if coordinator.data else None
+    return int(current) & 0xFF if isinstance(current, int) else 0
+
+
 def register_schedule_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
     """Register schedule-related services."""
 
@@ -53,11 +63,9 @@ def register_schedule_services(hass: HomeAssistant, deps: ServiceHandlerDeps) ->
                 deps.logger.error("Failed to set schedule start for %s", entity_id)
                 continue
 
-            if temperature is not None:
-                temp_byte = max(0, min(39, round((temperature - 16.0) * 2)))
-            else:
-                current = coordinator.data.get(setting_register) if coordinator.data else None
-                temp_byte = int(current) & 0xFF if isinstance(current, int) else 0
+            temp_byte = _resolve_schedule_temperature_byte(
+                coordinator, setting_register, temperature
+            )
             aatt_value = ((clamped_airflow & 0xFF) << 8) | (temp_byte & 0xFF)
 
             if not await deps.write_register(


### PR DESCRIPTION
### Motivation
- Reduce duplicated refresh+info logging and small branching logic across service handler modules to improve readability and maintainability without changing public behavior.
- Keep service schemas, names, write order, and coordinator interactions unchanged while removing repeated patterns.

### Description
- Applied small helper extractions and call-site replacements in four service handler modules: `services_handlers_maintenance.py`, `services_handlers_parameters.py`, `services_handlers_mode.py`, and `services_handlers_schedule.py`.
- Added `_refresh_and_log`, `_refresh_and_log_success`, and `_refresh_and_log_mode_success` to centralize the `async_request_refresh()` + `logger.info()` pattern and replaced repeated inline sequences with these helpers.
- Extracted `_resolve_schedule_temperature_byte` to isolate the temperature→byte conversion and removed the inline conditional branch in the schedule handler.
- Preserved all service registrations, schema references, service names, register write calls, and exception behavior (no schema/coordinator changes were made).

### Testing
- Ran dependency install and environment validation via `python -m pip install -q -r requirements-dev.txt` and compile checks with `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both of which succeeded.
- Ran linter `ruff check custom_components tests tools` which passed after minor import formatting fixes.
- Executed focused service tests with `pytest -q tests/test_services_handlers_*.py tests/test_services.py tests/test_services_scaling.py` and then the full test suite with `pytest tests/ -q`, and all tests passed (with the expected skips for optional extras).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19f2e03088326a07428ef954ef444)