### PR TITLE
Clarify timeout behavior in call_with_optional_timeout docstring

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow_runtime.py
+++ b/custom_components/thessla_green_modbus/config_flow_runtime.py
@@ -50,7 +50,11 @@ async def run_with_retry(
 
 
 async def call_with_optional_timeout(func: Callable[[], Any], timeout: float) -> Any:
-    """Call ``func`` and apply timeout only to awaitable results."""
+    """Call ``func`` and apply timeout only to awaitable results.
+
+    This keeps synchronous helper callbacks inexpensive while still
+    enforcing IO timeouts for coroutine-returning scanner operations.
+    """
     result = func()
     if inspect.isawaitable(result):
         return await asyncio.wait_for(result, timeout=timeout)


### PR DESCRIPTION
### Motivation
- Clarify that `call_with_optional_timeout` applies timeouts only to awaitable results so synchronous helper callbacks remain inexpensive while IO timeouts are enforced for coroutine-returning scanner operations.

### Description
- Expand the docstring for `call_with_optional_timeout` in `custom_components/thessla_green_modbus/config_flow_runtime.py` to explain the timeout semantics and rationale without changing runtime behavior.

### Testing
- Ran the repository's automated test suite with `pytest -q` and static checks with `flake8`, and all tests/checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a93955a88326950bef271185ee35)