### PR TITLE
Refactor entity availability checks and centralize register write logic

### DIFF
--- a/custom_components/thessla_green_modbus/entity.py
+++ b/custom_components/thessla_green_modbus/entity.py
@@ -73,11 +73,17 @@ class ThesslaGreenEntity(CoordinatorEntity):
         This property forms part of the entity API and is queried by Home
         Assistant even though it is not referenced in the codebase.
         """
-        return (
-            self.coordinator.last_update_success
-            and self.coordinator.data.get(self._key) is not None
-            and not getattr(self.coordinator, "offline_state", False)
+        return self._coordinator_connected() and self._has_value(self._key)
+
+    def _coordinator_connected(self) -> bool:
+        """Return True when coordinator has an up-to-date online state."""
+        return self.coordinator.last_update_success and not getattr(
+            self.coordinator, "offline_state", False
         )
+
+    def _has_value(self, key: str) -> bool:
+        """Return True when a key has non-None state in coordinator data."""
+        return self.coordinator.data.get(key) is not None
 
     def _percentage_limits(self) -> tuple[int, int]:
         """Return min/max percentage limits derived from coordinator data."""

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -91,11 +91,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
     @property
     def available(self) -> bool:
         """Return if the fan entity is available."""
-        return (
-            self.coordinator.last_update_success
-            and self.coordinator.data.get("on_off_panel_mode") is not None
-            and not getattr(self.coordinator, "offline_state", False)
-        )
+        return self._coordinator_connected() and self._has_value("on_off_panel_mode")
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -191,15 +191,8 @@ class ThesslaGreenNumber(ThesslaGreenEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         try:
-            success = await self.coordinator.async_write_register(
-                self.register_name, value, refresh=False, offset=0
-            )
-            if success:
-                await self.coordinator.async_request_refresh()
-                _LOGGER.debug("Set %s to %.2f", self.register_name, value)
-            else:
-                _LOGGER.error("Failed to set %s to %.2f", self.register_name, value)
-                raise RuntimeError(f"Failed to write register {self.register_name}")
+            await self._write_register(self.register_name, value, include_offset=True)
+            _LOGGER.debug("Set %s to %.2f", self.register_name, value)
 
         except (ModbusException, ConnectionException, RuntimeError) as exc:
             _LOGGER.error("Failed to set %s to %.2f: %s", self.register_name, value, exc)

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -104,9 +104,7 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
         the entity disappearing as «unavailable».
         """
         if self._register_name.startswith(BCD_TIME_PREFIXES + SETTING_SCHEDULE_PREFIXES):
-            return self.coordinator.last_update_success and not getattr(
-                self.coordinator, "offline_state", False
-            )
+            return self._coordinator_connected()
         return super().available
 
     @property
@@ -135,9 +133,11 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
 
         value = self._states[option]
         try:
-            success = await self.coordinator.async_write_register(
-                self._register_name, value, refresh=False
-            )
+            await self._write_register(self._register_name, value)
+        except RuntimeError as err:
+            msg = f"Failed to set {self._register_name} to {option}: {err}"
+            _LOGGER.error(msg)
+            raise HomeAssistantError(msg) from err
         except (ModbusException, ConnectionException) as err:
             err_txt = str(err)
             for prefix in ("Modbus Error: [Connection] ", "Modbus Error: "):
@@ -147,10 +147,3 @@ class ThesslaGreenSelect(ThesslaGreenEntity, SelectEntity):
             msg = f"Error setting {self._register_name} to {option}: {err_txt}"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg) from err
-
-        if success:
-            await self.coordinator.async_request_refresh()
-        else:
-            msg = f"Failed to set {self._register_name} to {option}"
-            _LOGGER.error(msg)
-            raise HomeAssistantError(msg)

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -245,4 +245,4 @@ class ThesslaGreenSwitch(ThesslaGreenEntity, SwitchEntity):
         """Return if entity is available."""
         # For switch entities, we don't require the register to be in current data
         # as they are primarily for control, not just display.
-        return bool(self.coordinator.last_update_success)
+        return self._coordinator_connected()

--- a/custom_components/thessla_green_modbus/text.py
+++ b/custom_components/thessla_green_modbus/text.py
@@ -89,9 +89,7 @@ class ThesslaGreenText(ThesslaGreenEntity, TextEntity):
     @property
     def available(self) -> bool:
         """Return True whenever the coordinator is connected."""
-        return self.coordinator.last_update_success and not getattr(
-            self.coordinator, "offline_state", False
-        )
+        return self._coordinator_connected()
 
     @property
     def native_value(self) -> str | None:
@@ -104,14 +102,9 @@ class ThesslaGreenText(ThesslaGreenEntity, TextEntity):
     async def async_set_value(self, value: str) -> None:
         """Write a new string value to the register."""
         try:
-            success = await self.coordinator.async_write_register(
-                self._register_name, value, refresh=False
-            )
+            await self._write_register(self._register_name, value)
         except (ModbusException, ConnectionException) as err:
             _LOGGER.error("Error setting %s to %r: %s", self._register_name, value, err)
             return
-
-        if success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.error("Failed to set %s to %r", self._register_name, value)
+        except RuntimeError as err:
+            _LOGGER.error("Failed to set %s to %r: %s", self._register_name, value, err)

--- a/custom_components/thessla_green_modbus/time.py
+++ b/custom_components/thessla_green_modbus/time.py
@@ -94,9 +94,7 @@ class ThesslaGreenTime(ThesslaGreenEntity, TimeEntity):
         0xFFFF), so we keep the entity available to allow the user to set
         an initial value.
         """
-        return self.coordinator.last_update_success and not getattr(
-            self.coordinator, "offline_state", False
-        )
+        return self._coordinator_connected()
 
     @property
     def native_value(self) -> dt_time | None:
@@ -130,14 +128,9 @@ class ThesslaGreenTime(ThesslaGreenEntity, TimeEntity):
         """
         time_str = f"{value.hour:02d}:{value.minute:02d}"
         try:
-            success = await self.coordinator.async_write_register(
-                self._register_name, time_str, refresh=False
-            )
+            await self._write_register(self._register_name, time_str)
         except (ModbusException, ConnectionException) as err:
             _LOGGER.error("Error setting %s to %s: %s", self._register_name, time_str, err)
             return
-
-        if success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.error("Failed to set %s to %s", self._register_name, time_str)
+        except RuntimeError as err:
+            _LOGGER.error("Failed to set %s to %s: %s", self._register_name, time_str, err)


### PR DESCRIPTION
### Motivation

- Consolidate and standardize how entities determine coordinator connectivity and presence of register values.
- Centralize register write behavior to ensure consistent offset/refresh handling and unified error reporting across entities.

### Description

- Add `_coordinator_connected` and `_has_value` helpers to `ThesslaGreenEntity` and replace scattered availability checks with these helpers in `fan.py`, `select.py`, `switch.py`, `text.py`, and `time.py`.
- Replace direct calls to `coordinator.async_write_register` with the `_write_register` wrapper in `number.py`, `select.py`, `text.py`, and `time.py` to unify write semantics and include offset handling where needed.
- Update `ThesslaGreenFan.available` to require the `on_off_panel_mode` value via `_has_value`, and simplify `ThesslaGreenSwitch.available` to use the coordinator-connected check.
- Improve error handling when writes fail by logging and mapping errors to appropriate exceptions (including raising `HomeAssistantError` for select writes).

### Testing

- Ran the repository unit test suite with `pytest` and all tests passed.
- Ran static checks with `flake8` and `mypy` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a94cf9ac8326a1ed7745612f1274)