### PR TITLE
refactor: continue mapping builder cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -101,6 +101,36 @@ def _build_season_setting_mapping(register: str) -> dict[str, Any]:
     }
 
 
+def _build_switch_mapping(register: str) -> dict[str, Any]:
+    """Return standard mapping payload for writable on/off style registers."""
+    return {
+        "icon": "mdi:toggle-switch",
+        "register": register,
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": register,
+    }
+
+
+def _build_binary_toggle_mapping(register: str) -> dict[str, Any]:
+    """Return standard mapping payload for read-only on/off style registers."""
+    return {
+        "translation_key": register,
+        "icon": "mdi:checkbox-marked-circle-outline",
+        "register_type": "holding_registers",
+    }
+
+
+def _build_select_mapping(register: str, states: dict[str, int]) -> dict[str, Any]:
+    """Return standard mapping payload for select entities based on states."""
+    return {
+        "icon": "mdi:format-list-bulleted",
+        "translation_key": register,
+        "states": states,
+        "register_type": "holding_registers",
+    }
+
+
 def _get_parent() -> Any:
     """Return the parent mappings package module for attribute resolution.
 
@@ -419,36 +449,21 @@ def _extend_entity_mappings_from_registers() -> None:
                         continue
                     switch_mappings.setdefault(
                         register,
-                        {
-                            "icon": "mdi:toggle-switch",
-                            "register": register,
-                            "register_type": "holding_registers",
-                            "category": None,
-                            "translation_key": register,
-                        },
+                        _build_switch_mapping(register),
                     )
                 else:
                     if register not in binary_keys:
                         continue
                     binary_mappings.setdefault(
                         register,
-                        {
-                            "translation_key": register,
-                            "icon": "mdi:checkbox-marked-circle-outline",
-                            "register_type": "holding_registers",
-                        },
+                        _build_binary_toggle_mapping(register),
                     )
             elif "W" in access:
                 if register not in select_keys:
                     continue
                 select_mappings.setdefault(
                     register,
-                    {
-                        "icon": "mdi:format-list-bulleted",
-                        "translation_key": register,
-                        "states": enum_states,
-                        "register_type": "holding_registers",
-                    },
+                    _build_select_mapping(register, enum_states),
                 )
             else:
                 sensor_mappings.setdefault(
@@ -468,24 +483,14 @@ def _extend_entity_mappings_from_registers() -> None:
                         continue
                     switch_mappings.setdefault(
                         register,
-                        {
-                            "icon": "mdi:toggle-switch",
-                            "register": register,
-                            "register_type": "holding_registers",
-                            "category": None,
-                            "translation_key": register,
-                        },
+                        _build_switch_mapping(register),
                     )
                 else:
                     if register not in binary_keys:
                         continue
                     binary_mappings.setdefault(
                         register,
-                        {
-                            "translation_key": register,
-                            "icon": "mdi:checkbox-marked-circle-outline",
-                            "register_type": "holding_registers",
-                        },
+                        _build_binary_toggle_mapping(register),
                     )
                 continue
 
@@ -496,12 +501,7 @@ def _extend_entity_mappings_from_registers() -> None:
                         continue
                     select_mappings.setdefault(
                         register,
-                        {
-                            "icon": "mdi:format-list-bulleted",
-                            "translation_key": register,
-                            "states": states,
-                            "register_type": "holding_registers",
-                        },
+                        _build_select_mapping(register, states),
                     )
                     continue
 

--- a/tests/test_entity_mappings_helpers.py
+++ b/tests/test_entity_mappings_helpers.py
@@ -1,7 +1,10 @@
 """Direct tests for pure mapping-builder helper functions."""
 
 from custom_components.thessla_green_modbus.mappings._mapping_builders import (
+    _build_binary_toggle_mapping,
     _build_problem_binary_mapping,
+    _build_select_mapping,
+    _build_switch_mapping,
     _build_time_like_mapping,
     _is_already_mapped,
     _is_mapped_as_binary_source,
@@ -59,5 +62,32 @@ def test_build_time_like_mapping_shape() -> None:
     assert _build_time_like_mapping("schedule_slot") == {
         "translation_key": "schedule_slot",
         "icon": "mdi:clock-outline",
+        "register_type": "holding_registers",
+    }
+
+
+def test_build_switch_mapping_shape() -> None:
+    assert _build_switch_mapping("enable_feature") == {
+        "icon": "mdi:toggle-switch",
+        "register": "enable_feature",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "enable_feature",
+    }
+
+
+def test_build_binary_toggle_mapping_shape() -> None:
+    assert _build_binary_toggle_mapping("filter_dirty") == {
+        "translation_key": "filter_dirty",
+        "icon": "mdi:checkbox-marked-circle-outline",
+        "register_type": "holding_registers",
+    }
+
+
+def test_build_select_mapping_shape() -> None:
+    assert _build_select_mapping("mode", {"auto": 0, "manual": 1}) == {
+        "icon": "mdi:format-list-bulleted",
+        "translation_key": "mode",
+        "states": {"auto": 0, "manual": 1},
         "register_type": "holding_registers",
     }


### PR DESCRIPTION
### Motivation
- Reduce duplicated inline mapping payload dicts in `_extend_entity_mappings_from_registers` by extracting pure helper builders to improve clarity and testability.
- Preserve exact mapping output shape and behavior while making payload construction explicit and re-usable.

### Description
- Added three pure helper builders in `mappings/_mapping_builders.py`: `_build_switch_mapping`, `_build_binary_toggle_mapping`, and `_build_select_mapping` that return the exact mapping payload shapes for switch, binary-toggle and select entities respectively.
- Replaced duplicated inline dict literals in `_extend_entity_mappings_from_registers` with calls to the new helpers so mapping behavior is unchanged but duplication is removed.
- Added focused exact-shape unit tests in `tests/test_entity_mappings_helpers.py` to assert the helpers return the expected dictionaries and guard against regressions.

### Testing
- Ran linting and build checks with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both succeeded.
- Ran focused mapping tests with `pytest -q tests/test_entity_mappings*.py`, which passed, and additional platform tests `pytest -q tests/test_sensor_platform.py tests/test_select.py tests/test_switch.py tests/test_number.py tests/test_binary_sensor.py`, which passed.
- Full test suite `pytest tests/ -q` failed during collection due to pre-existing coordinator import errors unrelated to these mapping changes (`cannot import name 'dt_util'` / `cannot import name '_utcnow'`), so a full-suite run did not complete successfully.
- Maintainability check `python tools/check_maintainability.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1be53797c8326a687ac1fd5c9025f)