### PR TITLE
refactor(scanner): extract helpers and simplify read/error handling

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -52,6 +52,35 @@ def _log_read_abort(kind: str, start: int, end: int, attempt: int, retry: int) -
         retry,
     )
 
+def _handle_error_response(scanner: Any, *, register_type: str, start: int, end: int, code: int | None) -> None:
+    """Record failed range and unsupported range hints from an exception response."""
+    if register_type == "input_registers":
+        scanner._failed_input.update(range(start, end + 1))
+        scanner._mark_input_unsupported(start, end, code)
+    else:
+        scanner._failed_holding.update(range(start, end + 1))
+        scanner._mark_holding_unsupported(start, end, code)
+    _mark_failed_addresses(scanner, register_type, start, end)
+
+
+def _validate_register_response(response: Any) -> tuple[bool, int | None]:
+    """Return (is_error, exception_code) for a Modbus response-like object."""
+    if response is None:
+        return False, None
+    if response.isError():
+        return True, getattr(response, "exception_code", None)
+    return False, None
+
+
+def _should_abort_input_exception(exc: Exception) -> bool:
+    """Return True when input reads should stop retries immediately."""
+    if isinstance(exc, ModbusIOException):
+        return (
+            classify_transport_error(exc).kind is ErrorKind.CANCELLED
+            or is_request_cancelled_error(exc)
+        )
+    return isinstance(exc, (TimeoutError, OSError))
+
 
 def _log_read_failure(kind: str, start: int, end: int, retry: int) -> None:
     """Log terminal read failure after retry budget is exhausted."""
@@ -116,17 +145,21 @@ async def read_input(
                     backoff_jitter=scanner.backoff_jitter,
                 )
             if response is not None:
-                if response.isError():
-                    code = getattr(response, "exception_code", None)
+                is_error, code = _validate_register_response(response)
+                if is_error:
                     _LOGGER.warning(
                         "Exception code %s while reading input registers %d-%d",
                         code,
                         start,
                         end,
                     )
-                    scanner._failed_input.update(range(start, end + 1))
-                    scanner._mark_input_unsupported(start, end, code)
-                    _mark_failed_addresses(scanner, "input_registers", start, end)
+                    _handle_error_response(
+                        scanner,
+                        register_type="input_registers",
+                        start=start,
+                        end=end,
+                        code=code,
+                    )
                     return None
                 if skip_cache and count == 1:
                     scanner._mark_input_supported(address)
@@ -134,7 +167,6 @@ async def read_input(
                 _LOGGER.debug("Read input registers %d-%d: %s", start, end, registers)
                 return registers
         except ModbusIOException as exc:
-            decision = classify_transport_error(exc)
             log_scanner_retry(
                 operation=f"read_input:{start}-{end}",
                 attempt=attempt,
@@ -142,11 +174,11 @@ async def read_input(
                 exc=exc,
                 backoff=scanner.backoff,
             )
-            if decision.kind is ErrorKind.CANCELLED or is_request_cancelled_error(exc):
+            if _should_abort_input_exception(exc):
                 aborted_transiently = True
                 break
             track_input_failure(scanner, count, address)
-        except TimeoutError as exc:
+        except (TimeoutError, OSError) as exc:
             log_scanner_retry(
                 operation=f"read_input:{start}-{end}",
                 attempt=attempt,
@@ -154,16 +186,7 @@ async def read_input(
                 exc=exc,
                 backoff=scanner.backoff,
             )
-            aborted_transiently = True
-            break
-        except OSError as exc:
-            log_scanner_retry(
-                operation=f"read_input:{start}-{end}",
-                attempt=attempt,
-                max_attempts=scanner.retry,
-                exc=exc,
-                backoff=scanner.backoff,
-            )
+            aborted_transiently = isinstance(exc, TimeoutError)
             break
         except (ModbusException, ConnectionException) as exc:
             log_scanner_retry(
@@ -283,8 +306,8 @@ async def read_holding(
                     backoff_jitter=scanner.backoff_jitter,
                 )
             if response is not None:
-                if response.isError():
-                    code = getattr(response, "exception_code", None)
+                is_error, code = _validate_register_response(response)
+                if is_error:
                     _LOGGER.warning(
                         "Exception code %s while reading holding registers %d-%d",
                         code,
@@ -292,16 +315,24 @@ async def read_holding(
                         end,
                     )
                     if code == 2:
-                        scanner._failed_holding.update(range(start, end + 1))
-                        scanner._mark_holding_unsupported(start, end, code)
-                        _mark_failed_addresses(scanner, "holding_registers", start, end)
+                        _handle_error_response(
+                            scanner,
+                            register_type="holding_registers",
+                            start=start,
+                            end=end,
+                            code=code,
+                        )
                         return None
                     if count == 1:
                         track_holding_failure(scanner, count, address)
                         if address in scanner._failed_holding:
-                            scanner._failed_holding.update(range(start, end + 1))
-                            scanner._mark_holding_unsupported(start, end, code or 0)
-                            _mark_failed_addresses(scanner, "holding_registers", start, end)
+                            _handle_error_response(
+                                scanner,
+                                register_type="holding_registers",
+                                start=start,
+                                end=end,
+                                code=code or 0,
+                            )
                             return None
                     continue
                 if skip_cache and count == 1:

--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -26,6 +26,17 @@ from .io import is_request_cancelled_error
 _LOGGER = logging.getLogger(__name__)
 
 
+
+
+def _uses_custom_scan_impl(scanner: Any) -> bool:
+    """Return True when scanner.scan is overridden outside scanner.core."""
+    scan_method = scanner.scan
+    base_scan = getattr(type(scanner), "scan", None)
+    return getattr(scan_method, "__func__", None) is not base_scan or getattr(
+        base_scan, "__module__", ""
+    ) != "custom_components.thessla_green_modbus.scanner.core"
+
+
 async def run_full_scan(
     scanner: Any,
     input_max: int,
@@ -289,12 +300,7 @@ async def scan(scanner: Any) -> dict[str, Any]:
 async def scan_device(scanner: Any) -> dict[str, Any]:
     """Open the Modbus connection, perform a scan and close the client."""
     scan_method = scanner.scan
-    base_scan = getattr(type(scanner), "scan", None)
-    if (
-        getattr(scan_method, "__func__", None) is not base_scan
-        or getattr(base_scan, "__module__", "")
-        != "custom_components.thessla_green_modbus.scanner.core"
-    ):
+    if _uses_custom_scan_impl(scanner):
         try:
             scan_result: Any = scan_method()
             if inspect.isawaitable(scan_result):


### PR DESCRIPTION
### Motivation
- Continue cleanup of scanner I/O after extraction of read helpers by centralizing response/error handling and reducing duplicated logic in read flows.

### Description
- Added `_handle_error_response`, `_validate_register_response`, and `_should_abort_input_exception` to `scanner/io_read.py` and replaced duplicated response/error handling in `read_input` and `read_holding` with these helpers.
- Consolidated timeout/OS error handling into a single branch in `read_input` while preserving retry/backoff and failure-tracking semantics.
- Added `_uses_custom_scan_impl` to `scanner/orchestration.py` and used it in `scan_device` to isolate custom scan detection logic.
- Removed small duplicated blocks and improved readability while preserving behavior for unsupported-range handling, code==2 handling, and single-register failure tracking.

### Testing
- Ran lint and static checks with `ruff check custom_components tests tools` which passed.
- Verified byte-compile with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed.
- Ran scanner-focused tests `pytest -q tests/test_scanner_io.py tests/test_device_scanner.py` which passed.
- Ran unit tests `pytest -q tests/unit/test_transport_retry.py tests/unit/test_errors.py` which passed.
- Ran broader scanner test suite `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` which reported failures in `tests/test_scanner_close.py` due to coordinator attribute import expectations outside the allowed edit scope.
- Ran full `pytest tests/ -q` which failed during collection on coordinator-related imports that are outside the permitted change set, so the full test suite did not pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1be4cfae08326aa47ae1f81b0174b)