### PR TITLE
refactor: tighten coordinator package boundaries

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/errors.py
+++ b/custom_components/thessla_green_modbus/coordinator/errors.py
@@ -37,7 +37,7 @@ async def handle_update_error(
     use_helper: bool = True,
 ) -> UpdateFailed:
     """Shared error-handling path for coordinator update failures."""
-    from .errors import is_invalid_auth_error
+    from ..errors import is_invalid_auth_error
 
     apply_update_failure_state(coordinator, exc, timeout_error=timeout_error)
     await coordinator._disconnect()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -54,7 +54,7 @@ HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
 from custom_components.thessla_green_modbus.coordinator import (
     ThesslaGreenModbusCoordinator,
 )
-from custom_components.thessla_green_modbus.coordinator import (
+from custom_components.thessla_green_modbus.coordinator.coordinator import (
     dt_util as coordinator_dt_util,
 )
 
@@ -657,7 +657,7 @@ def test_post_process_data(coordinator):
     coordinator._last_power_timestamp = fake_now - timedelta(hours=1)
 
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.dt_util.utcnow",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.dt_util.utcnow",
         return_value=fake_now,
     ):
         processed_data = coordinator._post_process_data(raw_data)
@@ -803,7 +803,7 @@ async def test_reconfigure_does_not_leak_connections(coordinator):
             self.connected = False
 
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.AsyncModbusTcpClient",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.AsyncModbusTcpClient",
         FakeClient,
     ):
         for _ in range(3):
@@ -936,7 +936,7 @@ async def test_async_setup_invalid_capabilities(coordinator):
 
     with (
         patch(
-            "custom_components.thessla_green_modbus.coordinator.ThesslaGreenDeviceScanner.create",
+            "custom_components.thessla_green_modbus.coordinator.coordinator.ThesslaGreenDeviceScanner.create",
             AsyncMock(return_value=scanner_instance),
         ),
         pytest.raises(CannotConnect) as err,

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -476,7 +476,7 @@ def test_coordinator_init_max_registers_less_than_1():
 
 def test_coordinator_init_entry_bad_capabilities():
     """Invalid capabilities dict in entry.data is caught (lines 397-399)."""
-    from custom_components.thessla_green_modbus.coordinator import DeviceCapabilities
+    from custom_components.thessla_green_modbus.scanner import DeviceCapabilities
 
     entry = MagicMock()
     entry.entry_id = "test"
@@ -687,7 +687,7 @@ def test_apply_scan_cache_normalise_exception():
 
 def test_apply_scan_cache_invalid_capabilities():
     """Invalid capabilities dict in cache is caught silently (lines 994-995)."""
-    from custom_components.thessla_green_modbus.coordinator import DeviceCapabilities
+    from custom_components.thessla_green_modbus.scanner import DeviceCapabilities
 
     coord = _make_coordinator()
     with patch.object(DeviceCapabilities, "__init__", side_effect=TypeError("bad")):
@@ -1059,7 +1059,7 @@ def test_post_process_data_naive_now_aware_last_ts():
     coord._last_power_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     # Patch _utcnow to return naive datetime
     with patch(
-        "custom_components.thessla_green_modbus.coordinator._utcnow",
+        "custom_components.thessla_green_modbus.coordinator.coordinator._utcnow",
         return_value=datetime(2024, 1, 1, 12, 0, 30),  # naive
     ):
         data = {"dac_supply": 3.0, "dac_exhaust": 3.0}

--- a/tests/test_coordinator_setup.py
+++ b/tests/test_coordinator_setup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from unittest.mock import MagicMock
 
-from custom_components.thessla_green_modbus.coordinator import (
+from custom_components.thessla_green_modbus.coordinator.coordinator import (
     ThesslaGreenModbusCoordinator,
     _utcnow,
 )
@@ -77,5 +77,4 @@ def test_coordinator_init_jitter_zero():
     """backoff_jitter = 0 is stored as 0.0 (line 331-332)."""
     coord = _make_coordinator(backoff_jitter=0)
     assert coord.backoff_jitter == 0.0
-
 

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from custom_components.thessla_green_modbus.coordinator import (
+from custom_components.thessla_green_modbus.coordinator.coordinator import (
     ThesslaGreenModbusCoordinator,
     _utcnow,
 )


### PR DESCRIPTION
### Motivation
- The coordinator was migrated from a single `coordinator.py` module into a `coordinator/` package and the package surface needed to be tightened to avoid accidental self-imports and excessive re-exports.  
- A runtime import error during test collection revealed a bad internal import and tests relying on package-root re-exports that no longer exist.  

### Description
- Fix `handle_update_error` to import the integration-level helper with `from ..errors import is_invalid_auth_error` instead of importing from the coordinator package itself.  
- Update tests to import internal implementation symbols from the owning module, e.g. `from custom_components.thessla_green_modbus.coordinator.coordinator import dt_util` and `from custom_components.thessla_green_modbus.coordinator.coordinator import _utcnow` to reduce reliance on package-root re-exports.  
- Change `tests/test_coordinator_coverage.py` to import `DeviceCapabilities` directly from `custom_components.thessla_green_modbus.scanner` where it is defined.  
- No compatibility shims, proxy modules, or recreation of `coordinator.py` were added and the coordinator package public API was not widened.  

### Testing
- Ran `ruff check custom_components tests tools` and the linter passed.  
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` and compilation passed.  
- Ran `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` which completed but left 13 failing coordinator-related tests (failures are primarily around register-write behavior and connection/socket interaction in coordinator tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1be409c448326b92f24be4c961e4d)