### PR TITLE
test: further split scanner coverage tests

### DIFF
--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -9,10 +9,6 @@ from custom_components.thessla_green_modbus.const import (
     KNOWN_MISSING_REGISTERS,
     SENSOR_UNAVAILABLE,
 )
-from custom_components.thessla_green_modbus.modbus_exceptions import (
-    ModbusException,
-    ModbusIOException,
-)
 from custom_components.thessla_green_modbus.registers.loader import get_registers_by_function
 from custom_components.thessla_green_modbus.scanner.core import (
     DeviceCapabilities,
@@ -95,40 +91,8 @@ def mock_modbus_response():
     return response
 
 
-async def test_read_coil_retries_on_failure(caplog):
-    """Coil reads should retry on failure."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
-    mock_client = AsyncMock()
-
-    with (
-        patch(
-            "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
-            AsyncMock(side_effect=ModbusException("boom")),
-        ) as call_mock,
-        caplog.at_level(logging.DEBUG),
-        patch("asyncio.sleep", AsyncMock()),
-    ):
-        result = await scanner._read_coil(mock_client, 0, 1)
-        assert result is None
-        assert call_mock.await_count == scanner.retry
 
 
-async def test_read_discrete_retries_on_failure(caplog):
-    """Discrete input reads should retry on failure."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
-    mock_client = AsyncMock()
-
-    with (
-        patch(
-            "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
-            AsyncMock(side_effect=ModbusException("boom")),
-        ) as call_mock,
-        caplog.at_level(logging.DEBUG),
-        patch("asyncio.sleep", AsyncMock()),
-    ):
-        result = await scanner._read_discrete(mock_client, 0, 1)
-        assert result is None
-        assert call_mock.await_count == scanner.retry
 
 
 async def test_scan_device_success_static(mock_modbus_response):
@@ -177,199 +141,15 @@ async def test_scan_device_success_static(mock_modbus_response):
                 assert "expansion" in result["available_registers"]["discrete_inputs"]
 
 
-async def test_scan_device_connection_failure():
-    """Test device scan with connection failure."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
-
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
-        mock_client = AsyncMock()
-        mock_client.connect.return_value = False
-        mock_client_class.return_value = mock_client
-
-        with pytest.raises(Exception, match="Failed to connect"):
-            scanner.connection_mode = CONNECTION_MODE_TCP
-            await scanner.scan_device()
-        await scanner.close()
 
 
 
 
 
-async def test_scan_blocks_propagated():
-    """Ensure scan_device returns discovered register blocks."""
-    # Avoid scanning full register set for test speed
-    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
-    with patch.object(
-        ThesslaGreenDeviceScanner,
-        "_load_registers",
-        AsyncMock(return_value=(empty_regs, {})),
-    ):
-        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
-
-        async def fake_read_input(client, address, count):
-            return [1] * count
-
-        async def fake_read_holding(client, address, count, **kwargs):
-            return [1] * count
-
-        async def fake_read_coil(client, address, count):
-            return [False] * count
-
-        async def fake_read_discrete(client, address, count):
-            return [False] * count
-
-        with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.connect.return_value = True
-            mock_client.read_input_registers = AsyncMock(
-                return_value=MagicMock(isError=lambda: False, registers=[4, 85, 0, 0, 0])
-            )
-            mock_client_class.return_value = mock_client
-
-            with (
-                patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)),
-                patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
-                patch.object(scanner, "_read_coil", AsyncMock(side_effect=fake_read_coil)),
-                patch.object(scanner, "_read_discrete", AsyncMock(side_effect=fake_read_discrete)),
-            ):
-                scanner.connection_mode = CONNECTION_MODE_TCP
-                result = await scanner.scan_device()
-
-    expected_blocks = {
-        "input_registers": (
-            min(INPUT_REGISTERS.values()),
-            max(INPUT_REGISTERS.values()),
-        ),
-        "holding_registers": (
-            min(HOLDING_REGISTERS.values()),
-            max(HOLDING_REGISTERS.values()),
-        ),
-        "coil_registers": (
-            min(COIL_REGISTERS.values()),
-            max(COIL_REGISTERS.values()),
-        ),
-        "discrete_inputs": (
-            min(DISCRETE_INPUT_REGISTERS.values()),
-            max(DISCRETE_INPUT_REGISTERS.values()),
-        ),
-    }
-
-    assert result["scan_blocks"] == expected_blocks
 
 
-async def test_full_register_scan_collects_unknown_registers():
-    """Ensure full register scan returns unknown registers and statistics."""
-    reg_map = {4: {0: "ir0", 2: "ir2"}, 3: {0: "hr0", 2: "hr2"}, 1: {}, 2: {}}
-    with patch.object(
-        ThesslaGreenDeviceScanner,
-        "_load_registers",
-        AsyncMock(return_value=(reg_map, {}, {})),
-    ):
-        scanner = await ThesslaGreenDeviceScanner.create(
-            "192.168.1.1", 502, 10, full_register_scan=True
-        )
-
-        async def fake_read_input(client, address, count, **kwargs):
-            return [address]
-
-        async def fake_read_holding(client, address, count, **kwargs):
-            return [address + 10]
-
-        with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.connect.return_value = True
-            mock_client.read_input_registers = AsyncMock(
-                return_value=MagicMock(isError=lambda: False, registers=[0])
-            )
-            mock_client_class.return_value = mock_client
-
-            with (
-                patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)),
-                patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
-                patch.object(scanner, "_read_coil", AsyncMock(return_value=[False])),
-                patch.object(scanner, "_read_discrete", AsyncMock(return_value=[False])),
-                patch.object(scanner, "_is_valid_register_value", return_value=True),
-            ):
-                scanner.connection_mode = CONNECTION_MODE_TCP
-                result = await scanner.scan_device()
-
-    assert result["unknown_registers"]["input_registers"] == {1: 1}
-    assert result["unknown_registers"]["holding_registers"] == {1: 11}
-    assert result["scanned_registers"]["input_registers"] == 3
-    assert result["scanned_registers"]["holding_registers"] == 3
 
 
-async def test_scan_device_batch_fallback():
-    """Batch read failures should fall back to single-register reads."""
-    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
-    with patch.object(
-        ThesslaGreenDeviceScanner, "_load_registers", AsyncMock(return_value=(empty_regs, {}))
-    ):
-        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
-
-    async def fake_read_input(client, address, count, **kwargs):
-        if address == 0 and count == 5:
-            return [4, 85, 0, 0, 0]
-        if count > 1:
-            return None
-        return [0]
-
-    async def fake_read_holding(client, address, count, **kwargs):
-        if count > 1:
-            return None
-        return [0]
-
-    async def fake_read_coil(client, address, count, **kwargs):
-        if count > 1:
-            return None
-        return [False]
-
-    async def fake_read_discrete(client, address, count, **kwargs):
-        if count > 1:
-            return None
-        return [False]
-
-    scanner._input_register_map = {"ir1": 16, "ir2": 17}
-    scanner._holding_register_map = {"hr1": 32, "hr2": 33}
-    scanner._coil_register_map = {"cr1": 0, "cr2": 1}
-    scanner._discrete_input_register_map = {"dr1": 0, "dr2": 1}
-    scanner._known_missing_registers = {
-        "input_registers": set(),
-        "holding_registers": set(),
-        "coil_registers": set(),
-        "discrete_inputs": set(),
-    }
-    scanner._update_known_missing_addresses()
-
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
-        mock_client = AsyncMock()
-        mock_client.connect.return_value = True
-        mock_client.read_input_registers = AsyncMock(
-            return_value=MagicMock(isError=lambda: False, registers=[4, 85, 0, 0, 0])
-        )
-        mock_client_class.return_value = mock_client
-
-        with (
-            patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)) as ri,
-            patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
-            patch.object(scanner, "_read_coil", AsyncMock(side_effect=fake_read_coil)),
-            patch.object(scanner, "_read_discrete", AsyncMock(side_effect=fake_read_discrete)),
-        ):
-            scanner.connection_mode = CONNECTION_MODE_TCP
-            result = await scanner.scan_device()
-
-    assert set(result["available_registers"]["input_registers"]) == {"ir1", "ir2"}
-    assert set(result["available_registers"]["holding_registers"]) == {"hr1", "hr2"}
-    assert set(result["available_registers"]["coil_registers"]) == {"cr1", "cr2"}
-    assert set(result["available_registers"]["discrete_inputs"]) == {"dr1", "dr2"}
-
-    # Ensure batch read was attempted and individual fallback reads occurred
-    batch_calls = [call for call in ri.await_args_list if call.args[1] == 16]
-    assert any(call.args[2] == 2 for call in batch_calls)
-
-    single_calls = [call.args[1] for call in ri.await_args_list if call.args[2] == 1]
-    assert single_calls.count(16) == 1
-    assert single_calls.count(17) == 1
 
 
 async def test_missing_register_logged_once(caplog):
@@ -718,129 +498,10 @@ async def test_scan_populates_device_name_with_non_ascii_bytes() -> None:
     assert result["device_info"]["device_name"] == "Test AirPac�"
 
 
-async def test_scan_falls_back_to_single_input_reads_after_failed_batch():
-    """Input addresses should be recovered via single-register probes after batch failure."""
-    scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
-    scanner._client = object()
-    scanner._transport = MagicMock()
-    scanner._transport.is_connected.return_value = True
-
-    async def fake_read_input(address, count, *, skip_cache=False):
-        if skip_cache and count == 1:
-            values = {
-                0: 3,
-                1: 0,
-                4: 11,
-                16: 215,
-                17: 220,
-            }
-            value = values.get(address)
-            return [value] if value is not None else None
-        if (address, count) == (16, 2):
-            return None
-        if (address, count) == (0, 2):
-            return [3, 0]
-        if (address, count) == (4, 1):
-            return [11]
-        return []
-
-    with (
-        patch.dict(
-            "custom_components.thessla_green_modbus.scanner.core.INPUT_REGISTERS",
-            {
-                "version_major": 0,
-                "version_minor": 1,
-                "version_patch": 4,
-                "outside_temperature": 16,
-                "supply_temperature": 17,
-            },
-            clear=True,
-        ),
-        patch.dict(
-            "custom_components.thessla_green_modbus.scanner.core.HOLDING_REGISTERS",
-            {},
-            clear=True,
-        ),
-        patch.dict(
-            "custom_components.thessla_green_modbus.scanner.core.COIL_REGISTERS",
-            {},
-            clear=True,
-        ),
-        patch.dict(
-            "custom_components.thessla_green_modbus.scanner.core.DISCRETE_INPUT_REGISTERS",
-            {},
-            clear=True,
-        ),
-        patch.object(scanner, "_read_input_block", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)),
-        patch.object(scanner, "_read_holding", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_holding_block", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_coil", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_discrete", AsyncMock(return_value=[])),
-        patch.object(scanner, "_analyze_capabilities", return_value=DeviceCapabilities()),
-    ):
-        result = await scanner.scan()
-
-    assert "outside_temperature" in result["available_registers"]["input_registers"]
-    assert "supply_temperature" in result["available_registers"]["input_registers"]
 
 
-async def test_scan_reports_diagnostic_registers_on_error():
-    """Diagnostic registers that failed Modbus probing are NOT force-added.
-
-    When all holding register reads fail (return None), the failed addresses
-    are recorded in failed_addresses["modbus_exceptions"]["holding_registers"].
-    The force-add loop must respect these failures and skip those addresses so
-    HA does not create permanently-unavailable entities for unsupported registers.
-    """
-    scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
-    scanner._client = object()
-    diag_regs = {"alarm": 0, "error": 1, "e_99": 2, "s_2": 3}
-    scanner._registers = {
-        4: {},
-        3: {addr: name for name, addr in diag_regs.items()},
-        1: {},
-        2: {},
-    }
-    scanner.available_registers = {
-        "input_registers": set(),
-        "holding_registers": set(),
-        "coil_registers": set(),
-        "discrete_inputs": set(),
-    }
-    with (
-        patch(
-            "custom_components.thessla_green_modbus.scanner.core.HOLDING_REGISTERS",
-            diag_regs,
-        ),
-        patch.object(scanner, "_read_input", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_holding", AsyncMock(return_value=None)),
-        patch.object(scanner, "_read_coil", AsyncMock(return_value=None)),
-        patch.object(scanner, "_read_discrete", AsyncMock(return_value=None)),
-        patch.object(scanner, "_analyze_capabilities", return_value=DeviceCapabilities()),
-    ):
-        result = await scanner.scan()
-
-    # All four addresses (0-3) failed → none should be force-added
-    assert result["available_registers"]["holding_registers"] == set()
 
 
-@pytest.mark.parametrize("async_close", [True, False])
-async def test_close_terminates_client(async_close):
-    """Ensure close() handles both async and sync client close methods."""
-    scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
-    mock_client = AsyncMock() if async_close else MagicMock()
-    scanner._client = mock_client
-
-    await scanner.close()
-
-    if async_close:
-        mock_client.close.assert_called_once()
-        mock_client.close.assert_awaited_once()
-    else:
-        mock_client.close.assert_called_once()
-
-    assert scanner._client is None
 
 
 async def test_log_invalid_value_debug_when_not_verbose(caplog):
@@ -898,49 +559,6 @@ async def test_log_invalid_value_invalid_time(caplog):
     assert "decoded=9216 (invalid)" in caplog.text
 
 
-async def test_failed_addresses_recorded_on_exception():
-    """Addresses are recorded when a Modbus read raises an exception."""
-    scanner = await ThesslaGreenDeviceScanner.create("host", 502)
-    scanner._client = AsyncMock()
-
-    async def fake_call(func, slave_id, address, *, count=None):
-        if address == 0 and count == 1:
-            raise ModbusIOException("boom")
-        resp = MagicMock()
-        resp.isError.return_value = False
-        if func.__name__ in ("read_input_registers", "read_holding_registers"):
-            resp.registers = [0] * (count or 1)
-        else:
-            resp.bits = [0] * (count or 1)
-        return resp
-
-    with (
-        patch.dict(
-            "custom_components.thessla_green_modbus.scanner.core.INPUT_REGISTERS",
-            {"version_major": 0},
-        ),
-        patch.dict(
-            "custom_components.thessla_green_modbus.scanner.core.HOLDING_REGISTERS",
-            {},
-        ),
-        patch.dict(
-            "custom_components.thessla_green_modbus.scanner.core.COIL_REGISTERS",
-            {},
-        ),
-        patch.dict(
-            "custom_components.thessla_green_modbus.scanner.core.DISCRETE_INPUT_REGISTERS",
-            {},
-        ),
-        patch(
-            "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
-            AsyncMock(side_effect=fake_call),
-        ),
-        patch("asyncio.sleep", AsyncMock()),
-    ):
-        result = await scanner.scan()
-
-    failed = result["failed_addresses"]["modbus_exceptions"]
-    assert failed
 
 
 async def test_deep_scan_collects_raw_registers():

--- a/tests/test_device_scanner_errors.py
+++ b/tests/test_device_scanner_errors.py
@@ -1,0 +1,172 @@
+"""Device scanner error-path tests."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.const import CONNECTION_MODE_TCP
+from custom_components.thessla_green_modbus.modbus_exceptions import (
+    ModbusException,
+    ModbusIOException,
+)
+from custom_components.thessla_green_modbus.scanner.core import (
+    DeviceCapabilities,
+    ThesslaGreenDeviceScanner,
+)
+
+pytestmark = pytest.mark.asyncio
+
+async def test_read_coil_retries_on_failure(caplog):
+    """Coil reads should retry on failure."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
+    mock_client = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
+            AsyncMock(side_effect=ModbusException("boom")),
+        ) as call_mock,
+        caplog.at_level(logging.DEBUG),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        result = await scanner._read_coil(mock_client, 0, 1)
+        assert result is None
+        assert call_mock.await_count == scanner.retry
+
+
+async def test_read_discrete_retries_on_failure(caplog):
+    """Discrete input reads should retry on failure."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
+    mock_client = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
+            AsyncMock(side_effect=ModbusException("boom")),
+        ) as call_mock,
+        caplog.at_level(logging.DEBUG),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        result = await scanner._read_discrete(mock_client, 0, 1)
+        assert result is None
+        assert call_mock.await_count == scanner.retry
+
+
+async def test_scan_device_connection_failure():
+    """Test device scan with connection failure."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
+
+    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.connect.return_value = False
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(Exception, match="Failed to connect"):
+            scanner.connection_mode = CONNECTION_MODE_TCP
+            await scanner.scan_device()
+        await scanner.close()
+
+
+async def test_scan_reports_diagnostic_registers_on_error():
+    """Diagnostic registers that failed Modbus probing are NOT force-added.
+
+    When all holding register reads fail (return None), the failed addresses
+    are recorded in failed_addresses["modbus_exceptions"]["holding_registers"].
+    The force-add loop must respect these failures and skip those addresses so
+    HA does not create permanently-unavailable entities for unsupported registers.
+    """
+    scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
+    scanner._client = object()
+    diag_regs = {"alarm": 0, "error": 1, "e_99": 2, "s_2": 3}
+    scanner._registers = {
+        4: {},
+        3: {addr: name for name, addr in diag_regs.items()},
+        1: {},
+        2: {},
+    }
+    scanner.available_registers = {
+        "input_registers": set(),
+        "holding_registers": set(),
+        "coil_registers": set(),
+        "discrete_inputs": set(),
+    }
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.scanner.core.HOLDING_REGISTERS",
+            diag_regs,
+        ),
+        patch.object(scanner, "_read_input", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_holding", AsyncMock(return_value=None)),
+        patch.object(scanner, "_read_coil", AsyncMock(return_value=None)),
+        patch.object(scanner, "_read_discrete", AsyncMock(return_value=None)),
+        patch.object(scanner, "_analyze_capabilities", return_value=DeviceCapabilities()),
+    ):
+        result = await scanner.scan()
+
+    # All four addresses (0-3) failed → none should be force-added
+    assert result["available_registers"]["holding_registers"] == set()
+
+
+@pytest.mark.parametrize("async_close", [True, False])
+async def test_close_terminates_client(async_close):
+    """Ensure close() handles both async and sync client close methods."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
+    mock_client = AsyncMock() if async_close else MagicMock()
+    scanner._client = mock_client
+
+    await scanner.close()
+
+    if async_close:
+        mock_client.close.assert_called_once()
+        mock_client.close.assert_awaited_once()
+    else:
+        mock_client.close.assert_called_once()
+
+    assert scanner._client is None
+
+
+async def test_failed_addresses_recorded_on_exception():
+    """Addresses are recorded when a Modbus read raises an exception."""
+    scanner = await ThesslaGreenDeviceScanner.create("host", 502)
+    scanner._client = AsyncMock()
+
+    async def fake_call(func, slave_id, address, *, count=None):
+        if address == 0 and count == 1:
+            raise ModbusIOException("boom")
+        resp = MagicMock()
+        resp.isError.return_value = False
+        if func.__name__ in ("read_input_registers", "read_holding_registers"):
+            resp.registers = [0] * (count or 1)
+        else:
+            resp.bits = [0] * (count or 1)
+        return resp
+
+    with (
+        patch.dict(
+            "custom_components.thessla_green_modbus.scanner.core.INPUT_REGISTERS",
+            {"version_major": 0},
+        ),
+        patch.dict(
+            "custom_components.thessla_green_modbus.scanner.core.HOLDING_REGISTERS",
+            {},
+        ),
+        patch.dict(
+            "custom_components.thessla_green_modbus.scanner.core.COIL_REGISTERS",
+            {},
+        ),
+        patch.dict(
+            "custom_components.thessla_green_modbus.scanner.core.DISCRETE_INPUT_REGISTERS",
+            {},
+        ),
+        patch(
+            "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
+            AsyncMock(side_effect=fake_call),
+        ),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        result = await scanner.scan()
+
+    failed = result["failed_addresses"]["modbus_exceptions"]
+    assert failed
+
+

--- a/tests/test_device_scanner_selection.py
+++ b/tests/test_device_scanner_selection.py
@@ -1,0 +1,263 @@
+"""Device scanner register/selection tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.const import CONNECTION_MODE_TCP
+from custom_components.thessla_green_modbus.registers.loader import get_registers_by_function
+from custom_components.thessla_green_modbus.scanner.core import (
+    DeviceCapabilities,
+    ThesslaGreenDeviceScanner,
+)
+
+COIL_REGISTERS = {r.name: r.address for r in get_registers_by_function(1)}
+DISCRETE_INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function(2)}
+HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function(3)}
+INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function(4)}
+
+pytestmark = pytest.mark.asyncio
+
+async def test_scan_blocks_propagated():
+    """Ensure scan_device returns discovered register blocks."""
+    # Avoid scanning full register set for test speed
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
+    with patch.object(
+        ThesslaGreenDeviceScanner,
+        "_load_registers",
+        AsyncMock(return_value=(empty_regs, {})),
+    ):
+        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
+
+        async def fake_read_input(client, address, count):
+            return [1] * count
+
+        async def fake_read_holding(client, address, count, **kwargs):
+            return [1] * count
+
+        async def fake_read_coil(client, address, count):
+            return [False] * count
+
+        async def fake_read_discrete(client, address, count):
+            return [False] * count
+
+        with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.connect.return_value = True
+            mock_client.read_input_registers = AsyncMock(
+                return_value=MagicMock(isError=lambda: False, registers=[4, 85, 0, 0, 0])
+            )
+            mock_client_class.return_value = mock_client
+
+            with (
+                patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)),
+                patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
+                patch.object(scanner, "_read_coil", AsyncMock(side_effect=fake_read_coil)),
+                patch.object(scanner, "_read_discrete", AsyncMock(side_effect=fake_read_discrete)),
+            ):
+                scanner.connection_mode = CONNECTION_MODE_TCP
+                result = await scanner.scan_device()
+
+    expected_blocks = {
+        "input_registers": (
+            min(INPUT_REGISTERS.values()),
+            max(INPUT_REGISTERS.values()),
+        ),
+        "holding_registers": (
+            min(HOLDING_REGISTERS.values()),
+            max(HOLDING_REGISTERS.values()),
+        ),
+        "coil_registers": (
+            min(COIL_REGISTERS.values()),
+            max(COIL_REGISTERS.values()),
+        ),
+        "discrete_inputs": (
+            min(DISCRETE_INPUT_REGISTERS.values()),
+            max(DISCRETE_INPUT_REGISTERS.values()),
+        ),
+    }
+
+    assert result["scan_blocks"] == expected_blocks
+
+
+async def test_full_register_scan_collects_unknown_registers():
+    """Ensure full register scan returns unknown registers and statistics."""
+    reg_map = {4: {0: "ir0", 2: "ir2"}, 3: {0: "hr0", 2: "hr2"}, 1: {}, 2: {}}
+    with patch.object(
+        ThesslaGreenDeviceScanner,
+        "_load_registers",
+        AsyncMock(return_value=(reg_map, {}, {})),
+    ):
+        scanner = await ThesslaGreenDeviceScanner.create(
+            "192.168.1.1", 502, 10, full_register_scan=True
+        )
+
+        async def fake_read_input(client, address, count, **kwargs):
+            return [address]
+
+        async def fake_read_holding(client, address, count, **kwargs):
+            return [address + 10]
+
+        with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.connect.return_value = True
+            mock_client.read_input_registers = AsyncMock(
+                return_value=MagicMock(isError=lambda: False, registers=[0])
+            )
+            mock_client_class.return_value = mock_client
+
+            with (
+                patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)),
+                patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
+                patch.object(scanner, "_read_coil", AsyncMock(return_value=[False])),
+                patch.object(scanner, "_read_discrete", AsyncMock(return_value=[False])),
+                patch.object(scanner, "_is_valid_register_value", return_value=True),
+            ):
+                scanner.connection_mode = CONNECTION_MODE_TCP
+                result = await scanner.scan_device()
+
+    assert result["unknown_registers"]["input_registers"] == {1: 1}
+    assert result["unknown_registers"]["holding_registers"] == {1: 11}
+    assert result["scanned_registers"]["input_registers"] == 3
+    assert result["scanned_registers"]["holding_registers"] == 3
+
+
+async def test_scan_device_batch_fallback():
+    """Batch read failures should fall back to single-register reads."""
+    empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
+    with patch.object(
+        ThesslaGreenDeviceScanner, "_load_registers", AsyncMock(return_value=(empty_regs, {}))
+    ):
+        scanner = await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 10)
+
+    async def fake_read_input(client, address, count, **kwargs):
+        if address == 0 and count == 5:
+            return [4, 85, 0, 0, 0]
+        if count > 1:
+            return None
+        return [0]
+
+    async def fake_read_holding(client, address, count, **kwargs):
+        if count > 1:
+            return None
+        return [0]
+
+    async def fake_read_coil(client, address, count, **kwargs):
+        if count > 1:
+            return None
+        return [False]
+
+    async def fake_read_discrete(client, address, count, **kwargs):
+        if count > 1:
+            return None
+        return [False]
+
+    scanner._input_register_map = {"ir1": 16, "ir2": 17}
+    scanner._holding_register_map = {"hr1": 32, "hr2": 33}
+    scanner._coil_register_map = {"cr1": 0, "cr2": 1}
+    scanner._discrete_input_register_map = {"dr1": 0, "dr2": 1}
+    scanner._known_missing_registers = {
+        "input_registers": set(),
+        "holding_registers": set(),
+        "coil_registers": set(),
+        "discrete_inputs": set(),
+    }
+    scanner._update_known_missing_addresses()
+
+    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.connect.return_value = True
+        mock_client.read_input_registers = AsyncMock(
+            return_value=MagicMock(isError=lambda: False, registers=[4, 85, 0, 0, 0])
+        )
+        mock_client_class.return_value = mock_client
+
+        with (
+            patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)) as ri,
+            patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
+            patch.object(scanner, "_read_coil", AsyncMock(side_effect=fake_read_coil)),
+            patch.object(scanner, "_read_discrete", AsyncMock(side_effect=fake_read_discrete)),
+        ):
+            scanner.connection_mode = CONNECTION_MODE_TCP
+            result = await scanner.scan_device()
+
+    assert set(result["available_registers"]["input_registers"]) == {"ir1", "ir2"}
+    assert set(result["available_registers"]["holding_registers"]) == {"hr1", "hr2"}
+    assert set(result["available_registers"]["coil_registers"]) == {"cr1", "cr2"}
+    assert set(result["available_registers"]["discrete_inputs"]) == {"dr1", "dr2"}
+
+    # Ensure batch read was attempted and individual fallback reads occurred
+    batch_calls = [call for call in ri.await_args_list if call.args[1] == 16]
+    assert any(call.args[2] == 2 for call in batch_calls)
+
+    single_calls = [call.args[1] for call in ri.await_args_list if call.args[2] == 1]
+    assert single_calls.count(16) == 1
+    assert single_calls.count(17) == 1
+
+
+async def test_scan_falls_back_to_single_input_reads_after_failed_batch():
+    """Input addresses should be recovered via single-register probes after batch failure."""
+    scanner = await ThesslaGreenDeviceScanner.create("host", 502, 10)
+    scanner._client = object()
+    scanner._transport = MagicMock()
+    scanner._transport.is_connected.return_value = True
+
+    async def fake_read_input(address, count, *, skip_cache=False):
+        if skip_cache and count == 1:
+            values = {
+                0: 3,
+                1: 0,
+                4: 11,
+                16: 215,
+                17: 220,
+            }
+            value = values.get(address)
+            return [value] if value is not None else None
+        if (address, count) == (16, 2):
+            return None
+        if (address, count) == (0, 2):
+            return [3, 0]
+        if (address, count) == (4, 1):
+            return [11]
+        return []
+
+    with (
+        patch.dict(
+            "custom_components.thessla_green_modbus.scanner.core.INPUT_REGISTERS",
+            {
+                "version_major": 0,
+                "version_minor": 1,
+                "version_patch": 4,
+                "outside_temperature": 16,
+                "supply_temperature": 17,
+            },
+            clear=True,
+        ),
+        patch.dict(
+            "custom_components.thessla_green_modbus.scanner.core.HOLDING_REGISTERS",
+            {},
+            clear=True,
+        ),
+        patch.dict(
+            "custom_components.thessla_green_modbus.scanner.core.COIL_REGISTERS",
+            {},
+            clear=True,
+        ),
+        patch.dict(
+            "custom_components.thessla_green_modbus.scanner.core.DISCRETE_INPUT_REGISTERS",
+            {},
+            clear=True,
+        ),
+        patch.object(scanner, "_read_input_block", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)),
+        patch.object(scanner, "_read_holding", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_holding_block", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_coil", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_discrete", AsyncMock(return_value=[])),
+        patch.object(scanner, "_analyze_capabilities", return_value=DeviceCapabilities()),
+    ):
+        result = await scanner.scan()
+
+    assert "outside_temperature" in result["available_registers"]["input_registers"]
+    assert "supply_temperature" in result["available_registers"]["input_registers"]
+
+

--- a/tests/test_scanner_coverage.py
+++ b/tests/test_scanner_coverage.py
@@ -209,47 +209,12 @@ async def test_param_coerce_stop_bits_invalid():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_close_transport_raises_oserror():
-    """Lines 686-687: OSError from transport.close() is caught and logged."""
-    scanner = await _make_scanner()
-    scanner._transport = _make_transport(raises_on_close=OSError("boom"))
-    # Should not raise
-    await scanner.close()
-    assert scanner._transport is None
 
 
-@pytest.mark.asyncio
-async def test_close_transport_raises_connection_exception():
-    """Lines 686-687: ConnectionException from transport.close() is caught."""
-    scanner = await _make_scanner()
-    scanner._transport = _make_transport(raises_on_close=ConnectionException("err"))
-    await scanner.close()
-    assert scanner._transport is None
 
 
-@pytest.mark.asyncio
-async def test_close_client_raises_oserror():
-    """Lines 697-698: OSError from client.close() is caught and logged."""
-    scanner = await _make_scanner()
-    scanner._transport = None
-    mock_client = MagicMock()
-    mock_client.close = MagicMock(side_effect=OSError("client boom"))
-    scanner._client = mock_client
-    await scanner.close()
-    assert scanner._client is None
 
 
-@pytest.mark.asyncio
-async def test_close_client_raises_modbus_io_exception():
-    """Lines 697-698: ModbusIOException from client.close() is caught."""
-    scanner = await _make_scanner()
-    scanner._transport = None
-    mock_client = MagicMock()
-    mock_client.close = MagicMock(side_effect=ModbusIOException("io err"))
-    scanner._client = mock_client
-    await scanner.close()
-    assert scanner._client is None
 
 
 # ---------------------------------------------------------------------------
@@ -257,21 +222,6 @@ async def test_close_client_raises_modbus_io_exception():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_verify_connection_safe_holding_registers():
-    """Lines 824-829: safe_holding is non-empty when date_time is in REGISTER_DEFINITIONS."""
-    from custom_components.thessla_green_modbus.scanner.core import REGISTER_DEFINITIONS
-
-    scanner = await _make_scanner()
-    # date_time is a holding register in SAFE_REGISTERS
-    if "date_time" not in REGISTER_DEFINITIONS:
-        pytest.skip("date_time not in REGISTER_DEFINITIONS")
-
-    fake_transport = _make_transport()
-    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
-        await scanner.verify_connection()
-
-    fake_transport.read_holding_registers.assert_called()
 
 
 # ---------------------------------------------------------------------------
@@ -279,55 +229,12 @@ async def test_verify_connection_safe_holding_registers():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_verify_connection_cancelled_error_reraises():
-    """Line 845: asyncio.CancelledError is re-raised."""
-    scanner = await _make_scanner()
-    fake_transport = _make_transport(ensure_side_effect=asyncio.CancelledError())
-    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
-        with pytest.raises(asyncio.CancelledError):
-            await scanner.verify_connection()
 
 
-@pytest.mark.asyncio
-async def test_verify_connection_modbus_io_cancelled_raises_timeout():
-    """Lines 847-850: ModbusIOException with 'cancelled' raises TimeoutError."""
-    scanner = await _make_scanner()
-    exc = ModbusIOException("Request cancelled outside pymodbus")
-    fake_transport = _make_transport(ensure_side_effect=exc)
-    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
-        with pytest.raises(TimeoutError):
-            await scanner.verify_connection()
 
 
-@pytest.mark.asyncio
-async def test_verify_connection_timeout_error_logs_warning(caplog):
-    """Lines 852-853: TimeoutError logs a warning."""
-    scanner = await _make_scanner()
-    fake_transport = _make_transport(ensure_side_effect=TimeoutError("timed out"))
-
-    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
-        with caplog.at_level(logging.WARNING):
-            with pytest.raises(TimeoutError):
-                await scanner.verify_connection()
-
-    assert "Timeout during verify_connection" in caplog.text
 
 
-@pytest.mark.asyncio
-async def test_verify_connection_transport_close_exception_in_finally(caplog):
-    """Lines 862-865: Exception during transport.close() in finally is logged."""
-    scanner = await _make_scanner()
-    fake_transport = MagicMock()
-    fake_transport.ensure_connected = AsyncMock(side_effect=ConnectionException("fail"))
-    fake_transport.close = MagicMock(side_effect=OSError("close fail"))
-
-    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
-        with caplog.at_level(logging.DEBUG):
-            with pytest.raises((ConnectionException, Exception)):
-                await scanner.verify_connection()
-
-    assert "Error closing Modbus transport during verify_connection" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scanner_error_paths.py
+++ b/tests/test_scanner_error_paths.py
@@ -1,0 +1,146 @@
+"""Scanner error-path and cleanup coverage tests."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.modbus_exceptions import (
+    ConnectionException,
+    ModbusIOException,
+)
+from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+
+
+def _make_ok_response(registers):
+    resp = MagicMock()
+    resp.isError.return_value = False
+    resp.registers = list(registers)
+    return resp
+
+
+async def _make_scanner(**kwargs):
+    return await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 1, **kwargs)
+
+
+def _make_transport(*, raises_on_close=None, ensure_side_effect=None, input_response=None, holding_response=None):
+    t = MagicMock()
+    t.close = AsyncMock(side_effect=raises_on_close) if raises_on_close else AsyncMock()
+    t.ensure_connected = AsyncMock(side_effect=ensure_side_effect) if ensure_side_effect else AsyncMock()
+    t.read_input_registers = AsyncMock(return_value=input_response or _make_ok_response([1]))
+    t.read_holding_registers = AsyncMock(return_value=holding_response or _make_ok_response([1]))
+    t.is_connected = MagicMock(return_value=True)
+    return t
+
+
+@pytest.mark.asyncio
+async def test_close_transport_raises_oserror():
+    """Lines 686-687: OSError from transport.close() is caught and logged."""
+    scanner = await _make_scanner()
+    scanner._transport = _make_transport(raises_on_close=OSError("boom"))
+    # Should not raise
+    await scanner.close()
+    assert scanner._transport is None
+
+
+@pytest.mark.asyncio
+async def test_close_transport_raises_connection_exception():
+    """Lines 686-687: ConnectionException from transport.close() is caught."""
+    scanner = await _make_scanner()
+    scanner._transport = _make_transport(raises_on_close=ConnectionException("err"))
+    await scanner.close()
+    assert scanner._transport is None
+
+
+@pytest.mark.asyncio
+async def test_close_client_raises_oserror():
+    """Lines 697-698: OSError from client.close() is caught and logged."""
+    scanner = await _make_scanner()
+    scanner._transport = None
+    mock_client = MagicMock()
+    mock_client.close = MagicMock(side_effect=OSError("client boom"))
+    scanner._client = mock_client
+    await scanner.close()
+    assert scanner._client is None
+
+
+@pytest.mark.asyncio
+async def test_close_client_raises_modbus_io_exception():
+    """Lines 697-698: ModbusIOException from client.close() is caught."""
+    scanner = await _make_scanner()
+    scanner._transport = None
+    mock_client = MagicMock()
+    mock_client.close = MagicMock(side_effect=ModbusIOException("io err"))
+    scanner._client = mock_client
+    await scanner.close()
+    assert scanner._client is None
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_safe_holding_registers():
+    """Lines 824-829: safe_holding is non-empty when date_time is in REGISTER_DEFINITIONS."""
+    from custom_components.thessla_green_modbus.scanner.core import REGISTER_DEFINITIONS
+
+    scanner = await _make_scanner()
+    # date_time is a holding register in SAFE_REGISTERS
+    if "date_time" not in REGISTER_DEFINITIONS:
+        pytest.skip("date_time not in REGISTER_DEFINITIONS")
+
+    fake_transport = _make_transport()
+    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
+        await scanner.verify_connection()
+
+    fake_transport.read_holding_registers.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_cancelled_error_reraises():
+    """Line 845: asyncio.CancelledError is re-raised."""
+    scanner = await _make_scanner()
+    fake_transport = _make_transport(ensure_side_effect=asyncio.CancelledError())
+    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
+        with pytest.raises(asyncio.CancelledError):
+            await scanner.verify_connection()
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_modbus_io_cancelled_raises_timeout():
+    """Lines 847-850: ModbusIOException with 'cancelled' raises TimeoutError."""
+    scanner = await _make_scanner()
+    exc = ModbusIOException("Request cancelled outside pymodbus")
+    fake_transport = _make_transport(ensure_side_effect=exc)
+    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
+        with pytest.raises(TimeoutError):
+            await scanner.verify_connection()
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_timeout_error_logs_warning(caplog):
+    """Lines 852-853: TimeoutError logs a warning."""
+    scanner = await _make_scanner()
+    fake_transport = _make_transport(ensure_side_effect=TimeoutError("timed out"))
+
+    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(TimeoutError):
+                await scanner.verify_connection()
+
+    assert "Timeout during verify_connection" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_transport_close_exception_in_finally(caplog):
+    """Lines 862-865: Exception during transport.close() in finally is logged."""
+    scanner = await _make_scanner()
+    fake_transport = MagicMock()
+    fake_transport.ensure_connected = AsyncMock(side_effect=ConnectionException("fail"))
+    fake_transport.close = MagicMock(side_effect=OSError("close fail"))
+
+    with patch.object(scanner, "_build_tcp_transport", return_value=fake_transport):
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises((ConnectionException, Exception)):
+                await scanner.verify_connection()
+
+    assert "Error closing Modbus transport during verify_connection" in caplog.text
+
+


### PR DESCRIPTION
### Motivation
- Break up two remaining large scanner test modules into smaller, focused test files to improve maintainability and make intent of groups clearer while preserving existing coverage and assertions.

### Description
- Added focused test modules: `tests/test_scanner_error_paths.py`, `tests/test_device_scanner_errors.py`, and `tests/test_device_scanner_selection.py` and removed the corresponding relocated blocks from `tests/test_scanner_coverage.py` and `tests/test_device_scanner.py`.
- Moved complete decorated test blocks (preserving decorators, parametrization, fixtures, monkeypatching and assertions) for error/cleanup, retry/diagnostic/close, and selection/register-batching behavior into the new files; the moved tests include the lists shown in the rollout transcript (error paths, device-scanner errors, and selection/batching tests).
- Updated imports and small housekeeping in the remaining modules (removed now-unused imports from `tests/test_device_scanner.py` and organized imports in the new files) and ensured helper functions used by the moved tests were preserved alongside them.
- Did not modify production code; only tests and related test imports were changed.

### Testing
- Ran `ruff check --fix` on changed files and then `ruff check custom_components tests tools`, which passed after fixes.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools`, which completed successfully.
- Ran `python tools/check_maintainability.py`, which reported the maintainability gate passed.
- Attempted `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py`, but the run was blocked in this environment by missing test dependencies (`pydantic` / `pytest_homeassistant_custom_component`), so full pytest against the suite could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c2f36ab883269d623dff4795b3e3)