### PR TITLE
refactor: decompose mapping builder transformations

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -131,6 +131,86 @@ def _build_select_mapping(register: str, states: dict[str, int]) -> dict[str, An
     }
 
 
+
+
+def _resolve_parent_child_mappings(parent: Any) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Return mutable mapping dictionaries from parent module."""
+
+    def _maps(name: str) -> dict[str, Any]:
+        return getattr(parent, name, {}) if parent else {}
+
+    return (
+        _maps("NUMBER_ENTITY_MAPPINGS"),
+        _maps("SENSOR_ENTITY_MAPPINGS"),
+        _maps("BINARY_SENSOR_ENTITY_MAPPINGS"),
+        _maps("SWITCH_ENTITY_MAPPINGS"),
+        _maps("SELECT_ENTITY_MAPPINGS"),
+        _maps("TEXT_ENTITY_MAPPINGS"),
+        _maps("TIME_ENTITY_MAPPINGS"),
+    )
+
+
+def _classify_enum_mapping(register: str, enum: dict[Any, Any], access: str, switch_keys: set[str], binary_keys: set[str], select_keys: set[str]) -> tuple[str | None, dict[str, Any] | None]:
+    """Classify enum register into target mapping bucket and payload."""
+    enum_states = {_to_snake_case(str(v)): int(k) for k, v in enum.items()}
+    enum_values = {int(k) for k in enum}
+
+    if len(enum) == 2 and enum_values == {0, 1}:
+        if "W" in access:
+            if register not in switch_keys:
+                return None, None
+            return "switch", _build_switch_mapping(register)
+        if register not in binary_keys:
+            return None, None
+        return "binary", _build_binary_toggle_mapping(register)
+
+    if "W" in access:
+        if register not in select_keys:
+            return None, None
+        return "select", _build_select_mapping(register, enum_states)
+
+    return "sensor", {
+        "translation_key": register,
+        "icon": "mdi:information-outline",
+        "register_type": "holding_registers",
+    }
+
+
+def _classify_min_max_mapping(register: str, access: str, min_val: Any, max_val: Any, info_text: str, unit: Any, step: Any, scale: Any, switch_keys: set[str], binary_keys: set[str], select_keys: set[str], number_keys: set[str]) -> tuple[str | None, dict[str, Any] | None]:
+    """Classify numeric min/max register into a mapping bucket and payload."""
+    if min_val is None or max_val is None:
+        return None, None
+
+    if max_val <= 1:
+        if "W" in access:
+            if register not in switch_keys:
+                return None, None
+            return "switch", _build_switch_mapping(register)
+        if register not in binary_keys:
+            return None, None
+        return "binary", _build_binary_toggle_mapping(register)
+
+    if "W" in access and info_text and ";" in info_text and max_val <= 10:
+        states = _parse_info_states(info_text)
+        if states:
+            if register not in select_keys:
+                return None, None
+            return "select", _build_select_mapping(register, states)
+
+    if "W" in access:
+        if register not in number_keys:
+            return None, None
+        return "number", {
+            "unit": unit,
+            "icon": _infer_icon(register, unit),
+            "min": min_val,
+            "max": max_val,
+            "step": step,
+            "scale": scale,
+        }
+
+    return None, None
+
 def _get_parent() -> Any:
     """Return the parent mappings package module for attribute resolution.
 
@@ -351,17 +431,15 @@ def _extend_entity_mappings_from_registers() -> None:
     _num_tkeys = _resolve("_number_translation_keys", _number_translation_keys)
 
     parent = _get_parent()
-
-    def _maps(name: str) -> dict[str, Any]:
-        return getattr(parent, name, {}) if parent else {}
-
-    number_mappings = _maps("NUMBER_ENTITY_MAPPINGS")
-    sensor_mappings = _maps("SENSOR_ENTITY_MAPPINGS")
-    binary_mappings = _maps("BINARY_SENSOR_ENTITY_MAPPINGS")
-    switch_mappings = _maps("SWITCH_ENTITY_MAPPINGS")
-    select_mappings = _maps("SELECT_ENTITY_MAPPINGS")
-    text_mappings = _maps("TEXT_ENTITY_MAPPINGS")
-    time_mappings = _maps("TIME_ENTITY_MAPPINGS")
+    (
+        number_mappings,
+        sensor_mappings,
+        binary_mappings,
+        switch_mappings,
+        select_mappings,
+        text_mappings,
+        time_mappings,
+    ) = _resolve_parent_child_mappings(parent)
 
     translations = _tkeys()
     binary_keys = translations["binary_sensor"]
@@ -442,83 +520,49 @@ def _extend_entity_mappings_from_registers() -> None:
         step = reg.resolution or scale
 
         if reg.enum and not (reg.extra and reg.extra.get("bitmask")):
-            enum_states = {_to_snake_case(str(v)): int(k) for k, v in reg.enum.items()}
-            if len(reg.enum) == 2 and set(int(k) for k in reg.enum) == {0, 1}:
-                if "W" in access:
-                    if register not in switch_keys:
-                        continue
-                    switch_mappings.setdefault(
-                        register,
-                        _build_switch_mapping(register),
-                    )
-                else:
-                    if register not in binary_keys:
-                        continue
-                    binary_mappings.setdefault(
-                        register,
-                        _build_binary_toggle_mapping(register),
-                    )
-            elif "W" in access:
-                if register not in select_keys:
-                    continue
-                select_mappings.setdefault(
-                    register,
-                    _build_select_mapping(register, enum_states),
-                )
-            else:
-                sensor_mappings.setdefault(
-                    register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:information-outline",
-                        "register_type": "holding_registers",
-                    },
-                )
+            target, payload = _classify_enum_mapping(
+                register,
+                reg.enum,
+                access,
+                switch_keys,
+                binary_keys,
+                select_keys,
+            )
+            if target == "switch":
+                switch_mappings.setdefault(register, payload)
+            elif target == "binary":
+                binary_mappings.setdefault(register, payload)
+            elif target == "select":
+                select_mappings.setdefault(register, payload)
+            elif target == "sensor":
+                sensor_mappings.setdefault(register, payload)
             continue
 
-        if min_val is not None and max_val is not None:
-            if max_val <= 1:
-                if "W" in access:
-                    if register not in switch_keys:
-                        continue
-                    switch_mappings.setdefault(
-                        register,
-                        _build_switch_mapping(register),
-                    )
-                else:
-                    if register not in binary_keys:
-                        continue
-                    binary_mappings.setdefault(
-                        register,
-                        _build_binary_toggle_mapping(register),
-                    )
-                continue
-
-            if "W" in access and info_text and ";" in info_text and max_val <= 10:
-                states = _parse_info_states(info_text)
-                if states:
-                    if register not in select_keys:
-                        continue
-                    select_mappings.setdefault(
-                        register,
-                        _build_select_mapping(register, states),
-                    )
-                    continue
-
-            if "W" in access:
-                if register not in number_keys:
-                    continue
-                number_mappings.setdefault(
-                    register,
-                    {
-                        "unit": unit,
-                        "icon": _infer_icon(register, unit),
-                        "min": min_val,
-                        "max": max_val,
-                        "step": step,
-                        "scale": scale,
-                    },
-                )
+        target, payload = _classify_min_max_mapping(
+            register,
+            access,
+            min_val,
+            max_val,
+            info_text,
+            unit,
+            step,
+            scale,
+            switch_keys,
+            binary_keys,
+            select_keys,
+            number_keys,
+        )
+        if target == "switch":
+            switch_mappings.setdefault(register, payload)
+            continue
+        if target == "binary":
+            binary_mappings.setdefault(register, payload)
+            continue
+        if target == "select":
+            select_mappings.setdefault(register, payload)
+            continue
+        if target == "number":
+            number_mappings.setdefault(register, payload)
 
 
 
@@ -527,6 +571,8 @@ __all__ = [
     "_build_problem_binary_mapping",
     "_build_season_setting_mapping",
     "_build_time_like_mapping",
+    "_classify_enum_mapping",
+    "_classify_min_max_mapping",
     "_extend_entity_mappings_from_registers",
     "_get_parent",
     "_is_already_mapped",
@@ -537,4 +583,5 @@ __all__ = [
     "_load_number_mappings",
     "_parse_info_states",
     "_resolve",
+    "_resolve_parent_child_mappings",
 ]

--- a/tests/test_entity_mappings_builder_transformations.py
+++ b/tests/test_entity_mappings_builder_transformations.py
@@ -1,0 +1,83 @@
+"""Tests for extracted transformation helpers in mapping builders."""
+
+from custom_components.thessla_green_modbus.mappings._mapping_builders import (
+    _classify_enum_mapping,
+    _classify_min_max_mapping,
+    _resolve_parent_child_mappings,
+)
+
+
+def test_resolve_parent_child_mappings_returns_parent_dicts() -> None:
+    parent = type(
+        "Parent",
+        (),
+        {
+            "NUMBER_ENTITY_MAPPINGS": {"a": {}},
+            "SENSOR_ENTITY_MAPPINGS": {"b": {}},
+            "BINARY_SENSOR_ENTITY_MAPPINGS": {"c": {}},
+            "SWITCH_ENTITY_MAPPINGS": {"d": {}},
+            "SELECT_ENTITY_MAPPINGS": {"e": {}},
+            "TEXT_ENTITY_MAPPINGS": {"f": {}},
+            "TIME_ENTITY_MAPPINGS": {"g": {}},
+        },
+    )
+
+    maps = _resolve_parent_child_mappings(parent)
+    assert maps[0] is parent.NUMBER_ENTITY_MAPPINGS
+    assert maps[6] is parent.TIME_ENTITY_MAPPINGS
+
+
+def test_classify_enum_mapping_shapes() -> None:
+    target, payload = _classify_enum_mapping(
+        "mode", {"0": "Off", "1": "On", "2": "Auto"}, "RW", set(), set(), {"mode"}
+    )
+    assert target == "select"
+    assert payload == {
+        "icon": "mdi:format-list-bulleted",
+        "translation_key": "mode",
+        "states": {"off": 0, "on": 1, "auto": 2},
+        "register_type": "holding_registers",
+    }
+
+
+def test_classify_min_max_mapping_select_then_number() -> None:
+    target, payload = _classify_min_max_mapping(
+        "fan_mode",
+        "RW",
+        0,
+        10,
+        "0 - low;1 - high",
+        None,
+        1,
+        1,
+        set(),
+        set(),
+        {"fan_mode"},
+        set(),
+    )
+    assert target == "select"
+    assert payload and payload["states"] == {"low": 0, "high": 1}
+
+    target, payload = _classify_min_max_mapping(
+        "speed",
+        "RW",
+        0,
+        100,
+        "",
+        "%",
+        5,
+        1,
+        set(),
+        set(),
+        set(),
+        {"speed"},
+    )
+    assert target == "number"
+    assert payload == {
+        "unit": "%",
+        "icon": "mdi:percent-outline",
+        "min": 0,
+        "max": 100,
+        "step": 5,
+        "scale": 1,
+    }


### PR DESCRIPTION
### Motivation
- Reduce complexity and branching in `_extend_entity_mappings_from_registers` to make mapping classification easier to read and test.
- Isolate pure transformation logic so behavior can be validated with focused unit tests while preserving mapping outputs.

### Description
- Extracted `_resolve_parent_child_mappings` to centralize retrieval of mutable mapping dicts from the parent mappings module.
- Extracted `_classify_enum_mapping` to encapsulate enum-based mapping classification into switch/binary/select/sensor payloads.
- Extracted `_classify_min_max_mapping` to encapsulate numeric min/max based classification into switch/binary/select/number payloads.
- Updated `_extend_entity_mappings_from_registers` to delegate enum and min/max decision logic to the new helpers while preserving existing mapping payload shapes and routing.
- Added `tests/test_entity_mappings_builder_transformations.py` with exact-shape assertions for the new helpers and a parent-resolution test.

### Testing
- `ruff check` passed against `custom_components`, `tests`, and `tools`.
- `python -m compileall` completed successfully for the changed modules.
- Focused pytest runs `tests/test_entity_mappings*.py` and platform-specific tests (`test_sensor_platform.py`, `test_select.py`, `test_switch.py`, `test_number.py`, `test_binary_sensor.py`) passed.
- Added helper tests in `tests/test_entity_mappings_builder_transformations.py` passed under the focused test runs.
- Maintainability checks passed (`tools/check_maintainability.py`).
- Full test run (`pytest tests/ -q`) did not complete cleanly due to one unrelated coordinator test failing with a socket usage blockage (`pytest_socket.SocketBlockedError`), which is outside the scope of these mapping changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c2e73eb8832692816065aadaaa1e)