### PR TITLE
refactor: decompose maintenance service handlers

### DIFF
--- a/custom_components/thessla_green_modbus/services_dispatch.py
+++ b/custom_components/thessla_green_modbus/services_dispatch.py
@@ -51,3 +51,29 @@ async def write_optional_register(
         logger.error(error_message, entity_id)
         return False
     return True
+
+
+async def write_mapped_optional_register(
+    coordinator: Any,
+    register_name: str,
+    option_value: str | None,
+    option_map: dict[str, int],
+    entity_id: str,
+    action: str,
+    error_message: str,
+    write_register_func: Any,
+    logger: Any,
+) -> bool:
+    """Write mapped register value when option is provided."""
+    if option_value is None:
+        return True
+    return await write_optional_register(
+        coordinator,
+        register_name,
+        option_map[option_value],
+        entity_id,
+        action,
+        error_message,
+        write_register_func,
+        logger,
+    )

--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from .modbus_exceptions import ConnectionException, ModbusException
-from .services_dispatch import refresh_and_log_success
+from .services_dispatch import refresh_and_log_success, write_mapped_optional_register
 from .services_handler_deps import ServiceHandlerDeps
 from .services_schema import (
     RESET_FILTERS_SCHEMA,
@@ -15,34 +15,13 @@ from .services_schema import (
     START_PRESSURE_TEST_SCHEMA,
     SYNC_TIME_SCHEMA,
 )
-
-FILTER_TYPE_MAP = {"presostat": 1, "flat_filters": 2, "cleanpad": 3, "cleanpad_pure": 4}
-BAUD_MAP = {
-    "4800": 0,
-    "9600": 1,
-    "14400": 2,
-    "19200": 3,
-    "28800": 4,
-    "38400": 5,
-    "57600": 6,
-    "76800": 7,
-    "115200": 8,
-}
-PARITY_MAP = {"none": 0, "even": 1, "odd": 2}
-STOP_MAP = {"1": 0, "2": 1}
-
-
-def _normalize_modbus_options(deps: ServiceHandlerDeps, call: ServiceCall) -> tuple[str, str | None, str | None, str | None]:
-    port = deps.normalize_option(call.data["port"])
-    baud_rate = call.data.get("baud_rate")
-    parity = call.data.get("parity")
-    stop_bits = call.data.get("stop_bits")
-    return (
-        port,
-        deps.normalize_option(baud_rate) if baud_rate else None,
-        deps.normalize_option(parity) if parity else None,
-        deps.normalize_option(stop_bits) if stop_bits else None,
-    )
+from .services_validation import (
+    BAUD_MAP,
+    FILTER_TYPE_MAP,
+    PARITY_MAP,
+    STOP_MAP,
+    normalize_modbus_options,
+)
 
 
 async def _write_device_name(coordinator: object, device_name: str, batch: int) -> bool:
@@ -105,40 +84,46 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
             await refresh_and_log_success(coordinator, deps.logger, "Started pressure test for %s", entity_id)
 
     async def set_modbus_parameters(call: ServiceCall) -> None:
-        port, baud_rate, parity, stop_bits = _normalize_modbus_options(deps, call)
+        port, baud_rate, parity, stop_bits = normalize_modbus_options(deps.normalize_option, call.data)
 
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
             port_prefix = "uart_0" if port == "air_b" else "uart_1"
-            if baud_rate:
-                if not await deps.write_register(
-                    coordinator,
-                    f"{port_prefix}_baud",
-                    BAUD_MAP[baud_rate],
-                    entity_id,
-                    "set Modbus parameters",
-                ):
-                    deps.logger.error("Failed to set baud rate for %s", entity_id)
-                    continue
-            if parity:
-                if not await deps.write_register(
-                    coordinator,
-                    f"{port_prefix}_parity",
-                    PARITY_MAP[parity],
-                    entity_id,
-                    "set Modbus parameters",
-                ):
-                    deps.logger.error("Failed to set parity for %s", entity_id)
-                    continue
-            if stop_bits:
-                if not await deps.write_register(
-                    coordinator,
-                    f"{port_prefix}_stop",
-                    STOP_MAP[stop_bits],
-                    entity_id,
-                    "set Modbus parameters",
-                ):
-                    deps.logger.error("Failed to set stop bits for %s", entity_id)
-                    continue
+            if not await write_mapped_optional_register(
+                coordinator,
+                f"{port_prefix}_baud",
+                baud_rate,
+                BAUD_MAP,
+                entity_id,
+                "set Modbus parameters",
+                "Failed to set baud rate for %s",
+                deps.write_register,
+                deps.logger,
+            ):
+                continue
+            if not await write_mapped_optional_register(
+                coordinator,
+                f"{port_prefix}_parity",
+                parity,
+                PARITY_MAP,
+                entity_id,
+                "set Modbus parameters",
+                "Failed to set parity for %s",
+                deps.write_register,
+                deps.logger,
+            ):
+                continue
+            if not await write_mapped_optional_register(
+                coordinator,
+                f"{port_prefix}_stop",
+                stop_bits,
+                STOP_MAP,
+                entity_id,
+                "set Modbus parameters",
+                "Failed to set stop bits for %s",
+                deps.write_register,
+                deps.logger,
+            ):
+                continue
             await refresh_and_log_success(coordinator, deps.logger, "Set Modbus parameters for %s", entity_id)
 
     async def set_device_name(call: ServiceCall) -> None:

--- a/custom_components/thessla_green_modbus/services_validation.py
+++ b/custom_components/thessla_green_modbus/services_validation.py
@@ -8,6 +8,21 @@ import voluptuous as vol
 
 from .const import DOMAIN
 
+FILTER_TYPE_MAP = {"presostat": 1, "flat_filters": 2, "cleanpad": 3, "cleanpad_pure": 4}
+BAUD_MAP = {
+    "4800": 0,
+    "9600": 1,
+    "14400": 2,
+    "19200": 3,
+    "28800": 4,
+    "38400": 5,
+    "57600": 6,
+    "76800": 7,
+    "115200": 8,
+}
+PARITY_MAP = {"none": 0, "even": 1, "odd": 2}
+STOP_MAP = {"1": 0, "2": 1}
+
 
 def validate_bypass_temperature_range(data: dict[str, Any]) -> dict[str, Any]:
     """Validate bypass temperature range independently from voluptuous internals."""
@@ -51,3 +66,17 @@ def normalize_option(value: str) -> str:
         if value.startswith(prefix):
             return value[len(prefix) :]
     return value
+
+
+def normalize_modbus_options(normalize: Any, data: dict[str, Any]) -> tuple[str, str | None, str | None, str | None]:
+    """Normalize set_modbus_parameters payload options."""
+    port = normalize(data["port"])
+    baud_rate = data.get("baud_rate")
+    parity = data.get("parity")
+    stop_bits = data.get("stop_bits")
+    return (
+        port,
+        normalize(baud_rate) if baud_rate else None,
+        normalize(parity) if parity else None,
+        normalize(stop_bits) if stop_bits else None,
+    )

--- a/tests/test_services_dispatch_validation.py
+++ b/tests/test_services_dispatch_validation.py
@@ -8,10 +8,13 @@ import voluptuous as vol
 from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 from custom_components.thessla_green_modbus.services_dispatch import (
     refresh_and_log_success,
+    write_mapped_optional_register,
     write_optional_register,
     write_register,
 )
 from custom_components.thessla_green_modbus.services_validation import (
+    BAUD_MAP,
+    normalize_modbus_options,
     normalize_option,
     validate_bypass_temperature_range,
     validate_gwc_temperature_range,
@@ -73,3 +76,38 @@ def test_validate_bypass_temperature_range_rejects_out_of_range():
 
 def test_normalize_option_removes_domain_and_prefix():
     assert normalize_option("thessla_green_modbus.modbus_parity_even") == "even"
+
+
+def test_normalize_modbus_options_returns_normalized_values():
+    port, baud, parity, stop_bits = normalize_modbus_options(
+        normalize_option,
+        {
+            "port": "thessla_green_modbus.modbus_port_air_b",
+            "baud_rate": "thessla_green_modbus.modbus_baud_rate_115200",
+            "parity": "thessla_green_modbus.modbus_parity_even",
+            "stop_bits": "thessla_green_modbus.modbus_stop_bits_2",
+        },
+    )
+    assert (port, baud, parity, stop_bits) == ("air_b", "115200", "even", "2")
+
+
+@pytest.mark.asyncio
+async def test_write_mapped_optional_register_maps_and_writes():
+    write_func = AsyncMock(return_value=True)
+    logger = SimpleNamespace(error=AsyncMock())
+
+    coordinator = object()
+    result = await write_mapped_optional_register(
+        coordinator,
+        "uart_0_baud",
+        "115200",
+        BAUD_MAP,
+        "climate.a",
+        "act",
+        "err %s",
+        write_func,
+        logger,
+    )
+
+    assert result is True
+    write_func.assert_awaited_once_with(coordinator, "uart_0_baud", 8, "climate.a", "act")


### PR DESCRIPTION
### Motivation
- Reduce duplication and hotspot logic in the maintenance service handlers by moving normalization/mapping and repeated write patterns into reusable helpers.
- Make `set_modbus_parameters` clearer and easier to test by extracting Modbus option normalization and mapped-write flows.

### Description
- Moved Modbus-related maps and a `normalize_modbus_options` helper into `services_validation.py` and re-used the existing `normalize_option` flow.
- Added `write_mapped_optional_register` to `services_dispatch.py` to encapsulate the pattern of mapping an option to a register value and writing it only when provided.
- Updated `services_handlers_maintenance.py` to use the new `normalize_modbus_options` and `write_mapped_optional_register` helpers and removed duplicated mapping logic while preserving service names and behavior.
- Added focused tests in `tests/test_services_dispatch_validation.py` covering `normalize_modbus_options` and `write_mapped_optional_register` and updated imports accordingly.

### Testing
- Ran `ruff` and auto-fixed import ordering issues, and `python -m compileall` with no errors reported.
- Ran focused service tests `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` and they passed.
- Ran full test suite `pytest tests/ -q` which failed with an unrelated `pytest_socket.SocketBlockedError` in `tests/test_coordinator.py::test_reconfigure_does_not_leak_connections` due to the environment blocking socket usage.
- `python tools/check_maintainability.py` passed and repository-wide grep checks found no compatibility shims or TODO backward-compat notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c2e089cc8326adc0f0367d66ba33)