### PR TITLE
refactor: decompose config flow validation and schema helpers

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow_device_validation.py
+++ b/custom_components/thessla_green_modbus/config_flow_device_validation.py
@@ -20,6 +20,120 @@ from .errors import CannotConnect, InvalidAuth, is_invalid_auth_error
 from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
 
 
+def _normalize_connection_params(
+    data: dict[str, Any],
+    *,
+    normalize_connection_type: Callable[[dict[str, Any]], str],
+    validate_slave_id: Callable[[dict[str, Any]], int],
+    validate_tcp_config: Callable[[dict[str, Any]], tuple[str, int]],
+    validate_rtu_config: Callable[[dict[str, Any]], None],
+    conf_name: str,
+    conf_timeout: str,
+    default_name: str,
+    default_port: int,
+    default_timeout: float,
+    default_deep_scan: bool,
+    default_parity: str,
+    default_stop_bits: int,
+    connection_type_tcp: str,
+) -> dict[str, Any]:
+    """Normalize connection-related parameters from user data."""
+    connection_type = normalize_connection_type(data)
+    slave_id = validate_slave_id(data)
+    name = data.get(conf_name, default_name)
+    timeout = data.get(conf_timeout, default_timeout)
+    host = ""
+    port = default_port
+    if connection_type == connection_type_tcp:
+        host, port = validate_tcp_config(data)
+    else:
+        validate_rtu_config(data)
+    return {
+        "connection_type": connection_type,
+        "slave_id": slave_id,
+        "name": name,
+        "timeout": timeout,
+        "host": host,
+        "port": port,
+        "deep_scan": data.get(CONF_DEEP_SCAN, default_deep_scan),
+        "connection_mode": data.get(CONF_CONNECTION_MODE),
+        "serial_port": data.get(CONF_SERIAL_PORT),
+        "baud_rate": data.get(CONF_BAUD_RATE),
+        "parity": data.get(CONF_PARITY, default_parity),
+        "stop_bits": data.get(CONF_STOP_BITS, default_stop_bits),
+    }
+
+
+def _build_success_payload(name: str, scan_result: dict[str, Any]) -> dict[str, Any]:
+    """Construct final success payload for config flow."""
+    return {
+        "title": name,
+        "device_info": scan_result.get("device_info", {}),
+        "scan_result": scan_result,
+    }
+
+
+async def _maybe_close_scanner(scanner: Any | None) -> None:
+    """Close scanner instance when available."""
+    if scanner is not None and hasattr(scanner, "close"):
+        close_result = scanner.close()
+        if inspect.isawaitable(close_result):
+            await close_result
+
+
+def _map_validation_exception(
+    exc: BaseException,
+    *,
+    is_request_cancelled_error: Callable[[ModbusIOException], bool],
+    classify_os_error: Callable[[OSError], str],
+    should_log_timeout_traceback: Callable[[BaseException], bool],
+    logger: Any,
+    timeout_exceptions: tuple[type[BaseException], ...],
+) -> Exception:
+    """Map low-level exceptions to flow-facing exceptions."""
+    if isinstance(exc, ConnectionException):
+        logger.error("Connection error: %s", exc)
+        logger.debug("Traceback:\n%s", traceback.format_exc())
+        return CannotConnect("cannot_connect")
+    if isinstance(exc, ModbusIOException):
+        if is_request_cancelled_error(exc):
+            logger.info("Modbus request cancelled during device validation.")
+            return CannotConnect("timeout")
+        logger.error("Modbus IO error during device validation: %s", exc)
+        logger.debug("Traceback:\n%s", traceback.format_exc())
+        return CannotConnect("io_error")
+    if isinstance(exc, timeout_exceptions):
+        logger.warning("Timeout during device validation: %s", exc)
+        if should_log_timeout_traceback(exc):
+            logger.debug("Traceback:\n%s", traceback.format_exc())
+        return CannotConnect("timeout")
+    if isinstance(exc, ModbusException):
+        logger.error("Modbus error: %s", exc)
+        logger.debug("Traceback:\n%s", traceback.format_exc())
+        if is_invalid_auth_error(exc):
+            return InvalidAuth()
+        return CannotConnect("modbus_error")
+    if isinstance(exc, AttributeError):
+        logger.error("Attribute error during device validation: %s", exc)
+        logger.debug("Traceback:\n%s", traceback.format_exc())
+        return CannotConnect("missing_method")
+    if isinstance(exc, OSError):
+        reason = classify_os_error(exc)
+        if reason == "dns_failure":
+            logger.error("DNS resolution failed: %s", exc)
+        elif reason == "connection_refused":
+            logger.error("Connection refused: %s", exc)
+        else:
+            logger.error("Unexpected error during device validation: %s", exc)
+        logger.debug("Traceback:\n%s", traceback.format_exc())
+        return CannotConnect(reason)
+    if isinstance(exc, (ValueError, TypeError, RuntimeError, ImportError)):
+        logger.error("Unexpected error during device validation: %s", exc)
+        logger.debug("Traceback:\n%s", traceback.format_exc())
+        return CannotConnect("cannot_connect")
+    return exc  # passthrough
+
+
 async def validate_input_impl(
     hass: Any,
     data: dict[str, Any],
@@ -53,17 +167,22 @@ async def validate_input_impl(
 ) -> dict[str, Any]:
     """Validate user-provided connection data and return scan payload."""
 
-    connection_type = normalize_connection_type(data)
-    slave_id = validate_slave_id(data)
-
-    name = data.get(conf_name, default_name)
-    timeout = data.get(conf_timeout, default_timeout)
-    host = ""
-    port = default_port
-    if connection_type == connection_type_tcp:
-        host, port = validate_tcp_config(data)
-    else:
-        validate_rtu_config(data)
+    params = _normalize_connection_params(
+        data,
+        normalize_connection_type=normalize_connection_type,
+        validate_slave_id=validate_slave_id,
+        validate_tcp_config=validate_tcp_config,
+        validate_rtu_config=validate_rtu_config,
+        conf_name=conf_name,
+        conf_timeout=conf_timeout,
+        default_name=default_name,
+        default_port=default_port,
+        default_timeout=default_timeout,
+        default_deep_scan=default_deep_scan,
+        default_parity=default_parity,
+        default_stop_bits=default_stop_bits,
+        connection_type_tcp=connection_type_tcp,
+    )
 
     module = await load_scanner_module(hass)
     scanner_cls = scanner_cls_override or module.ThesslaGreenDeviceScanner
@@ -73,26 +192,26 @@ async def validate_input_impl(
     try:
         scanner = await run_with_retry(
             lambda: scanner_cls.create(
-                host=host,
-                port=port,
-                slave_id=slave_id,
-                timeout=timeout,
+                host=params["host"],
+                port=params["port"],
+                slave_id=params["slave_id"],
+                timeout=params["timeout"],
                 retry=default_retry,
                 backoff=config_flow_backoff,
-                deep_scan=data.get(CONF_DEEP_SCAN, default_deep_scan),
-                connection_type=connection_type,
-                connection_mode=data.get(CONF_CONNECTION_MODE),
-                serial_port=data.get(CONF_SERIAL_PORT),
-                baud_rate=data.get(CONF_BAUD_RATE),
-                parity=data.get(CONF_PARITY, default_parity),
-                stop_bits=data.get(CONF_STOP_BITS, default_stop_bits),
+                deep_scan=params["deep_scan"],
+                connection_type=params["connection_type"],
+                connection_mode=params["connection_mode"],
+                serial_port=params["serial_port"],
+                baud_rate=params["baud_rate"],
+                parity=params["parity"],
+                stop_bits=params["stop_bits"],
                 hass=hass,
             ),
             default_retry,
             config_flow_backoff,
         )
 
-        short_timeout = max(2, timeout)
+        short_timeout = max(2, params["timeout"])
         verify_cb = getattr(scanner, "verify_connection", None)
         if not callable(verify_cb):
             raise AttributeError("verify_connection")
@@ -104,7 +223,7 @@ async def validate_input_impl(
         )
 
         scan_result = await run_with_retry(
-            lambda: call_with_optional_timeout(scanner.scan_device, timeout),
+            lambda: call_with_optional_timeout(scanner.scan_device, params["timeout"]),
             default_retry,
             config_flow_backoff,
         )
@@ -114,60 +233,22 @@ async def validate_input_impl(
 
         caps_dict = process_scan_capabilities(scan_result, capabilities_cls)
         scan_result["capabilities"] = caps_dict
-        device_info = scan_result.get("device_info", {})
-
-        return {
-            "title": name,
-            "device_info": device_info,
-            "scan_result": scan_result,
-        }
-
-    except ConnectionException as exc:
-        logger.error("Connection error: %s", exc)
-        logger.debug("Traceback:\n%s", traceback.format_exc())
-        raise CannotConnect("cannot_connect") from exc
+        return _build_success_payload(params["name"], scan_result)
     except asyncio.CancelledError:
         raise
-    except ModbusIOException as exc:
-        if is_request_cancelled_error(exc):
-            logger.info("Modbus request cancelled during device validation.")
-            raise CannotConnect("timeout") from exc
-        logger.error("Modbus IO error during device validation: %s", exc)
-        logger.debug("Traceback:\n%s", traceback.format_exc())
-        raise CannotConnect("io_error") from exc
-    except timeout_exceptions as exc:
-        logger.warning("Timeout during device validation: %s", exc)
-        if should_log_timeout_traceback(exc):
-            logger.debug("Traceback:\n%s", traceback.format_exc())
-        raise CannotConnect("timeout") from exc
-    except ModbusException as exc:
-        logger.error("Modbus error: %s", exc)
-        logger.debug("Traceback:\n%s", traceback.format_exc())
-        if is_invalid_auth_error(exc):
-            raise InvalidAuth from exc
-        raise CannotConnect("modbus_error") from exc
-    except AttributeError as exc:
-        logger.error("Attribute error during device validation: %s", exc)
-        logger.debug("Traceback:\n%s", traceback.format_exc())
-        raise CannotConnect("missing_method") from exc
-    except OSError as exc:
-        reason = classify_os_error(exc)
-        if reason == "dns_failure":
-            logger.error("DNS resolution failed: %s", exc)
-        elif reason == "connection_refused":
-            logger.error("Connection refused: %s", exc)
-        else:
-            logger.error("Unexpected error during device validation: %s", exc)
-        logger.debug("Traceback:\n%s", traceback.format_exc())
-        raise CannotConnect(reason) from exc
     except CannotConnect:
         raise
-    except (ValueError, TypeError, RuntimeError, ImportError) as exc:
-        logger.error("Unexpected error during device validation: %s", exc)
-        logger.debug("Traceback:\n%s", traceback.format_exc())
-        raise CannotConnect("cannot_connect") from exc
+    except BaseException as exc:
+        mapped = _map_validation_exception(
+            exc,
+            is_request_cancelled_error=is_request_cancelled_error,
+            classify_os_error=classify_os_error,
+            should_log_timeout_traceback=should_log_timeout_traceback,
+            logger=logger,
+            timeout_exceptions=timeout_exceptions,
+        )
+        if mapped is exc:
+            raise
+        raise mapped from exc
     finally:
-        if scanner is not None and hasattr(scanner, "close"):
-            close_result = scanner.close()
-            if inspect.isawaitable(close_result):
-                await close_result
+        await _maybe_close_scanner(scanner)

--- a/custom_components/thessla_green_modbus/config_flow_schema.py
+++ b/custom_components/thessla_green_modbus/config_flow_schema.py
@@ -46,6 +46,80 @@ def _option_default(prefix: str, options: list[Any], value: Any, fallback: Any) 
     return target
 
 
+def _resolve_defaults(
+    current_values: dict[str, Any], discovered_host: str | None
+) -> dict[str, Any]:
+    """Resolve normalized defaults used by schema sections."""
+    connection_default = current_values.get(CONF_CONNECTION_TYPE, DEFAULT_CONNECTION_TYPE)
+    port_default = current_values.get(CONF_PORT, DEFAULT_PORT)
+    normalized_type, resolved_mode = resolve_connection_settings(
+        connection_default,
+        current_values.get("connection_mode"),
+        port_default,
+    )
+    if normalized_type == CONNECTION_TYPE_TCP and resolved_mode == "tcp_rtu":
+        connection_default = CONNECTION_TYPE_TCP_RTU
+    else:
+        connection_default = normalized_type
+    return {
+        "connection_default": connection_default,
+        "host_default": current_values.get(CONF_HOST, discovered_host or ""),
+        "port_default": port_default,
+        "slave_default": current_values.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID),
+        "serial_port_default": current_values.get(CONF_SERIAL_PORT, DEFAULT_SERIAL_PORT),
+    }
+
+
+def _build_connection_type_field(connection_default: str) -> dict[Any, Any]:
+    return {
+        vol.Required(
+            CONF_CONNECTION_TYPE,
+            default=connection_default,
+            description={
+                "selector": {
+                    "select": {
+                        "options": [
+                            {"value": CONNECTION_TYPE_TCP, "label": f"{DOMAIN}.connection_type_tcp"},
+                            {
+                                "value": CONNECTION_TYPE_TCP_RTU,
+                                "label": f"{DOMAIN}.connection_type_tcp_rtu",
+                            },
+                            {"value": CONNECTION_TYPE_RTU, "label": f"{DOMAIN}.connection_type_rtu"},
+                        ]
+                    }
+                }
+            },
+        ): vol.In({CONNECTION_TYPE_TCP, CONNECTION_TYPE_TCP_RTU, CONNECTION_TYPE_RTU})
+    }
+
+
+def _build_tcp_fields(host_default: str, port_default: int) -> dict[Any, Any]:
+    return {
+        vol.Required(CONF_HOST, default=host_default): str,
+        vol.Required(CONF_PORT, default=port_default): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=65535)
+        ),
+    }
+
+
+def _build_rtu_fields(
+    serial_port_default: str,
+    *,
+    baud_default: Any,
+    baud_validator: Any,
+    parity_default: Any,
+    parity_validator: Any,
+    stop_bits_default: Any,
+    stop_bits_validator: Any,
+) -> dict[Any, Any]:
+    return {
+        vol.Required(CONF_SERIAL_PORT, default=serial_port_default): str,
+        vol.Required(CONF_BAUD_RATE, default=baud_default): baud_validator,
+        vol.Required(CONF_PARITY, default=parity_default): parity_validator,
+        vol.Required(CONF_STOP_BITS, default=stop_bits_default): stop_bits_validator,
+    }
+
+
 def build_connection_schema(
     defaults: dict[str, Any],
     *,
@@ -57,21 +131,12 @@ def build_connection_schema(
     """Return schema for connection details with provided defaults."""
     current_values = defaults or {}
 
-    connection_default = current_values.get(CONF_CONNECTION_TYPE, DEFAULT_CONNECTION_TYPE)
-    host_default = current_values.get(CONF_HOST, discovered_host or "")
-    port_default = current_values.get(CONF_PORT, DEFAULT_PORT)
-    slave_default = current_values.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID)
-    connection_mode_default = current_values.get("connection_mode")
-
-    normalized_type, resolved_mode = resolve_connection_settings(
-        connection_default, connection_mode_default, port_default
-    )
-    if normalized_type == CONNECTION_TYPE_TCP and resolved_mode == "tcp_rtu":
-        connection_default = CONNECTION_TYPE_TCP_RTU
-    else:
-        connection_default = normalized_type
-
-    serial_port_default = current_values.get(CONF_SERIAL_PORT, DEFAULT_SERIAL_PORT)
+    resolved_defaults = _resolve_defaults(current_values, discovered_host)
+    connection_default = resolved_defaults["connection_default"]
+    host_default = resolved_defaults["host_default"]
+    port_default = resolved_defaults["port_default"]
+    slave_default = resolved_defaults["slave_default"]
+    serial_port_default = resolved_defaults["serial_port_default"]
 
     baud_options = modbus_baud_rates if modbus_baud_rates is not None else []
     parity_options = modbus_parity if modbus_parity is not None else []
@@ -119,30 +184,7 @@ def build_connection_schema(
     )
 
     data_schema: dict[Any, Any] = {
-        vol.Required(
-            CONF_CONNECTION_TYPE,
-            default=connection_default,
-            description={
-                "selector": {
-                    "select": {
-                        "options": [
-                            {
-                                "value": CONNECTION_TYPE_TCP,
-                                "label": f"{DOMAIN}.connection_type_tcp",
-                            },
-                            {
-                                "value": CONNECTION_TYPE_TCP_RTU,
-                                "label": f"{DOMAIN}.connection_type_tcp_rtu",
-                            },
-                            {
-                                "value": CONNECTION_TYPE_RTU,
-                                "label": f"{DOMAIN}.connection_type_rtu",
-                            },
-                        ]
-                    }
-                }
-            },
-        ): vol.In({CONNECTION_TYPE_TCP, CONNECTION_TYPE_TCP_RTU, CONNECTION_TYPE_RTU}),
+        **_build_connection_type_field(connection_default),
         vol.Required(CONF_SLAVE_ID, default=slave_default): vol.All(
             vol.Coerce(int), vol.Range(min=0, max=247)
         ),
@@ -162,22 +204,18 @@ def build_connection_schema(
     }
 
     if connection_default in (CONNECTION_TYPE_TCP, CONNECTION_TYPE_TCP_RTU):
-        data_schema.update(
-            {
-                vol.Required(CONF_HOST, default=host_default): str,
-                vol.Required(CONF_PORT, default=port_default): vol.All(
-                    vol.Coerce(int), vol.Range(min=1, max=65535)
-                ),
-            }
-        )
+        data_schema.update(_build_tcp_fields(host_default, port_default))
     else:
         data_schema.update(
-            {
-                vol.Required(CONF_SERIAL_PORT, default=serial_port_default): str,
-                vol.Required(CONF_BAUD_RATE, default=baud_default): baud_validator,
-                vol.Required(CONF_PARITY, default=parity_default): parity_validator,
-                vol.Required(CONF_STOP_BITS, default=stop_bits_default): stop_bits_validator,
-            }
+            _build_rtu_fields(
+                serial_port_default,
+                baud_default=baud_default,
+                baud_validator=baud_validator,
+                parity_default=parity_default,
+                parity_validator=parity_validator,
+                stop_bits_default=stop_bits_default,
+                stop_bits_validator=stop_bits_validator,
+            )
         )
 
     return vol.Schema(data_schema)


### PR DESCRIPTION
### Motivation
- Reduce complexity in the config flow hotspots by extracting pure helpers from `validate_input_impl` and `build_connection_schema` so orchestration code is easier to read and test.
- Isolate connection normalization, exception mapping, payload construction, and schema section builders to make intent explicit and enable focused unit tests.

### Description
- Extracted parameter normalization into `_normalize_connection_params` and success payload construction into `_build_success_payload` in `config_flow_device_validation.py`, and replaced the inline logic in `validate_input_impl` to use these helpers.
- Added `_map_validation_exception` to centralize mapping of low-level exceptions to `CannotConnect`/`InvalidAuth` and `_maybe_close_scanner` to unify scanner cleanup behavior in `config_flow_device_validation.py`.
- Decomposed `build_connection_schema` in `config_flow_schema.py` into `_resolve_defaults`, `_build_connection_type_field`, `_build_tcp_fields`, and `_build_rtu_fields`, and restructured the schema assembly to call these section builders.
- Preserved public behavior and flow error semantics, kept UI schema options/selectors unchanged, and limited edits to the allowed files only.

### Testing
- Ran linting and static checks with `ruff check custom_components tests tools` and byte-compiled with `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both succeeded.
- Ran targeted tests with `pytest -q tests/test_config_flow_*.py` and `pytest -q tests/test_integration.py tests/test_migration.py`, which passed.
- Ran full test suite with `pytest tests/ -q` which failed due to an unrelated `pytest_socket.SocketBlockedError` in `tests/test_coordinator.py::test_reconfigure_does_not_leak_connections` and not caused by the modified config flow code.
- Maintainability check `python tools/check_maintainability.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c2d91e608326b4693f7d14948445)