### PR TITLE
refactor: tighten coordinator package public API

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/__init__.py
+++ b/custom_components/thessla_green_modbus/coordinator/__init__.py
@@ -1,25 +1,12 @@
 """Coordinator package public API."""
 
-from .coordinator import (
-    AsyncModbusTcpClient,
-    CoordinatorConfig,
-    DeviceCapabilities,
-    ThesslaGreenDeviceScanner,
-    ThesslaGreenModbusCoordinator,
-    _PermanentModbusError,
-    _utcnow,
-    dt_util,
-    get_register_definition,
-)
+from ..registers.loader import get_register_definition
+from ..scanner.core import ThesslaGreenDeviceScanner
+from .coordinator import CoordinatorConfig, ThesslaGreenModbusCoordinator
 
 __all__ = [
-    "AsyncModbusTcpClient",
     "CoordinatorConfig",
-    "DeviceCapabilities",
     "ThesslaGreenDeviceScanner",
     "ThesslaGreenModbusCoordinator",
-    "_PermanentModbusError",
-    "_utcnow",
-    "dt_util",
     "get_register_definition",
 ]

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _get_register_definition(register_name: str) -> Any:
-    """Resolve register definitions via coordinator module for tests."""
+    """Resolve register definitions via coordinator package API."""
 
     from custom_components.thessla_green_modbus import coordinator as coordinator_module
 

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 import custom_components.thessla_green_modbus.config_flow as config_flow
 import custom_components.thessla_green_modbus.coordinator as coordinator
-import custom_components.thessla_green_modbus.coordinator.retry as coordinator_retry
 import custom_components.thessla_green_modbus.scanner.core as scanner_core
 import custom_components.thessla_green_modbus.services as services
 import custom_components.thessla_green_modbus.services_schema as services_schema
 import custom_components.thessla_green_modbus.services_targets as services_targets
 
 
-def test_coordinator_exports_permanent_modbus_error() -> None:
-    """Coordinator should expose permanent modbus error type."""
-    assert coordinator._PermanentModbusError is coordinator_retry._PermanentModbusError
-    assert "_PermanentModbusError" in coordinator.__all__
+def test_coordinator_package_public_api_is_minimal() -> None:
+    """Coordinator package should expose only public coordinator entrypoints."""
+    assert set(coordinator.__all__) == {"CoordinatorConfig", "ThesslaGreenDeviceScanner", "ThesslaGreenModbusCoordinator", "get_register_definition"}
+    for export_name in coordinator.__all__:
+        assert hasattr(coordinator, export_name)
 
 
 def test_scanner_core_public_api_is_minimal() -> None:

--- a/tests/test_coordinator_errors.py
+++ b/tests/test_coordinator_errors.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from custom_components.thessla_green_modbus.coordinator import (
-    ThesslaGreenModbusCoordinator,
-    _PermanentModbusError,
-)
+from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+from custom_components.thessla_green_modbus.coordinator.retry import _PermanentModbusError
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_io.py
+++ b/tests/test_coordinator_io.py
@@ -4,10 +4,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from custom_components.thessla_green_modbus.coordinator import (
-    ThesslaGreenModbusCoordinator,
-    _PermanentModbusError,
-)
+from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+from custom_components.thessla_green_modbus.coordinator.retry import _PermanentModbusError
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
 
 


### PR DESCRIPTION
### Motivation
- Reduce the coordinator package root API surface to only true public entrypoints and remove implementation/test-patching internals from `custom_components.thessla_green_modbus.coordinator`.
- Ensure tests and internal modules import implementation details from their owning modules rather than relying on package-root re-exports.
- Preserve existing runtime behavior while making the package-root API clearer and harder to misuse.

### Description
- Tightened `custom_components/thessla_green_modbus/coordinator/__init__.py` to re-export only `CoordinatorConfig`, `ThesslaGreenModbusCoordinator`, `ThesslaGreenDeviceScanner`, and `get_register_definition` (with `get_register_definition` imported from the registers loader and `ThesslaGreenDeviceScanner` from `scanner.core`).
- Removed package-root re-exports of internal/test-only symbols such as `AsyncModbusTcpClient`, `DeviceCapabilities`, `_PermanentModbusError`, `_utcnow`, and `dt_util`.
- Updated tests to import `_PermanentModbusError` from its owning module (`custom_components.thessla_green_modbus.coordinator.retry`) and updated the API contract test to assert the new minimal `__all__` set.
- Left schedule/write helpers unchanged in behavior while clarifying the intended source of register-definition resolution through the coordinator package API.

### Testing
- Ran static/lint and build checks with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed.
- Ran targeted tests with `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` which passed.
- Ran full test suite with `pytest tests/ -q` which passed in this environment.
- Ran maintainability checks with `python tools/check_maintainability.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c2a5fdac8326963481b7940d7a35)