### PR TITLE
test: split coordinator register-write tests into dedicated module

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -109,69 +109,6 @@ def test_coordinator_clamps_effective_batch():
 
 
 @pytest.mark.asyncio
-async def test_async_write_invalid_register(coordinator):
-    """Return False and do not refresh on unknown register."""
-    coordinator._ensure_connection = AsyncMock()
-    result = await coordinator.async_write_register("invalid", 1)
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_async_write_valid_register(coordinator):
-    """Test successful register write and refresh outside lock."""
-    coordinator._ensure_connection = AsyncMock()
-    client = MagicMock()
-    response = MagicMock()
-    response.isError.return_value = False
-    client.write_register = AsyncMock(return_value=response)
-    coordinator.client = client
-
-    lock_state_during_refresh = None
-
-    async def refresh_side_effect():
-        nonlocal lock_state_during_refresh
-        lock_state_during_refresh = coordinator._write_lock.locked()
-
-    coordinator.async_request_refresh = AsyncMock(side_effect=refresh_side_effect)
-
-    result = await coordinator.async_write_register("mode", 1)
-
-    assert result is True
-    coordinator.async_request_refresh.assert_called_once()
-    assert lock_state_during_refresh is False
-
-
-@pytest.mark.asyncio
-async def test_async_write_register_numeric_out_of_range(coordinator, monkeypatch):
-    """Numeric values outside defined range should raise."""
-    coordinator._ensure_connection = AsyncMock()
-    coordinator.client = MagicMock()
-
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
-
-    reg = RegisterDef(function="03", address=0, name="num", access="rw", min=0, max=10)
-    monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: reg)
-
-    with pytest.raises(ValueError):
-        await coordinator.async_write_register("num", 11)
-
-
-@pytest.mark.asyncio
-async def test_async_write_register_enum_invalid(coordinator, monkeypatch):
-    """Invalid enum values should raise and be propagated."""
-    coordinator._ensure_connection = AsyncMock()
-    coordinator.client = MagicMock()
-
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
-
-    reg = RegisterDef(function="03", address=0, name="mode", access="rw", enum={0: "off", 1: "on"})
-    monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: reg)
-
-    with pytest.raises(ValueError):
-        await coordinator.async_write_register("mode", "invalid")
-
-
-@pytest.mark.asyncio
 async def test_read_holding_registers_none_client(coordinator, caplog):
     """Return empty data when no Modbus client is present."""
     coordinator.client = None

--- a/tests/test_coordinator_register_writes.py
+++ b/tests/test_coordinator_register_writes.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+from custom_components.thessla_green_modbus.registers.loader import RegisterDef
+
+
+@pytest.fixture
+def coordinator() -> ThesslaGreenModbusCoordinator:
+    hass = MagicMock()
+    available_registers = {
+        "holding_registers": {"mode", "air_flow_rate_manual", "special_mode"},
+        "input_registers": {"outside_temperature", "supply_temperature"},
+        "coil_registers": {"system_on_off"},
+        "discrete_inputs": set(),
+    }
+    coord = ThesslaGreenModbusCoordinator.from_params(
+        hass=hass,
+        host="localhost",
+        port=502,
+        slave_id=1,
+        name="test",
+        scan_interval=30,
+        timeout=10,
+        retry=3,
+    )
+    coord.available_registers = available_registers
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_async_write_invalid_register(coordinator):
+    """Return False and do not refresh on unknown register."""
+    coordinator._ensure_connection = AsyncMock()
+    result = await coordinator.async_write_register("invalid", 1)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_async_write_valid_register(coordinator):
+    """Test successful register write and refresh outside lock."""
+    coordinator._ensure_connection = AsyncMock()
+    client = MagicMock()
+    response = MagicMock()
+    response.isError.return_value = False
+    client.write_register = AsyncMock(return_value=response)
+    coordinator.client = client
+
+    lock_state_during_refresh = None
+
+    async def refresh_side_effect():
+        nonlocal lock_state_during_refresh
+        lock_state_during_refresh = coordinator._write_lock.locked()
+
+    coordinator.async_request_refresh = AsyncMock(side_effect=refresh_side_effect)
+
+    result = await coordinator.async_write_register("mode", 1)
+
+    assert result is True
+    coordinator.async_request_refresh.assert_called_once()
+    assert lock_state_during_refresh is False
+
+
+@pytest.mark.asyncio
+async def test_async_write_register_numeric_out_of_range(coordinator, monkeypatch):
+    """Numeric values outside defined range should raise."""
+    coordinator._ensure_connection = AsyncMock()
+    coordinator.client = MagicMock()
+
+    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+
+    reg = RegisterDef(function="03", address=0, name="num", access="rw", min=0, max=10)
+    monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: reg)
+
+    with pytest.raises(ValueError):
+        await coordinator.async_write_register("num", 11)
+
+
+@pytest.mark.asyncio
+async def test_async_write_register_enum_invalid(coordinator, monkeypatch):
+    """Invalid enum values should raise and be propagated."""
+    coordinator._ensure_connection = AsyncMock()
+    coordinator.client = MagicMock()
+
+    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+
+    reg = RegisterDef(function="03", address=0, name="mode", access="rw", enum={0: "off", 1: "on"})
+    monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: reg)
+
+    with pytest.raises(ValueError):
+        await coordinator.async_write_register("mode", "invalid")
+
+


### PR DESCRIPTION
### Motivation
- Reduce the size and cognitive load of large coordinator tests by extracting register-write focused tests into their own module for easier future decomposition and focused maintenance.

### Description
- Added `tests/test_coordinator_register_writes.py` containing the async register-write tests and a local coordinator fixture used by those tests.
- Removed the moved tests from `tests/test_coordinator.py` while preserving original decorators, parametrization, fixtures, monkeypatching, and assertions.
- Kept test helpers and fixture setup local to the new module to avoid creating proxy test modules or broad `conftest.py` changes, and did not touch any production code.

### Testing
- Ran `ruff check tests/test_coordinator.py tests/test_coordinator_register_writes.py` which passed.
- Ran `ruff check custom_components tests tools` which passed.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed.
- Attempted `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` but execution was blocked by missing dependency `pydantic` in the environment, preventing full pytest validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c59fd52c8326b2e49dcf208c9682)