### PR TITLE
refactor: tighten transport error handling helpers

### DIFF
--- a/custom_components/thessla_green_modbus/transport/base.py
+++ b/custom_components/thessla_green_modbus/transport/base.py
@@ -1,1 +1,130 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Base transport primitives used by transport implementations."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+from .._transport_retry import apply_transport_backoff, log_transport_retry
+from ..error_policy import to_log_message
+from ..modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
+from .retry import classify_transport_error
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BaseModbusTransport(ABC):
+    """Base interface for transport implementations."""
+
+    def __init__(
+        self,
+        *,
+        max_retries: int,
+        base_backoff: float,
+        max_backoff: float,
+        timeout: float,
+        offline_state: bool = False,
+    ) -> None:
+        self.max_retries = max(1, int(max_retries))
+        self.base_backoff = max(0.0, float(base_backoff))
+        self.max_backoff = max(0.0, float(max_backoff))
+        self.timeout = float(timeout)
+        self.offline_state = offline_state
+        self._lock = asyncio.Lock()
+
+    @property
+    def offline(self) -> bool:
+        return self.offline_state
+
+    def is_connected(self) -> bool:
+        return self._is_connected()
+
+    async def _mark_offline_and_reset(self) -> None:
+        self.offline_state = True
+        await self._reset_connection()
+
+    async def _execute(self, func: Any, *, ensure_connection: bool = False) -> Any:
+        try:
+            if ensure_connection:
+                await self.ensure_connected()
+            result = await func()
+            self.offline_state = False
+            return result
+        except asyncio.CancelledError:
+            self.offline_state = True
+            try:
+                await self._reset_connection()
+            except (ConnectionException, ModbusException, OSError, RuntimeError) as exc:
+                _LOGGER.debug("Reset connection failed during CancelledError handling: %s", exc)
+            raise
+        except (TimeoutError, ModbusIOException, ConnectionException, OSError):
+            await self._mark_offline_and_reset()
+            raise
+        except ModbusException as exc:
+            decision = classify_transport_error(exc)
+            _LOGGER.error(
+                "Permanent Modbus error (%s/%s): %s",
+                decision.kind.value,
+                decision.reason,
+                to_log_message(exc),
+            )
+            self.offline_state = True
+            raise
+        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:  # pragma: no cover
+            _LOGGER.error("Unexpected transport error: %s", to_log_message(exc))
+            self.offline_state = True
+            raise
+
+    async def ensure_connected(self) -> None:
+        async with self._lock:
+            if self._is_connected():
+                return
+            await self._reset_connection()
+            await self._connect()
+
+    async def close(self) -> None:
+        async with self._lock:
+            await self._reset_connection()
+            self.offline_state = True
+
+    async def _handle_timeout(self, attempt: int, exc: Exception) -> None:
+        log_transport_retry(
+            logger=_LOGGER,
+            operation="timeout",
+            attempt=attempt,
+            max_attempts=self.max_retries,
+            exc=exc,
+            base_backoff=self.base_backoff,
+        )
+        await self._mark_offline_and_reset()
+        await self._apply_backoff(attempt)
+
+    async def _handle_transient(self, attempt: int, exc: Exception) -> None:
+        log_transport_retry(
+            logger=_LOGGER,
+            operation="transient",
+            attempt=attempt,
+            max_attempts=self.max_retries,
+            exc=exc,
+            base_backoff=self.base_backoff,
+        )
+        await self._mark_offline_and_reset()
+        await self._apply_backoff(attempt)
+
+    async def _apply_backoff(self, attempt: int) -> None:
+        await apply_transport_backoff(
+            attempt=attempt,
+            base_backoff=self.base_backoff,
+            max_backoff=self.max_backoff,
+        )
+
+    @abstractmethod
+    def _is_connected(self) -> bool: ...
+
+    @abstractmethod
+    async def _connect(self) -> None: ...
+
+    @abstractmethod
+    async def _reset_connection(self) -> None: ...

--- a/custom_components/thessla_green_modbus/transport/crc.py
+++ b/custom_components/thessla_green_modbus/transport/crc.py
@@ -1,1 +1,16 @@
-"""TODO: module scaffold for branch test refactor."""
+"""CRC helpers for RTU framing."""
+
+from __future__ import annotations
+
+
+def crc16(data: bytes) -> int:
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0xA001 if crc & 1 else crc >> 1
+    return crc & 0xFFFF
+
+
+def append_crc(data: bytes) -> bytes:
+    return data + crc16(data).to_bytes(2, "little")

--- a/custom_components/thessla_green_modbus/transport/rtu.py
+++ b/custom_components/thessla_green_modbus/transport/rtu.py
@@ -1,1 +1,68 @@
-"""TODO: module scaffold for branch test refactor."""
+"""RTU transport implementation."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+try:
+    from pymodbus.client import AsyncModbusSerialClient as _AsyncModbusSerialClient
+except (ImportError, AttributeError) as serial_import_err:  # pragma: no cover
+    _AsyncModbusSerialClient = None
+    SERIAL_IMPORT_ERROR: Exception | None = serial_import_err
+else:  # pragma: no cover
+    SERIAL_IMPORT_ERROR = None
+
+from ..modbus_exceptions import ConnectionException
+from ..modbus_helpers import async_maybe_await_close
+from .base import BaseModbusTransport
+
+
+class RtuModbusTransport(BaseModbusTransport):
+    def __init__(self, *, serial_port: str, baudrate: int, parity: str, stopbits: int, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.serial_port = serial_port
+        self.baudrate = baudrate
+        self.parity = parity
+        self.stopbits = stopbits
+        self.client: Any | None = None
+
+    def _is_connected(self) -> bool:
+        return bool(self.client and getattr(self.client, "connected", False))
+
+    async def _connect(self) -> None:
+        if _AsyncModbusSerialClient is None:
+            msg = "Modbus serial client is unavailable."
+            if SERIAL_IMPORT_ERROR is not None:
+                msg = f"{msg} ({SERIAL_IMPORT_ERROR})"
+            raise ConnectionException(msg)
+        if not self.serial_port:
+            raise ConnectionException("Serial port not configured for RTU transport")
+        self.client = _AsyncModbusSerialClient(
+            method="rtu",
+            port=self.serial_port,
+            baudrate=self.baudrate,
+            parity=self.parity,
+            stopbits=self.stopbits,
+            timeout=self.timeout,
+        )
+        connect_method = getattr(self.client, "connect", None)
+        if callable(connect_method):
+            connected = connect_method()
+            if inspect.isawaitable(connected):
+                connected = await connected
+        else:
+            connected = True
+            self.client.connected = True
+        if not connected:
+            self.offline_state = True
+            raise ConnectionException(f"Could not connect to {self.serial_port}")
+        self.offline_state = False
+
+    async def _reset_connection(self) -> None:
+        if self.client is None:
+            return
+        try:
+            await async_maybe_await_close(self.client)
+        finally:
+            self.client = None

--- a/custom_components/thessla_green_modbus/transport/rtu_over_tcp.py
+++ b/custom_components/thessla_green_modbus/transport/rtu_over_tcp.py
@@ -1,1 +1,25 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Raw RTU-over-TCP utilities."""
+
+from __future__ import annotations
+
+from .crc import append_crc, crc16
+
+
+def validate_crc(payload: bytes, crc_bytes: bytes) -> None:
+    expected = crc16(payload).to_bytes(2, "little")
+    if crc_bytes != expected:
+        raise ValueError("CRC mismatch in RTU response")
+
+
+def build_read_frame(slave_id: int, function: int, address: int, count: int) -> bytes:
+    payload = bytes(
+        [
+            slave_id & 0xFF,
+            function & 0xFF,
+            (address >> 8) & 0xFF,
+            address & 0xFF,
+            (count >> 8) & 0xFF,
+            count & 0xFF,
+        ]
+    )
+    return append_crc(payload)

--- a/custom_components/thessla_green_modbus/transport/tcp.py
+++ b/custom_components/thessla_green_modbus/transport/tcp.py
@@ -1,1 +1,77 @@
-"""TODO: module scaffold for branch test refactor."""
+"""TCP transport helpers and implementation."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from pymodbus.client import AsyncModbusTcpClient
+
+from ..const import CONNECTION_TYPE_TCP, CONNECTION_TYPE_TCP_RTU
+from ..modbus_exceptions import ConnectionException
+from ..modbus_helpers import async_maybe_await_close, get_rtu_framer
+from .base import BaseModbusTransport
+
+
+class TcpModbusTransport(BaseModbusTransport):
+    """TCP Modbus transport implementation."""
+
+    def __init__(self, *, host: str, port: int, connection_type: str = CONNECTION_TYPE_TCP, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.host = host
+        self.port = port
+        self.connection_type = connection_type
+        self.client: AsyncModbusTcpClient | None = None
+
+    def _is_connected(self) -> bool:
+        return bool(self.client and getattr(self.client, "connected", False))
+
+    def _build_tcp_client(self, *, framer: Any | None = None) -> AsyncModbusTcpClient:
+        common_kwargs: dict[str, Any] = {
+            "port": self.port,
+            "timeout": self.timeout,
+            "reconnect_delay": 1,
+            "reconnect_delay_max": 300,
+            "retries": self.max_retries,
+        }
+        if framer is not None:
+            common_kwargs["framer"] = framer
+        try:
+            return AsyncModbusTcpClient(self.host, **common_kwargs)
+        except TypeError:
+            fallback = {k: v for k, v in common_kwargs.items() if k in {"port", "timeout", "framer"}}
+            try:
+                return AsyncModbusTcpClient(self.host, **fallback)
+            except TypeError:
+                client = AsyncModbusTcpClient()
+                client.host = self.host
+                client.port = self.port
+                return client
+
+    async def _connect(self) -> None:
+        framer = None
+        if self.connection_type == CONNECTION_TYPE_TCP_RTU:
+            framer = get_rtu_framer()
+            if framer is None:
+                raise ConnectionException("RTU framer support is unavailable")
+        self.client = self._build_tcp_client(framer=framer)
+        connect_method = getattr(self.client, "connect", None)
+        if callable(connect_method):
+            connected = connect_method()
+            if inspect.isawaitable(connected):
+                connected = await connected
+        else:
+            connected = True
+            self.client.connected = True
+        if not connected:
+            self.offline_state = True
+            raise ConnectionException(f"Could not connect to {self.host}:{self.port}")
+        self.offline_state = False
+
+    async def _reset_connection(self) -> None:
+        if self.client is None:
+            return
+        try:
+            await async_maybe_await_close(self.client)
+        finally:
+            self.client = None


### PR DESCRIPTION
### Motivation
- Improve maintainability and testability of the transport layer by replacing scaffold modules with focused, small modules and by extracting duplicated offline/reset logic. 
- Preserve existing Modbus behavior and retry semantics while making the code easier to reason about and unit-test. 

### Description
- Introduced a concrete `BaseModbusTransport` with a shared helper `_mark_offline_and_reset` and consolidated execute/backoff/error handling in `custom_components/thessla_green_modbus/transport/base.py`. 
- Implemented client-backed TCP and RTU transports in `custom_components/thessla_green_modbus/transport/tcp.py` and `custom_components/thessla_green_modbus/transport/rtu.py` with safe connect/reset handling and async/sync connect compatibility. 
- Added CRC and RTU framing utilities in `custom_components/thessla_green_modbus/transport/crc.py` and `custom_components/thessla_green_modbus/transport/rtu_over_tcp.py` to centralize framing/CRC logic. 
- Kept `transport/retry.py` as the single source of truth for retry classification and used it from the base transport for logging decisions. 
- Files changed: `base.py`, `tcp.py`, `rtu.py`, `crc.py`, `rtu_over_tcp.py` (all under `custom_components/thessla_green_modbus/transport`). 

### Testing
- Ran development and static checks: `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, all succeeded. 
- Executed targeted transport tests: `pytest -q tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py`, which passed. 
- Executed full test suite: `pytest tests/ -q`, which completed successfully (a few tests were skipped for expected reasons). 
- Maintained the repository maintainability gate by running `python tools/check_maintainability.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c6619ca88326a17176e33541201a)