### PR TITLE
refactor: tighten register codec and planner helpers

### DIFF
--- a/custom_components/thessla_green_modbus/registers/codec.py
+++ b/custom_components/thessla_green_modbus/registers/codec.py
@@ -1,1 +1,86 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Pure codec helpers for register encode/decode operations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from typing import Any
+
+
+def decode_enum_value(raw: int, enum_map: Mapping[int | str, Any] | None) -> Any | None:
+    """Decode ``raw`` using register enum map when possible."""
+    if enum_map is None:
+        return None
+    if raw in enum_map:
+        return enum_map[raw]
+    key = str(raw)
+    if key in enum_map:
+        return enum_map[key]
+    return None
+
+
+def decode_bitmask_value(raw: int, enum_map: Mapping[int | str, Any] | None) -> list[Any]:
+    """Decode bit flags into a list of labels sorted by numeric bit value."""
+    if not enum_map:
+        return []
+    flags: list[Any] = []
+    entries = sorted(((int(k), v) for k, v in enum_map.items()), key=lambda pair: pair[0])
+    for bit, label in entries:
+        if raw & bit:
+            flags.append(label)
+    return flags
+
+
+def encode_enum_value(value: Any, enum_map: Mapping[int | str, Any] | None, name: str) -> int:
+    """Encode value according to enum map or raise ``ValueError``."""
+    if enum_map is None:
+        return int(value)
+    if isinstance(value, str):
+        for key, label in enum_map.items():
+            if label == value:
+                return int(key)
+        raise ValueError(f"Invalid enum value {value!r} for {name}")
+    if value in enum_map or str(value) in enum_map:
+        return int(value)
+    raise ValueError(f"Invalid enum value {value!r} for {name}")
+
+
+def apply_output_scaling(value: Any, multiplier: float | None, resolution: float | None) -> Any:
+    """Apply multiplier/resolution scaling to decoded value."""
+    if multiplier not in (None, 1):
+        value *= multiplier
+    if resolution not in (None, 1):
+        steps = round(value / resolution)
+        value = steps * resolution
+    return value
+
+
+def coerce_scaled_input(
+    *,
+    value: Any,
+    raw_value: Any,
+    minimum: float | None,
+    maximum: float | None,
+    multiplier: float | None,
+    resolution: float | None,
+    name: str,
+) -> Any:
+    """Validate and convert user-facing value to raw register-domain value."""
+    try:
+        num_val = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return raw_value
+
+    if minimum is not None and num_val < Decimal(str(minimum)):
+        raise ValueError(f"{value} is below minimum {minimum} for {name}")
+    if maximum is not None and num_val > Decimal(str(maximum)):
+        raise ValueError(f"{value} is above maximum {maximum} for {name}")
+
+    scaled = Decimal(str(raw_value))
+    if resolution not in (None, 1):
+        step = Decimal(str(resolution))
+        scaled = (scaled / step).quantize(Decimal("1"), rounding=ROUND_HALF_UP) * step
+    if multiplier not in (None, 1):
+        mult = Decimal(str(multiplier))
+        scaled = (scaled / mult).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    return scaled

--- a/custom_components/thessla_green_modbus/registers/register_def.py
+++ b/custom_components/thessla_green_modbus/registers/register_def.py
@@ -10,6 +10,14 @@ from datetime import time
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import Any
 
+from .codec import (
+    apply_output_scaling,
+    coerce_scaled_input,
+    decode_bitmask_value,
+    decode_enum_value,
+    encode_enum_value,
+)
+
 _LOGGER = logging.getLogger(__name__)
 
 @dataclass(slots=True)
@@ -126,20 +134,12 @@ class RegisterDef:
 
         # Bitmask registers map set bits to enum labels
         if self.extra and self.extra.get("bitmask") and self.enum:
-            flags: list[Any] = []
-            for key, label in sorted(
-                ((int(k), v) for k, v in self.enum.items()), key=lambda x: x[0]
-            ):
-                if raw & key:
-                    flags.append(label)
-            return flags
+            return decode_bitmask_value(raw, self.enum)
 
         # Regular enum registers return the mapped label
-        if self.enum is not None:
-            if raw in self.enum:
-                return self.enum[raw]
-            if str(raw) in self.enum:
-                return self.enum[str(raw)]
+        decoded_enum = decode_enum_value(raw, self.enum)
+        if decoded_enum is not None:
+            return decoded_enum
 
         typ = self.extra.get("type") if self.extra else None
         if typ == "i16":
@@ -212,17 +212,7 @@ class RegisterDef:
 
         raw: Any = value
         if self.enum and not (self.extra and self.extra.get("bitmask")):
-            if isinstance(value, str):
-                for k, v in self.enum.items():
-                    if v == value:
-                        raw = int(k)
-                        break
-                else:
-                    raise ValueError(f"Invalid enum value {value!r} for {self.name}")
-            elif value in self.enum or str(value) in self.enum:
-                raw = int(value)
-            else:
-                raise ValueError(f"Invalid enum value {value!r} for {self.name}")
+            raw = encode_enum_value(value, self.enum, self.name)
 
         try:
             num_val = Decimal(str(value))
@@ -249,12 +239,7 @@ class RegisterDef:
         return int(raw)
 
     def _apply_output_scaling(self, value: Any) -> Any:
-        if self.multiplier not in (None, 1):
-            value *= self.multiplier
-        if self.resolution not in (None, 1):
-            steps = round(value / self.resolution)
-            value = steps * self.resolution
-        return value
+        return apply_output_scaling(value, self.multiplier, self.resolution)
 
     def _encode_multi_register(self, value: Any) -> list[int]:
         if self.extra and self.extra.get("type") == "string":
@@ -295,20 +280,13 @@ class RegisterDef:
         return words
 
     def _coerce_scaled_input(self, *, value: Any, raw_value: Any) -> Any:
-        try:
-            num_val = Decimal(str(value))
-        except (InvalidOperation, TypeError, ValueError):
-            return raw_value
-        if self.min is not None and num_val < Decimal(str(self.min)):
-            raise ValueError(f"{value} is below minimum {self.min} for {self.name}")
-        if self.max is not None and num_val > Decimal(str(self.max)):
-            raise ValueError(f"{value} is above maximum {self.max} for {self.name}")
-        scaled = Decimal(str(raw_value))
-        if self.resolution not in (None, 1):
-            step = Decimal(str(self.resolution))
-            scaled = (scaled / step).quantize(Decimal("1"), rounding=ROUND_HALF_UP) * step
-        if self.multiplier not in (None, 1):
-            mult = Decimal(str(self.multiplier))
-            scaled = (scaled / mult).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
-        return scaled
+        return coerce_scaled_input(
+            value=value,
+            raw_value=raw_value,
+            minimum=self.min,
+            maximum=self.max,
+            multiplier=self.multiplier,
+            resolution=self.resolution,
+            name=self.name,
+        )
 

--- a/tests/unit/test_register_codec_helpers.py
+++ b/tests/unit/test_register_codec_helpers.py
@@ -1,0 +1,36 @@
+from custom_components.thessla_green_modbus.registers.codec import (
+    apply_output_scaling,
+    coerce_scaled_input,
+    decode_bitmask_value,
+    decode_enum_value,
+    encode_enum_value,
+)
+
+
+def test_decode_enum_value_str_key() -> None:
+    assert decode_enum_value(1, {"1": "on"}) == "on"
+
+
+def test_decode_bitmask_value_sorted() -> None:
+    assert decode_bitmask_value(5, {4: "c", 1: "a", 2: "b"}) == ["a", "c"]
+
+
+def test_encode_enum_value() -> None:
+    assert encode_enum_value("on", {0: "off", 1: "on"}, "mode") == 1
+
+
+def test_apply_output_scaling() -> None:
+    assert apply_output_scaling(10, 0.5, 0.5) == 5.0
+
+
+def test_coerce_scaled_input_resolution_multiplier() -> None:
+    scaled = coerce_scaled_input(
+        value=12.0,
+        raw_value=12.0,
+        minimum=0,
+        maximum=100,
+        multiplier=0.5,
+        resolution=0.5,
+        name="x",
+    )
+    assert int(scaled) == 24


### PR DESCRIPTION
### Motivation
- Centralise and clarify the register encode/decode logic so it is easier to test and maintain without changing public register behaviour. 
- Reduce duplicated/inline codec logic in `RegisterDef` by extracting pure helpers. 
- Keep register JSON, addresses and names unchanged while making the code more modular and testable.

### Description
- Added `custom_components/thessla_green_modbus/registers/codec.py` implementing pure helpers: `decode_enum_value`, `decode_bitmask_value`, `encode_enum_value`, `apply_output_scaling`, and `coerce_scaled_input`.
- Updated `custom_components/thessla_green_modbus/registers/register_def.py` to delegate enum/bitmask handling and scaling/coercion to the new codec helpers while preserving existing BCD/AATT/temperature semantics.
- Added unit tests `tests/unit/test_register_codec_helpers.py` that cover enum decoding/encoding, bitmask ordering, output scaling, and input coercion behaviour.
- No register JSON, addresses, names, or intended runtime behavior were changed as part of this refactor.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, and `python -m compileall -q custom_components/thessla_green_modbus tests tools` with no issues.
- Ran `pytest -q tests/unit/test_register_*.py tests/test_airflow_unit.py` and then `pytest tests/ -q`, and the test suite passed (with a few previously existing skipped tests). 
- Ran the maintainability gate `python tools/check_maintainability.py` which passed.
- The new unit tests in `tests/unit/test_register_codec_helpers.py` passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c655b5b8832692115f1fb970c86d)