### PR TITLE
chore: align test tooling configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,10 @@ jobs:
           python -m pip install homeassistant==${{ matrix.ha-version }} hacs
 
       - name: Ruff
-        run: ruff check .
+        run: ruff check custom_components tests tools
+
+      - name: Compile Python sources
+        run: python -m compileall -q custom_components/thessla_green_modbus tests tools
 
       - name: Compare registers with vendor reference
         run: python tools/compare_registers_with_reference.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ addopts = [
     "-q",
 ]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,5 +12,6 @@ addopts =
     -q
     -p no:pytest_homeassistant_custom_component
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
 markers =
     asyncio: mark test as asynchronous


### PR DESCRIPTION
### Motivation
- Align CI validation with the local/baseline tooling to ensure the same files are linted and compiled in CI as during local development.
- Ensure the CI pipeline runs a lightweight compile step that mirrors local validation to catch syntax/compile issues early.
- Remove reliance on implicit/hidden pytest asyncio defaults by making the fixture loop scope explicit to avoid environment-dependent test behavior.

### Description
- Updated `.github/workflows/ci.yaml` to run `ruff check custom_components tests tools` instead of `ruff check .` and added a `python -m compileall -q custom_components/thessla_green_modbus tests tools` step to the lint job.
- Added `asyncio_default_fixture_loop_scope = "function"` to the pytest settings in `pyproject.toml` under `[tool.pytest.ini_options]` to make asyncio loop scope explicit.
- Added `asyncio_default_fixture_loop_scope = function` to the root `pytest.ini` to keep pytest configuration consistent across invocation paths.
- Files changed: `/.github/workflows/ci.yaml`, `/pyproject.toml`, and `/pytest.ini`.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt` and the install completed successfully.
- Ran `ruff check custom_components tests tools` and it passed with no new failures.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` and compilation completed successfully.
- Ran `pytest tests/ -q` (full test suite) which passed with only the repository's existing skips, and `python tools/check_maintainability.py` which returned "Maintainability gate passed."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c616f1748326a8553f37fe36e8c9)