### PR TITLE
chore: align service metadata translations

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1601,7 +1601,7 @@
           "name": "End Time"
         },
         "period": {
-          "description": "Day period (1 or 2)",
+          "description": "Day slot number (1-4)",
           "name": "Period",
           "selector": {
             "select": {
@@ -1611,6 +1611,10 @@
               }
             }
           }
+        },
+        "season": {
+          "description": "Select summer or winter schedule bank",
+          "name": "Season"
         },
         "start_time": {
           "description": "Start time for the period (HH:MM)",
@@ -1801,6 +1805,12 @@
     },
     "sync_time": {
       "description": "Synchronise the AirPack real-time clock to the current Home Assistant time. Useful after power loss.",
+      "fields": {
+        "entity_id": {
+          "description": "The climate entity of the AirPack device.",
+          "name": "Entity"
+        }
+      },
       "name": "Sync Device Clock"
     },
     "refresh_device_data": {

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1601,7 +1601,7 @@
           "name": "End Time"
         },
         "period": {
-          "description": "Day period (1 or 2)",
+          "description": "Day slot number (1-4)",
           "name": "Period",
           "selector": {
             "select": {
@@ -1611,6 +1611,10 @@
               }
             }
           }
+        },
+        "season": {
+          "description": "Select summer or winter schedule bank",
+          "name": "Season"
         },
         "start_time": {
           "description": "Start time for the period (HH:MM)",
@@ -1801,6 +1805,12 @@
     },
     "sync_time": {
       "description": "Synchronise the AirPack real-time clock to the current Home Assistant time. Useful after power loss.",
+      "fields": {
+        "entity_id": {
+          "description": "The climate entity of the AirPack device.",
+          "name": "Entity"
+        }
+      },
       "name": "Sync Device Clock"
     },
     "refresh_device_data": {

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1601,7 +1601,7 @@
           "name": "Czas zakończenia"
         },
         "period": {
-          "description": "Okres dnia (1 lub 2)",
+          "description": "Numer przedziału dnia (1-4)",
           "name": "Okres",
           "selector": {
             "select": {
@@ -1611,6 +1611,10 @@
               }
             }
           }
+        },
+        "season": {
+          "description": "Wybierz bank harmonogramu lato/zima",
+          "name": "Sezon"
         },
         "start_time": {
           "description": "Czas rozpoczęcia okresu (HH:MM)",
@@ -1801,6 +1805,12 @@
     },
     "sync_time": {
       "description": "Synchronizuje zegar rekuperatora AirPack z aktualnym czasem Home Assistant. Przydatne po zaniku zasilania.",
+      "fields": {
+        "entity_id": {
+          "description": "Encja climate urządzenia AirPack.",
+          "name": "Encja"
+        }
+      },
       "name": "Synchronizuj zegar urządzenia"
     },
     "refresh_device_data": {

--- a/tests/test_services_metadata.py
+++ b/tests/test_services_metadata.py
@@ -1,0 +1,63 @@
+"""Service metadata consistency tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent / "custom_components" / "thessla_green_modbus"
+
+
+class Loader(yaml.SafeLoader):
+    """YAML loader with !include support for services.yaml."""
+
+
+def _include(loader: Loader, node: yaml.Node):
+    file_path = ROOT / loader.construct_scalar(node)
+    with open(file_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+Loader.add_constructor("!include", _include)
+
+
+with open(ROOT / "services.yaml", encoding="utf-8") as f:
+    SERVICES_YAML = yaml.load(f, Loader=Loader)  # nosec B506
+with open(ROOT / "strings.json", encoding="utf-8") as f:
+    STRINGS = json.load(f)
+with open(ROOT / "translations" / "en.json", encoding="utf-8") as f:
+    EN = json.load(f)
+with open(ROOT / "translations" / "pl.json", encoding="utf-8") as f:
+    PL = json.load(f)
+
+
+def _service_field_keys(data: dict, service: str) -> set[str]:
+    return set((data.get("services", {}).get(service, {}).get("fields") or {}).keys())
+
+
+def test_service_and_field_keys_match_metadata() -> None:
+    """Every service and field in services.yaml must exist in all metadata files."""
+    service_keys = set(SERVICES_YAML.keys())
+    for trans in (STRINGS, EN, PL):
+        translated_services = set(trans.get("services", {}).keys())
+        assert service_keys == translated_services  # nosec B101
+
+        for service in service_keys:
+            yaml_fields = set((SERVICES_YAML[service].get("fields") or {}).keys())
+            assert yaml_fields == _service_field_keys(trans, service)  # nosec B101
+
+
+def test_service_translation_structures_match() -> None:
+    """Ensure en/pl service metadata structures have matching keys."""
+
+    def compare_keys(en: dict, pl: dict) -> None:
+        assert set(en.keys()) == set(pl.keys())  # nosec B101
+        for key, en_value in en.items():
+            pl_value = pl[key]
+            if isinstance(en_value, dict):
+                assert isinstance(pl_value, dict)  # nosec B101
+                compare_keys(en_value, pl_value)
+
+    compare_keys(EN["services"], PL["services"])


### PR DESCRIPTION
### Motivation

- Services metadata in `services.yaml` had mismatches with `strings.json` and locale translations which could cause missing UI labels and failing translation tests.
- Tests expect identical service keys and field keys across `services.yaml`, `strings.json`, and translation files, so mismatches must be fixed to avoid regressions.

### Description

- Added the missing `season` field metadata for the `set_airflow_schedule` service to `strings.json`, `translations/en.json`, and `translations/pl.json` to match `services.yaml`.
- Updated the `set_airflow_schedule.period` description in `strings.json`, `translations/en.json`, and `translations/pl.json` to reflect the actual range (`1-4`) defined in `services.yaml`.
- Added the missing `entity_id` field metadata under the `sync_time` service to `strings.json`, `translations/en.json`, and `translations/pl.json` to match `services.yaml`.
- Added `tests/test_services_metadata.py`, a new test that asserts service keys and service field keys are identical across `services.yaml`, `strings.json`, and `translations/en.json`/`pl.json`, and that the English/Polish service structures match.

### Testing

- Ran `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` and the targeted service tests completed successfully.
- Ran full `pytest tests/ -q` and all tests passed (skipped tests noted by test suite were expected and not related to these changes).
- Ran `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` with no errors.
- Ran `python tools/check_maintainability.py` and the maintainability gate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c6102604832682a214c35b202a7f)