### PR TITLE
docs: refresh maintainability audit after latest refactors

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -7,66 +7,74 @@ Date: 2026-04-29
 Executed:
 
 - `python -m pip install -q -r requirements-dev.txt`
-- `ruff check custom_components tests tools`
+- `ruff check custom_components tests tools` *(fails currently due to an existing test lint issue: `tests/test_device_scanner.py:253` unused local `result`)*
 - `python -m compileall -q custom_components/thessla_green_modbus tests tools`
-- `pytest tests/ -q`
-- `python tools/check_maintainability.py`
+- `pytest tests/ -q` *(passed; 4 skipped)*
+- `python tools/check_maintainability.py` *(passed)*
 
 ## 1) Largest files (by non-empty lines)
 
-1. `tests/test_scanner_coverage.py` (~1441)
-2. `tests/test_coordinator_coverage.py` (~1364)
+1. `tests/test_scanner_coverage.py` (~1255)
+2. `tests/test_coordinator_coverage.py` (~1061)
 3. `tests/test_config_flow_validation.py` (~865)
-4. `tests/test_device_scanner.py` (~840)
-5. `tests/test_coordinator.py` (~787)
-6. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (~736)
-7. `tests/test_optimized_integration.py` (~693)
-8. `tests/test_entity_mappings.py` (~683)
-9. `tests/test_config_flow_user.py` (~638)
-10. `tests/test_services_handlers_parameters.py` (~523)
+4. `tests/test_coordinator.py` (~743)
+5. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (~737)
+6. `tests/test_entity_mappings.py` (~683)
+7. `tests/test_config_flow_user.py` (~638)
+8. `tests/test_services_handlers_parameters.py` (~523)
+9. `tests/test_config_flow_helpers.py` (~508)
+10. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` (~500)
 
-Interpretation: pressure remains primarily in test modules, with the coordinator package implementation (`coordinator/coordinator.py`) still the main production hotspot.
+Interpretation: the largest hotspots are still primarily in tests, while `coordinator/coordinator.py` and `mappings/_mapping_builders.py` remain the most notable production-scale modules.
 
 ## 2) Largest classes
 
-1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (~674)
-2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (~450)
-3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (~432)
-4. `ThesslaGreenClimate` in `climate.py` (~333)
-5. `RegisterDefinition` in `registers/schema.py` (~313)
+1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (~585)
+2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (~408)
+3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (~394)
+4. `RegisterDefinition` in `registers/schema.py` (~273)
+5. `RawRtuOverTcpTransport` in `modbus_transport_raw.py` (~246)
 
 ## 3) Largest methods/functions
 
-1. `_extend_entity_mappings_from_registers` in `mappings/_mapping_builders.py` (~210)
-2. `main` in `tools/validate_entity_mappings.py` (~176)
-3. `validate_input_impl` in `config_flow_device_validation.py` (~151)
-4. `register_maintenance_services` in `services_handlers_maintenance.py` (~151)
-5. `_post_process_data` in `coordinator/capabilities.py` (~149)
-6. `async_write_registers` in `coordinator/schedule.py` (~145)
-7. `async_write_register` in `coordinator/schedule.py` (~137)
-8. `read_holding` in `scanner/io_read.py` (~135)
-9. `build_connection_schema` in `config_flow_schema.py` (~135)
-10. `scan` in `scanner/orchestration.py` (~131)
+1. `main` in `tools/validate_entity_mappings.py` (~156)
+2. `register_maintenance_services` in `services_handlers_maintenance.py` (~146)
+3. `read_holding` in `scanner/io_read.py` (~136)
+4. `_extend_entity_mappings_from_registers` in `mappings/_mapping_builders.py` (~133)
+5. `async_write_register` in `coordinator/schedule.py` (~123)
+6. `run_full_scan` in `scanner/orchestration.py` (~122)
+7. `verify_connection` in `scanner/setup.py` (~121)
+8. `_post_process_data` in `coordinator/capabilities.py` (~120)
+9. `scan` in `scanner/orchestration.py` (~119)
+10. `read_input` in `scanner/io_read.py` (~119)
 
-## 4) Completed refactors reflected in current state
+## 4) Completed refactors reflected in current state (PRs #1411–#1421)
 
-- Coordinator package migration completed (`coordinator/` canonical; old top-level `coordinator.py` removed).
-- Services dispatch/validation helper cleanup completed (`services_dispatch.py` and `services_validation.py` active).
-- Scanner I/O read helper cleanup completed (`scanner/io_read.py` and related split modules active).
-- Platform/entity helper cleanup completed.
+- Diagnostics helper split completed.
+- Service metadata/translations consistency alignment completed.
+- Tooling/CI alignment completed.
+- Optimized integration test split completed.
+- Registers codec helper extraction completed.
+- Transport layer cleanup completed.
+- Climate helper extraction completed.
+- Scanner/device-scanner register and coverage test splits completed.
+- Coordinator register-write test split completed.
+- Coordinator schedule/capabilities helper extraction completed.
 
-## 5) Next recommended PRs
+## 5) Current invariants and architectural constraints (verified)
 
-1. Further split `tests/test_scanner_coverage.py` by capability areas.
-2. Further split `tests/test_coordinator_coverage.py` by behavior domains.
-3. Decompose `mappings/_mapping_builders.py` large transformation function.
-4. Decompose `services_handlers_maintenance.py` registration workflow.
-5. Reduce private coupling in tests by favoring package-level contracts where practical.
-
-## 6) Constraints to keep
-
+- `coordinator/` is canonical.
+- Top-level `custom_components/thessla_green_modbus/coordinator.py` is removed.
 - No compatibility shims.
 - No proxy modules.
 - No re-export-only modules.
 - No legacy modules.
-- `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant.
+- `core/`, `transport/`, `registers/`, and `scanner/` do not import Home Assistant.
+
+## 6) Next recommended PRs
+
+1. Split `tests/test_scanner_coverage.py` further by scanner flow domains (setup, I/O, orchestration, cache/error contracts).
+2. Split `tests/test_coordinator_coverage.py` further by coordinator concern areas (init/config, read cycle, write flow, retry/reconnect, capabilities).
+3. Decompose `custom_components/thessla_green_modbus/mappings/_mapping_builders.py`, starting with `_extend_entity_mappings_from_registers` and `_load_discrete_mappings`.
+4. Decompose `custom_components/thessla_green_modbus/services_handlers_maintenance.py` registration workflow into narrower helpers.
+5. Reduce private helper coupling in tests where feasible by asserting package-level contracts.


### PR DESCRIPTION
### Motivation

- The maintainability audit document was stale after a wave of refactors and test splits and needed to reflect the repository's current structure and hotspots.  
- The change records the completed refactor wave (#1411–#1421) and re-evaluates priorities based on measured file/class/function sizes.  
- The update also documents verification of architectural invariants (coordinator canonical layout and no-shim/no-proxy/no-legacy constraints) to keep policy and docs aligned with code.

### Description

- Updated `docs/maintainability_audit.md` with the current date, executed checks and their real outcomes, and refreshed hotspot rankings for largest files, classes, and functions.  
- Removed stale entries that no longer reflect post-split file sizes and added a `Completed refactors` section that enumerates the items from PRs #1411–#1421.  
- Recomputed largest files, classes, and functions from the repository and updated the `Next recommended PRs` list to target present hotspots such as large coverage tests and the `mappings/_mapping_builders.py` helpers.  
- Explicitly recorded verified invariants: `coordinator/` is canonical, top-level `coordinator.py` removed, no compatibility shims/proxies/re-export-only/legacy modules, and `core/`, `transport/`, `registers/`, and `scanner/` do not import Home Assistant.

### Testing

- `python -m pip install -q -r requirements-dev.txt` was executed successfully.  
- `ruff check custom_components tests tools` reports a pre-existing lint failure (`F841`) in `tests/test_device_scanner.py:253` and therefore fails.  
- `python -m compileall -q custom_components/thessla_green_modbus tests tools` completed successfully.  
- `pytest tests/ -q` completed successfully (tests passed; 4 tests skipped) and `python tools/check_maintainability.py` reported the maintainability gate as passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ccd7b73c8326b721bfd7c3a832fe)