### PR TITLE
refactor: decompose mapping builder transformations

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -131,6 +131,55 @@ def _build_select_mapping(register: str, states: dict[str, int]) -> dict[str, An
     }
 
 
+def _route_enum_mapping(
+    target: str | None,
+    register: str,
+    payload: dict[str, Any] | None,
+    sensor_mappings: dict[str, Any],
+    binary_mappings: dict[str, Any],
+    switch_mappings: dict[str, Any],
+    select_mappings: dict[str, Any],
+) -> bool:
+    """Apply enum-classification result to mapping stores and return handled state."""
+    if target == "switch":
+        switch_mappings.setdefault(register, payload)
+        return True
+    if target == "binary":
+        binary_mappings.setdefault(register, payload)
+        return True
+    if target == "select":
+        select_mappings.setdefault(register, payload)
+        return True
+    if target == "sensor":
+        sensor_mappings.setdefault(register, payload)
+        return True
+    return False
+
+
+def _route_min_max_mapping(
+    target: str | None,
+    register: str,
+    payload: dict[str, Any] | None,
+    number_mappings: dict[str, Any],
+    binary_mappings: dict[str, Any],
+    switch_mappings: dict[str, Any],
+    select_mappings: dict[str, Any],
+) -> bool:
+    """Apply min/max-classification result to mapping stores and return handled state."""
+    if target == "switch":
+        switch_mappings.setdefault(register, payload)
+        return True
+    if target == "binary":
+        binary_mappings.setdefault(register, payload)
+        return True
+    if target == "select":
+        select_mappings.setdefault(register, payload)
+        return True
+    if target == "number":
+        number_mappings.setdefault(register, payload)
+        return True
+    return False
+
 
 
 def _resolve_parent_child_mappings(parent: Any) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
@@ -528,14 +577,15 @@ def _extend_entity_mappings_from_registers() -> None:
                 binary_keys,
                 select_keys,
             )
-            if target == "switch":
-                switch_mappings.setdefault(register, payload)
-            elif target == "binary":
-                binary_mappings.setdefault(register, payload)
-            elif target == "select":
-                select_mappings.setdefault(register, payload)
-            elif target == "sensor":
-                sensor_mappings.setdefault(register, payload)
+            _route_enum_mapping(
+                target,
+                register,
+                payload,
+                sensor_mappings,
+                binary_mappings,
+                switch_mappings,
+                select_mappings,
+            )
             continue
 
         target, payload = _classify_min_max_mapping(
@@ -552,17 +602,15 @@ def _extend_entity_mappings_from_registers() -> None:
             select_keys,
             number_keys,
         )
-        if target == "switch":
-            switch_mappings.setdefault(register, payload)
-            continue
-        if target == "binary":
-            binary_mappings.setdefault(register, payload)
-            continue
-        if target == "select":
-            select_mappings.setdefault(register, payload)
-            continue
-        if target == "number":
-            number_mappings.setdefault(register, payload)
+        _route_min_max_mapping(
+            target,
+            register,
+            payload,
+            number_mappings,
+            binary_mappings,
+            switch_mappings,
+            select_mappings,
+        )
 
 
 
@@ -584,4 +632,6 @@ __all__ = [
     "_parse_info_states",
     "_resolve",
     "_resolve_parent_child_mappings",
+    "_route_enum_mapping",
+    "_route_min_max_mapping",
 ]

--- a/tests/test_entity_mappings_builder_transformations.py
+++ b/tests/test_entity_mappings_builder_transformations.py
@@ -4,6 +4,8 @@ from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _classify_enum_mapping,
     _classify_min_max_mapping,
     _resolve_parent_child_mappings,
+    _route_enum_mapping,
+    _route_min_max_mapping,
 )
 
 
@@ -81,3 +83,37 @@ def test_classify_min_max_mapping_select_then_number() -> None:
         "step": 5,
         "scale": 1,
     }
+
+
+def test_route_enum_mapping_routes_to_expected_bucket() -> None:
+    sensor: dict[str, dict[str, object]] = {}
+    binary: dict[str, dict[str, object]] = {}
+    switch: dict[str, dict[str, object]] = {}
+    select: dict[str, dict[str, object]] = {}
+    payload = {"translation_key": "mode", "states": {"auto": 2}}
+
+    handled = _route_enum_mapping(
+        "select", "mode", payload, sensor, binary, switch, select
+    )
+    assert handled is True
+    assert select == {"mode": payload}
+    assert sensor == {}
+    assert binary == {}
+    assert switch == {}
+
+
+def test_route_min_max_mapping_routes_to_expected_bucket() -> None:
+    number: dict[str, dict[str, object]] = {}
+    binary: dict[str, dict[str, object]] = {}
+    switch: dict[str, dict[str, object]] = {}
+    select: dict[str, dict[str, object]] = {}
+    payload = {"unit": "%", "min": 0, "max": 100}
+
+    handled = _route_min_max_mapping(
+        "number", "speed", payload, number, binary, switch, select
+    )
+    assert handled is True
+    assert number == {"speed": payload}
+    assert binary == {}
+    assert switch == {}
+    assert select == {}


### PR DESCRIPTION
### Motivation

- Reduce complexity in `_extend_entity_mappings_from_registers` by removing duplicated inline branching that routes classification results into mapping buckets. 
- Make small, pure routing steps explicit so they can be unit tested and reasoned about independently. 

### Description

- Added two routing helpers: `_route_enum_mapping(...)` and `_route_min_max_mapping(...)` to centralize application of classification results into mapping dictionaries. 
- Replaced the inline `if target == ...` blocks in `_extend_entity_mappings_from_registers` with calls to the new helpers, preserving the original `setdefault` semantics and control flow. 
- Exported the new helpers in `__all__` and added targeted unit tests in `tests/test_entity_mappings_builder_transformations.py` to assert bucket placement and payload shape. 
- Files changed: `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` and `tests/test_entity_mappings_builder_transformations.py`.

### Testing

- Ran project validation and tests: `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, and `python -m compileall -q custom_components/thessla_green_modbus tests tools`. 
- Ran focused and full test suites: `pytest -q tests/test_entity_mappings*.py`, `pytest -q tests/test_sensor_platform.py tests/test_select.py tests/test_switch.py tests/test_number.py tests/test_binary_sensor.py`, and `pytest tests/ -q`; the suites passed in this environment (existing unrelated skips reported by the suite). 
- Ran maintainability check `python tools/check_maintainability.py` which passed. 
- New routing tests (`test_route_enum_mapping_routes_to_expected_bucket` and `test_route_min_max_mapping_routes_to_expected_bucket`) passed as part of the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d372b5088326ae095576b3de0dbe)