### PR TITLE
refactor: decompose config flow validation helpers

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow_device_validation.py
+++ b/custom_components/thessla_green_modbus/config_flow_device_validation.py
@@ -73,6 +73,32 @@ def _build_success_payload(name: str, scan_result: dict[str, Any]) -> dict[str, 
     }
 
 
+def _validate_scan_result(scan_result: Any) -> dict[str, Any]:
+    """Validate scanner payload shape and return typed mapping."""
+    if not isinstance(scan_result, dict) or not scan_result:
+        raise CannotConnect("invalid_format")
+    return scan_result
+
+
+def _build_timeout_runner(
+    *,
+    run_with_retry: Callable[[Callable[[], Awaitable[Any]], int, float], Awaitable[Any]],
+    call_with_optional_timeout: Callable[[Callable[[], Any], float], Awaitable[Any]],
+    retries: int,
+    backoff: float,
+) -> Callable[[Callable[[], Any], float], Awaitable[Any]]:
+    """Create retry+timeout wrapper for scanner callbacks."""
+
+    async def _run(func: Callable[[], Any], timeout: float) -> Any:
+        return await run_with_retry(
+            lambda: call_with_optional_timeout(func, timeout),
+            retries,
+            backoff,
+        )
+
+    return _run
+
+
 async def _maybe_close_scanner(scanner: Any | None) -> None:
     """Close scanner instance when available."""
     if scanner is not None and hasattr(scanner, "close"):
@@ -211,25 +237,21 @@ async def validate_input_impl(
             config_flow_backoff,
         )
 
+        run_scanner_call = _build_timeout_runner(
+            run_with_retry=run_with_retry,
+            call_with_optional_timeout=call_with_optional_timeout,
+            retries=default_retry,
+            backoff=config_flow_backoff,
+        )
         short_timeout = max(2, params["timeout"])
         verify_cb = getattr(scanner, "verify_connection", None)
         if not callable(verify_cb):
             raise AttributeError("verify_connection")
+        await run_scanner_call(verify_cb, short_timeout)
 
-        await run_with_retry(
-            lambda: call_with_optional_timeout(verify_cb, short_timeout),
-            default_retry,
-            config_flow_backoff,
+        scan_result = _validate_scan_result(
+            await run_scanner_call(scanner.scan_device, params["timeout"])
         )
-
-        scan_result = await run_with_retry(
-            lambda: call_with_optional_timeout(scanner.scan_device, params["timeout"]),
-            default_retry,
-            config_flow_backoff,
-        )
-
-        if not isinstance(scan_result, dict) or not scan_result:
-            raise CannotConnect("invalid_format")
 
         caps_dict = process_scan_capabilities(scan_result, capabilities_cls)
         scan_result["capabilities"] = caps_dict

--- a/custom_components/thessla_green_modbus/config_flow_schema.py
+++ b/custom_components/thessla_green_modbus/config_flow_schema.py
@@ -120,6 +120,25 @@ def _build_rtu_fields(
     }
 
 
+def _build_scan_option_fields(current_values: dict[str, Any]) -> dict[Any, Any]:
+    """Build shared scan/options schema fields."""
+    return {
+        vol.Optional(CONF_NAME, default=current_values.get(CONF_NAME, DEFAULT_NAME)): str,
+        vol.Optional(
+            CONF_DEEP_SCAN,
+            default=current_values.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN),
+            description={"advanced": True},
+        ): bool,
+        vol.Optional(
+            CONF_MAX_REGISTERS_PER_REQUEST,
+            default=current_values.get(
+                CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
+            ),
+            description={"selector": {"number": {"min": 1, "max": MAX_BATCH_REGISTERS, "step": 1}}},
+        ): int,
+    }
+
+
 def build_connection_schema(
     defaults: dict[str, Any],
     *,
@@ -188,19 +207,7 @@ def build_connection_schema(
         vol.Required(CONF_SLAVE_ID, default=slave_default): vol.All(
             vol.Coerce(int), vol.Range(min=0, max=247)
         ),
-        vol.Optional(CONF_NAME, default=current_values.get(CONF_NAME, DEFAULT_NAME)): str,
-        vol.Optional(
-            CONF_DEEP_SCAN,
-            default=current_values.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN),
-            description={"advanced": True},
-        ): bool,
-        vol.Optional(
-            CONF_MAX_REGISTERS_PER_REQUEST,
-            default=current_values.get(
-                CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST
-            ),
-            description={"selector": {"number": {"min": 1, "max": MAX_BATCH_REGISTERS, "step": 1}}},
-        ): int,
+        **_build_scan_option_fields(current_values),
     }
 
     if connection_default in (CONNECTION_TYPE_TCP, CONNECTION_TYPE_TCP_RTU):


### PR DESCRIPTION
### Motivation
- Reduce complexity in the device validation orchestration by extracting small, testable helpers from `validate_input_impl`. 
- Isolate schema construction concerns in `build_connection_schema` so the connection section and scan/options section are built with clear boundaries. 

### Description
- Added `_validate_scan_result` and `_build_timeout_runner` and integrated them into `validate_input_impl` to encapsulate scan-result validation and retry+timeout invocation logic, keeping existing exception mapping and payload construction unchanged. 
- Extracted `_build_scan_option_fields` from the main schema builder and used it inside `build_connection_schema` to centralize the scan/options fields. 
- Kept existing connection, TCP and RTU schema composition, validators, and defaults intact. 
- Files changed: `custom_components/thessla_green_modbus/config_flow_device_validation.py`, `custom_components/thessla_green_modbus/config_flow_schema.py`. 

### Testing
- Ran `pytest -q tests/test_config_flow_*.py` and all config-flow tests passed. 
- Ran `pytest -q tests/test_integration.py tests/test_migration.py` and those test suites passed. 
- Ran `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed without issues. 
- Ran full `pytest tests/ -q` and the suite passed in this environment with only the pre-existing skips; `python tools/check_maintainability.py` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d380e5688326b47b417c63ad02ea)