### PR TITLE
refactor: reduce coordinator responsibilities by extracting setup and close helpers

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -510,22 +510,7 @@ class ThesslaGreenModbusCoordinator(
             self.config.connection_type.upper(),
         )
 
-        if self.force_full_register_list:
-            _LOGGER.info("Using full register list (skipping scan)")
-            self._load_full_register_list()
-        elif not self.enable_device_scan:
-            cache: dict[str, Any] = {}
-            if self.entry is not None:
-                raw_cache = self.entry.options.get("device_scan_cache", {})
-                if isinstance(raw_cache, dict):
-                    cache = raw_cache
-            if cache and self._apply_scan_cache(cache):
-                _LOGGER.info("Using cached device scan results")
-            else:
-                _LOGGER.info("Device scan disabled; falling back to full register list")
-                self._load_full_register_list()
-        else:
-            await self._run_device_scan()
+        await self._prepare_registers_for_setup()
 
         self._warn_missing_device_info()
 
@@ -542,6 +527,31 @@ class ThesslaGreenModbusCoordinator(
             )
 
         return True
+
+    async def _prepare_registers_for_setup(self) -> None:
+        """Prepare register availability from full list, cache, or device scan."""
+        if self.force_full_register_list:
+            _LOGGER.info("Using full register list (skipping scan)")
+            self._load_full_register_list()
+            return
+
+        if not self.enable_device_scan:
+            cache = self._get_scan_cache_from_entry()
+            if cache and self._apply_scan_cache(cache):
+                _LOGGER.info("Using cached device scan results")
+                return
+            _LOGGER.info("Device scan disabled; falling back to full register list")
+            self._load_full_register_list()
+            return
+
+        await self._run_device_scan()
+
+    def _get_scan_cache_from_entry(self) -> dict[str, Any]:
+        """Return cached scan payload from config entry options."""
+        if self.entry is None:
+            return {}
+        raw_cache = self.entry.options.get("device_scan_cache", {})
+        return raw_cache if isinstance(raw_cache, dict) else {}
 
     def _load_full_register_list(self) -> None:
         """Load full register list when forced."""
@@ -781,23 +791,27 @@ class ThesslaGreenModbusCoordinator(
             except OSError:
                 _LOGGER.exception("Unexpected error disconnecting")
         elif self.client is not None:
-            try:
-                close = getattr(self.client, "close", None)
-                if callable(close):
-                    if inspect.iscoroutinefunction(close):
-                        await close()
-                    else:
-                        result = close()
-                        if inspect.isawaitable(result):
-                            await result
-            except (ModbusException, ConnectionException):
-                _LOGGER.debug("Error disconnecting", exc_info=True)
-            except OSError:
-                _LOGGER.exception("Unexpected error disconnecting")
+            await self._close_client_connection()
 
         self.client = None
         self.offline_state = True
         _LOGGER.debug("Disconnected from Modbus device")
+
+    async def _close_client_connection(self) -> None:
+        """Close client object safely for sync or async close implementations."""
+        try:
+            close = getattr(self.client, "close", None)
+            if callable(close):
+                if inspect.iscoroutinefunction(close):
+                    await close()
+                else:
+                    result = close()
+                    if inspect.isawaitable(result):
+                        await result
+        except (ModbusException, ConnectionException):
+            _LOGGER.debug("Error disconnecting", exc_info=True)
+        except OSError:
+            _LOGGER.exception("Unexpected error disconnecting")
 
     async def _disconnect(self) -> None:
         """Disconnect from Modbus device."""


### PR DESCRIPTION
### Motivation
- Reduce complexity and single-method size in `ThesslaGreenModbusCoordinator` by moving obvious, self-contained responsibilities out of `async_setup` and `_disconnect_locked` to improve maintainability.
- Make the register-preparation and config-entry cache handling clearer and easier to test without changing runtime behavior.

### Description
- Extracted register-setup branching from `async_setup` into a new helper method ` _prepare_registers_for_setup()` to handle the full-list, cached, and device-scan paths.  (modified: `custom_components/thessla_green_modbus/coordinator/coordinator.py`)
- Moved config-entry cache retrieval into `_get_scan_cache_from_entry()` so type-checking and option access are centralized. (modified: `custom_components/thessla_green_modbus/coordinator/coordinator.py`)
- Pulled client close logic (sync/async `close` handling and exception logging) out of `_disconnect_locked()` into `_close_client_connection()` and replaced the inline block with a single call. (modified: `custom_components/thessla_green_modbus/coordinator/coordinator.py`)
- Preserved existing logs, exception handling, and control flow so behavior remains unchanged by these refactors.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt` and `ruff check custom_components tests tools` with no failures. 
- Compiled modules with `python -m compileall -q custom_components/thessla_green_modbus tests tools` successfully. 
- Executed targeted coordinator tests with `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` and the wider unit tests `pytest -q tests/unit/test_errors.py tests/unit/test_transport_retry.py`, both passing. 
- Ran the full test suite with `pytest tests/ -q` and `python tools/check_maintainability.py`, which completed successfully (some unrelated skips reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24237ecec8326900d9835c6309f05)