### PR TITLE
docs: refresh maintainability audit after validation

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -7,46 +7,46 @@ Date: 2026-04-29
 Executed:
 
 - `python -m pip install -q -r requirements-dev.txt`
-- `ruff check custom_components tests tools` *(fails currently due to an existing test lint issue: `tests/test_device_scanner.py:253` unused local `result`)*
-- `python -m compileall -q custom_components/thessla_green_modbus tests tools`
+- `ruff check custom_components tests tools` *(passed)*
+- `python -m compileall -q custom_components/thessla_green_modbus tests tools` *(passed)*
 - `pytest tests/ -q` *(passed; 4 skipped)*
 - `python tools/check_maintainability.py` *(passed)*
 
 ## 1) Largest files (by non-empty lines)
 
-1. `tests/test_scanner_coverage.py` (~1255)
-2. `tests/test_coordinator_coverage.py` (~1061)
-3. `tests/test_config_flow_validation.py` (~865)
-4. `tests/test_coordinator.py` (~743)
-5. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (~737)
+1. `tests/test_scanner_coverage.py` (~1171)
+2. `tests/test_config_flow_validation.py` (~865)
+3. `tests/test_coordinator_update_cycle.py` (~829)
+4. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (~746)
+5. `tests/test_coordinator.py` (~743)
 6. `tests/test_entity_mappings.py` (~683)
 7. `tests/test_config_flow_user.py` (~638)
-8. `tests/test_services_handlers_parameters.py` (~523)
-9. `tests/test_config_flow_helpers.py` (~508)
-10. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` (~500)
+8. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` (~567)
+9. `tests/test_services_handlers_parameters.py` (~523)
+10. `tests/test_config_flow_helpers.py` (~508)
 
-Interpretation: the largest hotspots are still primarily in tests, while `coordinator/coordinator.py` and `mappings/_mapping_builders.py` remain the most notable production-scale modules.
+Interpretation: hotspot pressure remains test-heavy; the largest production modules are still `coordinator/coordinator.py`, `mappings/_mapping_builders.py`, and scanner I/O helpers.
 
 ## 2) Largest classes
 
-1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (~585)
-2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (~408)
-3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (~394)
-4. `RegisterDefinition` in `registers/schema.py` (~273)
-5. `RawRtuOverTcpTransport` in `modbus_transport_raw.py` (~246)
+1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (~690)
+2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (~438)
+3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (~432)
+4. `RegisterDefinition` in `registers/schema.py` (~313)
+5. `RawRtuOverTcpTransport` in `modbus_transport_raw.py` (~280)
 
 ## 3) Largest methods/functions
 
-1. `main` in `tools/validate_entity_mappings.py` (~156)
-2. `register_maintenance_services` in `services_handlers_maintenance.py` (~146)
-3. `read_holding` in `scanner/io_read.py` (~136)
-4. `_extend_entity_mappings_from_registers` in `mappings/_mapping_builders.py` (~133)
-5. `async_write_register` in `coordinator/schedule.py` (~123)
-6. `run_full_scan` in `scanner/orchestration.py` (~122)
-7. `verify_connection` in `scanner/setup.py` (~121)
-8. `_post_process_data` in `coordinator/capabilities.py` (~120)
-9. `scan` in `scanner/orchestration.py` (~119)
-10. `read_input` in `scanner/io_read.py` (~119)
+1. `main` in `tools/validate_entity_mappings.py` (~176)
+2. `read_holding` in `scanner/io_read.py` (~143)
+3. `_extend_entity_mappings_from_registers` in `mappings/_mapping_builders.py` (~143)
+4. `async_write_register` in `coordinator/schedule.py` (~133)
+5. `verify_connection` in `scanner/setup.py` (~127)
+6. `_post_process_data` in `coordinator/capabilities.py` (~127)
+7. `run_full_scan` in `scanner/orchestration.py` (~125)
+8. `register_maintenance_services` in `services_handlers_maintenance.py` (~125)
+9. `read_input` in `scanner/io_read.py` (~125)
+10. `validate_input_impl` in `config_flow_device_validation.py` (~114)
 
 ## 4) Completed refactors reflected in current state (PRs #1411–#1421)
 
@@ -73,8 +73,8 @@ Interpretation: the largest hotspots are still primarily in tests, while `coordi
 
 ## 6) Next recommended PRs
 
-1. Split `tests/test_scanner_coverage.py` further by scanner flow domains (setup, I/O, orchestration, cache/error contracts).
-2. Split `tests/test_coordinator_coverage.py` further by coordinator concern areas (init/config, read cycle, write flow, retry/reconnect, capabilities).
-3. Decompose `custom_components/thessla_green_modbus/mappings/_mapping_builders.py`, starting with `_extend_entity_mappings_from_registers` and `_load_discrete_mappings`.
-4. Decompose `custom_components/thessla_green_modbus/services_handlers_maintenance.py` registration workflow into narrower helpers.
-5. Reduce private helper coupling in tests where feasible by asserting package-level contracts.
+1. Continue splitting `tests/test_scanner_coverage.py` into focused behavior suites (setup, I/O, orchestration, cache/error contracts).
+2. Further split coordinator-focused tests around update cycle vs retry/offline/error paths to reduce per-file coupling.
+3. Decompose `custom_components/thessla_green_modbus/mappings/_mapping_builders.py`, starting with `_extend_entity_mappings_from_registers` and discrete mapping load helpers.
+4. Refactor `custom_components/thessla_green_modbus/scanner/io_read.py` (`read_holding`/`read_input`) into narrower read/normalize helpers.
+5. Decompose `custom_components/thessla_green_modbus/services_handlers_maintenance.py` registration workflow into smaller composable helpers.


### PR DESCRIPTION
### Motivation

- Refresh the maintainability audit to reflect the true current `dev` state and remove stale notes about past lint failures.
- Recompute hotspots (largest files, classes, and functions) so next PR recommendations target real current complexity.
- Ensure the audit documents the current architectural invariants (coordinator package canonical, no top-level shim/proxy/legacy modules, and no HA imports in core/transport/registers/scanner).

### Description

- Updated `docs/maintainability_audit.md` Inputs and checks to show `ruff` and `compileall` now pass and reflected the current test run results.
- Recomputed and refreshed the largest files, classes, and functions lists from the repository tree and updated interpretations accordingly.
- Revised the “Next recommended PRs” list to prioritize decomposition work on real hotspots (tests, mapping builders, scanner I/O, and service handlers).
- Limited the change to documentation only; no production code or tests were modified.

### Testing

- Ran `python -m pip install -q -r requirements-dev.txt` and `ruff check custom_components tests tools`, both of which completed successfully.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed and `pytest tests/ -q` which passed with 4 expected skips.
- Executed `python tools/check_maintainability.py` which passed the maintainability gate.
- Performed repository scans (`rg` searches) to verify coordinator migration and absence of forbidden shims/proxy/legacy imports and found invariants satisfied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24a345640832683a0804116c54926)