### PR TITLE
docs: refresh maintainability audit after validation

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -25,7 +25,7 @@ Executed:
 9. `tests/test_services_handlers_parameters.py` (~523)
 10. `tests/test_config_flow_helpers.py` (~508)
 
-Interpretation: hotspot pressure remains test-heavy; the largest production modules are still `coordinator/coordinator.py`, `mappings/_mapping_builders.py`, and scanner I/O helpers.
+Interpretation: hotspot pressure remains test-heavy; the largest production modules are still `coordinator/coordinator.py`, `mappings/_mapping_builders.py`, and scanner I/O helpers (`scanner/io_read.py`).
 
 ## 2) Largest classes
 
@@ -48,7 +48,7 @@ Interpretation: hotspot pressure remains test-heavy; the largest production modu
 9. `read_input` in `scanner/io_read.py` (~125)
 10. `validate_input_impl` in `config_flow_device_validation.py` (~114)
 
-## 4) Completed refactors reflected in current state (PRs #1411–#1421)
+## 4) Completed refactors reflected in current dev state (latest merged PR batch #1411–#1421)
 
 - Diagnostics helper split completed.
 - Service metadata/translations consistency alignment completed.


### PR DESCRIPTION
### Motivation
- Refresh the maintainability audit to reflect the actual dev-state after re-running the full validation suite and remove stale wording about hotspots and merged PR context.

### Description
- Update `docs/maintainability_audit.md` to reference the latest merged PR batch context and clarify that `scanner/io_read.py` is included among the largest production hotspots, with no changes to production code or tests.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools` (passed), `python -m compileall -q custom_components/thessla_green_modbus tests tools` (passed), `pytest tests/ -q` (passed with 4 skipped), and `python tools/check_maintainability.py` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24b8391848326927f83bbcd7e8fe1)