### PR TITLE
refactor: extract routing and context helpers from mapping builders

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -241,6 +241,60 @@ def _route_min_max_mapping(
     return False
 
 
+def _build_sensor_season_setting_mapping(register: str) -> dict[str, Any]:
+    """Return read-only season setting mapping payload."""
+    return {
+        "translation_key": register,
+        "icon": "mdi:fan",
+        "register_type": "holding_registers",
+    }
+
+
+def _register_context(reg: Any) -> tuple[str, str, Any, Any, Any, str, Any, Any]:
+    """Return normalized register fields used by mapping classifiers."""
+    return (
+        reg.name,
+        (reg.access or "").upper(),
+        reg.min,
+        reg.max,
+        reg.unit,
+        reg.information or "",
+        reg.multiplier or 1,
+        reg.resolution or (reg.multiplier or 1),
+    )
+
+
+def _route_problem_mapping(register: str, binary_keys: set[str], binary_mappings: dict[str, Any]) -> bool:
+    """Route problem register to binary mappings when translation exists."""
+    if register not in binary_keys:
+        return False
+    binary_mappings.setdefault(register, _build_problem_binary_mapping(register))
+    return True
+
+
+def _route_time_and_season_mappings(
+    register: str,
+    access: str,
+    sensor_mappings: dict[str, Any],
+    time_mappings: dict[str, Any],
+    select_mappings: dict[str, Any],
+) -> bool:
+    """Route BCD-time and season-setting registers to dedicated mapping buckets."""
+    if any(register.startswith(prefix) for prefix in BCD_TIME_PREFIXES):
+        if register.startswith(_TIME_ENTITY_PREFIXES) and "W" in access:
+            time_mappings.setdefault(register, _build_time_like_mapping(register))
+        else:
+            sensor_mappings.setdefault(register, _build_time_like_mapping(register))
+        return True
+
+    if register.startswith(("setting_summer_", "setting_winter_")):
+        if "W" in access:
+            select_mappings.setdefault(register, _build_season_setting_mapping(register))
+        else:
+            sensor_mappings.setdefault(register, _build_sensor_season_setting_mapping(register))
+        return True
+    return False
+
 
 def _resolve_parent_child_mappings(parent: Any) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
     """Return mutable mapping dictionaries from parent module."""
@@ -526,7 +580,7 @@ def _extend_entity_mappings_from_registers() -> None:
     for reg in _get_all():
         if reg.function != 3 or not reg.name:
             continue
-        register = reg.name
+        register, access, min_val, max_val, unit, info_text, scale, step = _register_context(reg)
         if _is_register_mapped_anywhere(
             register,
             (
@@ -544,56 +598,20 @@ def _extend_entity_mappings_from_registers() -> None:
             continue
 
         if _is_problem_register(register):
-            if register not in binary_keys:
-                continue
-            binary_mappings.setdefault(
-                register,
-                _build_problem_binary_mapping(register),
-            )
+            _route_problem_mapping(register, binary_keys, binary_mappings)
             continue
 
         if register.startswith("date_time"):
             continue
 
-        if any(register.startswith(prefix) for prefix in BCD_TIME_PREFIXES):
-            reg_access = (reg.access or "").upper()
-            if register.startswith(_TIME_ENTITY_PREFIXES) and "W" in reg_access:
-                time_mappings.setdefault(
-                    register,
-                    _build_time_like_mapping(register),
-                )
-            else:
-                sensor_mappings.setdefault(
-                    register,
-                    _build_time_like_mapping(register),
-                )
+        if _route_time_and_season_mappings(
+            register,
+            access,
+            sensor_mappings,
+            time_mappings,
+            select_mappings,
+        ):
             continue
-
-        if register.startswith(("setting_summer_", "setting_winter_")):
-            reg_access = (reg.access or "").upper()
-            if "W" in reg_access:
-                select_mappings.setdefault(
-                    register,
-                    _build_season_setting_mapping(register),
-                )
-            else:
-                sensor_mappings.setdefault(
-                    register,
-                    {
-                        "translation_key": register,
-                        "icon": "mdi:fan",
-                        "register_type": "holding_registers",
-                    },
-                )
-            continue
-
-        access = (reg.access or "").upper()
-        min_val = reg.min
-        max_val = reg.max
-        unit = reg.unit
-        info_text = reg.information or ""
-        scale = reg.multiplier or 1
-        step = reg.resolution or scale
 
         if reg.enum and not (reg.extra and reg.extra.get("bitmask")):
             target, payload = _classify_enum_mapping(
@@ -646,6 +664,7 @@ __all__ = [
     "_build_base_translation_mapping",
     "_build_problem_binary_mapping",
     "_build_season_setting_mapping",
+    "_build_sensor_season_setting_mapping",
     "_build_time_like_mapping",
     "_classify_enum_mapping",
     "_classify_min_max_mapping",
@@ -661,8 +680,11 @@ __all__ = [
     "_load_discrete_mappings",
     "_load_number_mappings",
     "_parse_info_states",
+    "_register_context",
     "_resolve",
     "_resolve_parent_child_mappings",
     "_route_enum_mapping",
     "_route_min_max_mapping",
+    "_route_problem_mapping",
+    "_route_time_and_season_mappings",
 ]

--- a/tests/test_entity_mappings_builder_transformations.py
+++ b/tests/test_entity_mappings_builder_transformations.py
@@ -2,20 +2,32 @@
 
 from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _build_base_translation_mapping,
+    _build_sensor_season_setting_mapping,
     _classify_enum_mapping,
     _classify_min_max_mapping,
     _diag_register_candidates,
     _is_binary_state_pair,
     _iter_bitmask_binary_entries,
+    _register_context,
     _resolve_parent_child_mappings,
     _route_enum_mapping,
     _route_min_max_mapping,
+    _route_problem_mapping,
+    _route_time_and_season_mappings,
 )
 
 
 def test_build_base_translation_mapping_shape() -> None:
     assert _build_base_translation_mapping("pump", "holding_registers") == {
         "translation_key": "pump",
+        "register_type": "holding_registers",
+    }
+
+
+def test_build_sensor_season_setting_mapping_shape() -> None:
+    assert _build_sensor_season_setting_mapping("setting_summer_mode") == {
+        "translation_key": "setting_summer_mode",
+        "icon": "mdi:fan",
         "register_type": "holding_registers",
     }
 
@@ -154,3 +166,38 @@ def test_route_min_max_mapping_routes_to_expected_bucket() -> None:
     assert binary == {}
     assert switch == {}
     assert select == {}
+
+
+def test_register_context_normalizes_resolution_and_defaults() -> None:
+    reg = type(
+        "Reg",
+        (),
+        {
+            "name": "speed",
+            "access": "rw",
+            "min": 0,
+            "max": 100,
+            "unit": "%",
+            "information": None,
+            "multiplier": 10,
+            "resolution": None,
+        },
+    )
+    assert _register_context(reg) == ("speed", "RW", 0, 100, "%", "", 10, 10)
+
+
+def test_route_problem_mapping_requires_binary_translation_key() -> None:
+    binary: dict[str, dict[str, object]] = {}
+    assert _route_problem_mapping("alarm", {"alarm"}, binary) is True
+    assert "alarm" in binary
+    assert _route_problem_mapping("error", set(), binary) is False
+
+
+def test_route_time_and_season_mappings_routes_expected_buckets() -> None:
+    sensor: dict[str, dict[str, object]] = {}
+    time: dict[str, dict[str, object]] = {}
+    select: dict[str, dict[str, object]] = {}
+    assert _route_time_and_season_mappings("schedule_wake", "RW", sensor, time, select) is True
+    assert "schedule_wake" in time
+    assert _route_time_and_season_mappings("setting_winter_mode", "R", sensor, time, select) is True
+    assert "setting_winter_mode" in sensor


### PR DESCRIPTION
### Motivation
- Reduce complexity and inline branching in the hotspot `_extend_entity_mappings_from_registers` to make mapping logic easier to reason about and test. 
- Improve testability by extracting small, pure helpers that encapsulate register-context normalization and routing decisions without changing mapping semantics.

### Description
- Extracted helper functions from `custom_components/thessla_green_modbus/mappings/_mapping_builders.py`: ` _register_context`, `_route_problem_mapping`, `_route_time_and_season_mappings`, and `_build_sensor_season_setting_mapping` and integrated them into `_extend_entity_mappings_from_registers` to replace repeated inline logic. 
- Kept public exports consistent by updating and sorting `__all__` for Ruff compliance. 
- Added focused shape/unit tests in `tests/test_entity_mappings_builder_transformations.py` for the new helpers, including `test_register_context_normalizes_resolution_and_defaults`, `test_route_problem_mapping_requires_binary_translation_key`, `test_route_time_and_season_mappings_routes_expected_buckets`, and `test_build_sensor_season_setting_mapping_shape`.

### Testing
- Ran dependency install and linters: `python -m pip install -q -r requirements-dev.txt` and `ruff check custom_components tests tools`, which passed. 
- Verified byte-compile with `python -m compileall -q custom_components/thessla_green_modbus tests tools`, which passed. 
- Executed targeted tests with `pytest -q tests/test_entity_mappings*.py` and broader suites with `pytest tests/ -q` and `pytest -q tests/test_sensor_platform.py tests/test_select.py tests/test_switch.py tests/test_number.py tests/test_binary_sensor.py`, and all ran successfully (full pytest passed; a few tests were expectedly skipped). 
- Ran maintainability gate `python tools/check_maintainability.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24ee2cd488326bc432e5c2426bd6e)