### PR TITLE
refactor: reduce parameter service handler complexity

### DIFF
--- a/custom_components/thessla_green_modbus/services_dispatch.py
+++ b/custom_components/thessla_green_modbus/services_dispatch.py
@@ -94,3 +94,25 @@ async def write_register_batch(
             logger.error(error_messages[register_name], entity_id)
             return False
     return True
+
+
+async def write_register_steps(
+    coordinator: Any,
+    steps: list[tuple[str, object, bool, str]],
+    entity_id: str,
+    action: str,
+    write_register_func: Any,
+    logger: Any,
+) -> bool:
+    """Write required/optional register steps and stop on first failure.
+
+    Each step is ``(register_name, value, optional, error_message)``.
+    Optional values are skipped when ``value`` is ``None``.
+    """
+    for register_name, value, optional, error_message in steps:
+        if optional and value is None:
+            continue
+        if not await write_register_func(coordinator, register_name, value, entity_id, action):
+            logger.error(error_message, entity_id)
+            return False
+    return True

--- a/custom_components/thessla_green_modbus/services_handlers_parameters.py
+++ b/custom_components/thessla_green_modbus/services_handlers_parameters.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant, ServiceCall
 
-from .services_dispatch import refresh_and_log_success, write_optional_register
+from .services_dispatch import refresh_and_log_success, write_register_steps
 from .services_handler_deps import ServiceHandlerDeps
 from .services_schema import (
     SET_AIR_QUALITY_THRESHOLDS_SCHEMA,
@@ -12,6 +12,7 @@ from .services_schema import (
     SET_GWC_PARAMETERS_SCHEMA,
     SET_TEMPERATURE_CURVE_SCHEMA,
 )
+from .services_validation import BYPASS_MODE_MAP, GWC_MODE_MAP
 
 
 def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
@@ -20,16 +21,24 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
     async def set_bypass_parameters(call: ServiceCall) -> None:
         mode = deps.normalize_option(call.data["mode"])
         min_temperature = call.data.get("min_outdoor_temperature")
-        mode_value = {"auto": 0, "open": 1, "closed": 2}[mode]
+        mode_value = BYPASS_MODE_MAP[mode]
 
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            if not await deps.write_register(coordinator, "bypass_mode", mode_value, entity_id, "set bypass parameters"):
-                deps.logger.error("Failed to set bypass mode for %s", entity_id)
-                continue
-            if not await write_optional_register(
-                coordinator, "min_bypass_temperature", min_temperature, entity_id,
-                "set bypass parameters", "Failed to set bypass min temperature for %s",
-                deps.write_register, deps.logger,
+            if not await write_register_steps(
+                coordinator,
+                [
+                    ("bypass_mode", mode_value, False, "Failed to set bypass mode for %s"),
+                    (
+                        "min_bypass_temperature",
+                        min_temperature,
+                        True,
+                        "Failed to set bypass min temperature for %s",
+                    ),
+                ],
+                entity_id,
+                "set bypass parameters",
+                deps.write_register,
+                deps.logger,
             ):
                 continue
             await refresh_and_log_success(coordinator, deps.logger, "Set bypass parameters for %s", entity_id)
@@ -38,15 +47,31 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
         mode = deps.normalize_option(call.data["mode"])
         min_air_temperature = call.data.get("min_air_temperature")
         max_air_temperature = call.data.get("max_air_temperature")
-        mode_value = {"off": 0, "auto": 1, "forced": 2}[mode]
+        mode_value = GWC_MODE_MAP[mode]
 
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            if not await deps.write_register(coordinator, "gwc_mode", mode_value, entity_id, "set GWC parameters"):
-                deps.logger.error("Failed to set GWC mode for %s", entity_id)
-                continue
-            if not await write_optional_register(coordinator, "min_gwc_air_temperature", min_air_temperature, entity_id, "set GWC parameters", "Failed to set GWC min air temperature for %s", deps.write_register, deps.logger):
-                continue
-            if not await write_optional_register(coordinator, "max_gwc_air_temperature", max_air_temperature, entity_id, "set GWC parameters", "Failed to set GWC max air temperature for %s", deps.write_register, deps.logger):
+            if not await write_register_steps(
+                coordinator,
+                [
+                    ("gwc_mode", mode_value, False, "Failed to set GWC mode for %s"),
+                    (
+                        "min_gwc_air_temperature",
+                        min_air_temperature,
+                        True,
+                        "Failed to set GWC min air temperature for %s",
+                    ),
+                    (
+                        "max_gwc_air_temperature",
+                        max_air_temperature,
+                        True,
+                        "Failed to set GWC max air temperature for %s",
+                    ),
+                ],
+                entity_id,
+                "set GWC parameters",
+                deps.write_register,
+                deps.logger,
+            ):
                 continue
             await refresh_and_log_success(coordinator, deps.logger, "Set GWC parameters for %s", entity_id)
 
@@ -69,15 +94,29 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
         min_supply_temp = call.data.get("min_supply_temp")
 
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            if not await deps.write_register(coordinator, "heating_curve_slope", slope, entity_id, "set temperature curve"):
-                deps.logger.error("Failed to set heating curve slope for %s", entity_id)
-                continue
-            if not await deps.write_register(coordinator, "heating_curve_offset", offset, entity_id, "set temperature curve"):
-                deps.logger.error("Failed to set heating curve offset for %s", entity_id)
-                continue
-            if not await write_optional_register(coordinator, "max_supply_temperature", max_supply_temp, entity_id, "set temperature curve", "Failed to set max supply temperature for %s", deps.write_register, deps.logger):
-                continue
-            if not await write_optional_register(coordinator, "min_supply_temperature", min_supply_temp, entity_id, "set temperature curve", "Failed to set min supply temperature for %s", deps.write_register, deps.logger):
+            if not await write_register_steps(
+                coordinator,
+                [
+                    ("heating_curve_slope", slope, False, "Failed to set heating curve slope for %s"),
+                    ("heating_curve_offset", offset, False, "Failed to set heating curve offset for %s"),
+                    (
+                        "max_supply_temperature",
+                        max_supply_temp,
+                        True,
+                        "Failed to set max supply temperature for %s",
+                    ),
+                    (
+                        "min_supply_temperature",
+                        min_supply_temp,
+                        True,
+                        "Failed to set min supply temperature for %s",
+                    ),
+                ],
+                entity_id,
+                "set temperature curve",
+                deps.write_register,
+                deps.logger,
+            ):
                 continue
             await refresh_and_log_success(coordinator, deps.logger, "Set temperature curve for %s", entity_id)
 

--- a/custom_components/thessla_green_modbus/services_validation.py
+++ b/custom_components/thessla_green_modbus/services_validation.py
@@ -22,6 +22,8 @@ BAUD_MAP = {
 }
 PARITY_MAP = {"none": 0, "even": 1, "odd": 2}
 STOP_MAP = {"1": 0, "2": 1}
+BYPASS_MODE_MAP = {"auto": 0, "open": 1, "closed": 2}
+GWC_MODE_MAP = {"off": 0, "auto": 1, "forced": 2}
 
 
 def validate_bypass_temperature_range(data: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_services_dispatch_validation.py
+++ b/tests/test_services_dispatch_validation.py
@@ -12,6 +12,7 @@ from custom_components.thessla_green_modbus.services_dispatch import (
     write_optional_register,
     write_register,
     write_register_batch,
+    write_register_steps,
 )
 from custom_components.thessla_green_modbus.services_validation import (
     BAUD_MAP,
@@ -133,6 +134,29 @@ async def test_write_register_batch_logs_and_stops_on_failure():
     assert result is False
     assert write_func.await_count == 2
     logger.error.assert_called_once_with("err2 %s", "climate.a")
+
+
+@pytest.mark.asyncio
+async def test_write_register_steps_skips_optional_none_and_stops_on_failure():
+    write_func = AsyncMock(side_effect=[True, False])
+    logger = SimpleNamespace(error=AsyncMock())
+
+    result = await write_register_steps(
+        object(),
+        [
+            ("required", 1, False, "required err %s"),
+            ("optional", None, True, "optional err %s"),
+            ("required_2", 2, False, "required2 err %s"),
+        ],
+        "climate.a",
+        "action",
+        write_func,
+        logger,
+    )
+
+    assert result is False
+    assert write_func.await_count == 2
+    logger.error.assert_called_once_with("required2 err %s", "climate.a")
 
 
 def test_reset_settings_registers_all_settings():


### PR DESCRIPTION
### Motivation
- Parameter service handlers contained repeated required/optional register-write boilerplate and per-service mode mappings which made the code harder to maintain and extend.
- The intent is to centralize dispatch/validation patterns so handlers are table-driven and duplication is minimized while preserving existing service behavior.

### Description
- Added `write_register_steps` in `custom_components/thessla_green_modbus/services_dispatch.py` to perform required/optional register writes with fail-fast semantics and per-step error logging.
- Introduced `BYPASS_MODE_MAP` and `GWC_MODE_MAP` in `custom_components/thessla_green_modbus/services_validation.py` to centralize mode→register-value mappings.
- Reworked `custom_components/thessla_green_modbus/services_handlers_parameters.py` to use `write_register_steps` and the centralized mode maps for `set_bypass_parameters`, `set_gwc_parameters`, and `set_temperature_curve`.
- Added a focused unit test `test_write_register_steps_skips_optional_none_and_stops_on_failure` in `tests/test_services_dispatch_validation.py` to cover the new helper.

### Testing
- Ran linting and formatting checks with `ruff check custom_components tests tools` which passed after an automatic fix of imports.
- Compiled code with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed without errors.
- Executed unit tests with `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` and then `pytest tests/ -q`, and all tests passed (with the same skipped tests as before).
- Executed maintainability checks with `python tools/check_maintainability.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24ed9cb6c83268175ca375f775b3b)