### PR TITLE
refactor: split entity mapping validation tool

### DIFF
--- a/tests/test_validate_entity_mappings_tool.py
+++ b/tests/test_validate_entity_mappings_tool.py
@@ -1,0 +1,39 @@
+"""Tests for tools.validate_entity_mappings helper validations."""
+
+from tools import validate_entity_mappings as tool
+
+
+def test_validate_unique_ids_detects_duplicates() -> None:
+    entity_mappings = {
+        "sensor": {
+            "a": {"unique_id": "dup"},
+            "b": {"unique_id": "dup"},
+            "c": {"unique_id": "ok"},
+        }
+    }
+
+    errors = tool._validate_unique_ids(entity_mappings)
+
+    assert errors == [
+        "ERROR: duplicate unique_id 'dup' in domain 'sensor' for 'a' and 'b'"
+    ]
+
+
+def test_validate_register_references_ignores_synthetic_registers() -> None:
+    entity_mappings = {
+        "sensor": {
+            "a": {"register": "known"},
+            "b": {"register": "device_clock"},
+            "c": {"register": "missing"},
+        }
+    }
+
+    errors = tool._validate_register_references(
+        entity_mappings,
+        register_names={"known"},
+        synthetic_registers={"device_clock"},
+    )
+
+    assert errors == [
+        "ERROR: register 'missing' used by 'sensor.c' missing from register schema"
+    ]

--- a/tools/validate_entity_mappings.py
+++ b/tools/validate_entity_mappings.py
@@ -27,68 +27,67 @@ def _iter_mapping_entries(entity_mappings: dict[str, dict[str, dict[str, Any]]])
             yield domain, key, definition
 
 
-def main() -> int:
+def _ensure_homeassistant_importable() -> None:
     try:
         import homeassistant.const  # noqa: F401
+        return
     except ModuleNotFoundError:
         with suppress(Exception):
             from tests.platform_stubs import install_common_ha_stubs
 
             install_common_ha_stubs()
 
-        if "homeassistant.const" not in sys.modules:
-            sys.modules["homeassistant.const"] = types.ModuleType("homeassistant.const")
+    if "homeassistant.const" not in sys.modules:
+        sys.modules["homeassistant.const"] = types.ModuleType("homeassistant.const")
 
-        class _Platform(StrEnum):
-            BINARY_SENSOR = "binary_sensor"
-            CLIMATE = "climate"
-            FAN = "fan"
-            NUMBER = "number"
-            SELECT = "select"
-            SENSOR = "sensor"
-            SWITCH = "switch"
-            TEXT = "text"
-            TIME = "time"
+    class _Platform(StrEnum):
+        BINARY_SENSOR = "binary_sensor"
+        CLIMATE = "climate"
+        FAN = "fan"
+        NUMBER = "number"
+        SELECT = "select"
+        SENSOR = "sensor"
+        SWITCH = "switch"
+        TEXT = "text"
+        TIME = "time"
 
-        ha_mod = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
-        ha_const_mod = sys.modules["homeassistant.const"]
-        ha_const_mod.Platform = getattr(ha_const_mod, "Platform", _Platform)
-        ha_const_mod.CONF_NAME = getattr(ha_const_mod, "CONF_NAME", "name")
-        ha_const_mod.PERCENTAGE = getattr(ha_const_mod, "PERCENTAGE", "%")
-        ha_mod.const = ha_const_mod
-        sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
-        ha_helpers_entity = sys.modules.setdefault(
-            "homeassistant.helpers.entity", types.ModuleType("homeassistant.helpers.entity")
-        )
-        if not hasattr(ha_helpers_entity, "EntityCategory"):
+    ha_mod = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    ha_const_mod = sys.modules["homeassistant.const"]
+    ha_const_mod.Platform = getattr(ha_const_mod, "Platform", _Platform)
+    ha_const_mod.CONF_NAME = getattr(ha_const_mod, "CONF_NAME", "name")
+    ha_const_mod.PERCENTAGE = getattr(ha_const_mod, "PERCENTAGE", "%")
+    ha_mod.const = ha_const_mod
+    sys.modules.setdefault("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+    ha_helpers_entity = sys.modules.setdefault(
+        "homeassistant.helpers.entity", types.ModuleType("homeassistant.helpers.entity")
+    )
+    if not hasattr(ha_helpers_entity, "EntityCategory"):
 
-            class _EntityCategory(StrEnum):
-                CONFIG = "config"
-                DIAGNOSTIC = "diagnostic"
+        class _EntityCategory(StrEnum):
+            CONFIG = "config"
+            DIAGNOSTIC = "diagnostic"
 
-            ha_helpers_entity.EntityCategory = _EntityCategory
+        ha_helpers_entity.EntityCategory = _EntityCategory
 
+
+def _load_validation_inputs() -> tuple[object, dict[str, Any], dict[str, Any], set[str]]:
     from custom_components.thessla_green_modbus import mappings as mappings_mod
-
-    ENTITY_MAPPINGS = mappings_mod.ENTITY_MAPPINGS
 
     en = _load_json(CC_ROOT / "translations" / "en.json")
     pl = _load_json(CC_ROOT / "translations" / "pl.json")
-    _ = _load_json(CC_ROOT / "strings.json")
+    _load_json(CC_ROOT / "strings.json")
     registers_data = _load_json(CC_ROOT / "registers" / "thessla_green_registers_full.json")
-
-    en_entities: dict[str, dict[str, Any]] = en.get("entity", {})
-    pl_entities: dict[str, dict[str, Any]] = pl.get("entity", {})
-
     register_names = {
         item.get("name")
         for item in registers_data.get("registers", [])
         if isinstance(item, dict) and isinstance(item.get("name"), str)
     }
+    return mappings_mod, en, pl, register_names
 
-    errors: list[str] = []
+
+def _collect_domain_keys(entity_mappings: dict[str, dict[str, dict[str, Any]]]) -> dict[str, set[str]]:
     domain_keys: dict[str, set[str]] = {}
-    for domain, entries in ENTITY_MAPPINGS.items():
+    for domain, entries in entity_mappings.items():
         keys: set[str] = set()
         for key, definition in entries.items():
             tkey = str(definition.get("translation_key", key))
@@ -97,36 +96,31 @@ def main() -> int:
             keys.add(f"rekuperator_{key}")
             keys.add(f"rekuperator_{tkey}")
         domain_keys[domain] = keys
+    return domain_keys
 
-    ignored_orphan_translations = {("sensor", "error_codes")}
-    synthetic_registers = {
-        "device_clock",
-        "heat_recovery_efficiency",
-        "heat_recovery_power",
-        "electrical_power",
-    }
 
-    # 1) Every mapping key has translation in pl + en
-    for domain, key, definition in _iter_mapping_entries(ENTITY_MAPPINGS):
+def _validate_translations(
+    entity_mappings: dict[str, dict[str, dict[str, Any]]],
+    en_entities: dict[str, dict[str, Any]],
+    pl_entities: dict[str, dict[str, Any]],
+    ignored_orphan_translations: set[tuple[str, str]],
+) -> list[str]:
+    errors: list[str] = []
+    for domain, key, definition in _iter_mapping_entries(entity_mappings):
         tkey = definition.get("translation_key", key)
         if tkey not in en_entities.get(domain, {}):
-            errors.append(
-                f"ERROR: entity '{domain}.{tkey}' in entity_mappings missing from en.json"
-            )
+            errors.append(f"ERROR: entity '{domain}.{tkey}' in entity_mappings missing from en.json")
         if tkey not in pl_entities.get(domain, {}):
-            errors.append(
-                f"ERROR: entity '{domain}.{tkey}' in entity_mappings missing from pl.json"
-            )
+            errors.append(f"ERROR: entity '{domain}.{tkey}' in entity_mappings missing from pl.json")
 
-    # 2) No translation points to non-existing mapping entity
     for lang, entities in (("en", en_entities), ("pl", pl_entities)):
         for domain, domain_map in entities.items():
-            if domain not in ENTITY_MAPPINGS:
+            if domain not in entity_mappings:
                 continue
             for tkey in domain_map:
                 has_match = any(
                     definition.get("translation_key", key) == tkey
-                    for key, definition in ENTITY_MAPPINGS[domain].items()
+                    for key, definition in entity_mappings[domain].items()
                 )
                 if not tkey.startswith("rekuperator_"):
                     continue
@@ -134,9 +128,14 @@ def main() -> int:
                     errors.append(
                         f"ERROR: entity '{domain}.{tkey}' in {lang}.json missing from entity_mappings"
                     )
+    return errors
 
-    # 3) Every register_name in mappings exists in register JSON
-    for domain, key, definition in _iter_mapping_entries(ENTITY_MAPPINGS):
+
+def _validate_register_references(
+    entity_mappings: dict[str, dict[str, dict[str, Any]]], register_names: set[str], synthetic_registers: set[str]
+) -> list[str]:
+    errors: list[str] = []
+    for domain, key, definition in _iter_mapping_entries(entity_mappings):
         register_name = definition.get("register", key)
         if (
             isinstance(register_name, str)
@@ -146,8 +145,17 @@ def main() -> int:
             errors.append(
                 f"ERROR: register '{register_name}' used by '{domain}.{key}' missing from register schema"
             )
+    return errors
 
-    # 3b) Include standalone *_MAPPING dictionaries as well.
+
+def _validate_standalone_mappings(
+    mappings_mod: object,
+    en_entities: dict[str, dict[str, Any]],
+    pl_entities: dict[str, dict[str, Any]],
+    register_names: set[str],
+    synthetic_registers: set[str],
+) -> tuple[list[str], set[tuple[str, str]]]:
+    errors: list[str] = []
     standalone_mapping_keys: set[tuple[str, str]] = set()
     for var_name, mapping in vars(mappings_mod).items():
         if not var_name.endswith("_MAPPING") or not isinstance(mapping, dict):
@@ -158,29 +166,29 @@ def main() -> int:
             if not isinstance(key, str) or not isinstance(value, dict):
                 continue
             domain = str(value.get("domain", "")).strip()
-            if domain:
-                standalone_mapping_keys.add((domain, key))
-                if key not in en_entities.get(domain, {}):
-                    errors.append(
-                        f"ERROR: entity '{domain}.{key}' in {var_name} missing from en.json"
-                    )
-                if key not in pl_entities.get(domain, {}):
-                    errors.append(
-                        f"ERROR: entity '{domain}.{key}' in {var_name} missing from pl.json"
-                    )
-                register_name = value.get("register", key)
-                if (
-                    isinstance(register_name, str)
-                    and register_name not in register_names
-                    and register_name not in synthetic_registers
-                ):
-                    errors.append(
-                        f"ERROR: register '{register_name}' used by '{domain}.{key}' missing from register schema"
-                    )
+            if not domain:
+                continue
+            standalone_mapping_keys.add((domain, key))
+            if key not in en_entities.get(domain, {}):
+                errors.append(f"ERROR: entity '{domain}.{key}' in {var_name} missing from en.json")
+            if key not in pl_entities.get(domain, {}):
+                errors.append(f"ERROR: entity '{domain}.{key}' in {var_name} missing from pl.json")
+            register_name = value.get("register", key)
+            if (
+                isinstance(register_name, str)
+                and register_name not in register_names
+                and register_name not in synthetic_registers
+            ):
+                errors.append(
+                    f"ERROR: register '{register_name}' used by '{domain}.{key}' missing from register schema"
+                )
+    return errors, standalone_mapping_keys
 
-    # 4) Unique IDs must be unique within each domain.
+
+def _validate_unique_ids(entity_mappings: dict[str, dict[str, dict[str, Any]]]) -> list[str]:
+    errors: list[str] = []
     unique_ids_by_domain: dict[str, dict[str, str]] = {}
-    for domain, key, definition in _iter_mapping_entries(ENTITY_MAPPINGS):
+    for domain, key, definition in _iter_mapping_entries(entity_mappings):
         unique_id = definition.get("unique_id")
         if not isinstance(unique_id, str) or not unique_id:
             continue
@@ -192,15 +200,49 @@ def main() -> int:
             )
         else:
             by_domain[unique_id] = key
+    return errors
 
+
+def _report_errors(errors: list[str]) -> int:
     if errors:
         for err in errors:
             print(err)
         return 1
+    return 0
 
-    validated_count = sum(len(entries) for entries in ENTITY_MAPPINGS.values()) + len(
-        standalone_mapping_keys
+
+def main() -> int:
+    _ensure_homeassistant_importable()
+    mappings_mod, en, pl, register_names = _load_validation_inputs()
+    entity_mappings = mappings_mod.ENTITY_MAPPINGS
+
+    en_entities: dict[str, dict[str, Any]] = en.get("entity", {})
+    pl_entities: dict[str, dict[str, Any]] = pl.get("entity", {})
+
+    _collect_domain_keys(entity_mappings)
+    ignored_orphan_translations = {("sensor", "error_codes")}
+    synthetic_registers = {
+        "device_clock",
+        "heat_recovery_efficiency",
+        "heat_recovery_power",
+        "electrical_power",
+    }
+
+    errors: list[str] = []
+    errors.extend(
+        _validate_translations(entity_mappings, en_entities, pl_entities, ignored_orphan_translations)
     )
+    errors.extend(_validate_register_references(entity_mappings, register_names, synthetic_registers))
+    standalone_errors, standalone_mapping_keys = _validate_standalone_mappings(
+        mappings_mod, en_entities, pl_entities, register_names, synthetic_registers
+    )
+    errors.extend(standalone_errors)
+    errors.extend(_validate_unique_ids(entity_mappings))
+
+    if _report_errors(errors):
+        return 1
+
+    validated_count = sum(len(entries) for entries in entity_mappings.values()) + len(standalone_mapping_keys)
     print(f"OK: {validated_count} entities validated")
     return 0
 


### PR DESCRIPTION
### Motivation
- Reduce the complexity of the large `main()` in `tools/validate_entity_mappings.py` by extracting smaller, focused helpers while preserving validation behavior and output semantics.
- Improve testability of validation logic so targeted checks can be verified directly by unit tests.

### Description
- Extracted helpers from `tools/validate_entity_mappings.py`: `_ensure_homeassistant_importable`, `_load_validation_inputs`, `_collect_domain_keys`, `_validate_translations`, `_validate_register_references`, `_validate_standalone_mappings`, `_validate_unique_ids`, and `_report_errors` while keeping `main()` orchestration unchanged.
- Kept all original validation checks and error message formats, including translation presence, orphan translation detection, register existence (with synthetic-register exemptions), standalone `*_MAPPING` checks, and unique-ID duplication detection, and preserved the `OK: <count> entities validated` success output and non-zero exit on failure.
- Added unit tests in `tests/test_validate_entity_mappings_tool.py` that exercise the new helper functions for duplicate unique IDs and synthetic-register handling.
- Files changed: `tools/validate_entity_mappings.py` and new `tests/test_validate_entity_mappings_tool.py`.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt` which completed successfully.
- Ran `ruff check custom_components tests tools` which passed.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed.
- Executed the tool with `python tools/validate_entity_mappings.py` which printed `OK: 366 entities validated` and exited successfully.
- Ran `pytest tests/ -q` which passed (all tests passed except 4 skipped as reported by pytest).
- Ran `python tools/check_maintainability.py` which reported the maintainability gate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f272a5e74483268a77e88c1f6c041e)