### PR TITLE
refactor: tighten raw RTU transport helpers

### DIFF
--- a/custom_components/thessla_green_modbus/transport/crc.py
+++ b/custom_components/thessla_green_modbus/transport/crc.py
@@ -12,5 +12,10 @@ def crc16(data: bytes) -> int:
     return crc & 0xFFFF
 
 
+def crc16_bytes(data: bytes) -> bytes:
+    """Return Modbus CRC16 serialized in little-endian order."""
+    return crc16(data).to_bytes(2, "little")
+
+
 def append_crc(data: bytes) -> bytes:
-    return data + crc16(data).to_bytes(2, "little")
+    return data + crc16_bytes(data)

--- a/custom_components/thessla_green_modbus/transport/rtu_over_tcp.py
+++ b/custom_components/thessla_green_modbus/transport/rtu_over_tcp.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from .crc import append_crc, crc16
+from .crc import append_crc, crc16_bytes
 
 
 def validate_crc(payload: bytes, crc_bytes: bytes) -> None:
-    expected = crc16(payload).to_bytes(2, "little")
+    expected = crc16_bytes(payload)
     if crc_bytes != expected:
         raise ValueError("CRC mismatch in RTU response")
 

--- a/tests/test_modbus_transport_rtu_over_tcp_helpers.py
+++ b/tests/test_modbus_transport_rtu_over_tcp_helpers.py
@@ -1,0 +1,38 @@
+"""Tests for transport RTU-over-TCP framing helpers."""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.thessla_green_modbus.transport.crc import append_crc, crc16, crc16_bytes
+from custom_components.thessla_green_modbus.transport.rtu_over_tcp import (
+    build_read_frame,
+    validate_crc,
+)
+
+
+def test_crc16_and_bytes_use_little_endian() -> None:
+    payload = bytes([0x01, 0x04, 0x00, 0x64, 0x00, 0x02])
+    crc_value = crc16(payload)
+
+    assert crc16_bytes(payload) == crc_value.to_bytes(2, "little")
+    assert append_crc(payload) == payload + crc16_bytes(payload)
+
+
+def test_validate_crc_accepts_valid_frame_crc() -> None:
+    payload = bytes([0x0A, 0x04, 0x02, 0x12, 0x34])
+
+    validate_crc(payload, crc16_bytes(payload))
+
+
+def test_validate_crc_rejects_malformed_crc_bytes() -> None:
+    payload = bytes([0x0A, 0x04, 0x02, 0x12, 0x34])
+
+    with pytest.raises(ValueError, match="CRC mismatch"):
+        validate_crc(payload, b"\x00\x00")
+
+
+def test_build_read_frame_wires_payload_and_crc() -> None:
+    frame = build_read_frame(0x11, 0x04, 0x0064, 0x000A)
+
+    assert frame[:6] == bytes([0x11, 0x04, 0x00, 0x64, 0x00, 0x0A])
+    assert frame[6:] == crc16_bytes(frame[:6])


### PR DESCRIPTION
### Motivation

- Reduce duplicated CRC serialization logic and centralize little-endian CRC byte formatting for RTU-over-TCP framing.  
- Improve unit coverage for small RTU-over-TCP helpers (CRC bytes, frame composition, and malformed CRC handling).  
- Keep transport behavior, CRC algorithm, and retry/error semantics identical while making helpers clearer and more reusable.

### Description

- Added `crc16_bytes(data: bytes) -> bytes` to `custom_components/thessla_green_modbus/transport/crc.py` and made `append_crc()` use it, preserving the same CRC algorithm and little-endian output.  
- Updated `custom_components/thessla_green_modbus/transport/rtu_over_tcp.py` to reuse `crc16_bytes()` in `validate_crc()` and left `build_read_frame()` unchanged except for using the shared `append_crc()`.  
- Added focused tests in `tests/test_modbus_transport_rtu_over_tcp_helpers.py` to assert CRC integer/bytes consistency, validate acceptance/rejection of CRC bytes, and verify read-frame payload+CRC composition.  
- No changes were made to raw transport logic that handles retries, connection/reset, framing semantics in the main transport implementation.

### Testing

- Ran `ruff check custom_components tests tools` and the auto-fix for import ordering; linter checks passed.  
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` and compilation succeeded.  
- Ran focused tests: `pytest -q tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py` and full suite: `pytest tests/ -q`; both succeeded (test suite reported unrelated skips).  
- Ran the maintainability gate `python tools/check_maintainability.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f272b3052083268e40e77343978889)