### PR TITLE
refactor: decompose config flow validation and schema helpers

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow_device_validation.py
+++ b/custom_components/thessla_green_modbus/config_flow_device_validation.py
@@ -107,6 +107,21 @@ async def _maybe_close_scanner(scanner: Any | None) -> None:
             await close_result
 
 
+async def _run_scanner_validation(
+    *,
+    scanner: Any,
+    timeout: float,
+    run_scanner_call: Callable[[Callable[[], Any], float], Awaitable[Any]],
+) -> dict[str, Any]:
+    """Run connection verification and device scan."""
+    short_timeout = max(2, timeout)
+    verify_cb = getattr(scanner, "verify_connection", None)
+    if not callable(verify_cb):
+        raise AttributeError("verify_connection")
+    await run_scanner_call(verify_cb, short_timeout)
+    return _validate_scan_result(await run_scanner_call(scanner.scan_device, timeout))
+
+
 def _map_validation_exception(
     exc: BaseException,
     *,
@@ -158,6 +173,13 @@ def _map_validation_exception(
         logger.debug("Traceback:\n%s", traceback.format_exc())
         return CannotConnect("cannot_connect")
     return exc  # passthrough
+
+
+def _raise_if_unmapped(mapped: Exception, original: BaseException) -> None:
+    """Raise mapped exceptions, passthrough unknown ones untouched."""
+    if mapped is original:
+        raise original
+    raise mapped from original
 
 
 async def validate_input_impl(
@@ -215,6 +237,18 @@ async def validate_input_impl(
     capabilities_cls = capabilities_cls_override or module.DeviceCapabilities
 
     scanner: Any | None = None
+    handled_exceptions = (
+        ConnectionException,
+        ModbusIOException,
+        ModbusException,
+        AttributeError,
+        OSError,
+        ValueError,
+        TypeError,
+        RuntimeError,
+        ImportError,
+        *timeout_exceptions,
+    )
     try:
         scanner = await run_with_retry(
             lambda: scanner_cls.create(
@@ -243,14 +277,10 @@ async def validate_input_impl(
             retries=default_retry,
             backoff=config_flow_backoff,
         )
-        short_timeout = max(2, params["timeout"])
-        verify_cb = getattr(scanner, "verify_connection", None)
-        if not callable(verify_cb):
-            raise AttributeError("verify_connection")
-        await run_scanner_call(verify_cb, short_timeout)
-
-        scan_result = _validate_scan_result(
-            await run_scanner_call(scanner.scan_device, params["timeout"])
+        scan_result = await _run_scanner_validation(
+            scanner=scanner,
+            timeout=params["timeout"],
+            run_scanner_call=run_scanner_call,
         )
 
         caps_dict = process_scan_capabilities(scan_result, capabilities_cls)
@@ -260,7 +290,7 @@ async def validate_input_impl(
         raise
     except CannotConnect:
         raise
-    except BaseException as exc:
+    except handled_exceptions as exc:
         mapped = _map_validation_exception(
             exc,
             is_request_cancelled_error=is_request_cancelled_error,
@@ -269,8 +299,6 @@ async def validate_input_impl(
             logger=logger,
             timeout_exceptions=timeout_exceptions,
         )
-        if mapped is exc:
-            raise
-        raise mapped from exc
+        _raise_if_unmapped(mapped, exc)
     finally:
         await _maybe_close_scanner(scanner)

--- a/custom_components/thessla_green_modbus/config_flow_schema.py
+++ b/custom_components/thessla_green_modbus/config_flow_schema.py
@@ -139,28 +139,27 @@ def _build_scan_option_fields(current_values: dict[str, Any]) -> dict[Any, Any]:
     }
 
 
-def build_connection_schema(
-    defaults: dict[str, Any],
+def _resolve_option_lists(
+    modbus_baud_rates: list[int] | None,
+    modbus_parity: list[str] | None,
+    modbus_stop_bits: list[str] | None,
+) -> tuple[list[int], list[str], list[str]]:
+    """Resolve optional selector lists to concrete lists."""
+    return (
+        modbus_baud_rates if modbus_baud_rates is not None else [],
+        modbus_parity if modbus_parity is not None else [],
+        modbus_stop_bits if modbus_stop_bits is not None else [],
+    )
+
+
+def _build_serial_defaults_and_validators(
+    current_values: dict[str, Any],
     *,
-    discovered_host: str | None = None,
-    modbus_baud_rates: list[int] | None = None,
-    modbus_parity: list[str] | None = None,
-    modbus_stop_bits: list[str] | None = None,
-) -> vol.Schema:
-    """Return schema for connection details with provided defaults."""
-    current_values = defaults or {}
-
-    resolved_defaults = _resolve_defaults(current_values, discovered_host)
-    connection_default = resolved_defaults["connection_default"]
-    host_default = resolved_defaults["host_default"]
-    port_default = resolved_defaults["port_default"]
-    slave_default = resolved_defaults["slave_default"]
-    serial_port_default = resolved_defaults["serial_port_default"]
-
-    baud_options = modbus_baud_rates if modbus_baud_rates is not None else []
-    parity_options = modbus_parity if modbus_parity is not None else []
-    stop_bits_options = modbus_stop_bits if modbus_stop_bits is not None else []
-
+    baud_options: list[int],
+    parity_options: list[str],
+    stop_bits_options: list[str],
+) -> dict[str, Any]:
+    """Build RTU defaults and validators for baud/parity/stop bits."""
     baud_default = _option_default(
         "modbus_baud_rate_",
         baud_options,
@@ -190,16 +189,52 @@ def build_connection_schema(
     if not stop_bits_options:
         stop_bits_default = str(stop_bits_default)
 
-    baud_validator: Any = (
-        vol.In(baud_options)
-        if baud_options
-        else vol.All(vol.Coerce(int), vol.Range(min=1200, max=230400))
+    return {
+        "baud_default": baud_default,
+        "parity_default": parity_default,
+        "stop_bits_default": stop_bits_default,
+        "baud_validator": (
+            vol.In(baud_options)
+            if baud_options
+            else vol.All(vol.Coerce(int), vol.Range(min=1200, max=230400))
+        ),
+        "parity_validator": (
+            vol.In(parity_options) if parity_options else vol.In(["none", "even", "odd"])
+        ),
+        "stop_bits_validator": (
+            vol.In(stop_bits_options) if stop_bits_options else vol.In(["1", "2"])
+        ),
+    }
+
+
+def build_connection_schema(
+    defaults: dict[str, Any],
+    *,
+    discovered_host: str | None = None,
+    modbus_baud_rates: list[int] | None = None,
+    modbus_parity: list[str] | None = None,
+    modbus_stop_bits: list[str] | None = None,
+) -> vol.Schema:
+    """Return schema for connection details with provided defaults."""
+    current_values = defaults or {}
+
+    resolved_defaults = _resolve_defaults(current_values, discovered_host)
+    connection_default = resolved_defaults["connection_default"]
+    host_default = resolved_defaults["host_default"]
+    port_default = resolved_defaults["port_default"]
+    slave_default = resolved_defaults["slave_default"]
+    serial_port_default = resolved_defaults["serial_port_default"]
+
+    baud_options, parity_options, stop_bits_options = _resolve_option_lists(
+        modbus_baud_rates,
+        modbus_parity,
+        modbus_stop_bits,
     )
-    parity_validator: Any = (
-        vol.In(parity_options) if parity_options else vol.In(["none", "even", "odd"])
-    )
-    stop_bits_validator: Any = (
-        vol.In(stop_bits_options) if stop_bits_options else vol.In(["1", "2"])
+    serial_defaults = _build_serial_defaults_and_validators(
+        current_values,
+        baud_options=baud_options,
+        parity_options=parity_options,
+        stop_bits_options=stop_bits_options,
     )
 
     data_schema: dict[Any, Any] = {
@@ -216,12 +251,12 @@ def build_connection_schema(
         data_schema.update(
             _build_rtu_fields(
                 serial_port_default,
-                baud_default=baud_default,
-                baud_validator=baud_validator,
-                parity_default=parity_default,
-                parity_validator=parity_validator,
-                stop_bits_default=stop_bits_default,
-                stop_bits_validator=stop_bits_validator,
+                baud_default=serial_defaults["baud_default"],
+                baud_validator=serial_defaults["baud_validator"],
+                parity_default=serial_defaults["parity_default"],
+                parity_validator=serial_defaults["parity_validator"],
+                stop_bits_default=serial_defaults["stop_bits_default"],
+                stop_bits_validator=serial_defaults["stop_bits_validator"],
             )
         )
 

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -11,10 +11,18 @@ from custom_components.thessla_green_modbus.config_flow import (
     _normalize_stop_bits,
     _run_with_retry,
 )
+from custom_components.thessla_green_modbus.config_flow_device_validation import (
+    _build_success_payload,
+    _validate_scan_result,
+)
+from custom_components.thessla_green_modbus.config_flow_schema import (
+    _build_serial_defaults_and_validators,
+)
 from custom_components.thessla_green_modbus.config_flow_steps import (
     extract_discovered_state,
     resolve_reauth_defaults,
 )
+from custom_components.thessla_green_modbus.errors import CannotConnect
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
 
 # ---------------------------------------------------------------------------
@@ -249,6 +257,33 @@ async def test_build_connection_schema_empty_baud_rates_bad_baud_default():
         assert schema is not None
     finally:
         cf_mod.MODBUS_BAUD_RATES = original_baud
+
+
+def test_validate_scan_result_rejects_empty():
+    with pytest.raises(CannotConnect) as err:
+        _validate_scan_result({})
+    assert err.value.args[0] == "invalid_format"
+
+
+def test_build_success_payload_includes_title_and_scan_result():
+    scan_result = {"device_info": {"model": "x"}}
+    payload = _build_success_payload("Name", scan_result)
+    assert payload["title"] == "Name"
+    assert payload["device_info"] == {"model": "x"}
+    assert payload["scan_result"] is scan_result
+
+
+def test_build_serial_defaults_and_validators_without_option_lists():
+    values = {"baud_rate": "invalid_baud", "parity": "Odd", "stop_bits": 2}
+    resolved = _build_serial_defaults_and_validators(
+        values,
+        baud_options=[],
+        parity_options=[],
+        stop_bits_options=[],
+    )
+    assert resolved["baud_default"] == 9600
+    assert resolved["parity_default"] == "Odd"
+    assert resolved["stop_bits_default"] == "2"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Reduce complexity in config flow validation and schema construction by extracting pure helper logic so the orchestration code remains clear and easier to test.
- Isolate scanner execution, exception mapping, and RTU serial option handling to make behavior explicit while preserving existing validation semantics and UI schema shape.

### Description
- Extracted scanner execution into `_run_scanner_validation` which performs verification and device scan with timeout handling, and replaced inline logic in `validate_input_impl` to call the helper. (file: `custom_components/thessla_green_modbus/config_flow_device_validation.py`)
- Added `_raise_if_unmapped` to centralize raising mapped exceptions (or passthrough unknown exceptions) and simplified `validate_input_impl` error handling. (file: `custom_components/thessla_green_modbus/config_flow_device_validation.py`)
- Introduced `_resolve_option_lists` and `_build_serial_defaults_and_validators` to decompose `build_connection_schema` into list resolution and RTU defaults/validator construction, then used these helpers when assembling the schema. (file: `custom_components/thessla_green_modbus/config_flow_schema.py`)
- Added focused unit tests for the new helpers covering scan-result validation, success payload construction, and RTU serial defaults/validator fallback behavior. (file: `tests/test_config_flow_helpers.py`)
- Kept the public config-flow behavior and UI schema fields unchanged; only internal decomposition and test coverage were added. (files modified: `custom_components/thessla_green_modbus/config_flow_device_validation.py`, `custom_components/thessla_green_modbus/config_flow_schema.py`, `tests/test_config_flow_helpers.py`)

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt` and unit/integration suites as targeted in the workflow, and these commands completed successfully in this environment.
- `pytest -q tests/test_config_flow_*.py` passed without failures.
- `pytest -q tests/test_integration.py tests/test_migration.py` passed without failures and full `pytest tests/ -q` completed successfully with expected skips.
- Static checks and packaging gates succeeded: `ruff check`, `python -m compileall`, and `python tools/check_maintainability.py` all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f107d7888326bfbe02a731bfa640)