### PR TITLE
refactor: tighten coordinator package public API

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/__init__.py
+++ b/custom_components/thessla_green_modbus/coordinator/__init__.py
@@ -1,12 +1,8 @@
 """Coordinator package public API."""
 
-from ..registers.loader import get_register_definition
-from ..scanner.core import ThesslaGreenDeviceScanner
 from .coordinator import CoordinatorConfig, ThesslaGreenModbusCoordinator
 
 __all__ = [
     "CoordinatorConfig",
-    "ThesslaGreenDeviceScanner",
     "ThesslaGreenModbusCoordinator",
-    "get_register_definition",
 ]

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -18,9 +18,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _get_register_definition(register_name: str) -> Any:
-    """Resolve register definitions via coordinator package API."""
+    """Resolve register definitions via coordinator implementation module."""
 
-    from custom_components.thessla_green_modbus import coordinator as coordinator_module
+    from custom_components.thessla_green_modbus.coordinator import coordinator as coordinator_module
 
     return coordinator_module.get_register_definition(register_name)
 

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -12,7 +12,7 @@ import custom_components.thessla_green_modbus.services_targets as services_targe
 
 def test_coordinator_package_public_api_is_minimal() -> None:
     """Coordinator package should expose only public coordinator entrypoints."""
-    assert set(coordinator.__all__) == {"CoordinatorConfig", "ThesslaGreenDeviceScanner", "ThesslaGreenModbusCoordinator", "get_register_definition"}
+    assert set(coordinator.__all__) == {"CoordinatorConfig", "ThesslaGreenModbusCoordinator"}
     for export_name in coordinator.__all__:
         assert hasattr(coordinator, export_name)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -157,7 +157,7 @@ async def test_async_write_multi_register_start(coordinator, monkeypatch):
     client.write_registers = AsyncMock(return_value=response)
     coordinator.client = client
 
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coordinator_mod
 
     fake_def = RegisterDef(function=3, address=0, name="date_time_1", access="rw", length=4)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: fake_def)
@@ -183,7 +183,7 @@ async def test_async_write_multi_register_with_offset(coordinator, monkeypatch):
     client.write_registers = AsyncMock(return_value=response)
     coordinator.client = client
 
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coordinator_mod
 
     fake_def = RegisterDef(function=3, address=0, name="date_time_1", access="rw", length=4)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: fake_def)
@@ -209,7 +209,7 @@ async def test_async_write_multi_register_non_start(coordinator, monkeypatch):
     client.write_register = AsyncMock()
     coordinator.client = client
 
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coordinator_mod
 
     fake_def = RegisterDef(function=3, address=1, name="date_time_2", access="rw", length=1)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: fake_def)
@@ -232,7 +232,7 @@ async def test_async_write_multi_register_wrong_length(coordinator, monkeypatch)
     client.write_registers = AsyncMock()
     coordinator.client = client
 
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coordinator_mod
 
     fake_def = RegisterDef(function=3, address=0, name="date_time_1", access="rw", length=4)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: fake_def)
@@ -267,7 +267,7 @@ async def test_async_write_register_chunks(coordinator, batch, expected_calls, m
     coordinator.client = client
     coordinator.async_request_refresh = AsyncMock()
 
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coordinator_mod
 
     fake_def = SimpleNamespace(length=4, address=0, function=3, encode=lambda v: v)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: fake_def)
@@ -294,7 +294,7 @@ async def test_async_write_register_truncates_over_limit(coordinator, monkeypatc
     coordinator.client = client
     coordinator.async_request_refresh = AsyncMock()
 
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coordinator_mod
 
     fake_def = SimpleNamespace(length=20, address=0, function=3, encode=lambda v: v)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: fake_def)

--- a/tests/test_coordinator_capabilities.py
+++ b/tests/test_coordinator_capabilities.py
@@ -95,7 +95,7 @@ def test_compute_register_groups_safe_scan_key_error():
     coord.available_registers = {"holding_registers": {"mode"}}
     coord._register_maps = {"holding_registers": {"mode": 100}}
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         side_effect=KeyError("mode"),
     ):
         coord._compute_register_groups()
@@ -115,7 +115,7 @@ def test_compute_register_groups_non_safe_key_error():
     coord.available_registers = {"holding_registers": {"mode"}}
     coord._register_maps = {"holding_registers": {"mode": 100}}
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         side_effect=KeyError("mode"),
     ):
         coord._compute_register_groups()

--- a/tests/test_coordinator_read_cycle.py
+++ b/tests/test_coordinator_read_cycle.py
@@ -74,6 +74,6 @@ def test_process_register_value_sensor_unavailable_temperature():
     mock_def.is_temperature.return_value = True
     mock_def.enum = None
     mock_def.decode.return_value = 0
-    with patch("custom_components.thessla_green_modbus.coordinator.get_register_definition", return_value=mock_def):
+    with patch("custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition", return_value=mock_def):
         result = coord._process_register_value("outside_temperature", SENSOR_UNAVAILABLE)
     assert result is None

--- a/tests/test_coordinator_register_writes.py
+++ b/tests/test_coordinator_register_writes.py
@@ -69,7 +69,7 @@ async def test_async_write_register_numeric_out_of_range(coordinator, monkeypatc
     coordinator._ensure_connection = AsyncMock()
     coordinator.client = MagicMock()
 
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coordinator_mod
 
     reg = RegisterDef(function="03", address=0, name="num", access="rw", min=0, max=10)
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: reg)
@@ -84,7 +84,7 @@ async def test_async_write_register_enum_invalid(coordinator, monkeypatch):
     coordinator._ensure_connection = AsyncMock()
     coordinator.client = MagicMock()
 
-    import custom_components.thessla_green_modbus.coordinator as coordinator_mod
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coordinator_mod
 
     reg = RegisterDef(function="03", address=0, name="mode", access="rw", enum={0: "off", 1: "on"})
     monkeypatch.setattr(coordinator_mod, "get_register_definition", lambda _n: reg)

--- a/tests/test_coordinator_retry_reconnect.py
+++ b/tests/test_coordinator_retry_reconnect.py
@@ -214,7 +214,7 @@ async def test_async_write_register_multi_reg_chunk_error_last_attempt():
     coord._transport = transport
     coord.retry = 1
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_register("some_reg", [1, 2])
@@ -333,7 +333,7 @@ async def test_async_write_register_multi_reg_chunk_error_retry():
     coord.retry = 2
     coord.async_request_refresh = AsyncMock()
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_register("some_reg", [1, 2])

--- a/tests/test_coordinator_schedule.py
+++ b/tests/test_coordinator_schedule.py
@@ -32,7 +32,7 @@ async def test_async_write_temporary_airflow():
     mock_def = MagicMock()
     mock_def.encode = MagicMock(return_value=1)
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_temporary_airflow(50.0)
@@ -45,7 +45,7 @@ async def test_async_write_temporary_airflow_missing_register():
     """async_write_temporary_airflow returns False when registers unavailable (lines 2327-2329)."""
     coord = _make_coordinator()
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         side_effect=KeyError("cfg_mode_1"),
     ):
         result = await coord.async_write_temporary_airflow(50.0)
@@ -60,7 +60,7 @@ async def test_async_write_temporary_temperature():
     mock_def = MagicMock()
     mock_def.encode = MagicMock(return_value=1)
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_temporary_temperature(22.0)
@@ -73,7 +73,7 @@ async def test_async_write_temporary_temperature_missing_register():
     """async_write_temporary_temperature returns False when registers unavailable (lines 2352-2354)."""
     coord = _make_coordinator()
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         side_effect=KeyError("cfg_mode_2"),
     ):
         result = await coord.async_write_temporary_temperature(22.0)

--- a/tests/test_coordinator_update_cycle.py
+++ b/tests/test_coordinator_update_cycle.py
@@ -131,7 +131,7 @@ def test_process_register_value_sensor_unavailable_temperature():
     mock_def.enum = None
     mock_def.decode.return_value = 0
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = coord._process_register_value("outside_temperature", SENSOR_UNAVAILABLE)
@@ -154,7 +154,7 @@ def test_process_register_value_sensor_unavailable_non_temperature():
     mock_def.enum = None
     mock_def.decode.return_value = 0
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = coord._process_register_value(non_temp_reg, SENSOR_UNAVAILABLE)
@@ -174,7 +174,7 @@ async def test_async_write_register_multi_reg_offset_too_large():
     mock_def.address = 100
     mock_def.encode.return_value = [1, 2, 3]
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_register("some_reg", [1, 2, 3], offset=1)
@@ -283,7 +283,7 @@ async def test_async_write_register_non_writable_function():
     mock_def.address = 100
     mock_def.encode.return_value = 1
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_register("some_reg", 1)
@@ -361,7 +361,7 @@ async def test_async_write_register_multi_reg_non_int_values():
     transport.is_connected.return_value = True
     coord._transport = transport
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_register("some_reg", ["bad", "x", "y"], offset=0)
@@ -380,7 +380,7 @@ async def test_async_write_register_offset_exceeds_length():
     transport.is_connected.return_value = True
     coord._transport = transport
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_register("some_reg", 1, offset=2)
@@ -403,7 +403,7 @@ async def test_async_write_register_multi_reg_with_offset_via_transport():
     coord._transport = transport
     coord.async_request_refresh = AsyncMock()
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_register("some_reg", 5, offset=1)
@@ -498,7 +498,7 @@ async def test_async_write_register_encoded_non_list():
     coord._transport = transport
     coord.async_request_refresh = AsyncMock()
     with patch(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         return_value=mock_def,
     ):
         result = await coord.async_write_register("some_reg", 5, offset=0)


### PR DESCRIPTION
### Motivation

- Reduce the coordinator package root API to only the true public coordinator entry points and remove test/implementation conveniences that leaked from the package root.
- Ensure internal and test code import implementation details from their owning modules rather than relying on package-root re-exports.

### Description

- Narrowed `custom_components.thessla_green_modbus.coordinator.__all__` to only export `CoordinatorConfig` and `ThesslaGreenModbusCoordinator` by editing `custom_components/thessla_green_modbus/coordinator/__init__.py`.
- Updated the write-path register lookup in `custom_components/thessla_green_modbus/coordinator/schedule.py` to call the implementation owner (`coordinator.coordinator.get_register_definition`) instead of relying on package-root exports.
- Migrated coordinator-scoped tests to patch and import implementation symbols from the owning module (e.g. `custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition` and imports of `coordinator.coordinator` in multiple `tests/test_coordinator*.py` files).
- Adjusted package-root indirection for direct TCP client selection to use the implementation symbol directly (removed package-root fallback) so tests patch the owning implementation module.

### Testing

- Ran lint and static checks with `ruff check custom_components tests tools` which passed.
- Type/compile verification via `python -m compileall -q custom_components/thessla_green_modbus tests tools` passed.
- Ran focused coordinator tests with `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` which passed.
- Ran the full test suite with `pytest tests/ -q` which produced failures in tests outside the allowed change scope that still referenced removed package-root symbols (these remaining failures are from tests that must be migrated to owning-module imports in follow-ups); `python tools/check_maintainability.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f130600c8326add21979217df24f)