### PR TITLE
refactor: decompose mapping builder transformations

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -241,6 +241,81 @@ def _route_min_max_mapping(
     return False
 
 
+def _is_unmappable_holding_register(
+    register: str,
+    all_mappings: tuple[dict[str, Any], ...],
+    binary_mappings: dict[str, Any],
+) -> bool:
+    """Return True when register should be skipped before classification."""
+    return _is_register_mapped_anywhere(register, all_mappings) or _is_mapped_as_binary_source(register, binary_mappings)
+
+
+def _route_enum_or_min_max_mapping(
+    reg: Any,
+    register: str,
+    access: str,
+    min_val: Any,
+    max_val: Any,
+    unit: Any,
+    info_text: str,
+    scale: Any,
+    step: Any,
+    switch_keys: set[str],
+    binary_keys: set[str],
+    select_keys: set[str],
+    number_keys: set[str],
+    sensor_mappings: dict[str, Any],
+    number_mappings: dict[str, Any],
+    binary_mappings: dict[str, Any],
+    switch_mappings: dict[str, Any],
+    select_mappings: dict[str, Any],
+) -> None:
+    """Route register classification to enum or min/max handlers."""
+    if reg.enum and not (reg.extra and reg.extra.get("bitmask")):
+        target, payload = _classify_enum_mapping(
+            register,
+            reg.enum,
+            access,
+            switch_keys,
+            binary_keys,
+            select_keys,
+        )
+        _route_enum_mapping(
+            target,
+            register,
+            payload,
+            sensor_mappings,
+            binary_mappings,
+            switch_mappings,
+            select_mappings,
+        )
+        return
+
+    target, payload = _classify_min_max_mapping(
+        register,
+        access,
+        min_val,
+        max_val,
+        info_text,
+        unit,
+        step,
+        scale,
+        switch_keys,
+        binary_keys,
+        select_keys,
+        number_keys,
+    )
+    _route_min_max_mapping(
+        target,
+        register,
+        payload,
+        number_mappings,
+        binary_mappings,
+        switch_mappings,
+        select_mappings,
+    )
+
+
 def _build_sensor_season_setting_mapping(register: str) -> dict[str, Any]:
     """Return read-only season setting mapping payload."""
     return {
@@ -581,9 +656,9 @@ def _extend_entity_mappings_from_registers() -> None:
         if reg.function != 3 or not reg.name:
             continue
         register, access, min_val, max_val, unit, info_text, scale, step = _register_context(reg)
-        if _is_register_mapped_anywhere(
+        if _is_unmappable_holding_register(
             register,
-            (
+            all_mappings=(
                 number_mappings,
                 sensor_mappings,
                 binary_mappings,
@@ -592,9 +667,8 @@ def _extend_entity_mappings_from_registers() -> None:
                 text_mappings,
                 time_mappings,
             ),
+            binary_mappings=binary_mappings,
         ):
-            continue
-        if _is_mapped_as_binary_source(register, binary_mappings):
             continue
 
         if _is_problem_register(register):
@@ -613,48 +687,25 @@ def _extend_entity_mappings_from_registers() -> None:
         ):
             continue
 
-        if reg.enum and not (reg.extra and reg.extra.get("bitmask")):
-            target, payload = _classify_enum_mapping(
-                register,
-                reg.enum,
-                access,
-                switch_keys,
-                binary_keys,
-                select_keys,
-            )
-            _route_enum_mapping(
-                target,
-                register,
-                payload,
-                sensor_mappings,
-                binary_mappings,
-                switch_mappings,
-                select_mappings,
-            )
-            continue
-
-        target, payload = _classify_min_max_mapping(
-            register,
-            access,
-            min_val,
-            max_val,
-            info_text,
-            unit,
-            step,
-            scale,
-            switch_keys,
-            binary_keys,
-            select_keys,
-            number_keys,
-        )
-        _route_min_max_mapping(
-            target,
-            register,
-            payload,
-            number_mappings,
-            binary_mappings,
-            switch_mappings,
-            select_mappings,
+        _route_enum_or_min_max_mapping(
+            reg=reg,
+            register=register,
+            access=access,
+            min_val=min_val,
+            max_val=max_val,
+            unit=unit,
+            info_text=info_text,
+            scale=scale,
+            step=step,
+            switch_keys=switch_keys,
+            binary_keys=binary_keys,
+            select_keys=select_keys,
+            number_keys=number_keys,
+            sensor_mappings=sensor_mappings,
+            number_mappings=number_mappings,
+            binary_mappings=binary_mappings,
+            switch_mappings=switch_mappings,
+            select_mappings=select_mappings,
         )
 
 
@@ -676,6 +727,7 @@ __all__ = [
     "_is_mapped_as_binary_source",
     "_is_problem_register",
     "_is_register_mapped_anywhere",
+    "_is_unmappable_holding_register",
     "_iter_bitmask_binary_entries",
     "_load_discrete_mappings",
     "_load_number_mappings",
@@ -684,6 +736,7 @@ __all__ = [
     "_resolve",
     "_resolve_parent_child_mappings",
     "_route_enum_mapping",
+    "_route_enum_or_min_max_mapping",
     "_route_min_max_mapping",
     "_route_problem_mapping",
     "_route_time_and_season_mappings",

--- a/tests/test_entity_mappings_helpers.py
+++ b/tests/test_entity_mappings_helpers.py
@@ -1,5 +1,7 @@
 """Direct tests for pure mapping-builder helper functions."""
 
+from types import SimpleNamespace
+
 from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _build_binary_toggle_mapping,
     _build_problem_binary_mapping,
@@ -10,7 +12,9 @@ from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _is_mapped_as_binary_source,
     _is_problem_register,
     _is_register_mapped_anywhere,
+    _is_unmappable_holding_register,
     _parse_info_states,
+    _route_enum_or_min_max_mapping,
 )
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
@@ -90,4 +94,94 @@ def test_build_select_mapping_shape() -> None:
         "translation_key": "mode",
         "states": {"auto": 0, "manual": 1},
         "register_type": "holding_registers",
+    }
+
+
+def test_is_unmappable_holding_register_checks_direct_and_binary_source() -> None:
+    all_maps = ({"mapped_reg": {"translation_key": "mapped_reg"}}, {})
+    binary = {"mapped_from_source": {"register": "source_reg", "bit": 1}}
+
+    assert _is_unmappable_holding_register("mapped_reg", all_maps, binary) is True
+    assert _is_unmappable_holding_register("source_reg", all_maps, binary) is True
+    assert _is_unmappable_holding_register("free_reg", all_maps, binary) is False
+
+
+def test_route_enum_or_min_max_mapping_routes_enum_to_switch() -> None:
+    reg = SimpleNamespace(enum={0: "off", 1: "on"}, extra=None)
+    sensor: dict[str, dict] = {}
+    number: dict[str, dict] = {}
+    binary: dict[str, dict] = {}
+    switch: dict[str, dict] = {}
+    select: dict[str, dict] = {}
+
+    _route_enum_or_min_max_mapping(
+        reg=reg,
+        register="enum_switch_reg",
+        access="RW",
+        min_val=None,
+        max_val=None,
+        unit=None,
+        info_text="",
+        scale=1,
+        step=1,
+        switch_keys={"enum_switch_reg"},
+        binary_keys={"enum_switch_reg"},
+        select_keys=set(),
+        number_keys=set(),
+        sensor_mappings=sensor,
+        number_mappings=number,
+        binary_mappings=binary,
+        switch_mappings=switch,
+        select_mappings=select,
+    )
+
+    assert switch["enum_switch_reg"] == {
+        "icon": "mdi:toggle-switch",
+        "register": "enum_switch_reg",
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": "enum_switch_reg",
+    }
+    assert sensor == {}
+    assert number == {}
+    assert binary == {}
+    assert select == {}
+
+
+def test_route_enum_or_min_max_mapping_routes_min_max_to_number() -> None:
+    reg = SimpleNamespace(enum=None, extra=None)
+    sensor: dict[str, dict] = {}
+    number: dict[str, dict] = {}
+    binary: dict[str, dict] = {}
+    switch: dict[str, dict] = {}
+    select: dict[str, dict] = {}
+
+    _route_enum_or_min_max_mapping(
+        reg=reg,
+        register="number_reg",
+        access="RW",
+        min_val=0,
+        max_val=100,
+        unit="%",
+        info_text="",
+        scale=1,
+        step=5,
+        switch_keys=set(),
+        binary_keys=set(),
+        select_keys=set(),
+        number_keys={"number_reg"},
+        sensor_mappings=sensor,
+        number_mappings=number,
+        binary_mappings=binary,
+        switch_mappings=switch,
+        select_mappings=select,
+    )
+
+    assert number["number_reg"] == {
+        "unit": "%",
+        "icon": "mdi:percent-outline",
+        "min": 0,
+        "max": 100,
+        "step": 5,
+        "scale": 1,
     }


### PR DESCRIPTION
### Motivation
- Reduce the complexity and hot-path size of `_extend_entity_mappings_from_registers` by extracting pure transformation and routing logic into small helpers. 
- Make the register classification flow easier to unit-test without changing any mapping outputs or runtime behavior.

### Description
- Added `_is_unmappable_holding_register` to centralize membership/duplicate checks that skip classification. 
- Added `_route_enum_or_min_max_mapping` to consolidate enum vs min/max classification and routing to `switch`, `binary`, `select`, `sensor`, or `number` mappings. 
- Rewrote `_extend_entity_mappings_from_registers` to call the new helpers; updated `__all__` to export the new helpers. 
- Added unit tests in `tests/test_entity_mappings_helpers.py` covering the new helpers and exact mapping payload shapes; updated the number icon expectation to match the inferred icon output. 
- Files changed: `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` and `tests/test_entity_mappings_helpers.py`.

### Testing
- Ran `ruff` and applied fixes, and the lint checks now pass. 
- Verified syntax with `python -m compileall` on `custom_components` and `tests`. 
- Executed targeted tests with `pytest -q tests/test_entity_mappings*.py` which passed. 
- Ran the full test suite (`pytest tests/ -q`) and `python tools/check_maintainability.py`, both of which passed (existing skips remained unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f1153414832683c7deef50bf031a)