### PR TITLE
refactor: decompose maintenance service handlers

### DIFF
--- a/custom_components/thessla_green_modbus/services_dispatch.py
+++ b/custom_components/thessla_green_modbus/services_dispatch.py
@@ -116,3 +116,14 @@ async def write_register_steps(
             logger.error(error_message, entity_id)
             return False
     return True
+
+
+async def write_device_name_chunks(coordinator: Any, device_name: str, batch: int) -> bool:
+    """Write a short device name in chunked register writes with offsets."""
+    chars_per_batch = batch * 2
+    for i in range(0, len(device_name), chars_per_batch):
+        chunk = device_name[i : i + chars_per_batch]
+        reg_offset = i // 2
+        if not await coordinator.async_write_register("device_name", chunk, refresh=False, offset=reg_offset):
+            return False
+    return True

--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from .modbus_exceptions import ConnectionException, ModbusException
 from .services_dispatch import (
     refresh_and_log_success,
+    write_device_name_chunks,
     write_mapped_optional_register,
     write_register_batch,
 )
@@ -22,21 +23,12 @@ from .services_schema import (
     SYNC_TIME_SCHEMA,
 )
 from .services_validation import (
-    FILTER_TYPE_MAP,
+    filter_reset_value,
     iter_modbus_parameter_writes,
     normalize_modbus_options,
+    pressure_test_payload,
     reset_settings_registers,
 )
-
-
-async def _write_device_name(coordinator: object, device_name: str, batch: int) -> bool:
-    chars_per_batch = batch * 2
-    for i in range(0, len(device_name), chars_per_batch):
-        chunk = device_name[i : i + chars_per_batch]
-        reg_offset = i // 2
-        if not await coordinator.async_write_register("device_name", chunk, refresh=False, offset=reg_offset):
-            return False
-    return True
 
 
 def _to_bcd(value: int) -> int:
@@ -55,7 +47,7 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
     """Register maintenance services."""
 
     async def reset_filters(call: ServiceCall) -> None:
-        filter_value = FILTER_TYPE_MAP[deps.normalize_option(call.data["filter_type"])]
+        filter_value = filter_reset_value(deps.normalize_option, call.data["filter_type"])
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
             if not await deps.write_register(coordinator, "filter_change", filter_value, entity_id, "reset filters"):
                 deps.logger.error("Failed to reset filters for %s", entity_id)
@@ -86,12 +78,9 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
 
     async def start_pressure_test(call: ServiceCall) -> None:
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            now = deps.dt_now()
-            day_of_week = now.weekday()
-            time_hhmm = now.hour * 100 + now.minute
             if not await write_register_batch(
                 coordinator,
-                [("pres_check_day_2", day_of_week), ("pres_check_time_2", time_hhmm)],
+                pressure_test_payload(deps.dt_now()),
                 entity_id,
                 "start pressure test",
                 deps.write_register,
@@ -135,7 +124,7 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                 if len(device_name) >= 16:
                     success = await coordinator.async_write_register("device_name", device_name, refresh=False)
                 else:
-                    success = await _write_device_name(
+                    success = await write_device_name_chunks(
                         coordinator,
                         device_name,
                         getattr(coordinator, "effective_batch", 2),

--- a/custom_components/thessla_green_modbus/services_validation.py
+++ b/custom_components/thessla_green_modbus/services_validation.py
@@ -107,3 +107,16 @@ def iter_modbus_parameter_writes(
         (f"{port_prefix}_parity", parity, PARITY_MAP, "Failed to set parity for %s"),
         (f"{port_prefix}_stop", stop_bits, STOP_MAP, "Failed to set stop bits for %s"),
     ]
+
+
+def filter_reset_value(normalize: Any, raw_filter_type: str) -> int:
+    """Map filter reset option payload to register value."""
+    return FILTER_TYPE_MAP[normalize(raw_filter_type)]
+
+
+def pressure_test_payload(now: Any) -> list[tuple[str, int]]:
+    """Build pressure-test register writes from current datetime."""
+    return [
+        ("pres_check_day_2", now.weekday()),
+        ("pres_check_time_2", now.hour * 100 + now.minute),
+    ]

--- a/tests/test_services_dispatch_validation.py
+++ b/tests/test_services_dispatch_validation.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 from custom_components.thessla_green_modbus.services_dispatch import (
     refresh_and_log_success,
+    write_device_name_chunks,
     write_mapped_optional_register,
     write_optional_register,
     write_register,
@@ -16,8 +17,10 @@ from custom_components.thessla_green_modbus.services_dispatch import (
 )
 from custom_components.thessla_green_modbus.services_validation import (
     BAUD_MAP,
+    filter_reset_value,
     normalize_modbus_options,
     normalize_option,
+    pressure_test_payload,
     reset_settings_registers,
     validate_bypass_temperature_range,
     validate_gwc_temperature_range,
@@ -164,3 +167,23 @@ def test_reset_settings_registers_all_settings():
         ("hard_reset_settings", 1),
         ("hard_reset_schedule", 1),
     ]
+
+
+def test_filter_reset_value_uses_normalized_option():
+    assert filter_reset_value(normalize_option, "thessla_green_modbus.filter_type_cleanpad") == 3
+
+
+def test_pressure_test_payload_builds_day_and_time():
+    now = SimpleNamespace(weekday=lambda: 1, hour=9, minute=7)
+    assert pressure_test_payload(now) == [("pres_check_day_2", 1), ("pres_check_time_2", 907)]
+
+
+@pytest.mark.asyncio
+async def test_write_device_name_chunks_writes_offsets():
+    coordinator = SimpleNamespace(async_write_register=AsyncMock(return_value=True))
+    result = await write_device_name_chunks(coordinator, "ABCDEFGH", 2)
+
+    assert result is True
+    assert coordinator.async_write_register.await_count == 2
+    coordinator.async_write_register.assert_any_await("device_name", "ABCD", refresh=False, offset=0)
+    coordinator.async_write_register.assert_any_await("device_name", "EFGH", refresh=False, offset=2)


### PR DESCRIPTION
### Motivation
- Reduce complexity in `services_handlers_maintenance.py` by extracting repeated validation and dispatch logic into focused helpers.  
- Make payload normalization and coordinator dispatch patterns reusable and testable without changing service names or behavior.  
- Improve readability and maintainability of maintenance service handlers while preserving existing error handling and log messages.

### Description
- Added `write_device_name_chunks` dispatch helper in `services_dispatch.py` to handle chunked `device_name` writes with offsets and reused it from `services_handlers_maintenance.py`.  
- Added `filter_reset_value` and `pressure_test_payload` helpers to `services_validation.py` to centralize filter-type mapping and pressure-test payload construction.  
- Updated `services_handlers_maintenance.py` to use the new helpers and removed the inline chunked write and inline payload/mapping logic, keeping the registration list and schemas unchanged.  
- Added focused unit tests in `tests/test_services_dispatch_validation.py` for `write_device_name_chunks`, `filter_reset_value`, and `pressure_test_payload` and adjusted imports to exercise the new helpers.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt` and executed `pytest -q tests/test_services*.py tests/test_services_handlers_*.py`, which passed.  
- Ran linter/validation and full test suite with `ruff`, `python -m compileall`, `pytest tests/ -q`, and `python tools/check_maintainability.py`, all of which passed in this environment.  
- All added and existing automated tests passed (with unrelated skips present in the test suite).  
- Commit hash for this change is `b664f882`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f10e09288326a2f0c810a355eddf)