### PR TITLE
test: split RTU and duplicate user-flow config flow tests

### DIFF
--- a/tests/test_config_flow_user.py
+++ b/tests/test_config_flow_user.py
@@ -1,6 +1,5 @@
 """Test config flow for ThesslaGreen Modbus integration."""
 
-import logging
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -20,13 +19,7 @@ from custom_components.thessla_green_modbus.const import (
     CONF_SLAVE_ID,
     CONF_STOP_BITS,
     CONNECTION_MODE_AUTO,
-    CONNECTION_MODE_TCP_RTU,
-    CONNECTION_TYPE_RTU,
     CONNECTION_TYPE_TCP,
-    CONNECTION_TYPE_TCP_RTU,
-    DEFAULT_BAUD_RATE,
-    DEFAULT_PARITY,
-    DEFAULT_STOP_BITS,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT
 
@@ -71,53 +64,6 @@ async def test_form_user():
     assert CONF_BAUD_RATE not in schema_keys
     assert CONF_PARITY not in schema_keys
     assert CONF_STOP_BITS not in schema_keys
-
-@pytest.mark.asyncio
-async def test_form_user_rtu_requires_serial_port():
-    """Modbus RTU requires a serial port path."""
-    flow = ConfigFlow()
-    flow.hass = None
-
-    with patch(
-        "custom_components.thessla_green_modbus.scanner.core.ThesslaGreenDeviceScanner.create"
-    ) as create_mock:
-        result = await flow.async_step_user(
-            dict(
-                DEFAULT_USER_INPUT,
-                **{
-                    CONF_CONNECTION_TYPE: CONNECTION_TYPE_RTU,
-                    CONF_SERIAL_PORT: "",
-                },
-            )
-        )
-
-    assert result["type"] == "form"
-    assert result["errors"] == {CONF_SERIAL_PORT: "invalid_serial_port"}
-    create_mock.assert_not_called()
-
-@pytest.mark.asyncio
-async def test_form_user_rtu_invalid_baud_rate():
-    """Invalid RTU baud rate should be rejected."""
-    flow = ConfigFlow()
-    flow.hass = None
-
-    with patch(
-        "custom_components.thessla_green_modbus.scanner.core.ThesslaGreenDeviceScanner.create"
-    ) as create_mock:
-        result = await flow.async_step_user(
-            dict(
-                DEFAULT_USER_INPUT,
-                **{
-                    CONF_CONNECTION_TYPE: CONNECTION_TYPE_RTU,
-                    CONF_SERIAL_PORT: "/dev/ttyUSB0",
-                    CONF_BAUD_RATE: "invalid",
-                },
-            )
-        )
-
-    assert result["type"] == "form"
-    assert result["errors"] == {CONF_BAUD_RATE: "invalid_baud_rate"}
-    create_mock.assert_not_called()
 
 @pytest.mark.asyncio
 async def test_form_user_invalid_ipv6():
@@ -288,166 +234,6 @@ async def test_form_user_success():
     assert data["capabilities"]["expansion_module"] is True
     assert result2["options"][CONF_DEEP_SCAN] is True
     assert result2["options"][CONF_MAX_REGISTERS_PER_REQUEST] == 5
-
-@pytest.mark.asyncio
-async def test_form_user_rtu_success_creates_serial_entry():
-    """RTU configuration should persist serial settings."""
-    flow = ConfigFlow()
-    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
-
-    validation_result = {
-        "title": "ThesslaGreen Serial",
-        "device_info": {"device_name": "Serial", "firmware": "1.0", "serial_number": "ABC"},
-        "scan_result": {
-            "device_info": {"device_name": "Serial", "firmware": "1.0", "serial_number": "ABC"},
-            "capabilities": {"basic_control": True},
-            "register_count": 3,
-        },
-    }
-
-    user_input = dict(
-        DEFAULT_USER_INPUT,
-        **{
-            CONF_CONNECTION_TYPE: CONNECTION_TYPE_RTU,
-            CONF_SERIAL_PORT: "/dev/ttyUSB0",
-            CONF_BAUD_RATE: DEFAULT_BAUD_RATE,
-            CONF_PARITY: DEFAULT_PARITY,
-            CONF_STOP_BITS: DEFAULT_STOP_BITS,
-        },
-    )
-
-    with (
-        patch(
-            "custom_components.thessla_green_modbus.config_flow.validate_input",
-            return_value=validation_result,
-        ),
-        patch("custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"),
-        patch(
-            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
-            "_abort_if_unique_id_configured"
-        ),
-    ):
-        result = await flow.async_step_user(user_input)
-        assert result["type"] == "form"
-        result2 = await flow.async_step_confirm({})
-
-    data = result2["data"]
-    assert data[CONF_CONNECTION_TYPE] == CONNECTION_TYPE_RTU
-    assert data[CONF_SERIAL_PORT] == "/dev/ttyUSB0"
-    assert data[CONF_BAUD_RATE] == DEFAULT_BAUD_RATE
-    assert data[CONF_PARITY] == DEFAULT_PARITY
-    assert data[CONF_STOP_BITS] == DEFAULT_STOP_BITS
-    # Host/port remain available for diagnostics when provided
-    assert data.get(CONF_HOST) == DEFAULT_USER_INPUT[CONF_HOST]
-    assert data.get(CONF_PORT) == DEFAULT_USER_INPUT[CONF_PORT]
-
-@pytest.mark.asyncio
-async def test_form_user_tcp_rtu_success_creates_tcp_rtu_entry():
-    """TCP RTU configuration should normalize to TCP with TCP RTU mode."""
-    flow = ConfigFlow()
-    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
-
-    validation_result = {
-        "title": "ThesslaGreen TCP RTU",
-        "device_info": {"device_name": "TCP RTU", "firmware": "1.0", "serial_number": "XYZ"},
-        "scan_result": {
-            "device_info": {"device_name": "TCP RTU", "firmware": "1.0", "serial_number": "XYZ"},
-            "capabilities": {"basic_control": True},
-            "register_count": 2,
-        },
-    }
-
-    user_input = dict(
-        DEFAULT_USER_INPUT,
-        **{
-            CONF_CONNECTION_TYPE: CONNECTION_TYPE_TCP_RTU,
-        },
-    )
-
-    with (
-        patch(
-            "custom_components.thessla_green_modbus.config_flow.validate_input",
-            return_value=validation_result,
-        ),
-        patch("custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"),
-        patch(
-            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
-            "_abort_if_unique_id_configured"
-        ),
-        patch(
-            "homeassistant.helpers.translation.async_get_translations",
-            new=AsyncMock(return_value={}),
-        ),
-    ):
-        result = await flow.async_step_user(user_input)
-        assert result["type"] == "form"
-        result2 = await flow.async_step_confirm({})
-
-    data = result2["data"]
-    assert data[CONF_CONNECTION_TYPE] == CONNECTION_TYPE_TCP
-    assert data[CONF_CONNECTION_MODE] == CONNECTION_MODE_TCP_RTU
-    assert data[CONF_HOST] == DEFAULT_USER_INPUT[CONF_HOST]
-    assert data[CONF_PORT] == DEFAULT_USER_INPUT[CONF_PORT]
-
-@pytest.mark.asyncio
-async def test_duplicate_entry_aborts():
-    """Attempting to add a duplicate entry should abort the flow."""
-    flow = ConfigFlow()
-    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
-
-    validation_result = {
-        "title": "ThesslaGreen 192.168.1.100",
-        "device_info": {},
-        "scan_result": {},
-    }
-
-    with (
-        patch(
-            "custom_components.thessla_green_modbus.config_flow.validate_input",
-            return_value=validation_result,
-        ),
-        patch("custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"),
-        patch(
-            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
-            "_abort_if_unique_id_configured",
-            side_effect=[None, AbortFlow("already_configured")],
-        ),
-    ):
-        await flow.async_step_user(DEFAULT_USER_INPUT)
-
-        with pytest.raises(AbortFlow):
-            await flow.async_step_confirm({})
-
-@pytest.mark.asyncio
-async def test_user_step_duplicate_entry_aborts_silently(caplog):
-    """Duplicate device during user step should abort without logging errors."""
-    flow = ConfigFlow()
-    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
-
-    validation_result = {
-        "title": "ThesslaGreen 192.168.1.100",
-        "device_info": {},
-        "scan_result": {},
-    }
-
-    with (
-        patch(
-            "custom_components.thessla_green_modbus.config_flow.validate_input",
-            return_value=validation_result,
-        ),
-        patch("custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"),
-        patch(
-            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
-            "_abort_if_unique_id_configured",
-            side_effect=AbortFlow("already_configured"),
-        ),
-        caplog.at_level(logging.ERROR),
-        pytest.raises(AbortFlow) as err,
-    ):
-        await flow.async_step_user(DEFAULT_USER_INPUT)
-
-    assert err.value.reason == "already_configured"
-    assert not caplog.records
 
 @pytest.mark.parametrize(
     "registers,expected_note",

--- a/tests/test_config_flow_user_duplicates.py
+++ b/tests/test_config_flow_user_duplicates.py
@@ -1,0 +1,94 @@
+"""Duplicate-handling user-flow tests for config flow."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from custom_components.thessla_green_modbus.config_flow import ConfigFlow
+from custom_components.thessla_green_modbus.const import (
+    CONF_CONNECTION_TYPE,
+    CONF_SLAVE_ID,
+    CONNECTION_TYPE_TCP,
+)
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+CONF_NAME = "name"
+
+DEFAULT_USER_INPUT = {
+    CONF_CONNECTION_TYPE: CONNECTION_TYPE_TCP,
+    CONF_HOST: "192.168.1.100",
+    CONF_PORT: 502,
+    CONF_SLAVE_ID: 10,
+    CONF_NAME: "My Device",
+}
+
+
+class AbortFlow(Exception):
+    """Mock AbortFlow to simulate Home Assistant aborts."""
+
+    def __init__(self, reason: str) -> None:  # pragma: no cover - simple container
+        super().__init__(reason)
+        self.reason = reason
+
+
+@pytest.mark.asyncio
+async def test_duplicate_entry_aborts():
+    """Attempting to add a duplicate entry should abort the flow."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+    validation_result = {
+        "title": "ThesslaGreen 192.168.1.100",
+        "device_info": {},
+        "scan_result": {},
+    }
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            return_value=validation_result,
+        ),
+        patch("custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
+            "_abort_if_unique_id_configured",
+            side_effect=[None, AbortFlow("already_configured")],
+        ),
+    ):
+        await flow.async_step_user(DEFAULT_USER_INPUT)
+
+        with pytest.raises(AbortFlow):
+            await flow.async_step_confirm({})
+
+@pytest.mark.asyncio
+async def test_user_step_duplicate_entry_aborts_silently(caplog):
+    """Duplicate device during user step should abort without logging errors."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+    validation_result = {
+        "title": "ThesslaGreen 192.168.1.100",
+        "device_info": {},
+        "scan_result": {},
+    }
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            return_value=validation_result,
+        ),
+        patch("custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
+            "_abort_if_unique_id_configured",
+            side_effect=AbortFlow("already_configured"),
+        ),
+        caplog.at_level(logging.ERROR),
+        pytest.raises(AbortFlow) as err,
+    ):
+        await flow.async_step_user(DEFAULT_USER_INPUT)
+
+    assert err.value.reason == "already_configured"
+    assert not caplog.records
+

--- a/tests/test_config_flow_user_rtu.py
+++ b/tests/test_config_flow_user_rtu.py
@@ -1,0 +1,182 @@
+"""RTU/TCP-RTU user-flow tests for config flow."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.config_flow import ConfigFlow
+from custom_components.thessla_green_modbus.const import (
+    CONF_BAUD_RATE,
+    CONF_CONNECTION_MODE,
+    CONF_CONNECTION_TYPE,
+    CONF_PARITY,
+    CONF_SERIAL_PORT,
+    CONF_SLAVE_ID,
+    CONF_STOP_BITS,
+    CONNECTION_MODE_TCP_RTU,
+    CONNECTION_TYPE_RTU,
+    CONNECTION_TYPE_TCP,
+    CONNECTION_TYPE_TCP_RTU,
+    DEFAULT_BAUD_RATE,
+    DEFAULT_PARITY,
+    DEFAULT_STOP_BITS,
+)
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+CONF_NAME = "name"
+
+DEFAULT_USER_INPUT = {
+    CONF_CONNECTION_TYPE: CONNECTION_TYPE_TCP,
+    CONF_HOST: "192.168.1.100",
+    CONF_PORT: 502,
+    CONF_SLAVE_ID: 10,
+    CONF_NAME: "My Device",
+}
+
+@pytest.mark.asyncio
+async def test_form_user_rtu_requires_serial_port():
+    """Modbus RTU requires a serial port path."""
+    flow = ConfigFlow()
+    flow.hass = None
+
+    with patch(
+        "custom_components.thessla_green_modbus.scanner.core.ThesslaGreenDeviceScanner.create"
+    ) as create_mock:
+        result = await flow.async_step_user(
+            dict(
+                DEFAULT_USER_INPUT,
+                **{
+                    CONF_CONNECTION_TYPE: CONNECTION_TYPE_RTU,
+                    CONF_SERIAL_PORT: "",
+                },
+            )
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_SERIAL_PORT: "invalid_serial_port"}
+    create_mock.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_form_user_rtu_invalid_baud_rate():
+    """Invalid RTU baud rate should be rejected."""
+    flow = ConfigFlow()
+    flow.hass = None
+
+    with patch(
+        "custom_components.thessla_green_modbus.scanner.core.ThesslaGreenDeviceScanner.create"
+    ) as create_mock:
+        result = await flow.async_step_user(
+            dict(
+                DEFAULT_USER_INPUT,
+                **{
+                    CONF_CONNECTION_TYPE: CONNECTION_TYPE_RTU,
+                    CONF_SERIAL_PORT: "/dev/ttyUSB0",
+                    CONF_BAUD_RATE: "invalid",
+                },
+            )
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_BAUD_RATE: "invalid_baud_rate"}
+    create_mock.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_form_user_rtu_success_creates_serial_entry():
+    """RTU configuration should persist serial settings."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+    validation_result = {
+        "title": "ThesslaGreen Serial",
+        "device_info": {"device_name": "Serial", "firmware": "1.0", "serial_number": "ABC"},
+        "scan_result": {
+            "device_info": {"device_name": "Serial", "firmware": "1.0", "serial_number": "ABC"},
+            "capabilities": {"basic_control": True},
+            "register_count": 3,
+        },
+    }
+
+    user_input = dict(
+        DEFAULT_USER_INPUT,
+        **{
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_RTU,
+            CONF_SERIAL_PORT: "/dev/ttyUSB0",
+            CONF_BAUD_RATE: DEFAULT_BAUD_RATE,
+            CONF_PARITY: DEFAULT_PARITY,
+            CONF_STOP_BITS: DEFAULT_STOP_BITS,
+        },
+    )
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            return_value=validation_result,
+        ),
+        patch("custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
+            "_abort_if_unique_id_configured"
+        ),
+    ):
+        result = await flow.async_step_user(user_input)
+        assert result["type"] == "form"
+        result2 = await flow.async_step_confirm({})
+
+    data = result2["data"]
+    assert data[CONF_CONNECTION_TYPE] == CONNECTION_TYPE_RTU
+    assert data[CONF_SERIAL_PORT] == "/dev/ttyUSB0"
+    assert data[CONF_BAUD_RATE] == DEFAULT_BAUD_RATE
+    assert data[CONF_PARITY] == DEFAULT_PARITY
+    assert data[CONF_STOP_BITS] == DEFAULT_STOP_BITS
+    # Host/port remain available for diagnostics when provided
+    assert data.get(CONF_HOST) == DEFAULT_USER_INPUT[CONF_HOST]
+    assert data.get(CONF_PORT) == DEFAULT_USER_INPUT[CONF_PORT]
+
+@pytest.mark.asyncio
+async def test_form_user_tcp_rtu_success_creates_tcp_rtu_entry():
+    """TCP RTU configuration should normalize to TCP with TCP RTU mode."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+    validation_result = {
+        "title": "ThesslaGreen TCP RTU",
+        "device_info": {"device_name": "TCP RTU", "firmware": "1.0", "serial_number": "XYZ"},
+        "scan_result": {
+            "device_info": {"device_name": "TCP RTU", "firmware": "1.0", "serial_number": "XYZ"},
+            "capabilities": {"basic_control": True},
+            "register_count": 2,
+        },
+    }
+
+    user_input = dict(
+        DEFAULT_USER_INPUT,
+        **{
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_TCP_RTU,
+        },
+    )
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.validate_input",
+            return_value=validation_result,
+        ),
+        patch("custom_components.thessla_green_modbus.config_flow.ConfigFlow.async_set_unique_id"),
+        patch(
+            "custom_components.thessla_green_modbus.config_flow.ConfigFlow."
+            "_abort_if_unique_id_configured"
+        ),
+        patch(
+            "homeassistant.helpers.translation.async_get_translations",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        result = await flow.async_step_user(user_input)
+        assert result["type"] == "form"
+        result2 = await flow.async_step_confirm({})
+
+    data = result2["data"]
+    assert data[CONF_CONNECTION_TYPE] == CONNECTION_TYPE_TCP
+    assert data[CONF_CONNECTION_MODE] == CONNECTION_MODE_TCP_RTU
+    assert data[CONF_HOST] == DEFAULT_USER_INPUT[CONF_HOST]
+    assert data[CONF_PORT] == DEFAULT_USER_INPUT[CONF_PORT]
+


### PR DESCRIPTION
### Motivation

- Reduce the size and cognitive load of `tests/test_config_flow_user.py` by isolating RTU/TCP-RTU scenarios into a focused module. 
- Separate duplicate/abort behavior into its own module to make duplicate-entry tests easier to reason about and maintain. 
- Preserve original test semantics and decorated test blocks to avoid changing behavior while improving organization.

### Description

- Moved RTU and TCP-RTU specific user-flow tests into `tests/test_config_flow_user_rtu.py` (kept complete decorated test blocks and supporting imports). 
- Moved duplicate/abort user-flow tests into `tests/test_config_flow_user_duplicates.py` (kept complete decorated test blocks and supporting imports). 
- Cleaned up unused imports in `tests/test_config_flow_user.py` to reflect the reduced scope and preserved the remaining non-RTU, non-duplicate tests. 
- No production code was changed and all moved tests preserved fixtures, parametrization, monkeypatching, and assertions.

### Testing

- Installed dev requirements with `python -m pip install -q -r requirements-dev.txt` which completed successfully. 
- Ran linters and fixes with `ruff check` and `ruff check --fix` on the affected test files which completed successfully. 
- Verified compile-time sanity with `python -m compileall -q` on the modified test files which succeeded. 
- Ran focused tests with `pytest -q tests/test_config_flow_user.py tests/test_config_flow_user_rtu.py` and `pytest -q tests/test_config_flow_user.py tests/test_config_flow_user_duplicates.py tests/test_config_flow_user_rtu.py` which passed (all moved tests and remaining tests in those modules succeeded). 
- Running the full test-suite via `pytest tests/ -q` exposed unrelated pre-existing failures that patch symbols expected from the `coordinator` module (these failures are external to the edits in this PR and did not result from changes to production code). 
- Changes were committed as `aa203cee` and only the following files were modified: `tests/test_config_flow_user.py`, `tests/test_config_flow_user_rtu.py`, and `tests/test_config_flow_user_duplicates.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31405f85083268c7e3484eb981737)