### PR TITLE
test: continue scanner coverage test split

### DIFF
--- a/tests/test_scanner_cache.py
+++ b/tests/test_scanner_cache.py
@@ -1,0 +1,12 @@
+"""Scanner register cache/runtime coverage tests."""
+
+
+def test_build_register_maps_direct():
+    from custom_components.thessla_green_modbus.scanner.register_map_runtime import (
+        build_register_maps,
+    )
+
+    build_register_maps()
+    from custom_components.thessla_green_modbus.scanner.core import REGISTER_DEFINITIONS
+
+    assert isinstance(REGISTER_DEFINITIONS, dict)

--- a/tests/test_scanner_coverage.py
+++ b/tests/test_scanner_coverage.py
@@ -1,9 +1,7 @@
-"""Targeted coverage tests for scanner_core.py uncovered lines."""
+"""Shared scanner test helpers kept for split scanner test modules."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 
 
@@ -43,6 +41,8 @@ def _ok_input_block(count):
 async def _run_minimal_scan(
     scanner, *, input_return=None, holding_return=None, coil_return=None, discrete_return=None
 ):
+    from unittest.mock import patch
+
     with (
         patch.object(scanner, "_read_input_block", AsyncMock(return_value=_ok_input_block(30))),
         patch.object(scanner, "_read_holding_block", AsyncMock(return_value=[])),
@@ -64,96 +64,3 @@ def _sized_read_mock(value=1):
         return [value] * count
 
     return _mock
-
-
-def test_build_register_maps_direct():
-    from custom_components.thessla_green_modbus.scanner.register_map_runtime import (
-        build_register_maps,
-    )
-
-    build_register_maps()
-    from custom_components.thessla_green_modbus.scanner.core import REGISTER_DEFINITIONS
-
-    assert isinstance(REGISTER_DEFINITIONS, dict)
-
-
-@pytest.mark.asyncio
-async def test_scan_raises_without_transport_and_client():
-    scanner = await _make_scanner()
-    scanner._transport = None
-    scanner._client = None
-    with pytest.raises(ConnectionException, match="Transport not connected"):
-        await scanner.scan()
-
-
-@pytest.mark.asyncio
-async def test_scan_raises_when_transport_disconnected_and_no_client():
-    scanner = await _make_scanner()
-    mock_transport = MagicMock()
-    mock_transport.is_connected.return_value = False
-    scanner._transport = mock_transport
-    scanner._client = None
-    with pytest.raises(ConnectionException, match="Transport not connected"):
-        await scanner.scan()
-
-
-@pytest.mark.asyncio
-async def test_full_register_scan_discrete_unknown_addr():
-    scanner = await _make_scanner(full_register_scan=True, retry=1)
-    scanner._client = AsyncMock()
-    scanner._registers = {4: {}, 3: {}, 1: {}, 2: {2: "fake_discrete"}}
-    scanner._names_by_address[2] = {2: {"fake_discrete"}}
-
-    async def discrete_mock(*args, **kw):
-        count = 1
-        for a in reversed(args):
-            if isinstance(a, int):
-                count = a
-                break
-        return [True] * count
-
-    with (
-        patch.object(scanner, "_read_input_block", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_holding_block", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_input", AsyncMock(return_value=None)),
-        patch.object(scanner, "_read_holding", AsyncMock(return_value=None)),
-        patch.object(scanner, "_read_coil", AsyncMock(return_value=None)),
-        patch.object(scanner, "_read_discrete", side_effect=discrete_mock),
-    ):
-        result = await scanner.scan()
-
-    assert 0 in result["unknown_registers"]["discrete_inputs"]
-
-
-@pytest.mark.asyncio
-async def test_scan_input_probe_returns_invalid_value_v2():
-    scanner = await _make_scanner(retry=1)
-    scanner._client = AsyncMock()
-    scanner._registers = {4: {9999: "fake_input"}, 3: {}, 1: {}, 2: {}}
-    scanner._names_by_address[4] = {9999: {"fake_input"}}
-
-    async def smart_read_input(*args, **kwargs):
-        skip_cache = kwargs.get("skip_cache", False)
-        addr = None
-        if len(args) >= 2:
-            for a in args:
-                if isinstance(a, int):
-                    addr = a
-                    break
-        if addr == 9999:
-            if not skip_cache:
-                return None
-            return [65535]
-        return None
-
-    with (
-        patch.object(scanner, "_read_input_block", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_holding_block", AsyncMock(return_value=[])),
-        patch.object(scanner, "_read_input", side_effect=smart_read_input),
-        patch.object(scanner, "_read_holding", AsyncMock(return_value=None)),
-        patch.object(scanner, "_read_coil", AsyncMock(return_value=None)),
-        patch.object(scanner, "_read_discrete", AsyncMock(return_value=None)),
-    ):
-        result = await scanner.scan()
-
-    assert 9999 in result["failed_addresses"]["invalid_values"]["input_registers"]

--- a/tests/test_scanner_full_scan_coverage.py
+++ b/tests/test_scanner_full_scan_coverage.py
@@ -1,0 +1,76 @@
+"""Additional full-register scan coverage tests for scanner core."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+
+
+def _ok_input_block(count):
+    return [0] * count
+
+
+async def _make_scanner(**kwargs):
+    return await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 1, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_full_register_scan_discrete_unknown_addr():
+    scanner = await _make_scanner(full_register_scan=True, retry=1)
+    scanner._client = AsyncMock()
+    scanner._registers = {4: {}, 3: {}, 1: {}, 2: {2: "fake_discrete"}}
+    scanner._names_by_address[2] = {2: {"fake_discrete"}}
+
+    async def discrete_mock(*args, **kw):
+        count = 1
+        for a in reversed(args):
+            if isinstance(a, int):
+                count = a
+                break
+        return [True] * count
+
+    with (
+        patch.object(scanner, "_read_input_block", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_holding_block", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_input", AsyncMock(return_value=None)),
+        patch.object(scanner, "_read_holding", AsyncMock(return_value=None)),
+        patch.object(scanner, "_read_coil", AsyncMock(return_value=None)),
+        patch.object(scanner, "_read_discrete", side_effect=discrete_mock),
+    ):
+        result = await scanner.scan()
+
+    assert 0 in result["unknown_registers"]["discrete_inputs"]
+
+
+@pytest.mark.asyncio
+async def test_scan_input_probe_returns_invalid_value_v2():
+    scanner = await _make_scanner(retry=1)
+    scanner._client = AsyncMock()
+    scanner._registers = {4: {9999: "fake_input"}, 3: {}, 1: {}, 2: {}}
+    scanner._names_by_address[4] = {9999: {"fake_input"}}
+
+    async def smart_read_input(*args, **kwargs):
+        skip_cache = kwargs.get("skip_cache", False)
+        addr = None
+        if len(args) >= 2:
+            for a in args:
+                if isinstance(a, int):
+                    addr = a
+                    break
+        if addr == 9999:
+            if not skip_cache:
+                return None
+            return [65535]
+        return None
+
+    with (
+        patch.object(scanner, "_read_input_block", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_holding_block", AsyncMock(return_value=[])),
+        patch.object(scanner, "_read_input", side_effect=smart_read_input),
+        patch.object(scanner, "_read_holding", AsyncMock(return_value=None)),
+        patch.object(scanner, "_read_coil", AsyncMock(return_value=None)),
+        patch.object(scanner, "_read_discrete", AsyncMock(return_value=None)),
+    ):
+        result = await scanner.scan()
+
+    assert 9999 in result["failed_addresses"]["invalid_values"]["input_registers"]

--- a/tests/test_scanner_orchestration_coverage.py
+++ b/tests/test_scanner_orchestration_coverage.py
@@ -1,0 +1,31 @@
+"""Orchestration edge-case coverage tests for scanner core."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
+from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+
+
+async def _make_scanner(**kwargs):
+    return await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 1, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_scan_raises_without_transport_and_client():
+    scanner = await _make_scanner()
+    scanner._transport = None
+    scanner._client = None
+    with pytest.raises(ConnectionException, match="Transport not connected"):
+        await scanner.scan()
+
+
+@pytest.mark.asyncio
+async def test_scan_raises_when_transport_disconnected_and_no_client():
+    scanner = await _make_scanner()
+    mock_transport = MagicMock()
+    mock_transport.is_connected.return_value = False
+    scanner._transport = mock_transport
+    scanner._client = None
+    with pytest.raises(ConnectionException, match="Transport not connected"):
+        await scanner.scan()


### PR DESCRIPTION
### Motivation
- Reduce the size of the monolithic `tests/test_scanner_coverage.py` by moving coherent scanner-core coverage tests into focused files to improve test locality and maintainability.
- Preserve shared helper functions in a central helper module so existing scanner test suites that import them do not break during the staged split.

### Description
- Split scanner-core tests into three focused test modules: `tests/test_scanner_cache.py`, `tests/test_scanner_full_scan_coverage.py`, and `tests/test_scanner_orchestration_coverage.py` and left shared helpers in `tests/test_scanner_coverage.py`.
- Moved these specific tests: `test_build_register_maps_direct`, `test_full_register_scan_discrete_unknown_addr`, `test_scan_input_probe_returns_invalid_value_v2`, `test_scan_raises_without_transport_and_client`, and `test_scan_raises_when_transport_disconnected_and_no_client` into the appropriate new files.
- Kept all fixtures, decorators, parametrization, monkeypatching and assertions intact and did not modify any production code.
- Files changed in this PR: `tests/test_scanner_cache.py`, `tests/test_scanner_full_scan_coverage.py`, `tests/test_scanner_orchestration_coverage.py`, and `tests/test_scanner_coverage.py` (helpers only).

### Testing
- Installed dev requirements with `python -m pip install -q -r requirements-dev.txt` and ran `ruff check custom_components tests tools`, both of which passed.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed and `python tools/check_maintainability.py` which passed the maintainability gate.
- Ran the focused scanner tests `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` which produced failures unrelated to these moved tests (errors from pre-existing tests patching `custom_components.thessla_green_modbus.coordinator` for attributes that are not present), causing the full test run to fail.
- Ran `pytest tests/ -q` which also failed for the same pre-existing coordinator patch target issues; these failures are outside the scope of the split and not caused by the test-file moves.
- Commit created for this change: `91fb2ee3`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f313fd622483268eb5549c7fd155a0)