### PR TITLE
refactor: extract coordinator register-setup helper to scan module

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -136,6 +136,9 @@ from .scan import (
     normalise_cached_register_name as _normalise_cached_register_name_impl,
 )
 from .scan import (
+    prepare_registers_for_setup as _prepare_registers_for_setup_impl,
+)
+from .scan import (
     store_scan_cache as _store_scan_cache_impl,
 )
 from .schedule import _CoordinatorScheduleMixin
@@ -530,21 +533,7 @@ class ThesslaGreenModbusCoordinator(
 
     async def _prepare_registers_for_setup(self) -> None:
         """Prepare register availability from full list, cache, or device scan."""
-        if self.force_full_register_list:
-            _LOGGER.info("Using full register list (skipping scan)")
-            self._load_full_register_list()
-            return
-
-        if not self.enable_device_scan:
-            cache = self._get_scan_cache_from_entry()
-            if cache and self._apply_scan_cache(cache):
-                _LOGGER.info("Using cached device scan results")
-                return
-            _LOGGER.info("Device scan disabled; falling back to full register list")
-            self._load_full_register_list()
-            return
-
-        await self._run_device_scan()
+        await _prepare_registers_for_setup_impl(self)
 
     def _get_scan_cache_from_entry(self) -> dict[str, Any]:
         """Return cached scan payload from config entry options."""

--- a/custom_components/thessla_green_modbus/coordinator/scan.py
+++ b/custom_components/thessla_green_modbus/coordinator/scan.py
@@ -126,3 +126,22 @@ def store_scan_cache(coordinator: Any) -> None:
     options = dict(coordinator.entry.options)
     options["device_scan_cache"] = cache
     coordinator.hass.config_entries.async_update_entry(coordinator.entry, options=options)
+
+
+async def prepare_registers_for_setup(coordinator: Any) -> None:
+    """Prepare register availability from full list, cache, or device scan."""
+    if coordinator.force_full_register_list:
+        _LOGGER.info("Using full register list (skipping scan)")
+        coordinator._load_full_register_list()
+        return
+
+    if not coordinator.enable_device_scan:
+        cache = coordinator._get_scan_cache_from_entry()
+        if cache and coordinator._apply_scan_cache(cache):
+            _LOGGER.info("Using cached device scan results")
+            return
+        _LOGGER.info("Device scan disabled; falling back to full register list")
+        coordinator._load_full_register_list()
+        return
+
+    await coordinator._run_device_scan()


### PR DESCRIPTION
### Motivation
- Reduce the responsibility of the coordinator by moving the setup-time register availability decision flow into a dedicated helper to improve modularity and readability.

### Description
- Extracted the setup register-preparation logic into `custom_components/thessla_green_modbus/coordinator/scan.py::prepare_registers_for_setup()` and left `ThesslaGreenModbusCoordinator._prepare_registers_for_setup()` as a thin delegator to that helper.
- Updated imports in `coordinator/coordinator.py` to reference the new helper and preserved the existing branches for force-full-list, cache reuse, scan-disabled fallback, and active scan path.
- No intended change to coordinator runtime behavior; this is a refactor-only movement of existing logic.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, and `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed, and ran targeted `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` which passed.
- Full test run `pytest tests/ -q` failed due to existing, out-of-scope package API migration tests that patch removed top-level attributes (failures reference `ThesslaGreenDeviceScanner` and `get_register_definition`), while `python tools/check_maintainability.py` passed.
- Commit: `de1173fad9328d0949ab21fa05c08f31bbdfacea`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f313e17bcc8326a2a70150afc582c6)