### PR TITLE
test: clean up post-split test leftovers

### DIFF
--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -1,1 +1,0 @@
-"""Split device scanner tests; moved to focused modules."""

--- a/tests/test_scanner_setup_coverage.py
+++ b/tests/test_scanner_setup_coverage.py
@@ -7,7 +7,36 @@ import pytest
 from custom_components.thessla_green_modbus.const import CONNECTION_MODE_TCP, CONNECTION_TYPE_RTU
 from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 
-from tests.test_scanner_coverage import _make_scanner, _make_transport
+
+def _make_ok_response(registers):
+    resp = MagicMock()
+    resp.isError.return_value = False
+    resp.registers = list(registers)
+    return resp
+
+
+async def _make_scanner(**kwargs):
+    from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+
+    return await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 1, **kwargs)
+
+
+def _make_transport(
+    *, raises_on_close=None, ensure_side_effect=None, input_response=None, holding_response=None
+):
+    transport = MagicMock()
+    if raises_on_close:
+        transport.close = AsyncMock(side_effect=raises_on_close)
+    else:
+        transport.close = AsyncMock()
+    if ensure_side_effect:
+        transport.ensure_connected = AsyncMock(side_effect=ensure_side_effect)
+    else:
+        transport.ensure_connected = AsyncMock()
+    transport.read_input_registers = AsyncMock(return_value=input_response or _make_ok_response([1]))
+    transport.read_holding_registers = AsyncMock(return_value=holding_response or _make_ok_response([1]))
+    transport.is_connected = MagicMock(return_value=True)
+    return transport
 
 
 def test_ensure_pymodbus_import_fails():


### PR DESCRIPTION
### Motivation
- Remove stale cross-test imports and placeholder-only test modules left after splitting scanner tests so each test module is self-contained and no longer depends on fragile re-exports from other test files.

### Description
- Inlined local scanner test helpers (`_make_ok_response`, `_make_scanner`, `_make_transport`) into `tests/test_scanner_setup_coverage.py` and removed the stale `from tests.test_scanner_coverage import ...` import.
- Deleted `tests/test_device_scanner.py`, which was a placeholder-only leftover with no executable tests.

### Testing
- Validation commands run: `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `pytest tests/ -q`, and `python tools/check_maintainability.py`.
- `ruff` and `compileall` passed, and `python tools/check_maintainability.py` passed.
- `pytest tests/ -q` did not fully pass in this environment (7 failing tests, 4 skipped) due to pre-existing coordinator-package API patch-target failures unrelated to this cleanup.
- Commit: `18325a6b` and files changed: `tests/test_scanner_setup_coverage.py` (modified), `tests/test_device_scanner.py` (deleted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f340bef9a48326bcb9a9fc6e46fd75)