### PR TITLE
test: finish coordinator package API import migration

### DIFF
--- a/tests/test_force_full_register_list.py
+++ b/tests/test_force_full_register_list.py
@@ -42,7 +42,7 @@ async def _setup_coordinator():
 
     with (
         patch(
-            "custom_components.thessla_green_modbus.coordinator.ThesslaGreenDeviceScanner.create",
+            "custom_components.thessla_green_modbus.coordinator.coordinator.ThesslaGreenDeviceScanner.create",
             AsyncMock(return_value=scanner),
         ),
         patch.object(ThesslaGreenModbusCoordinator, "_test_connection", AsyncMock()),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -133,7 +133,7 @@ async def test_write_retries_logged(monkeypatch, caplog):
             return val
 
     monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         lambda name: Def(),
     )
 

--- a/tests/test_multi_register_write.py
+++ b/tests/test_multi_register_write.py
@@ -130,7 +130,7 @@ async def test_async_write_temporary_airflow_uses_three_registers(monkeypatch):
         return SimpleNamespace(encode=lambda value: value)
 
     monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         fake_def,
     )
 
@@ -159,7 +159,7 @@ async def test_async_write_temporary_temperature_uses_three_registers(monkeypatc
         return SimpleNamespace(encode=lambda value: value)
 
     monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         fake_def,
     )
 
@@ -193,7 +193,7 @@ async def test_async_write_temporary_airflow_writes_three_registers(monkeypatch)
         return SimpleNamespace(encode=lambda value: value)
 
     monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.coordinator.get_register_definition",
+        "custom_components.thessla_green_modbus.coordinator.coordinator.get_register_definition",
         fake_def,
     )
 

--- a/tests/test_scanner_close.py
+++ b/tests/test_scanner_close.py
@@ -39,7 +39,7 @@ def test_async_setup_closes_scanner():
 
         with (
             patch(
-                "custom_components.thessla_green_modbus.coordinator.ThesslaGreenDeviceScanner.create",
+                "custom_components.thessla_green_modbus.coordinator.coordinator.ThesslaGreenDeviceScanner.create",
                 AsyncMock(return_value=scanner),
             ),
             patch.object(coordinator, "_test_connection", AsyncMock()),
@@ -79,7 +79,7 @@ def test_async_setup_cancel_mid_scan(caplog):
 
         with (
             patch(
-                "custom_components.thessla_green_modbus.coordinator.ThesslaGreenDeviceScanner.create",
+                "custom_components.thessla_green_modbus.coordinator.coordinator.ThesslaGreenDeviceScanner.create",
                 AsyncMock(return_value=scanner),
             ),
             patch.object(coordinator, "_test_connection", AsyncMock()),


### PR DESCRIPTION
### Motivation
- The coordinator package public API was narrowed to a minimal surface, causing tests to patch or import non-public implementation symbols from the package root which led to pytest failures.
- Tests should target the owning implementation modules instead of relying on removed package-root internals to preserve the tightened public API and avoid shims.

### Description
- Updated tests to patch the owning implementation module paths instead of package-root symbols by switching targets from `...coordinator.ThesslaGreenDeviceScanner.create` to `...coordinator.coordinator.ThesslaGreenDeviceScanner.create`.
- Updated tests to patch the register definition lookup from `...coordinator.get_register_definition` to `...coordinator.coordinator.get_register_definition`.
- Modified the following test files: `tests/test_force_full_register_list.py`, `tests/test_logging.py`, `tests/test_multi_register_write.py`, and `tests/test_scanner_close.py` to apply the above changes.
- No production code API was broadened and no compatibility shims, proxies, or re-export modules were added.

### Testing
- Installed dev requirements and linted with `ruff check custom_components tests tools`, and compilation via `python -m compileall -q custom_components/thessla_green_modbus tests tools` succeeded.
- Ran `pytest tests/ -q` and the test suite passed (with the existing skips reported previously) and the focused coordinator-related test runs also passed.
- Ran `python tools/check_maintainability.py` which passed and search checks for legacy/shim patterns returned no regressions.
- Commit: `6e3a65e2`; files changed: `tests/test_force_full_register_list.py`, `tests/test_logging.py`, `tests/test_multi_register_write.py`, `tests/test_scanner_close.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f340d755d88326bdbde7b3e67b6785)