### PR TITLE
ci: align dev dependency resolution with HA test stack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        ha-version: ["2026.1.0"]
+        ha-version: ["2026.2.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,7 +38,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -c constraints.txt -e ".[dev]"
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
           python -m pip install homeassistant==${{ matrix.ha-version }} hacs
 
       - name: Ruff
@@ -69,7 +70,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        ha-version: ["2026.1.0"]
+        ha-version: ["2026.2.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -87,7 +88,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -c constraints.txt -e ".[dev]"
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
           python -m pip install homeassistant==${{ matrix.ha-version }} hacs
 
       - name: Pytest with coverage
@@ -105,7 +107,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        ha-version: ["2026.1.0"]
+        ha-version: ["2026.2.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -123,7 +125,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -c constraints.txt -e ".[dev]"
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
           python -m pip install homeassistant==${{ matrix.ha-version }} hacs
 
       - name: Validate entity mappings
@@ -135,7 +138,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        ha-version: ["2026.1.0"]
+        ha-version: ["2026.2.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -153,7 +156,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -c constraints.txt -e ".[dev]"
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
           python -m pip install homeassistant==${{ matrix.ha-version }} hacs
 
       - name: hassfest validation
@@ -165,7 +169,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        ha-version: ["2026.1.0"]
+        ha-version: ["2026.2.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -183,7 +187,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -c constraints.txt -e ".[dev]"
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
           python -m pip install homeassistant==${{ matrix.ha-version }} hacs
 
       - name: HACS validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
     "isort>=5.13.0",
     "ruff>=0.6.0",
     "mypy>=1.10.0",
-    "pydantic>=2.0,<3",
+    "pydantic==2.12.2",
     "pre-commit>=3.7.0",
     "types-PyYAML>=6.0.12",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ aiodhcpwatcher>=1.1.0
 aiodiscover>=2.6.1
 PyYAML>=6.0
 types-PyYAML>=6.0.12
-pydantic>=2.0,<3
+pydantic==2.12.2
 
 # Code quality tools
 black>=24.4.0


### PR DESCRIPTION
### Motivation
- CI was failing during dependency installation due to a resolver conflict between the editable dev extras and the PHCC/Home Assistant stack (PHCC requires `pydantic==2.12.2` while dev extras allowed `pydantic>=2.0,<3`).
- Make CI dependency resolution deterministic and aligned with the known-good PHCC/HA versions so lint/tests can run reliably.

### Description
- Updated CI matrix Home Assistant version from `2026.1.0` to `2026.2.3` in `.github/workflows/ci.yaml` to match the PHCC-selected stack.
- Replaced the ambiguous install step `python -m pip install -c constraints.txt -e ".[dev]"` with a deterministic sequence in `ci.yaml`: `python -m pip install -r requirements-dev.txt`, `python -m pip install -e .`, then `python -m pip install homeassistant==${{ matrix.ha-version }} hacs`.
- Pinned `pydantic==2.12.2` in both `pyproject.toml` dev extras and `requirements-dev.txt` to satisfy PHCC exact requirement and avoid resolver conflicts.
- Changed files: `.github/workflows/ci.yaml`, `pyproject.toml`, and `requirements-dev.txt`.

### Testing
- Ran dependency install sequence: `python -m pip install --upgrade pip`, `python -m pip install -r requirements-dev.txt`, `python -m pip install -e .`, `python -m pip install homeassistant==2026.2.3 hacs`, and the installation completed successfully in this environment.
- Ran automated checks: `ruff check custom_components tests tools` (passed), `python -m compileall -q custom_components/thessla_green_modbus tests tools` (passed), `python tools/compare_registers_with_reference.py` (passed), `python tools/check_maintainability.py` (passed), `pytest tests/ -q` (passed with 4 skipped), and `python tools/validate_entity_mappings.py` (passed).
- Known unrelated repository baseline failures remain: `black --check .` (would reformat many files), `isort --check-only .` (many import-order issues), and `mypy .` (typing errors), and `python -m hassfest` / `python -m hacs validate` could not be executed in this environment (hassfest not installed and `hacs` not invokable as `-m` here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f344085ea083269fad868d910b2b51)