### PR TITLE
refactor: decompose scanner read helpers

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -92,6 +92,68 @@ def _normalize_register_result(response: Any) -> list[int]:
     return cast(list[int], response.registers)
 
 
+def _process_register_response(
+    scanner: Any,
+    *,
+    response: Any,
+    register_type: str,
+    start: int,
+    end: int,
+    address: int,
+    count: int,
+    skip_cache: bool,
+) -> tuple[bool, list[int] | None]:
+    """Normalize and classify a read response.
+
+    Returns (done, payload):
+    - done=True,payload=<values|None> when caller should return immediately.
+    - done=False,payload=None when caller should continue retries.
+    """
+    if response is None:
+        return False, None
+
+    is_error, code = _validate_register_response(response)
+    if is_error:
+        _LOGGER.warning(
+            "Exception code %s while reading %s %d-%d",
+            code,
+            register_type.replace("_", " "),
+            start,
+            end,
+        )
+        if register_type == "input_registers" or code == 2:
+            _handle_error_response(
+                scanner,
+                register_type=register_type,
+                start=start,
+                end=end,
+                code=code,
+            )
+            return True, None
+        if count == 1:
+            track_holding_failure(scanner, count, address)
+            if address in scanner._failed_holding:
+                _handle_error_response(
+                    scanner,
+                    register_type="holding_registers",
+                    start=start,
+                    end=end,
+                    code=code or 0,
+                )
+                return True, None
+        return False, None
+
+    if skip_cache and count == 1:
+        if register_type == "input_registers":
+            scanner._mark_input_supported(address)
+        else:
+            scanner._mark_holding_supported(address)
+
+    if register_type == "holding_registers" and address in scanner._holding_failures:
+        del scanner._holding_failures[address]
+    return True, _normalize_register_result(response)
+
+
 def _handle_terminal_read_failure(scanner: Any, register_type: str, start: int, end: int) -> None:
     """Mark all addresses in a terminally failed read range."""
     _mark_failed_addresses(scanner, register_type, start, end)
@@ -174,28 +236,20 @@ async def read_input(
                     backoff=scanner.backoff,
                     backoff_jitter=scanner.backoff_jitter,
                 )
-            if response is not None:
-                is_error, code = _validate_register_response(response)
-                if is_error:
-                    _LOGGER.warning(
-                        "Exception code %s while reading input registers %d-%d",
-                        code,
-                        start,
-                        end,
-                    )
-                    _handle_error_response(
-                        scanner,
-                        register_type="input_registers",
-                        start=start,
-                        end=end,
-                        code=code,
-                    )
-                    return None
-                if skip_cache and count == 1:
-                    scanner._mark_input_supported(address)
-                registers = cast(list[int], response.registers)
-                _LOGGER.debug("Read input registers %d-%d: %s", start, end, registers)
-                return registers
+            done, payload = _process_register_response(
+                scanner,
+                response=response,
+                register_type="input_registers",
+                start=start,
+                end=end,
+                address=address,
+                count=count,
+                skip_cache=skip_cache,
+            )
+            if done:
+                if payload is not None:
+                    _LOGGER.debug("Read input registers %d-%d: %s", start, end, payload)
+                return payload
         except ModbusIOException as exc:
             log_scanner_retry(
                 operation=f"read_input:{start}-{end}",
@@ -325,41 +379,18 @@ async def read_holding(
                     backoff=scanner.backoff,
                     backoff_jitter=scanner.backoff_jitter,
                 )
-            if response is not None:
-                is_error, code = _validate_register_response(response)
-                if is_error:
-                    _LOGGER.warning(
-                        "Exception code %s while reading holding registers %d-%d",
-                        code,
-                        start,
-                        end,
-                    )
-                    if code == 2:
-                        _handle_error_response(
-                            scanner,
-                            register_type="holding_registers",
-                            start=start,
-                            end=end,
-                            code=code,
-                        )
-                        return None
-                    if count == 1:
-                        track_holding_failure(scanner, count, address)
-                        if address in scanner._failed_holding:
-                            _handle_error_response(
-                                scanner,
-                                register_type="holding_registers",
-                                start=start,
-                                end=end,
-                                code=code or 0,
-                            )
-                            return None
-                    continue
-                if skip_cache and count == 1:
-                    scanner._mark_holding_supported(address)
-                if address in scanner._holding_failures:
-                    del scanner._holding_failures[address]
-                return _normalize_register_result(response)
+            done, payload = _process_register_response(
+                scanner,
+                response=response,
+                register_type="holding_registers",
+                start=start,
+                end=end,
+                address=address,
+                count=count,
+                skip_cache=skip_cache,
+            )
+            if done:
+                return payload
         except TimeoutError:
             _LOGGER.warning(
                 "Timeout reading holding %d (attempt %d/%d)",

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -124,3 +124,40 @@ async def test_read_holding_timeout_logging(caplog):
     assert any("Timeout reading holding 1" in msg for msg in warnings)
     errors = [r.message for r in caplog.records if r.levelno == logging.ERROR]
     assert any("Failed to read holding registers 1-1" in msg for msg in errors)
+
+
+async def test_read_holding_illegal_address_response_marks_unsupported():
+    """Holding illegal-address response should terminate immediately and cache failure."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=3)
+    mock_client = AsyncMock()
+    error_response = MagicMock()
+    error_response.isError.return_value = True
+    error_response.exception_code = 2
+
+    with patch(
+        "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
+        AsyncMock(return_value=error_response),
+    ) as call_mock:
+        result = await scanner._read_holding(mock_client, 50, 1)
+
+    assert result is None
+    assert call_mock.await_count == 1
+    assert 50 in scanner._failed_holding
+
+
+async def test_read_input_skip_cache_marks_single_register_supported():
+    """Single-register input success with skip_cache should mark support."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=2)
+    mock_client = AsyncMock()
+    ok_response = MagicMock()
+    ok_response.isError.return_value = False
+    ok_response.registers = [77]
+
+    with patch(
+        "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
+        AsyncMock(return_value=ok_response),
+    ):
+        result = await scanner._read_input(mock_client, 77, 1, skip_cache=True)
+
+    assert result == [77]
+    assert 77 not in scanner._failed_input


### PR DESCRIPTION
### Motivation
- `io_read.py` contained duplicated branching and normalization logic for `read_holding` and `read_input` that increased complexity and maintenance burden. 
- Extract a focused classification/normalization slice so both read paths share the same decision logic without changing scan behavior.

### Description
- Added `_process_register_response` in `custom_components/thessla_green_modbus/scanner/io_read.py` to centralize response validation, error classification, skip-cache marking, and normalization. 
- Refactored `read_input` and `read_holding` to call `_process_register_response`, removing duplicated branching while preserving all retry, backoff, failure-tracking, unsupported-range, and logging semantics. 
- Added two focused tests in `tests/test_scanner_io.py` covering illegal-address holding responses short-circuiting and single-register input reads with `skip_cache=True` marking support. 
- Did not introduce any Home Assistant imports, did not change Modbus semantics or register JSON, and preserved scanner public behavior.

### Testing
- Ran lint and static checks with `ruff check custom_components tests tools` and compile validation with `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed. 
- Ran register/maintainability tools: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, and both passed. 
- Ran unit tests: `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` and full test suite `pytest tests/ -q`; the test runs passed (with the repository's existing skips). 
- Focused scanner I/O tests added passed under the executed test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3842c262c8326b366be1f9cc249a2)