### PR TITLE
refactor: extract coordinator setup lifecycle into lifecycle module

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta
 from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as _dt_util
@@ -118,6 +117,7 @@ from .connection import (
     setup_client_with_retry as _setup_client_with_retry_impl,
 )
 from .io import _ModbusIOMixin
+from .lifecycle import async_setup as _async_setup_impl
 from .models import CoordinatorConfig
 from .retry import _PermanentModbusError
 from .scan import (
@@ -503,33 +503,7 @@ class ThesslaGreenModbusCoordinator(
 
     async def async_setup(self) -> bool:
         """Set up the coordinator by scanning the device."""
-        if self.config.connection_type == CONNECTION_TYPE_RTU:
-            endpoint = self.config.serial_port or "serial"
-        else:
-            endpoint = f"{self.config.host}:{self.config.port}"
-        _LOGGER.info(
-            "Setting up ThesslaGreen coordinator for %s via %s",
-            endpoint,
-            self.config.connection_type.upper(),
-        )
-
-        await self._prepare_registers_for_setup()
-
-        self._warn_missing_device_info()
-
-        # Pre-compute register groups for batch reading
-        self._compute_register_groups()
-
-        # Test initial connection
-        await self._test_connection()
-
-        # Ensure we clean up tasks when Home Assistant stops
-        if self._stop_listener is None and hasattr(self.hass, "bus"):
-            self._stop_listener = self.hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STOP, self._async_handle_stop
-            )
-
-        return True
+        return await _async_setup_impl(self)
 
     async def _prepare_registers_for_setup(self) -> None:
         """Prepare register availability from full list, cache, or device scan."""

--- a/custom_components/thessla_green_modbus/coordinator/lifecycle.py
+++ b/custom_components/thessla_green_modbus/coordinator/lifecycle.py
@@ -1,1 +1,44 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Coordinator setup/lifecycle orchestration helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+from ..const import CONNECTION_TYPE_RTU
+
+if TYPE_CHECKING:
+    from .coordinator import ThesslaGreenModbusCoordinator
+
+_LOGGER = logging.getLogger(__name__.rsplit(".", maxsplit=1)[0])
+
+
+def resolve_setup_endpoint(coordinator: ThesslaGreenModbusCoordinator) -> str:
+    """Return user-friendly endpoint string for setup logs."""
+    if coordinator.config.connection_type == CONNECTION_TYPE_RTU:
+        return coordinator.config.serial_port or "serial"
+    return f"{coordinator.config.host}:{coordinator.config.port}"
+
+
+async def async_setup(coordinator: ThesslaGreenModbusCoordinator) -> bool:
+    """Perform coordinator setup lifecycle without changing coordinator state contract."""
+    endpoint = resolve_setup_endpoint(coordinator)
+    _LOGGER.info(
+        "Setting up ThesslaGreen coordinator for %s via %s",
+        endpoint,
+        coordinator.config.connection_type.upper(),
+    )
+
+    await coordinator._prepare_registers_for_setup()
+    coordinator._warn_missing_device_info()
+    coordinator._compute_register_groups()
+    await coordinator._test_connection()
+
+    if coordinator._stop_listener is None and hasattr(coordinator.hass, "bus"):
+        coordinator._stop_listener = coordinator.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP, coordinator._async_handle_stop
+        )
+
+    return True

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+from custom_components.thessla_green_modbus.const import CONNECTION_TYPE_RTU
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+    lifecycle,
+)
 
 
 def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
@@ -42,3 +46,33 @@ async def test_async_shutdown_calls_disconnect():
     stop_listener_mock.assert_called_once()
     assert coord._stop_listener is None
     coord._disconnect.assert_called_once()
+
+
+def test_resolve_setup_endpoint_rtu_uses_serial_fallback():
+    coord = _make_coordinator(connection_type=CONNECTION_TYPE_RTU, serial_port="")
+
+    assert lifecycle.resolve_setup_endpoint(coord) == "serial"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_orchestration_registers_stop_listener_once():
+    coord = _make_coordinator()
+    coord._prepare_registers_for_setup = AsyncMock()
+    coord._warn_missing_device_info = MagicMock()
+    coord._compute_register_groups = MagicMock()
+    coord._test_connection = AsyncMock()
+    coord._async_handle_stop = AsyncMock()
+
+    stop_remove = MagicMock()
+    coord.hass.bus = MagicMock()
+    coord.hass.bus.async_listen_once.return_value = stop_remove
+
+    result = await lifecycle.async_setup(coord)
+
+    assert result is True
+    coord._prepare_registers_for_setup.assert_called_once()
+    coord._warn_missing_device_info.assert_called_once()
+    coord._compute_register_groups.assert_called_once()
+    coord._test_connection.assert_called_once()
+    coord.hass.bus.async_listen_once.assert_called_once()
+    assert coord._stop_listener is stop_remove


### PR DESCRIPTION
### Motivation
- Reduce responsibility and size pressure in `custom_components/thessla_green_modbus/coordinator/coordinator.py` by extracting setup/lifecycle orchestration into a focused module.
- Improve maintainability and testability while preserving runtime behavior and the package-root public API.

### Description
- Add `custom_components/thessla_green_modbus/coordinator/lifecycle.py` implementing `resolve_setup_endpoint` and `async_setup` to handle setup logging, register preparation, device-scan orchestration, initial connection test, and HA stop-listener wiring.
- Simplify `ThesslaGreenModbusCoordinator.async_setup()` to delegate to `lifecycle.async_setup` and update imports to reference the new implementation.
- Update `tests/test_coordinator_lifecycle.py` to cover `resolve_setup_endpoint`, orchestration call flow, and stop-listener registration.
- No public API expansion, no compatibility shims/proxies/re-exports, and the new module contains real implementation logic.

### Testing
- Installed dev requirements and ran static checks with `ruff check custom_components tests tools` and byte-compile via `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both succeeded.
- Ran integration validation scripts `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, and `python tools/validate_entity_mappings.py`, and the maintainability gate passed.
- Ran targeted tests `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` and the full test suite `pytest tests/ -q`, both completed successfully.
- Commit created: `406658a1` (internal PR mechanism was invoked but no publicly verifiable PR URL was produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38414135483269776ebf520c67f8d)