### PR TITLE
refactor: decompose register loader helpers

### DIFF
--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -18,6 +18,12 @@ from .cache import (
     clear_cache as _clear_register_cache,
 )
 from .definition import ReadPlan
+from .loader_helpers import (
+    build_register_map,
+    filter_registers_by_function,
+    resolve_registers_path,
+    sort_registers,
+)
 from .parser import async_load_registers_from_file, load_registers_from_file
 from .read_planner import group_registers as _group_registers_impl
 from .read_planner import plan_group_reads as _plan_group_reads_impl
@@ -36,7 +42,7 @@ def get_registers_path() -> Path:
 
 def load_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
     """Return cached register definitions, reloading if file changed."""
-    path = Path(json_path) if json_path is not None else _REGISTERS_PATH
+    path = resolve_registers_path(_REGISTERS_PATH, json_path)
     file_hash = registers_sha256(path)
     cached = get_cached_file_info(path)
     if cached is None:
@@ -53,7 +59,7 @@ async def async_load_registers(
     hass: Any | None, json_path: Path | str | None = None
 ) -> list[RegisterDef]:
     """Return cached register definitions asynchronously."""
-    path = Path(json_path) if json_path is not None else _REGISTERS_PATH
+    path = resolve_registers_path(_REGISTERS_PATH, json_path)
     file_hash = await async_registers_sha256(hass, path)
     cached = get_cached_file_info(path)
     if cached is None:
@@ -73,7 +79,7 @@ def clear_cache() -> None:  # pragma: no cover
 
 def get_all_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
     """Return all known registers ordered by function and address."""
-    return sorted(load_registers(json_path), key=lambda r: (r.function, r.address))
+    return sort_registers(load_registers(json_path))
 
 
 async def async_get_all_registers(
@@ -81,13 +87,13 @@ async def async_get_all_registers(
 ) -> list[RegisterDef]:
     """Return all known registers asynchronously."""
     regs = await async_load_registers(hass, json_path)
-    return sorted(regs, key=lambda r: (r.function, r.address))
+    return sort_registers(regs)
 
 
 def get_registers_by_function(fn: str, json_path: Path | str | None = None) -> list[RegisterDef]:
     """Return registers for the given function code or name."""
     code = _normalise_function(fn)
-    return [r for r in load_registers(json_path) if r.function == code]
+    return filter_registers_by_function(load_registers(json_path), code)
 
 
 async def async_get_registers_by_function(
@@ -95,12 +101,12 @@ async def async_get_registers_by_function(
 ) -> list[RegisterDef]:
     """Return registers for given function code/name asynchronously."""
     code = _normalise_function(fn)
-    return [r for r in await async_load_registers(hass, json_path) if r.function == code]
+    return filter_registers_by_function(await async_load_registers(hass, json_path), code)
 
 
 @lru_cache(maxsize=1)
 def _register_map() -> dict[str, RegisterDef]:
-    return {r.name: r for r in load_registers()}
+    return build_register_map(load_registers())
 
 
 def get_register_definition(name: str) -> RegisterDef:

--- a/custom_components/thessla_green_modbus/registers/loader_helpers.py
+++ b/custom_components/thessla_green_modbus/registers/loader_helpers.py
@@ -1,0 +1,27 @@
+"""Helper units for register loader orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .register_def import RegisterDef
+
+
+def resolve_registers_path(default_path: Path, json_path: Path | str | None) -> Path:
+    """Resolve user-provided path or return bundled default path."""
+    return Path(json_path) if json_path is not None else default_path
+
+
+def sort_registers(registers: list[RegisterDef]) -> list[RegisterDef]:
+    """Sort register definitions by function then address."""
+    return sorted(registers, key=lambda reg: (reg.function, reg.address))
+
+
+def filter_registers_by_function(registers: list[RegisterDef], function: int) -> list[RegisterDef]:
+    """Return registers matching normalized function code."""
+    return [reg for reg in registers if reg.function == function]
+
+
+def build_register_map(registers: list[RegisterDef]) -> dict[str, RegisterDef]:
+    """Build name -> RegisterDef map preserving existing loader behavior."""
+    return {reg.name: reg for reg in registers}

--- a/tests/unit/test_register_loader_helpers.py
+++ b/tests/unit/test_register_loader_helpers.py
@@ -1,0 +1,44 @@
+"""Unit tests for loader helper functions."""
+
+from pathlib import Path
+
+from custom_components.thessla_green_modbus.registers.loader_helpers import (
+    build_register_map,
+    filter_registers_by_function,
+    resolve_registers_path,
+    sort_registers,
+)
+from custom_components.thessla_green_modbus.registers.register_def import RegisterDef
+
+
+def _reg(function: int, address: int, name: str) -> RegisterDef:
+    return RegisterDef(function=function, address=address, name=name, access="ro")
+
+
+def test_resolve_registers_path_prefers_explicit_path(tmp_path: Path) -> None:
+    default = Path("/tmp/default.json")
+    explicit = tmp_path / "custom.json"
+    assert resolve_registers_path(default, explicit) == explicit
+
+
+def test_resolve_registers_path_falls_back_to_default() -> None:
+    default = Path("/tmp/default.json")
+    assert resolve_registers_path(default, None) == default
+
+
+def test_sort_registers_orders_by_function_then_address() -> None:
+    regs = [_reg(3, 2, "c"), _reg(1, 1, "a"), _reg(3, 1, "b")]
+    sorted_regs = sort_registers(regs)
+    assert [(r.function, r.address) for r in sorted_regs] == [(1, 1), (3, 1), (3, 2)]
+
+
+def test_filter_registers_by_function_returns_matching_items() -> None:
+    regs = [_reg(3, 0, "hold"), _reg(4, 0, "input")]
+    assert [r.name for r in filter_registers_by_function(regs, 3)] == ["hold"]
+
+
+def test_build_register_map_uses_register_name_as_key() -> None:
+    regs = [_reg(3, 0, "alpha"), _reg(3, 1, "beta")]
+    reg_map = build_register_map(regs)
+    assert set(reg_map) == {"alpha", "beta"}
+    assert reg_map["alpha"].address == 0


### PR DESCRIPTION
### Motivation
- Reduce complexity in `custom_components/thessla_green_modbus/registers/loader.py` by extracting deterministic, focused helper units to improve readability and testability.
- Make path resolution, sorting, function filtering and register map creation explicit helpers while preserving the loader's cache/codec behavior and JSON contract.

### Description
- Added `custom_components/thessla_green_modbus/registers/loader_helpers.py` implementing `resolve_registers_path`, `sort_registers`, `filter_registers_by_function`, and `build_register_map` as pure helper functions.
- Updated `custom_components/thessla_green_modbus/registers/loader.py` to delegate path resolution, sorting, filtering and map construction to the new helpers while keeping the public API and cache flow unchanged.
- Added focused unit tests in `tests/unit/test_register_loader_helpers.py` covering the new helper behavior.
- Changes are limited to the three new/updated files and do not modify any `registers/*.json` files or codec/lookup semantics (commit `3f05e552`).

### Testing
- Code quality and static checks: `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` — passed.
- Reference and maintainability: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py` — passed.
- Tests: `pytest -q tests/test_register_loader.py tests/unit/test_register_*.py tests/test_airflow_unit.py` and full suite `pytest tests/ -q` were run and passed (with the repository's expected skips reported).
- Entity/metadata validation: `python tools/validate_entity_mappings.py` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38436ecec8326a023ac387f3c67da)