### PR TITLE
refactor: extract enum/min-max classification from mapping builders

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -18,10 +18,15 @@ from ..registers.loader import get_all_registers
 from ..utils import BCD_TIME_PREFIXES, _to_snake_case
 from ._helpers import (
     _get_register_info,
-    _infer_icon,
     _load_translation_keys,
     _number_translation_keys,
     _parse_states,
+)
+from ._mapping_classification import (
+    classify_enum_mapping as _classify_enum_mapping,
+)
+from ._mapping_classification import (
+    classify_min_max_mapping as _classify_min_max_mapping,
 )
 
 _TIME_ENTITY_PREFIXES = (
@@ -387,67 +392,6 @@ def _resolve_parent_child_mappings(parent: Any) -> tuple[dict[str, Any], dict[st
         _maps("TIME_ENTITY_MAPPINGS"),
     )
 
-
-def _classify_enum_mapping(register: str, enum: dict[Any, Any], access: str, switch_keys: set[str], binary_keys: set[str], select_keys: set[str]) -> tuple[str | None, dict[str, Any] | None]:
-    """Classify enum register into target mapping bucket and payload."""
-    enum_states = {_to_snake_case(str(v)): int(k) for k, v in enum.items()}
-    enum_values = {int(k) for k in enum}
-
-    if len(enum) == 2 and enum_values == {0, 1}:
-        if "W" in access:
-            if register not in switch_keys:
-                return None, None
-            return "switch", _build_switch_mapping(register)
-        if register not in binary_keys:
-            return None, None
-        return "binary", _build_binary_toggle_mapping(register)
-
-    if "W" in access:
-        if register not in select_keys:
-            return None, None
-        return "select", _build_select_mapping(register, enum_states)
-
-    return "sensor", {
-        "translation_key": register,
-        "icon": "mdi:information-outline",
-        "register_type": "holding_registers",
-    }
-
-
-def _classify_min_max_mapping(register: str, access: str, min_val: Any, max_val: Any, info_text: str, unit: Any, step: Any, scale: Any, switch_keys: set[str], binary_keys: set[str], select_keys: set[str], number_keys: set[str]) -> tuple[str | None, dict[str, Any] | None]:
-    """Classify numeric min/max register into a mapping bucket and payload."""
-    if min_val is None or max_val is None:
-        return None, None
-
-    if max_val <= 1:
-        if "W" in access:
-            if register not in switch_keys:
-                return None, None
-            return "switch", _build_switch_mapping(register)
-        if register not in binary_keys:
-            return None, None
-        return "binary", _build_binary_toggle_mapping(register)
-
-    if "W" in access and info_text and ";" in info_text and max_val <= 10:
-        states = _parse_info_states(info_text)
-        if states:
-            if register not in select_keys:
-                return None, None
-            return "select", _build_select_mapping(register, states)
-
-    if "W" in access:
-        if register not in number_keys:
-            return None, None
-        return "number", {
-            "unit": unit,
-            "icon": _infer_icon(register, unit),
-            "min": min_val,
-            "max": max_val,
-            "step": step,
-            "scale": scale,
-        }
-
-    return None, None
 
 def _get_parent() -> Any:
     """Return the parent mappings package module for attribute resolution.

--- a/custom_components/thessla_green_modbus/mappings/_mapping_classification.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_classification.py
@@ -1,0 +1,131 @@
+"""Classification and routing helpers for generated entity mappings."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..utils import _to_snake_case
+from ._helpers import _infer_icon
+
+
+def _build_switch_mapping(register: str) -> dict[str, Any]:
+    return {
+        "icon": "mdi:toggle-switch",
+        "register": register,
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": register,
+    }
+
+
+def _build_binary_toggle_mapping(register: str) -> dict[str, Any]:
+    return {
+        "translation_key": register,
+        "icon": "mdi:checkbox-marked-circle-outline",
+        "register_type": "holding_registers",
+    }
+
+
+def _build_select_mapping(register: str, states: dict[str, int]) -> dict[str, Any]:
+    return {
+        "icon": "mdi:format-list-bulleted",
+        "translation_key": register,
+        "states": states,
+        "register_type": "holding_registers",
+    }
+
+
+def _parse_info_states(info_text: str) -> dict[str, int]:
+    states: dict[str, int] = {}
+    for part in info_text.split(";"):
+        part = part.strip()
+        if " - " not in part:
+            continue
+        val_str, label = part.split(" - ", 1)
+        try:
+            states[_to_snake_case(label)] = int(val_str.strip())
+        except ValueError:
+            continue
+    return states
+
+
+def classify_enum_mapping(
+    register: str,
+    enum: dict[Any, Any],
+    access: str,
+    switch_keys: set[str],
+    binary_keys: set[str],
+    select_keys: set[str],
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Classify enum register into target mapping bucket and payload."""
+    enum_states = {_to_snake_case(str(v)): int(k) for k, v in enum.items()}
+    enum_values = {int(k) for k in enum}
+
+    if len(enum) == 2 and enum_values == {0, 1}:
+        if "W" in access:
+            if register not in switch_keys:
+                return None, None
+            return "switch", _build_switch_mapping(register)
+        if register not in binary_keys:
+            return None, None
+        return "binary", _build_binary_toggle_mapping(register)
+
+    if "W" in access:
+        if register not in select_keys:
+            return None, None
+        return "select", _build_select_mapping(register, enum_states)
+
+    return "sensor", {
+        "translation_key": register,
+        "icon": "mdi:information-outline",
+        "register_type": "holding_registers",
+    }
+
+
+def classify_min_max_mapping(
+    register: str,
+    access: str,
+    min_val: Any,
+    max_val: Any,
+    info_text: str,
+    unit: Any,
+    step: Any,
+    scale: Any,
+    switch_keys: set[str],
+    binary_keys: set[str],
+    select_keys: set[str],
+    number_keys: set[str],
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Classify numeric min/max register into a mapping bucket and payload."""
+    if min_val is None or max_val is None:
+        return None, None
+
+    if max_val <= 1:
+        if "W" in access:
+            if register not in switch_keys:
+                return None, None
+            return "switch", _build_switch_mapping(register)
+        if register not in binary_keys:
+            return None, None
+        return "binary", _build_binary_toggle_mapping(register)
+
+    if "W" in access and info_text and ";" in info_text and max_val <= 10:
+        states = _parse_info_states(info_text)
+        if states:
+            if register not in select_keys:
+                return None, None
+            return "select", _build_select_mapping(register, states)
+
+    if "W" in access:
+        if register not in number_keys:
+            return None, None
+        return "number", {
+            "unit": unit,
+            "icon": _infer_icon(register, unit),
+            "min": min_val,
+            "max": max_val,
+            "step": step,
+            "scale": scale,
+        }
+
+    return None, None


### PR DESCRIPTION
### Motivation
- Reduce complexity and size pressure in `mappings/_mapping_builders.py` by isolating classification logic. 
- Make the enum and numeric min/max mapping classifiers easier to test and maintain without changing generated mapping outputs. 
- Preserve existing mapping semantics, IDs, names and validation invariants while improving module cohesion.

### Description
- Added a new helper module `custom_components/thessla_green_modbus/mappings/_mapping_classification.py` that implements `classify_enum_mapping` and `classify_min_max_mapping` and their small payload builders and state-parsing helpers. 
- Updated `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` to import the extracted helpers under the private aliases `_classify_enum_mapping` and `_classify_min_max_mapping` and removed the duplicated implementations from that file. 
- Kept all mapping payload shapes and routing behavior unchanged and left the external loader call sites intact. 
- No tests were removed; existing unit tests continue to validate the helper behavior through the original loader interfaces.

### Testing
- Ran `ruff check custom_components tests tools` and the import/style issues were automatically fixed and now pass. 
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which completed successfully. 
- Ran `python tools/validate_entity_mappings.py` which passed (`OK: 366 entities validated`). 
- Ran the full test suites with `pytest tests/ -q` which passed in this workspace (existing skips remain in place).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f384201cac8326b4326f1425b40454)