### PR TITLE
chore: align maintainability gate with current hotspots

### DIFF
--- a/tests/test_check_maintainability_tool.py
+++ b/tests/test_check_maintainability_tool.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from tools.check_maintainability import (
+    DEFAULT_MAX_FILE_LINES,
+    DEFAULT_MAX_FUNCTION_LINES,
+    STRICT_PATH_LIMITS,
+    _limits_for_path,
+)
+
+
+def test_limits_for_current_hotspots_match_strict_limits() -> None:
+    assert (
+        _limits_for_path(
+            Path("custom_components/thessla_green_modbus/coordinator/coordinator.py"),
+            DEFAULT_MAX_FILE_LINES,
+            DEFAULT_MAX_FUNCTION_LINES,
+        )
+        == STRICT_PATH_LIMITS[
+            "custom_components/thessla_green_modbus/coordinator/coordinator.py"
+        ]
+    )
+    assert (
+        _limits_for_path(
+            Path("custom_components/thessla_green_modbus/scanner/io_read.py"),
+            DEFAULT_MAX_FILE_LINES,
+            DEFAULT_MAX_FUNCTION_LINES,
+        )
+        == STRICT_PATH_LIMITS[
+            "custom_components/thessla_green_modbus/scanner/io_read.py"
+        ]
+    )
+
+
+def test_limits_for_path_supports_repo_absolute_paths() -> None:
+    repo_absolute = Path.cwd() / "custom_components/thessla_green_modbus/scanner/io_read.py"
+    assert _limits_for_path(
+        repo_absolute,
+        DEFAULT_MAX_FILE_LINES,
+        DEFAULT_MAX_FUNCTION_LINES,
+    ) == STRICT_PATH_LIMITS["custom_components/thessla_green_modbus/scanner/io_read.py"]
+
+
+def test_limits_for_non_strict_path_returns_defaults() -> None:
+    assert _limits_for_path(
+        Path("custom_components/thessla_green_modbus/__init__.py"),
+        100,
+        10,
+    ) == (100, 10)

--- a/tools/check_maintainability.py
+++ b/tools/check_maintainability.py
@@ -12,11 +12,11 @@ DEFAULT_MAX_FUNCTION_LINES = 260
 DEFAULT_SCAN_ROOTS = ("custom_components/thessla_green_modbus",)
 
 STRICT_PATH_LIMITS: dict[str, tuple[int, int]] = {
-    "custom_components/thessla_green_modbus/coordinator.py": (1200, 220),
+    "custom_components/thessla_green_modbus/coordinator/coordinator.py": (1200, 220),
     "custom_components/thessla_green_modbus/config_flow.py": (1000, 220),
     "custom_components/thessla_green_modbus/modbus_transport.py": (930, 210),
     "custom_components/thessla_green_modbus/registers/loader.py": (860, 210),
-    "custom_components/thessla_green_modbus/scanner/io.py": (820, 210),
+    "custom_components/thessla_green_modbus/scanner/io_read.py": (820, 210),
     "custom_components/thessla_green_modbus/scanner/core.py": (760, 210),
 }
 


### PR DESCRIPTION
### Motivation

- The maintainability gate referenced stale file paths that no longer exist, so strict limits were not being applied to current hotspot files.
- Update the strict-path mapping so the gate continues to monitor the real hotspots without weakening the tool's intent.

### Description

- Replace stale strict paths in `tools/check_maintainability.py`: use `custom_components/thessla_green_modbus/coordinator/coordinator.py` in place of the removed `coordinator.py`, and `custom_components/thessla_green_modbus/scanner/io_read.py` in place of the removed `scanner/io.py`.
- Add focused unit tests in `tests/test_check_maintainability_tool.py` that assert strict-path matching for the new canonical files, repository-absolute suffix matching, and fallback to defaults for non-strict paths.
- Do not change any production code under `custom_components/` and keep all existing strict limits and gate behavior unchanged apart from the path updates.

### Testing

- Installed dev requirements with `python -m pip install -q -r requirements-dev.txt` and ran `python tools/check_maintainability.py`, which reported "Maintainability gate passed.".
- Ran checks and validations: `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, and `python tools/compare_registers_with_reference.py`, all of which completed successfully.
- Executed unit tests: `pytest tests/test_check_maintainability_tool.py -q` passed, and the full test suite `pytest tests/ -q` passed (with expected skips); the maintainability gate also passed during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f385b6d2948326a2ef37171917107e)