### PR TITLE
docs: refresh maintainability audit and refactor status (2026-04-30)

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -9,74 +9,94 @@ Executed:
 - `python -m pip install -q -r requirements-dev.txt` *(passed; pip warning about root user)*
 - `ruff check custom_components tests tools` *(passed)*
 - `python -m compileall -q custom_components/thessla_green_modbus tests tools` *(passed)*
-- `pytest tests/ -q` *(failed: 7 tests, 4 skipped)*
+- `python tools/compare_registers_with_reference.py` *(passed; reports 62 extra integration entries and 242 name mismatches to verify with vendor)*
 - `python tools/check_maintainability.py` *(passed)*
+- `pytest tests/ -q` *(passed; 4 skipped)*
+- `python tools/validate_entity_mappings.py` *(passed; 366 entities validated)*
 
-## 1) Largest files (by non-empty lines)
+## 1) CI status and maintained CI gates
 
-1. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (~746)
-2. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` (~632)
-3. `tests/test_config_flow_user.py` (~583)
-4. `tests/test_config_flow_helpers.py` (~537)
-5. `tests/test_entity_mappings.py` (~526)
-6. `tests/test_coordinator.py` (~502)
-7. `custom_components/thessla_green_modbus/scanner/io_read.py` (~495)
-8. `tests/test_register_loader.py` (~478)
-9. `tests/test_scanner_io_coverage.py` (~472)
-10. `tests/test_modbus_helpers.py` (~463)
+The repository CI workflow (`.github/workflows/ci.yaml`) currently enforces three jobs:
 
-Interpretation: hotspot pressure is still mixed test + production. Largest production hotspots are `coordinator/coordinator.py`, `mappings/_mapping_builders.py`, `scanner/io_read.py`, and `scanner/core.py`.
+1. **Lint**: dependency install, `ruff check`, `python -m compileall`, `python tools/compare_registers_with_reference.py`, and `python tools/check_maintainability.py`.
+2. **Tests**: `pytest --cov --cov-report=xml --cov-report=term -q` plus Codecov upload.
+3. **Entity mappings validation**: `python tools/validate_entity_mappings.py`.
 
-## 2) Largest classes
+The local validation run used the same functional gates and all passed in this audit run.
 
-1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (~690)
-2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (~438)
-3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (~432)
-4. `RawRtuOverTcpTransport` in `modbus_transport_raw.py` (~280)
-5. `RegisterDef` in `registers/register_def.py` (~268)
+## 2) Largest files (by non-empty lines)
 
-## 3) Largest methods/functions
+1. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (717)
+2. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` (586)
+3. `tests/test_entity_mappings.py` (526)
+4. `custom_components/thessla_green_modbus/scanner/io_read.py` (520)
+5. `tests/test_coordinator.py` (502)
+6. `tests/test_register_loader.py` (478)
+7. `tests/test_scanner_io_coverage.py` (472)
+8. `tests/test_modbus_helpers.py` (463)
+9. `custom_components/thessla_green_modbus/scanner/core.py` (461)
+10. `tests/test_register_decoders.py` (455)
+11. `custom_components/thessla_green_modbus/mappings/_static_discrete.py` (455)
+12. `custom_components/thessla_green_modbus/mappings/_static_sensors.py` (437)
+13. `custom_components/thessla_green_modbus/config_flow.py` (437)
+14. `custom_components/thessla_green_modbus/modbus_helpers.py` (431)
+15. `custom_components/thessla_green_modbus/coordinator/schedule.py` (430)
 
-1. `read_holding` in `scanner/io_read.py` (~133)
-2. `async_write_register` in `coordinator/schedule.py` (~133)
-3. `verify_connection` in `scanner/setup.py` (~127)
-4. `_post_process_data` in `coordinator/capabilities.py` (~127)
-5. `run_full_scan` in `scanner/orchestration.py` (~125)
-6. `register_maintenance_services` in `services_handlers_maintenance.py` (~122)
-7. `validate_input_impl` in `config_flow_device_validation.py` (~120)
-8. `read_input` in `scanner/io_read.py` (~113)
-9. `scan_device` in `scanner/orchestration.py` (~110)
-10. `register_parameter_services` in `services_handlers_parameters.py` (~109)
+Interpretation: the largest remaining production hotspots are still coordinator orchestration, mapping construction/static mapping modules, and scanner I/O/core.
 
-## 4) Completed refactors reflected in current dev state (merged PR batch #1449–#1454)
+## 3) Largest classes
 
-- #1449: scanner coverage split progressed (coverage now centered in `tests/test_scanner_io_coverage.py` and related focused suites).
-- #1450: config-flow validation/schema helpers decomposed (hotspots now led by `test_config_flow_user.py` + `test_config_flow_helpers.py` instead of older monoliths).
-- #1451: coordinator package public API tightened (tests and API contract checks target a minimal coordinator package surface).
-- #1452: coordinator device/register-processing tests split into focused modules.
-- #1453: mapping builder helper decomposition applied; `mappings/_mapping_builders.py` remains a key production hotspot but reduced from earlier monolith shape.
-- #1454: maintenance service handler decomposition applied; `register_maintenance_services` remains one of the longer functions but extracted helper structure is present.
+1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (650)
+2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (438)
+3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (432)
+4. `RawRtuOverTcpTransport` in `modbus_transport_raw.py` (280)
+5. `RegisterDef` in `registers/register_def.py` (268)
+6. `ThesslaGreenFan` in `fan.py` (254)
+7. `_CoordinatorCapabilitiesMixin` in `coordinator/capabilities.py` (237)
+8. `ConfigFlow` in `config_flow.py` (217)
+9. `BaseModbusTransport` in `modbus_transport_base.py` (210)
+10. `ThesslaGreenBinarySensor` in `binary_sensor.py` (175)
 
-## 5) Current invariants and architectural constraints (verified)
+## 4) Largest functions/methods
+
+1. `async_write_register` in `coordinator/schedule.py` (133)
+2. `verify_connection` in `scanner/setup.py` (127)
+3. `_post_process_data` in `coordinator/capabilities.py` (127)
+4. `run_full_scan` in `scanner/orchestration.py` (125)
+5. `register_maintenance_services` in `services_handlers_maintenance.py` (122)
+6. `validate_input_impl` in `config_flow_device_validation.py` (120)
+7. `scan_device` in `scanner/orchestration.py` (110)
+8. `read_holding` in `scanner/io_read.py` (110)
+9. `register_parameter_services` in `services_handlers_parameters.py` (109)
+10. `async_write_registers` in `coordinator/schedule.py` (109)
+
+## 5) Completed refactors reflected in current dev state (latest merged batch #1449-#1454)
+
+- #1449: scanner test coverage split and stabilization landed; scanner coverage is now concentrated in focused suites.
+- #1450: config-flow validation/schema helper decomposition landed; legacy monolithic validation structure is reduced.
+- #1451: coordinator package public API contract was tightened and tests now guard minimal package surface.
+- #1452: coordinator device/register-processing tests were split into narrower modules.
+- #1453: mapping-builder helper decomposition landed; `mappings/_mapping_builders.py` remains a top hotspot but is now explicitly staged for continued extraction.
+- #1454: maintenance service handler decomposition landed; `register_maintenance_services` remains long but helper extraction is in place.
+
+## 6) Current invariants and architectural constraints (verified)
 
 - `coordinator/` is canonical.
-- Top-level `custom_components/thessla_green_modbus/coordinator.py` is removed.
+- Top-level `custom_components/thessla_green_modbus/coordinator.py` is absent and must remain absent.
+- No compatibility shims.
+- No proxy modules.
+- No re-export-only modules.
 - `core/`, `transport/`, `registers/`, and `scanner/` do not import Home Assistant.
-- Coordinator package public API is intentionally constrained (validated by package API tests).
 
-Current audit flags to keep visible:
+## 7) Remaining hotspots and recommended next PRs
 
-- Compatibility/proxy/re-export patterns still exist in selected non-coordinator modules (for example `modbus_transport_client.py`, `modbus_exceptions.py`, and explicit compatibility comments in `services.py`); these should not be expanded and should be evaluated for further cleanup only when safe.
+1. Continue splitting `custom_components/thessla_green_modbus/coordinator/coordinator.py` by moving update-cycle responsibilities into existing coordinator mixins/modules.
+2. Continue decomposition of `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` and static mapping modules where responsibilities overlap.
+3. Split `custom_components/thessla_green_modbus/scanner/io_read.py` (`read_holding`/`read_input`) into smaller normalization/retry helpers.
+4. Reduce `custom_components/thessla_green_modbus/scanner/core.py` complexity via orchestration helper extraction.
+5. Decompose `register_maintenance_services` in `services_handlers_maintenance.py` to reduce function breadth and coordinator-service coupling.
 
-## 6) Next recommended PRs
+## 8) Validation outcome summary
 
-1. Split `custom_components/thessla_green_modbus/coordinator/coordinator.py` by moving additional update-cycle orchestration into existing `coordinator/*` helper modules.
-2. Continue decomposing `custom_components/thessla_green_modbus/mappings/_mapping_builders.py`, starting with `_extend_entity_mappings_from_registers` follow-up extraction.
-3. Decompose `custom_components/thessla_green_modbus/scanner/io_read.py` (`read_holding`/`read_input`) into narrower I/O normalization helpers.
-4. Split remaining broad config-flow tests in `tests/test_config_flow_user.py` and `tests/test_config_flow_helpers.py` into path-focused suites.
-5. Further break down `register_maintenance_services` in `services_handlers_maintenance.py` to reduce coordinator-service coupling per function.
-
-## 7) Validation outcome summary
-
-- Full pytest: **failed** (7 failing tests, 4 skipped).
+- Full pytest: **passed** (4 skipped).
 - Maintainability gate: **passed**.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-04-29.
+Last reviewed: 2026-04-30.
 
 Related document:
 


### PR DESCRIPTION
### Motivation

- Bring maintainability documentation up to date after the recent refactor batch and CI stabilization so the audit reflects the repository's current state and gating checks. 
- Remove stale statements about failing test suites where the validation now shows `pytest` passing, to avoid confusion for contributors. 
- Surface current hotspots, CI gates, and recommended next PRs to guide follow-up refactors and reduce technical debt.

### Description

- Updated `docs/maintainability_audit.md` to the audit date `2026-04-30`, documented the CI jobs/gates from `.github/workflows/ci.yaml`, and refreshed largest files/classes/functions metrics using the provided metrics script. 
- Added the `python tools/compare_registers_with_reference.py` result summary to the audit and removed the stale statement that full `pytest` fails, reflecting that `pytest` now passes with 4 skips and the maintainability gate passes. 
- Preserved verified architectural invariants and the completed refactor batch notes (#1449–#1454) and updated the list of recommended next PRs / hotspots. 
- Updated `docs/refactor_status.md` review date to `2026-04-30` so metadata aligns with the refreshed audit.

### Testing

- Ran `python -m pip install -q -r requirements-dev.txt`, which completed (warning about running as root is noted). 
- Ran `ruff check custom_components tests tools`, which passed. 
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools`, which passed. 
- Ran `python tools/compare_registers_with_reference.py`, which passed and reported 62 extra integration entries and 242 name mismatches to verify with vendor. 
- Ran `python tools/check_maintainability.py`, which passed (maintainability gate passed). 
- Ran `pytest tests/ -q`, which passed (4 skipped). 
- Ran `python tools/validate_entity_mappings.py`, which passed (366 entities validated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38a8f20b48326b46388b95b4d8e87)