### PR TITLE
refactor: reduce static mapping builder duplication

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_static_discrete.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_discrete.py
@@ -6,6 +6,30 @@ from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
+
+def _select_payload(icon: str, translation_key: str, states: dict[str, int]) -> dict[str, Any]:
+    """Build a standard select entity mapping payload."""
+    return {
+        "icon": icon,
+        "translation_key": translation_key,
+        "states": states,
+        "register_type": "holding_registers",
+    }
+
+
+def _weekday_states() -> dict[str, int]:
+    """Return canonical weekday state map used by day selectors."""
+    return {
+        "monday": 0,
+        "tuesday": 1,
+        "wednesday": 2,
+        "thursday": 3,
+        "friday": 4,
+        "saturday": 5,
+        "sunday": 6,
+    }
+
+
 SELECT_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     "mode": {
         "icon": "mdi:cog",
@@ -42,52 +66,16 @@ SELECT_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
         "states": {"mode_1": 1, "mode_2": 2, "mode_3": 3},
         "register_type": "holding_registers",
     },
-    "cfg_mode_1": {
-        "icon": "mdi:tune",
-        "translation_key": "cfg_mode_1",
-        "states": {"auto": 0, "manual": 1, "temporary": 2},
-        "register_type": "holding_registers",
-    },
-    "cfg_mode_2": {
-        "icon": "mdi:tune",
-        "translation_key": "cfg_mode_2",
-        "states": {"auto": 0, "manual": 1, "temporary": 2},
-        "register_type": "holding_registers",
-    },
+    "cfg_mode_1": _select_payload("mdi:tune", "cfg_mode_1", {"auto": 0, "manual": 1, "temporary": 2}),
+    "cfg_mode_2": _select_payload("mdi:tune", "cfg_mode_2", {"auto": 0, "manual": 1, "temporary": 2}),
     "configuration_mode": {
         "icon": "mdi:cog-outline",
         "translation_key": "configuration_mode",
         "states": {"normal": 0, "duct_filter_pressure": 47, "afc_filter_pressure": 65},
         "register_type": "holding_registers",
     },
-    "pres_check_day": {
-        "icon": "mdi:calendar-week",
-        "translation_key": "pres_check_day",
-        "states": {
-            "monday": 0,
-            "tuesday": 1,
-            "wednesday": 2,
-            "thursday": 3,
-            "friday": 4,
-            "saturday": 5,
-            "sunday": 6,
-        },
-        "register_type": "holding_registers",
-    },
-    "pres_check_day_4432": {
-        "icon": "mdi:calendar-week",
-        "translation_key": "pres_check_day_4432",
-        "states": {
-            "monday": 0,
-            "tuesday": 1,
-            "wednesday": 2,
-            "thursday": 3,
-            "friday": 4,
-            "saturday": 5,
-            "sunday": 6,
-        },
-        "register_type": "holding_registers",
-    },
+    "pres_check_day": _select_payload("mdi:calendar-week", "pres_check_day", _weekday_states()),
+    "pres_check_day_4432": _select_payload("mdi:calendar-week", "pres_check_day_4432", _weekday_states()),
     "access_level": {
         "icon": "mdi:account-key",
         "translation_key": "access_level",

--- a/custom_components/thessla_green_modbus/mappings/_static_sensors.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_sensors.py
@@ -15,6 +15,22 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.entity import EntityCategory
 
+
+def _diagnostic_sensor_payload(
+    translation_key: str,
+    *,
+    icon: str = "mdi:information",
+    register_type: str = "input_registers",
+) -> dict[str, Any]:
+    """Build a standard diagnostic sensor payload."""
+    return {
+        "translation_key": translation_key,
+        "icon": icon,
+        "register_type": register_type,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    }
+
+
 SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     # Temperature sensors (Input Registers)
     "outside_temperature": {
@@ -180,42 +196,16 @@ SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
         "unit": UnitOfTime.SECONDS,
         "register_type": "input_registers",
     },
-    "version_major": {
-        "translation_key": "version_major",
-        "icon": "mdi:information",
-        "register_type": "input_registers",
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
-    "version_minor": {
-        "translation_key": "version_minor",
-        "icon": "mdi:information",
-        "register_type": "input_registers",
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
-    "version_patch": {
-        "translation_key": "version_patch",
-        "icon": "mdi:information",
-        "register_type": "input_registers",
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
-    "serial_number": {
-        "translation_key": "serial_number",
-        "icon": "mdi:barcode",
-        "register_type": "input_registers",
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
-    "cf_version": {
-        "translation_key": "cf_version",
-        "icon": "mdi:information",
-        "register_type": "holding_registers",
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
-    "exp_version": {
-        "translation_key": "exp_version",
-        "icon": "mdi:information-outline",
-        "register_type": "holding_registers",
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
+    "version_major": _diagnostic_sensor_payload("version_major"),
+    "version_minor": _diagnostic_sensor_payload("version_minor"),
+    "version_patch": _diagnostic_sensor_payload("version_patch"),
+    "serial_number": _diagnostic_sensor_payload("serial_number", icon="mdi:barcode"),
+    "cf_version": _diagnostic_sensor_payload("cf_version", register_type="holding_registers"),
+    "exp_version": _diagnostic_sensor_payload(
+        "exp_version",
+        icon="mdi:information-outline",
+        register_type="holding_registers",
+    ),
     # Mode and status sensors
     "antifreeze_stage": {
         "translation_key": "antifreeze_stage",

--- a/tests/test_entity_mappings_helpers.py
+++ b/tests/test_entity_mappings_helpers.py
@@ -16,7 +16,15 @@ from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _parse_info_states,
     _route_enum_or_min_max_mapping,
 )
+from custom_components.thessla_green_modbus.mappings._static_discrete import (
+    _select_payload,
+    _weekday_states,
+)
+from custom_components.thessla_green_modbus.mappings._static_sensors import (
+    _diagnostic_sensor_payload,
+)
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.helpers.entity import EntityCategory
 
 
 def test_is_already_mapped_true_and_false() -> None:
@@ -184,4 +192,44 @@ def test_route_enum_or_min_max_mapping_routes_min_max_to_number() -> None:
         "max": 100,
         "step": 5,
         "scale": 1,
+    }
+
+
+def test_select_payload_shape() -> None:
+    assert _select_payload("mdi:tune", "cfg_mode_1", {"auto": 0, "manual": 1}) == {
+        "icon": "mdi:tune",
+        "translation_key": "cfg_mode_1",
+        "states": {"auto": 0, "manual": 1},
+        "register_type": "holding_registers",
+    }
+
+
+def test_weekday_states_values() -> None:
+    assert _weekday_states() == {
+        "monday": 0,
+        "tuesday": 1,
+        "wednesday": 2,
+        "thursday": 3,
+        "friday": 4,
+        "saturday": 5,
+        "sunday": 6,
+    }
+
+
+def test_diagnostic_sensor_payload_defaults_and_overrides() -> None:
+    assert _diagnostic_sensor_payload("version_major") == {
+        "translation_key": "version_major",
+        "icon": "mdi:information",
+        "register_type": "input_registers",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    }
+    assert _diagnostic_sensor_payload(
+        "exp_version",
+        icon="mdi:information-outline",
+        register_type="holding_registers",
+    ) == {
+        "translation_key": "exp_version",
+        "icon": "mdi:information-outline",
+        "register_type": "holding_registers",
+        "entity_category": EntityCategory.DIAGNOSTIC,
     }


### PR DESCRIPTION
### Motivation
- Reduce duplication between static mapping modules and mapping-builder helpers by extracting small reusable payload builders while preserving exact entity mapping outputs.
- Keep mapping data payloads stable and make repeated patterns easier to maintain without changing semantics.

### Description
- Extracted `_select_payload(icon, translation_key, states)` and `_weekday_states()` in `custom_components/thessla_green_modbus/mappings/_static_discrete.py` and replaced duplicated select/day mapping blocks for `cfg_mode_1`, `cfg_mode_2`, `pres_check_day`, and `pres_check_day_4432` with the new helpers.
- Extracted `_diagnostic_sensor_payload(translation_key, *, icon, register_type)` in `custom_components/thessla_green_modbus/mappings/_static_sensors.py` and applied it to repeated diagnostic sensor entries (`version_*`, `serial_number`, `cf_version`, `exp_version`) to remove duplication without changing effective payloads.
- Added focused unit tests in `tests/test_entity_mappings_helpers.py` that assert the exact payload shapes for `_select_payload`, `_weekday_states`, and `_diagnostic_sensor_payload`.
- Files changed: `custom_components/thessla_green_modbus/mappings/_static_discrete.py`, `custom_components/thessla_green_modbus/mappings/_static_sensors.py`, and `tests/test_entity_mappings_helpers.py`.

### Testing
- Ran validation and test gates: `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, `python tools/validate_entity_mappings.py`, `pytest -q tests/test_entity_mappings*.py`, and `pytest tests/ -q`, and all completed successfully with existing skips.
- `python tools/validate_entity_mappings.py` reported `OK: 366 entities validated`, confirming entity mapping outputs remained stable.
- Commit hash for the change is `21f32abf730157d6c09e0ee2804b83b47705d44f` and maintainability gate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38ecc022883269f885516dcf810d2)