### PR TITLE
refactor: extract update-cycle result shaping into coordinator/update_result.py

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/update.py
+++ b/custom_components/thessla_green_modbus/coordinator/update.py
@@ -13,6 +13,7 @@ from pymodbus.exceptions import ModbusException
 from ..modbus_exceptions import ConnectionException
 from ..utils import utcnow as _utcnow
 from .errors import handle_update_error
+from .update_result import apply_success_result
 
 if TYPE_CHECKING:
     from .coordinator import ThesslaGreenModbusCoordinator
@@ -41,20 +42,7 @@ async def run_update_cycle(
         if transport is None or not transport.is_connected():
             raise ConnectionException("Modbus transport is not connected")
 
-    coordinator.statistics["successful_reads"] += 1
-    coordinator.statistics["last_successful_update"] = _utcnow()
-    coordinator._consecutive_failures = 0
-    coordinator.offline_state = False
-
-    response_time = (_utcnow() - start_time).total_seconds()
-    coordinator.statistics["average_response_time"] = (
-        coordinator.statistics["average_response_time"]
-        * (coordinator.statistics["successful_reads"] - 1)
-        + response_time
-    ) / coordinator.statistics["successful_reads"]
-
-    _LOGGER.debug("Data update successful: %d values read in %.2fs", len(data), response_time)
-    return data
+    return apply_success_result(coordinator, start_time=start_time, data=data)
 
 
 async def async_update_data(coordinator: ThesslaGreenModbusCoordinator) -> dict[str, Any]:

--- a/custom_components/thessla_green_modbus/coordinator/update_result.py
+++ b/custom_components/thessla_green_modbus/coordinator/update_result.py
@@ -1,0 +1,37 @@
+"""Update-cycle result shaping helpers for coordinator refreshes."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from ..utils import utcnow as _utcnow
+
+if TYPE_CHECKING:
+    from .coordinator import ThesslaGreenModbusCoordinator
+
+_LOGGER = logging.getLogger(__name__.rsplit(".", maxsplit=1)[0])
+
+
+def apply_success_result(
+    coordinator: ThesslaGreenModbusCoordinator,
+    *,
+    start_time: datetime,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply successful update-cycle side effects and return payload."""
+    coordinator.statistics["successful_reads"] += 1
+    coordinator.statistics["last_successful_update"] = _utcnow()
+    coordinator._consecutive_failures = 0
+    coordinator.offline_state = False
+
+    response_time = (_utcnow() - start_time).total_seconds()
+    coordinator.statistics["average_response_time"] = (
+        coordinator.statistics["average_response_time"]
+        * (coordinator.statistics["successful_reads"] - 1)
+        + response_time
+    ) / coordinator.statistics["successful_reads"]
+
+    _LOGGER.debug("Data update successful: %d values read in %.2fs", len(data), response_time)
+    return data

--- a/tests/test_coordinator_update_result.py
+++ b/tests/test_coordinator_update_result.py
@@ -1,0 +1,37 @@
+"""Tests for coordinator update-cycle result shaping helper."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from custom_components.thessla_green_modbus.coordinator.update_result import apply_success_result
+
+
+def test_apply_success_result_updates_coordinator_state() -> None:
+    """Successful result shaping should update counters, status and average latency."""
+    now = datetime(2026, 4, 30, 12, 0, 5, tzinfo=UTC)
+    start_time = now - timedelta(seconds=5)
+    coordinator = SimpleNamespace(
+        statistics={
+            "successful_reads": 1,
+            "last_successful_update": None,
+            "average_response_time": 2.0,
+        },
+        _consecutive_failures=4,
+        offline_state=True,
+    )
+
+    import custom_components.thessla_green_modbus.coordinator.update_result as update_result_module
+
+    update_result_module._utcnow = lambda: now
+    data = {"outside_temperature": 215}
+
+    result = apply_success_result(coordinator, start_time=start_time, data=data)
+
+    assert result == data
+    assert coordinator.statistics["successful_reads"] == 2
+    assert coordinator.statistics["last_successful_update"] == now
+    assert coordinator._consecutive_failures == 0
+    assert coordinator.offline_state is False
+    assert coordinator.statistics["average_response_time"] == 3.5


### PR DESCRIPTION
### Motivation
- Reduce complexity in `coordinator/update.py` by extracting a single coherent responsibility: shaping successful update-cycle results and applying related coordinator state changes and metrics.
- Move implementation logic (metrics, timestamping, offline/consecutive-failure state transitions and logging) into a focused helper to improve readability and enable targeted testing.
- Preserve runtime behavior and keep the coordinator package-root API unchanged (`CoordinatorConfig`, `ThesslaGreenModbusCoordinator`).

### Description
- Added `custom_components/thessla_green_modbus/coordinator/update_result.py` implementing `apply_success_result(...)` which updates `statistics`, `last_successful_update`, `_consecutive_failures`, `offline_state`, computes `average_response_time`, and emits the success debug log.
- Updated `custom_components/thessla_green_modbus/coordinator/update.py` to delegate the success-path side effects to `apply_success_result(...)` and otherwise keep orchestration and error handling unchanged.
- Added focused unit test `tests/test_coordinator_update_result.py` to assert the state/metrics mutations and return payload of `apply_success_result(...)`.
- No public API surface change at the package root and no compatibility shims or proxies were introduced.

### Testing
- Ran linters and static checks with `ruff check custom_components tests tools` which passed.
- Verified byte-compile with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed.
- Ran register reference check with `python tools/compare_registers_with_reference.py` which completed (reported expected reference differences to verify with vendor) and did not block the change.
- Ran maintainability audit with `python tools/check_maintainability.py` which passed.
- Executed unit tests with `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` and `pytest tests/ -q`, both of which passed (some tests skipped as expected). 
- Ran entity mappings validation with `python tools/validate_entity_mappings.py` which passed, and verified coordinator `__all__` contains only `CoordinatorConfig` and `ThesslaGreenModbusCoordinator` as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38ef1154c8326a2044c2ca74e1dd9)