### PR TITLE
refactor: continue scanner read-path decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -332,6 +332,71 @@ async def read_register_block(
     return results
 
 
+
+
+def _prepare_holding_read(scanner: Any, start: int, end: int, address: int, skip_cache: bool) -> bool:
+    """Return True when holding read should short-circuit as failed/unsupported."""
+    should_skip, skip_start, skip_end = _should_skip_holding_range(scanner, start, end, skip_cache)
+    if should_skip:
+        _handle_terminal_read_failure(scanner, "holding_registers", skip_start, skip_end)
+        return True
+
+    failures = scanner._holding_failures.get(address, 0)
+    if failures >= scanner.retry:
+        scanner.failed_addresses["modbus_exceptions"]["holding_registers"].add(address)
+        return True
+    return False
+
+
+def _handle_holding_read_exception(
+    scanner: Any,
+    exc: Exception,
+    *,
+    start: int,
+    end: int,
+    address: int,
+    count: int,
+    attempt: int,
+) -> tuple[bool, bool]:
+    """Handle holding read exception.
+
+    Returns (abort_transiently, stop_retries).
+    """
+    if isinstance(exc, TimeoutError):
+        _LOGGER.warning(
+            "Timeout reading holding %d (attempt %d/%d)",
+            address,
+            attempt,
+            scanner.retry,
+        )
+        track_holding_failure(scanner, count, address)
+        return True, False
+    if isinstance(exc, ModbusIOException):
+        if is_request_cancelled_error(exc):
+            _LOGGER.debug(
+                "Cancelled reading holding registers %d-%d on attempt %d/%d: %s",
+                start,
+                end,
+                attempt,
+                scanner.retry,
+                exc,
+            )
+            return True, True
+        track_holding_failure(scanner, count, address)
+        return False, False
+    if isinstance(exc, (ModbusException, ConnectionException)):
+        track_holding_failure(scanner, count, address)
+        return False, False
+    if isinstance(exc, OSError):
+        _LOGGER.error(
+            "Unexpected error reading holding %d on attempt %d: %s",
+            address,
+            attempt,
+            exc,
+            exc_info=True,
+        )
+        return False, True
+    raise exc
 async def read_holding(
     scanner: Any,
     client_or_address: AsyncModbusTcpClient | AsyncModbusSerialClientType | int,
@@ -345,14 +410,7 @@ async def read_holding(
     start = address
     end = address + count - 1
 
-    should_skip, skip_start, skip_end = _should_skip_holding_range(scanner, start, end, skip_cache)
-    if should_skip:
-        _handle_terminal_read_failure(scanner, "holding_registers", skip_start, skip_end)
-        return None
-
-    failures = scanner._holding_failures.get(address, 0)
-    if failures >= scanner.retry:
-        scanner.failed_addresses["modbus_exceptions"]["holding_registers"].add(address)
+    if _prepare_holding_read(scanner, start, end, address, skip_cache):
         return None
 
     transport, client = resolve_transport_and_client(scanner, client)
@@ -391,41 +449,21 @@ async def read_holding(
             )
             if done:
                 return payload
-        except TimeoutError:
-            _LOGGER.warning(
-                "Timeout reading holding %d (attempt %d/%d)",
-                address,
-                attempt,
-                scanner.retry,
-            )
-            track_holding_failure(scanner, count, address)
-            aborted_transiently = True
-        except ModbusIOException as exc:
-            if is_request_cancelled_error(exc):
-                _LOGGER.debug(
-                    "Cancelled reading holding registers %d-%d on attempt %d/%d: %s",
-                    start,
-                    end,
-                    attempt,
-                    scanner.retry,
-                    exc,
-                )
-                aborted_transiently = True
-                break
-            track_holding_failure(scanner, count, address)
-        except (ModbusException, ConnectionException):
-            track_holding_failure(scanner, count, address)
         except asyncio.CancelledError:
             raise
-        except OSError as exc:
-            _LOGGER.error(
-                "Unexpected error reading holding %d on attempt %d: %s",
-                address,
-                attempt,
+        except (TimeoutError, ModbusIOException, ModbusException, ConnectionException, OSError) as exc:
+            aborted, stop = _handle_holding_read_exception(
+                scanner,
                 exc,
-                exc_info=True,
+                start=start,
+                end=end,
+                address=address,
+                count=count,
+                attempt=attempt,
             )
-            break
+            aborted_transiently = aborted_transiently or aborted
+            if stop:
+                break
 
         await _sleep_retry_backoff(
             backoff=scanner.backoff,

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -161,3 +161,26 @@ async def test_read_input_skip_cache_marks_single_register_supported():
 
     assert result == [77]
     assert 77 not in scanner._failed_input
+
+
+async def test_read_holding_cancelled_modbusio_stops_retry_loop():
+    """Cancelled ModbusIOException aborts holding retries immediately."""
+    scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10, retry=3)
+    mock_client = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.scanner.io_core._call_modbus",
+            AsyncMock(side_effect=ModbusIOException("request cancelled")),
+        ) as call_mock,
+        patch(
+            "custom_components.thessla_green_modbus.scanner.io_read.is_request_cancelled_error",
+            return_value=True,
+        ),
+        patch("asyncio.sleep", AsyncMock()) as sleep_mock,
+    ):
+        result = await scanner._read_holding(mock_client, 3, 1)
+
+    assert result is None
+    assert call_mock.await_count == 1
+    sleep_mock.assert_not_called()


### PR DESCRIPTION
### Motivation

- Reduce complexity in `read_holding` by extracting narrow responsibilities around pre-read short-circuit logic and exception classification. 
- Centralize decision logic for unsupported/cached-failed ranges and failure-threshold skipping so behavior is easier to reason about and reuse. 
- Keep the previously extracted `_process_register_response` as the canonical response normalization/classification path and avoid duplicating its semantics.

### Description

- Added `_prepare_holding_read(scanner, start, end, address, skip_cache)` to short-circuit holding reads for unsupported ranges or when failure counters exceed retry thresholds. 
- Added `_handle_holding_read_exception(scanner, exc, *, start, end, address, count, attempt)` to classify holding-read exceptions, apply side effects (logging, failure tracking, unsupported marking) and return control signals for the retry loop. 
- Reworked `read_holding` to call the new helpers and preserved the existing retry/backoff loop, `_process_register_response` usage, logging, and failure-marking semantics. 
- Added a focused test `test_read_holding_cancelled_modbusio_stops_retry_loop` to verify that a cancelled `ModbusIOException` aborts the hold-read retry loop immediately and avoids backoff sleeps.

### Testing

- Ran lint and static checks: `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed. 
- Ran repository gates: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both passed (maintainability gate passed). 
- Ran targeted and full test suites: `pytest -q tests/test_scanner_io.py tests/test_scanner_io_coverage.py tests/test_scanner*.py tests/test_device_scanner*.py` and `pytest tests/ -q`, both passed (full pytest passed with 4 skipped). 
- Ran entity mappings validation: `python tools/validate_entity_mappings.py`, and grep audits for Home Assistant imports and shim keywords, all passed; commit recorded as `b6b6a1e4`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38edf3bf88326a8150113c675dd9a)