### PR TITLE
refactor: decompose scanner core orchestration (connection config)

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/core.py
+++ b/custom_components/thessla_green_modbus/scanner/core.py
@@ -159,14 +159,18 @@ class ThesslaGreenDeviceScanner(
             self.effective_batch = 1
         self.max_registers_per_request = self.effective_batch
 
-        resolved_type, resolved_mode = resolve_connection_settings(
-            connection_type, connection_mode, port
+        (
+            resolved_type,
+            resolved_mode,
+            resolved_fixed_mode,
+        ) = self._resolve_connection_configuration(
+            connection_type,
+            connection_mode,
+            port,
         )
         self.connection_type = resolved_type
         self.connection_mode = resolved_mode
-        self._resolved_connection_mode: str | None = (
-            resolved_mode if resolved_mode != CONNECTION_MODE_AUTO else None
-        )
+        self._resolved_connection_mode: str | None = resolved_fixed_mode
         self.serial_port = serial_port or DEFAULT_SERIAL_PORT
         try:
             self.baud_rate = int(baud_rate)
@@ -198,6 +202,19 @@ class ThesslaGreenDeviceScanner(
         """Pre-compute addresses of known missing registers for batch grouping."""
         scanner_setup.populate_known_missing_addresses(self)
         self._update_known_missing_addresses()
+
+    @staticmethod
+    def _resolve_connection_configuration(
+        connection_type: str,
+        connection_mode: str | None,
+        port: int,
+    ) -> tuple[str, str, str | None]:
+        """Resolve transport selection and cached fixed mode."""
+        resolved_type, resolved_mode = resolve_connection_settings(
+            connection_type, connection_mode, port
+        )
+        resolved_fixed_mode = resolved_mode if resolved_mode != CONNECTION_MODE_AUTO else None
+        return resolved_type, resolved_mode, resolved_fixed_mode
 
     def _update_known_missing_addresses(self) -> None:
         """Populate cached missing register addresses from known missing list."""

--- a/tests/test_device_scanner_setup.py
+++ b/tests/test_device_scanner_setup.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from custom_components.thessla_green_modbus.const import CONNECTION_MODE_AUTO
 from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 
@@ -67,3 +68,31 @@ async def test_scanner_has_read_coil_method():
     """Ensure scanner exposes coil reading helper."""
     scanner = await ThesslaGreenDeviceScanner.create("192.168.3.17", 8899, 10)
     assert hasattr(scanner, "_read_coil")
+
+
+def test_resolve_connection_configuration_fixed_mode():
+    """Resolved non-auto mode should be cached as fixed mode."""
+    resolved_type, resolved_mode, resolved_fixed_mode = (
+        ThesslaGreenDeviceScanner._resolve_connection_configuration(
+            "tcp",
+            "tcp",
+            502,
+        )
+    )
+    assert resolved_type == "tcp"
+    assert resolved_mode == "tcp"
+    assert resolved_fixed_mode == "tcp"
+
+
+def test_resolve_connection_configuration_auto_mode():
+    """Resolved auto mode should not pre-cache fixed mode."""
+    resolved_type, resolved_mode, resolved_fixed_mode = (
+        ThesslaGreenDeviceScanner._resolve_connection_configuration(
+            "tcp",
+            CONNECTION_MODE_AUTO,
+            502,
+        )
+    )
+    assert resolved_type == "tcp"
+    assert resolved_mode == CONNECTION_MODE_AUTO
+    assert resolved_fixed_mode is None


### PR DESCRIPTION
### Motivation
- Reduce complexity in `ThesslaGreenDeviceScanner.__init__` by extracting connection-mode resolution and fixed-mode caching into a single helper to clarify orchestration responsibility.
- Keep scan, auto-detect, RTU/TCP selection, and exception behavior unchanged while making the orchestration easier to test.

### Description
- Added `ThesslaGreenDeviceScanner._resolve_connection_configuration(...)` to centralize `resolve_connection_settings` usage and fixed-mode caching logic.
- Updated `ThesslaGreenDeviceScanner.__init__` to consume the new helper and set `connection_type`, `connection_mode`, and `_resolved_connection_mode` from its return values.
- Added unit tests `test_resolve_connection_configuration_fixed_mode` and `test_resolve_connection_configuration_auto_mode` to validate fixed vs auto-mode behavior.
- Changes are limited to `custom_components/thessla_green_modbus/scanner/core.py` and `tests/test_device_scanner_setup.py` and do not introduce Home Assistant imports.

### Testing
- Ran lint/compile/maintainability and tests: `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, `python tools/validate_entity_mappings.py` and they passed.
- Ran targeted and full test suites: `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` and `pytest tests/ -q` and all tests passed (existing skips preserved).
- Commit created: `bc8d1e24`.
- Files changed: `custom_components/thessla_green_modbus/scanner/core.py`, `tests/test_device_scanner_setup.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38ee73724832693a5ac364aa83d51)