### PR TITLE
refactor: reduce raw transport helper complexity

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_transport_raw.py
+++ b/custom_components/thessla_green_modbus/modbus_transport_raw.py
@@ -154,37 +154,50 @@ class RawRtuOverTcpTransport(BaseModbusTransport):
             payload.extend([(value >> 8) & 0xFF, value & 0xFF])
         return _append_crc(bytes(payload))
 
-    async def _read_response(self, slave_id: int, function: int) -> bytes:
-        header = await self._read_exactly(2)
+    @staticmethod
+    def _validate_response_header(header: bytes, *, slave_id: int, function: int) -> int:
         resp_slave, resp_func = header
 
         if resp_slave != (slave_id & 0xFF):
             raise ModbusIOException("Unexpected slave ID in RTU response")
-
         if resp_func & 0x80:
-            exception_code = await self._read_exactly(1)
-            crc_bytes = await self._read_exactly(2)
-            payload = header + exception_code
-            self._validate_crc(payload, crc_bytes)
-            raise ModbusException(f"Modbus exception {exception_code[0]} for function {resp_func}")
-
+            return resp_func
         if resp_func != (function & 0xFF):
             raise ModbusIOException("Unexpected function code in RTU response")
+        return resp_func
 
-        if function in (3, 4):
-            byte_count_raw = await self._read_exactly(1)
-            byte_count = byte_count_raw[0]
-            data = await self._read_exactly(byte_count)
-            crc_bytes = await self._read_exactly(2)
-            payload = header + byte_count_raw + data
-            self._validate_crc(payload, crc_bytes)
-            return data
+    async def _read_exception_response(self, header: bytes, *, function: int) -> bytes:
+        exception_code = await self._read_exactly(1)
+        crc_bytes = await self._read_exactly(2)
+        payload = header + exception_code
+        self._validate_crc(payload, crc_bytes)
+        raise ModbusException(f"Modbus exception {exception_code[0]} for function {function}")
 
+    async def _read_register_data_response(self, header: bytes) -> bytes:
+        byte_count_raw = await self._read_exactly(1)
+        byte_count = byte_count_raw[0]
+        data = await self._read_exactly(byte_count)
+        crc_bytes = await self._read_exactly(2)
+        payload = header + byte_count_raw + data
+        self._validate_crc(payload, crc_bytes)
+        return data
+
+    async def _read_write_body_response(self, header: bytes) -> bytes:
         body = await self._read_exactly(4)
         crc_bytes = await self._read_exactly(2)
         payload = header + body
         self._validate_crc(payload, crc_bytes)
         return body
+
+    async def _read_response(self, slave_id: int, function: int) -> bytes:
+        header = await self._read_exactly(2)
+        resp_func = self._validate_response_header(header, slave_id=slave_id, function=function)
+
+        if resp_func & 0x80:
+            return await self._read_exception_response(header, function=resp_func)
+        if function in (3, 4):
+            return await self._read_register_data_response(header)
+        return await self._read_write_body_response(header)
 
     async def _send_frame(self, frame: bytes, slave_id: int, function: int) -> bytes:
         async with self._request_lock:

--- a/tests/test_modbus_transport_raw.py
+++ b/tests/test_modbus_transport_raw.py
@@ -158,6 +158,23 @@ def test_build_write_single_frame_structure():
     assert frame[1] == 6  # function code for write single register
 
 
+
+
+def test_validate_response_header_wrong_slave():
+    t = _make_raw_tcp()
+    with pytest.raises(ModbusIOException, match="slave ID"):
+        t._validate_response_header(bytes([2, 4]), slave_id=1, function=4)
+
+
+def test_validate_response_header_wrong_function():
+    t = _make_raw_tcp()
+    with pytest.raises(ModbusIOException, match="function code"):
+        t._validate_response_header(bytes([1, 3]), slave_id=1, function=4)
+
+
+def test_validate_response_header_exception_function_passthrough():
+    t = _make_raw_tcp()
+    assert t._validate_response_header(bytes([1, 0x84]), slave_id=1, function=4) == 0x84
 def test_build_write_multiple_frame_structure():
     """_build_write_multiple_frame produces correct write multiple frame."""
     from custom_components.thessla_green_modbus.modbus_transport import RawRtuOverTcpTransport


### PR DESCRIPTION
### Motivation

- Reduce complexity and improve readability in the RTU-over-TCP response handling by extracting a narrow set of helpers.  
- Isolate header validation, exception parsing, register-data parsing, and write-body parsing to make intent explicit.  
- Preserve existing Modbus/RTU semantics, CRC checks, and retry behavior while making the code easier to test and maintain.

### Description

- Extracted response-parsing helpers on `RawRtuOverTcpTransport`: `_validate_response_header`, `_read_exception_response`, `_read_register_data_response`, and `_read_write_body_response`.  
- Rewrote `_read_response` to orchestrate the new helpers while preserving previous read sequences and CRC validation via existing `_validate_crc`.  
- Added focused unit tests in `tests/test_modbus_transport_raw.py` to assert header validation behavior (wrong slave, wrong function, and exception-function passthrough).  
- Changes are confined to `custom_components/thessla_green_modbus/modbus_transport_raw.py` and the corresponding tests, with no changes to CRC algorithm, retry/backoff logic, transport public interface, or Home Assistant imports.

### Testing

- Ran lint and static checks with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, which passed.  
- Ran repository validation scripts `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, which passed.  
- Executed targeted unit tests with `pytest -q tests/test_modbus_transport*.py tests/test_modbus_helpers.py tests/unit/test_transport_retry.py tests/unit/test_errors.py` and the full test suite with `pytest tests/ -q`, both of which passed (with existing skips).  
- Ran `python tools/validate_entity_mappings.py` and repository grep checks for forbidden HA imports/shims, all of which passed and confirmed transport remains Home Assistant independent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f392a63ea48326b7f5b4a0ec6b67c3)