### PR TITLE
refactor: extract diagnostic binary override from mapping builders

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -153,6 +153,29 @@ def _diag_register_candidates(holding_regs: set[str]) -> set[str]:
     return diag_registers
 
 
+
+def _apply_diagnostic_binary_overrides(
+    diag_registers: set[str],
+    holding_regs: set[str],
+    binary_keys: set[str],
+    binary_configs: dict[str, dict[str, Any]],
+    switch_configs: dict[str, dict[str, Any]],
+    select_configs: dict[str, dict[str, Any]],
+) -> None:
+    """Force diagnostic registers into binary mappings and clear conflicting buckets."""
+    for reg in diag_registers:
+        if reg not in holding_regs and reg not in {"alarm", "error"}:
+            continue
+        if reg not in binary_keys:
+            continue
+        binary_configs[reg] = {
+            "translation_key": reg,
+            "register_type": "holding_registers",
+            "entity_category": EntityCategory.DIAGNOSTIC,
+        }
+        switch_configs.pop(reg, None)
+        select_configs.pop(reg, None)
+
 def _iter_bitmask_binary_entries(reg: Any) -> list[tuple[str, dict[str, Any]]]:
     """Build binary mapping entries derived from a bitmask register definition."""
     func_map = {
@@ -543,19 +566,14 @@ def _load_discrete_mappings() -> tuple[
                 cfg["states"] = states
                 select_configs[reg] = cfg
 
-    diag_registers = _diag_register_candidates(holding_regs)
-    for reg in diag_registers:
-        if reg not in holding_regs and reg not in {"alarm", "error"}:
-            continue
-        if reg not in binary_keys:
-            continue
-        binary_configs[reg] = {
-            "translation_key": reg,
-            "register_type": "holding_registers",
-            "entity_category": EntityCategory.DIAGNOSTIC,
-        }
-        switch_configs.pop(reg, None)
-        select_configs.pop(reg, None)
+    _apply_diagnostic_binary_overrides(
+        _diag_register_candidates(holding_regs),
+        holding_regs,
+        binary_keys,
+        binary_configs,
+        switch_configs,
+        select_configs,
+    )
 
     for reg in _get_all():
         if not reg.name:
@@ -656,6 +674,7 @@ def _extend_entity_mappings_from_registers() -> None:
 
 __all__ = [
     "_TIME_ENTITY_PREFIXES",
+    "_apply_diagnostic_binary_overrides",
     "_build_base_translation_mapping",
     "_build_problem_binary_mapping",
     "_build_season_setting_mapping",

--- a/tests/test_entity_mappings_builder_transformations.py
+++ b/tests/test_entity_mappings_builder_transformations.py
@@ -1,6 +1,7 @@
 """Tests for extracted transformation helpers in mapping builders."""
 
 from custom_components.thessla_green_modbus.mappings._mapping_builders import (
+    _apply_diagnostic_binary_overrides,
     _build_base_translation_mapping,
     _build_sensor_season_setting_mapping,
     _classify_enum_mapping,
@@ -15,6 +16,7 @@ from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _route_problem_mapping,
     _route_time_and_season_mappings,
 )
+from homeassistant.helpers.entity import EntityCategory
 
 
 def test_build_base_translation_mapping_shape() -> None:
@@ -201,3 +203,52 @@ def test_route_time_and_season_mappings_routes_expected_buckets() -> None:
     assert "schedule_wake" in time
     assert _route_time_and_season_mappings("setting_winter_mode", "R", sensor, time, select) is True
     assert "setting_winter_mode" in sensor
+
+
+def test_apply_diagnostic_binary_overrides_sets_binary_and_clears_conflicts() -> None:
+    binary = {}
+    switch = {"alarm": {"translation_key": "alarm"}}
+    select = {"s_1": {"translation_key": "s_1"}}
+
+    _apply_diagnostic_binary_overrides(
+        {"alarm", "s_1", "unknown"},
+        {"s_1", "normal"},
+        {"alarm", "s_1"},
+        binary,
+        switch,
+        select,
+    )
+
+    assert binary == {
+        "alarm": {
+            "translation_key": "alarm",
+            "register_type": "holding_registers",
+            "entity_category": EntityCategory.DIAGNOSTIC,
+        },
+        "s_1": {
+            "translation_key": "s_1",
+            "register_type": "holding_registers",
+            "entity_category": EntityCategory.DIAGNOSTIC,
+        },
+    }
+    assert switch == {}
+    assert select == {}
+
+
+def test_apply_diagnostic_binary_overrides_skips_when_not_translated_or_not_holding() -> None:
+    binary = {}
+    switch = {"e_1": {"translation_key": "e_1"}}
+    select = {"e_1": {"translation_key": "e_1"}}
+
+    _apply_diagnostic_binary_overrides(
+        {"e_1", "random"},
+        {"normal"},
+        {"alarm"},
+        binary,
+        switch,
+        select,
+    )
+
+    assert binary == {}
+    assert switch == {"e_1": {"translation_key": "e_1"}}
+    assert select == {"e_1": {"translation_key": "e_1"}}


### PR DESCRIPTION
### Motivation

- Reduce complexity in `_mapping_builders.py` by isolating diagnostic-register override logic into a focused helper to make future decomposition easier while preserving mapping outputs.
- Make the diagnostic override behavior a pure, testable unit to allow direct unit testing of payload shapes and conflict-clearing behavior.

### Description

- Extracted a new helper `
_apply_diagnostic_binary_overrides` into `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` that forces diagnostic registers into binary mappings and clears conflicting switch/select entries.
- Rewired `
_load_discrete_mappings` to call the new helper so external behavior remains unchanged.
- Exported the new helper in the module `__all__` so tests and callers can access it consistently.
- Added focused unit tests in `tests/test_entity_mappings_builder_transformations.py` (`test_apply_diagnostic_binary_overrides_sets_binary_and_clears_conflicts` and `test_apply_diagnostic_binary_overrides_skips_when_not_translated_or_not_holding`) that assert exact payload shapes and conflict-clearing semantics.

### Testing

- Ran lint and static checks with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both completed successfully.
- Ran register/reference and maintainability checks with `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both completed successfully.
- Validated entity mapping stability with `python tools/validate_entity_mappings.py`, which passed with `OK: 366 entities validated`.
- Ran unit tests with `pytest -q tests/test_entity_mappings*.py` and full suite `pytest tests/ -q`, both passed (with expected skips reported by the suite).
- All automated validation gates in the local CI-equivalent run passed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f392af98ec83268c91f2fedbf5c952)