### PR TITLE
refactor: continue parameter service handler decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_parameters.py
+++ b/custom_components/thessla_green_modbus/services_handlers_parameters.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
+
+import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from .services_dispatch import refresh_and_log_success, write_register_steps
@@ -14,66 +17,80 @@ from .services_schema import (
 )
 from .services_validation import BYPASS_MODE_MAP, GWC_MODE_MAP
 
+WriteStep = tuple[str, object | None, bool, str]
+ServiceHandler = Callable[[ServiceCall], object]
+
+
+def _build_step_handler(
+    hass: HomeAssistant,
+    deps: ServiceHandlerDeps,
+    *,
+    context: str,
+    success_log: str,
+    step_builder: Callable[[ServiceCall], Sequence[WriteStep]],
+) -> ServiceHandler:
+    """Create a parameter handler based on write steps."""
+
+    async def _handler(call: ServiceCall) -> None:
+        steps = step_builder(call)
+        for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
+            if not await write_register_steps(
+                coordinator,
+                steps,
+                entity_id,
+                context,
+                deps.write_register,
+                deps.logger,
+            ):
+                continue
+            await refresh_and_log_success(coordinator, deps.logger, success_log, entity_id)
+
+    return _handler
+
 
 def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
     """Register parameter/configuration services."""
-
-    async def set_bypass_parameters(call: ServiceCall) -> None:
-        mode = deps.normalize_option(call.data["mode"])
-        min_temperature = call.data.get("min_outdoor_temperature")
-        mode_value = BYPASS_MODE_MAP[mode]
-
-        for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            if not await write_register_steps(
-                coordinator,
-                [
-                    ("bypass_mode", mode_value, False, "Failed to set bypass mode for %s"),
-                    (
-                        "min_bypass_temperature",
-                        min_temperature,
-                        True,
-                        "Failed to set bypass min temperature for %s",
-                    ),
-                ],
-                entity_id,
-                "set bypass parameters",
-                deps.write_register,
-                deps.logger,
-            ):
-                continue
-            await refresh_and_log_success(coordinator, deps.logger, "Set bypass parameters for %s", entity_id)
-
-    async def set_gwc_parameters(call: ServiceCall) -> None:
-        mode = deps.normalize_option(call.data["mode"])
-        min_air_temperature = call.data.get("min_air_temperature")
-        max_air_temperature = call.data.get("max_air_temperature")
-        mode_value = GWC_MODE_MAP[mode]
-
-        for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            if not await write_register_steps(
-                coordinator,
-                [
-                    ("gwc_mode", mode_value, False, "Failed to set GWC mode for %s"),
-                    (
-                        "min_gwc_air_temperature",
-                        min_air_temperature,
-                        True,
-                        "Failed to set GWC min air temperature for %s",
-                    ),
-                    (
-                        "max_gwc_air_temperature",
-                        max_air_temperature,
-                        True,
-                        "Failed to set GWC max air temperature for %s",
-                    ),
-                ],
-                entity_id,
-                "set GWC parameters",
-                deps.write_register,
-                deps.logger,
-            ):
-                continue
-            await refresh_and_log_success(coordinator, deps.logger, "Set GWC parameters for %s", entity_id)
+    set_bypass_parameters = _build_step_handler(
+        hass,
+        deps,
+        context="set bypass parameters",
+        success_log="Set bypass parameters for %s",
+        step_builder=lambda call: [
+            (
+                "bypass_mode",
+                BYPASS_MODE_MAP[deps.normalize_option(call.data["mode"])],
+                False,
+                "Failed to set bypass mode for %s",
+            ),
+            (
+                "min_bypass_temperature",
+                call.data.get("min_outdoor_temperature"),
+                True,
+                "Failed to set bypass min temperature for %s",
+            ),
+        ],
+    )
+    set_gwc_parameters = _build_step_handler(
+        hass,
+        deps,
+        context="set GWC parameters",
+        success_log="Set GWC parameters for %s",
+        step_builder=lambda call: [
+            ("gwc_mode", GWC_MODE_MAP[deps.normalize_option(call.data["mode"])], False, "Failed to set GWC mode for %s"),
+            (
+                "min_gwc_air_temperature",
+                call.data.get("min_air_temperature"),
+                True,
+                "Failed to set GWC min air temperature for %s",
+            ),
+            (
+                "max_gwc_air_temperature",
+                call.data.get("max_air_temperature"),
+                True,
+                "Failed to set GWC max air temperature for %s",
+            ),
+        ],
+    )
 
     async def set_air_quality_thresholds(call: ServiceCall) -> None:
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
@@ -87,40 +104,34 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
             if success:
                 await refresh_and_log_success(coordinator, deps.logger, "Set air quality thresholds for %s", entity_id)
 
-    async def set_temperature_curve(call: ServiceCall) -> None:
-        slope = call.data["slope"]
-        offset = call.data["offset"]
-        max_supply_temp = call.data.get("max_supply_temp")
-        min_supply_temp = call.data.get("min_supply_temp")
+    set_temperature_curve = _build_step_handler(
+        hass,
+        deps,
+        context="set temperature curve",
+        success_log="Set temperature curve for %s",
+        step_builder=lambda call: [
+            ("heating_curve_slope", call.data["slope"], False, "Failed to set heating curve slope for %s"),
+            ("heating_curve_offset", call.data["offset"], False, "Failed to set heating curve offset for %s"),
+            (
+                "max_supply_temperature",
+                call.data.get("max_supply_temp"),
+                True,
+                "Failed to set max supply temperature for %s",
+            ),
+            (
+                "min_supply_temperature",
+                call.data.get("min_supply_temp"),
+                True,
+                "Failed to set min supply temperature for %s",
+            ),
+        ],
+    )
 
-        for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            if not await write_register_steps(
-                coordinator,
-                [
-                    ("heating_curve_slope", slope, False, "Failed to set heating curve slope for %s"),
-                    ("heating_curve_offset", offset, False, "Failed to set heating curve offset for %s"),
-                    (
-                        "max_supply_temperature",
-                        max_supply_temp,
-                        True,
-                        "Failed to set max supply temperature for %s",
-                    ),
-                    (
-                        "min_supply_temperature",
-                        min_supply_temp,
-                        True,
-                        "Failed to set min supply temperature for %s",
-                    ),
-                ],
-                entity_id,
-                "set temperature curve",
-                deps.write_register,
-                deps.logger,
-            ):
-                continue
-            await refresh_and_log_success(coordinator, deps.logger, "Set temperature curve for %s", entity_id)
-
-    hass.services.async_register(deps.domain, "set_bypass_parameters", set_bypass_parameters, SET_BYPASS_PARAMETERS_SCHEMA)
-    hass.services.async_register(deps.domain, "set_gwc_parameters", set_gwc_parameters, SET_GWC_PARAMETERS_SCHEMA)
-    hass.services.async_register(deps.domain, "set_air_quality_thresholds", set_air_quality_thresholds, SET_AIR_QUALITY_THRESHOLDS_SCHEMA)
-    hass.services.async_register(deps.domain, "set_temperature_curve", set_temperature_curve, SET_TEMPERATURE_CURVE_SCHEMA)
+    registrations: tuple[tuple[str, ServiceHandler, vol.Schema], ...] = (
+        ("set_bypass_parameters", set_bypass_parameters, SET_BYPASS_PARAMETERS_SCHEMA),
+        ("set_gwc_parameters", set_gwc_parameters, SET_GWC_PARAMETERS_SCHEMA),
+        ("set_air_quality_thresholds", set_air_quality_thresholds, SET_AIR_QUALITY_THRESHOLDS_SCHEMA),
+        ("set_temperature_curve", set_temperature_curve, SET_TEMPERATURE_CURVE_SCHEMA),
+    )
+    for service_name, handler, schema in registrations:
+        hass.services.async_register(deps.domain, service_name, handler, schema)

--- a/tests/test_services_handlers_parameters_registration.py
+++ b/tests/test_services_handlers_parameters_registration.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from custom_components.thessla_green_modbus.services_handler_deps import ServiceHandlerDeps
+from custom_components.thessla_green_modbus.services_handlers_parameters import (
+    register_parameter_services,
+)
+from custom_components.thessla_green_modbus.services_schema import (
+    SET_AIR_QUALITY_THRESHOLDS_SCHEMA,
+    SET_BYPASS_PARAMETERS_SCHEMA,
+    SET_GWC_PARAMETERS_SCHEMA,
+    SET_TEMPERATURE_CURVE_SCHEMA,
+)
+
+
+class _Services:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object, object]] = []
+
+    def async_register(self, _domain: str, service: str, handler: object, schema: object) -> None:
+        self.calls.append((service, handler, schema))
+
+
+def _deps() -> ServiceHandlerDeps:
+    async def _noop_write(*_args, **_kwargs):
+        return True
+
+    return ServiceHandlerDeps(
+        domain="thessla_green_modbus",
+        logger=logging.getLogger(__name__),
+        special_function_map={},
+        day_to_device_key={},
+        air_quality_register_map={"co2_low": "co2_low", "co2_medium": "co2_medium", "co2_high": "co2_high", "humidity_target": "humidity_target"},
+        iter_target_coordinators=lambda _h, _c: [],
+        normalize_option=lambda value: value,
+        clamp_airflow_rate=lambda value: value,
+        write_register=_noop_write,
+        create_log_level_manager=lambda *_args, **_kwargs: None,
+        dt_now=lambda: None,
+        scanner_create=lambda *_args, **_kwargs: None,
+    )
+
+
+def test_register_parameter_services_preserves_order_and_schema() -> None:
+    hass = SimpleNamespace(services=_Services())
+
+    register_parameter_services(hass, _deps())
+
+    expected = [
+        ("set_bypass_parameters", SET_BYPASS_PARAMETERS_SCHEMA),
+        ("set_gwc_parameters", SET_GWC_PARAMETERS_SCHEMA),
+        ("set_air_quality_thresholds", SET_AIR_QUALITY_THRESHOLDS_SCHEMA),
+        ("set_temperature_curve", SET_TEMPERATURE_CURVE_SCHEMA),
+    ]
+    assert len(hass.services.calls) == len(expected)
+    assert [(service, schema) for service, _handler, schema in hass.services.calls] == expected


### PR DESCRIPTION
### Motivation
- Reduce duplicated logic in parameter/configuration service handlers by extracting a shared step-based dispatch helper to centralize target iteration, write-step execution and success refresh/log behavior.

### Description
- Added a `_build_step_handler` helper in `custom_components/thessla_green_modbus/services_handlers_parameters.py` to encapsulate iteration over targets, calling `write_register_steps`, and logging/refresh on success.
- Reworked `set_bypass_parameters`, `set_gwc_parameters`, and `set_temperature_curve` to use the new helper while preserving register names, optional/required semantics, error messages and success logs.
- Kept `set_air_quality_thresholds` behavior unchanged and introduced an explicit `registrations` table/loop to register services in a deterministic order.
- Added a focused test `tests/test_services_handlers_parameters_registration.py` asserting service registration order and schema bindings; files changed: `services_handlers_parameters.py`, `tests/test_services_handlers_parameters_registration.py`.

### Testing
- Installed dev deps with `python -m pip install -r requirements-dev.txt` and ran linters with `ruff check`, both passed (auto-fix applied where needed).
- Compiled sources with `python -m compileall -q custom_components/thessla_green_modbus tests tools` (passed) and ran register compare `python tools/compare_registers_with_reference.py` (ran; reported expected extras/mismatches to verify with vendor).
- Ran maintainability gate `python tools/check_maintainability.py` (passed) and entity mapping validation `python tools/validate_entity_mappings.py` (passed).
- Executed unit tests `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` and full test suite `pytest tests/ -q`, both passed (new registration test included and passed).
- Commit hash: `1086dbb5662cc3d0081e93099d21c8d2ece47e15`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f392b8b9bc83268c4f26f2788955cf)