### PR TITLE
refactor: decompose scanner orchestration helpers

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -103,6 +103,107 @@ def _uses_custom_scan_impl(scanner: Any) -> bool:
     ) != "custom_components.thessla_green_modbus.scanner.core"
 
 
+def _normalize_custom_scan_result(scanner: Any, scan_result: Any) -> dict[str, Any]:
+    """Normalize custom scan return shapes to a scan payload."""
+    if (
+        isinstance(scan_result, tuple)
+        and len(scan_result) >= 2
+        and isinstance(scan_result[0], ScannerDeviceInfo)
+        and isinstance(scan_result[1], DeviceCapabilities)
+    ):
+        device, caps = scan_result[0], scan_result[1]
+        unknown = scan_result[2] if len(scan_result) > 2 and isinstance(scan_result[2], dict) else {}
+        return {
+            "available_registers": {
+                k: sorted(v) for k, v in scanner.available_registers.items()
+            },
+            "device_info": device.as_dict(),
+            "capabilities": caps.as_dict(),
+            "register_count": sum(len(v) for v in scanner.available_registers.values()),
+            "unknown_registers": unknown,
+        }
+    if isinstance(scan_result, dict):
+        return scan_result
+    raise TypeError("scan() must return a dict")
+
+
+async def _run_custom_scan(scanner: Any) -> dict[str, Any]:
+    """Run overridden scan implementation and normalize result."""
+    scan_result: Any = scanner.scan()
+    if inspect.isawaitable(scan_result):
+        scan_result = await scan_result
+    return _normalize_custom_scan_result(scanner, scan_result)
+
+
+async def _auto_detect_tcp_transport(scanner: Any) -> None:
+    """Attempt TCP mode probes and keep first successful transport."""
+    last_error: Exception | None = None
+    for selected_mode, transport, timeout in scanner._build_auto_tcp_attempts():
+        try:
+            await asyncio.wait_for(transport.ensure_connected(), timeout=timeout)
+            try:
+                await transport.read_input_registers(scanner.slave_id, 0, count=2)
+            except TimeoutError:
+                raise
+            except ModbusIOException as exc:
+                if is_request_cancelled_error(exc):
+                    raise TimeoutError(str(exc)) from exc
+            except (
+                ModbusException,
+                ConnectionException,
+                OSError,
+                TypeError,
+                ValueError,
+                AttributeError,
+            ) as exc:
+                _LOGGER.debug("Protocol probe non-critical exception (protocol ok): %s", exc)
+        except (TimeoutError, ConnectionException, ModbusException, OSError) as exc:
+            last_error = exc
+            await transport.close()
+            continue
+        scanner._transport = transport
+        scanner._resolved_connection_mode = selected_mode
+        _LOGGER.info(
+            "scan_device: auto-selected Modbus transport %s for %s:%s",
+            selected_mode,
+            scanner.host,
+            scanner.port,
+        )
+        return
+    raise ConnectionException("Auto-detect Modbus transport failed") from last_error
+
+
+def _create_rtu_transport(scanner: Any) -> Any:
+    """Create RTU transport from scanner serial configuration."""
+    parity = SERIAL_PARITY_MAP.get(scanner.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
+    stop_bits = SERIAL_STOP_BITS_MAP.get(scanner.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS])
+    rtu_transport_cls = getattr(scanner, "_rtu_transport_cls", RtuModbusTransport)
+    return rtu_transport_cls(
+        serial_port=scanner.serial_port,
+        baudrate=scanner.baud_rate,
+        parity=parity,
+        stopbits=stop_bits,
+        max_retries=scanner.retry,
+        base_backoff=scanner.backoff,
+        max_backoff=DEFAULT_MAX_BACKOFF,
+        timeout=scanner.timeout,
+    )
+
+
+async def _prepare_scan_transport(scanner: Any) -> None:
+    """Prepare scanner transport according to connection strategy."""
+    if scanner.connection_type == CONNECTION_TYPE_RTU:
+        if not scanner.serial_port:
+            raise ConnectionException("Serial port not configured")
+        scanner._transport = _create_rtu_transport(scanner)
+        return
+    mode = scanner._resolved_connection_mode or scanner.connection_mode
+    if mode is None or mode == CONNECTION_MODE_AUTO:
+        await _auto_detect_tcp_transport(scanner)
+        return
+    scanner._transport = scanner._build_tcp_transport(mode)
+
+
 async def run_full_scan(
     scanner: Any,
     input_max: int,
@@ -327,99 +428,12 @@ async def scan(scanner: Any) -> dict[str, Any]:
 
 async def scan_device(scanner: Any) -> dict[str, Any]:
     """Open the Modbus connection, perform a scan and close the client."""
-    scan_method = scanner.scan
     if _uses_custom_scan_impl(scanner):
         try:
-            scan_result: Any = scan_method()
-            if inspect.isawaitable(scan_result):
-                scan_result = await scan_result
-            if (
-                isinstance(scan_result, tuple)
-                and len(scan_result) >= 2
-                and isinstance(scan_result[0], ScannerDeviceInfo)
-                and isinstance(scan_result[1], DeviceCapabilities)
-            ):
-                device, caps = scan_result[0], scan_result[1]
-                unknown = (
-                    scan_result[2]
-                    if len(scan_result) > 2 and isinstance(scan_result[2], dict)
-                    else {}
-                )
-                return {
-                    "available_registers": {
-                        k: sorted(v) for k, v in scanner.available_registers.items()
-                    },
-                    "device_info": device.as_dict(),
-                    "capabilities": caps.as_dict(),
-                    "register_count": sum(len(v) for v in scanner.available_registers.values()),
-                    "unknown_registers": unknown,
-                }
-            if isinstance(scan_result, dict):
-                return scan_result
-            raise TypeError("scan() must return a dict")
+            return await _run_custom_scan(scanner)
         finally:
             await scanner.close()
-
-    if scanner.connection_type == CONNECTION_TYPE_RTU:
-        if not scanner.serial_port:
-            raise ConnectionException("Serial port not configured")
-        parity = SERIAL_PARITY_MAP.get(scanner.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
-        stop_bits = SERIAL_STOP_BITS_MAP.get(
-            scanner.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
-        )
-        rtu_transport_cls = getattr(scanner, "_rtu_transport_cls", RtuModbusTransport)
-        scanner._transport = rtu_transport_cls(
-            serial_port=scanner.serial_port,
-            baudrate=scanner.baud_rate,
-            parity=parity,
-            stopbits=stop_bits,
-            max_retries=scanner.retry,
-            base_backoff=scanner.backoff,
-            max_backoff=DEFAULT_MAX_BACKOFF,
-            timeout=scanner.timeout,
-        )
-    else:
-        mode = scanner._resolved_connection_mode or scanner.connection_mode
-        if mode is None or mode == CONNECTION_MODE_AUTO:
-            last_error: Exception | None = None
-            for selected_mode, transport, timeout in scanner._build_auto_tcp_attempts():
-                try:
-                    await asyncio.wait_for(transport.ensure_connected(), timeout=timeout)
-                    try:
-                        await transport.read_input_registers(scanner.slave_id, 0, count=2)
-                    except TimeoutError:
-                        raise
-                    except ModbusIOException as exc:
-                        if is_request_cancelled_error(exc):
-                            raise TimeoutError(str(exc)) from exc
-                    except (
-                        ModbusException,
-                        ConnectionException,
-                        OSError,
-                        TypeError,
-                        ValueError,
-                        AttributeError,
-                    ) as exc:
-                        _LOGGER.debug(
-                            "Protocol probe non-critical exception (protocol ok): %s", exc
-                        )
-                except (TimeoutError, ConnectionException, ModbusException, OSError) as exc:
-                    last_error = exc
-                    await transport.close()
-                    continue
-                scanner._transport = transport
-                scanner._resolved_connection_mode = selected_mode
-                _LOGGER.info(
-                    "scan_device: auto-selected Modbus transport %s for %s:%s",
-                    selected_mode,
-                    scanner.host,
-                    scanner.port,
-                )
-                break
-            if scanner._transport is None:
-                raise ConnectionException("Auto-detect Modbus transport failed") from last_error
-        else:
-            scanner._transport = scanner._build_tcp_transport(mode)
+    await _prepare_scan_transport(scanner)
 
     try:
         await asyncio.wait_for(scanner._transport.ensure_connected(), timeout=scanner.timeout)

--- a/tests/test_device_scanner_errors.py
+++ b/tests/test_device_scanner_errors.py
@@ -2,6 +2,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_device_info import (
+    DeviceCapabilities,
+    ScannerDeviceInfo,
+)
 
 
 async def _make_scanner(**kwargs):
@@ -51,6 +55,29 @@ async def test_scan_device_legacy_returns_dict():
         result = await scanner.scan_device()
 
     assert result == {"custom_key": "custom_value"}
+
+
+@pytest.mark.asyncio
+async def test_scan_device_legacy_tuple_result_is_normalized():
+    scanner = await _make_scanner()
+    scanner.available_registers["input_registers"].add("outside_temperature")
+    scanner.available_registers["holding_registers"].add("mode")
+
+    device = ScannerDeviceInfo(model="AirPack", serial_number="123")
+    caps = DeviceCapabilities(basic_control=True)
+
+    async def fake_scan_returns_tuple():
+        return (device, caps, {"input_registers": {99: 1}})
+
+    scanner.scan = fake_scan_returns_tuple  # type: ignore[method-assign]
+
+    with patch.object(scanner, "close", AsyncMock()):
+        result = await scanner.scan_device()
+
+    assert result["device_info"]["model"] == "AirPack"
+    assert result["capabilities"]["basic_control"] is True
+    assert result["register_count"] == 2
+    assert result["unknown_registers"] == {"input_registers": {99: 1}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Reduce complexity in `scan_device` by extracting cohesive orchestration responsibilities into focused helpers while preserving existing scan behavior and return shapes. 
- Make the overridden/legacy `scan()` return-path explicit and easier to test by centralizing normalization of legacy tuple and dict shapes. 
- Isolate transport selection/probing logic (auto-detect TCP and RTU construction) so the connection orchestration is clearer and easier to maintain. 

### Description
- Added `_normalize_custom_scan_result` and `_run_custom_scan` to normalize legacy/custom `scan()` return values (tuple `(ScannerDeviceInfo, DeviceCapabilities, unknown?)` or dict) into the standard scan payload. 
- Extracted TCP auto-detect probing into `_auto_detect_tcp_transport` and RTU transport construction into `_create_rtu_transport`, and unified transport selection into `_prepare_scan_transport`. 
- Replaced the large branching block in `scan_device` with calls to the new helpers so behavior is preserved but orchestration flow is simplified. 
- Added a test `test_scan_device_legacy_tuple_result_is_normalized` in `tests/test_device_scanner_errors.py` to validate normalization of the legacy tuple result shape. 

### Testing
- Ran lint and static checks with `ruff check custom_components tests tools` which passed. 
- Compiled sources with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed. 
- Ran register reference and maintainability checks with `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py` which passed. 
- Ran unit tests with `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` and `pytest tests/ -q` and all tests passed (some unrelated tests skipped); the new test passed. 
- Validated entity mappings with `python tools/validate_entity_mappings.py` and performed repository grep checks for forbidden imports/terms which all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f392c02c808326ba27871b504d36af)