### PR TITLE
refactor: decompose coordinator capability post-processing

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/capabilities.py
+++ b/custom_components/thessla_green_modbus/coordinator/capabilities.py
@@ -16,6 +16,23 @@ def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
+def _clamp_percentage(value: float) -> float:
+    """Clamp a percentage value into the [0, 100] range."""
+    return max(0.0, min(100.0, value))
+
+
+def _flow_balance_status(balance: float) -> str:
+    """Return flow-balance status label for a computed balance value."""
+    if abs(balance) < 10:
+        return "balanced"
+    return "supply_dominant" if balance > 0 else "exhaust_dominant"
+
+
+def _coerce_bypass_open(raw_bypass: Any) -> bool:
+    """Return whether bypass mode indicates an open bypass damper."""
+    return raw_bypass in (1, 2)
+
+
 class _CoordinatorCapabilitiesMixin:
     """Capability and derived-value logic for the coordinator."""
 
@@ -151,8 +168,7 @@ class _CoordinatorCapabilitiesMixin:
         #     Note: this device exposes only 3 temperature sensors (TZ1, TN1, TP);
         #     the exhaust-outlet sensor TW is absent, so EN 308 η_exhaust and the
         #     Belgian mean-efficiency (η_epbd) cannot be computed.
-        bypass_raw = data.get("bypass_mode")
-        bypass_open = bypass_raw in (1, 2)
+        bypass_open = _coerce_bypass_open(data.get("bypass_mode"))
         if (
             all(
                 k in data
@@ -189,7 +205,7 @@ class _CoordinatorCapabilitiesMixin:
                         raw = (supply - outside) / (exhaust - outside)
 
                     efficiency = round(raw * 100, 1)
-                    data["calculated_efficiency"] = max(0.0, min(100.0, efficiency))
+                    data["calculated_efficiency"] = _clamp_percentage(efficiency)
                     data["heat_recovery_efficiency"] = data["calculated_efficiency"]
             except (ZeroDivisionError, TypeError, ValueError) as exc:
                 _LOGGER.debug("Could not calculate efficiency: %s", exc)
@@ -211,13 +227,7 @@ class _CoordinatorCapabilitiesMixin:
             try:
                 balance = float(data["supply_flow_rate"]) - float(data["exhaust_flow_rate"])
                 data["flow_balance"] = balance
-                data["flow_balance_status"] = (
-                    "balanced"
-                    if abs(balance) < 10
-                    else "supply_dominant"
-                    if balance > 0
-                    else "exhaust_dominant"
-                )
+                data["flow_balance_status"] = _flow_balance_status(balance)
             except (TypeError, ValueError) as exc:
                 _LOGGER.debug("Could not calculate flow balance: %s", exc)
         power = self.calculate_power_consumption(data)

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -6,6 +6,11 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+from custom_components.thessla_green_modbus.coordinator.capabilities import (
+    _clamp_percentage,
+    _coerce_bypass_open,
+    _flow_balance_status,
+)
 
 
 def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
@@ -52,6 +57,28 @@ def test_calculate_power_consumption_invalid_type_returns_none():
     coord = _make_coordinator()
     result = coord.calculate_power_consumption({"dac_supply": "bad", "dac_exhaust": 5.0})
     assert result is None
+
+
+def test_flow_balance_status_helper():
+    """flow balance helper should preserve existing status semantics."""
+    assert _flow_balance_status(9.99) == "balanced"
+    assert _flow_balance_status(10.0) == "supply_dominant"
+    assert _flow_balance_status(-10.0) == "exhaust_dominant"
+
+
+def test_clamp_percentage_helper():
+    """percentage helper should clamp values into 0-100."""
+    assert _clamp_percentage(-5.0) == 0.0
+    assert _clamp_percentage(42.5) == 42.5
+    assert _clamp_percentage(123.0) == 100.0
+
+
+def test_coerce_bypass_open_helper():
+    """bypass helper should only mark known open modes."""
+    assert _coerce_bypass_open(1) is True
+    assert _coerce_bypass_open(2) is True
+    assert _coerce_bypass_open(0) is False
+    assert _coerce_bypass_open("1") is False
 
 
 # ---------------------------------------------------------------------------
@@ -166,4 +193,3 @@ def test_post_process_data_naive_now_aware_last_ts():
         data = {"dac_supply": 3.0, "dac_exhaust": 3.0}
         result = coord._post_process_data(data)
     assert "estimated_power" in result
-


### PR DESCRIPTION
### Motivation
- Reduce inline branching and improve readability of `_post_process_data` by extracting small pure helpers for capability/state normalization.
- Make flow-balance, bypass-mode coercion and efficiency clamping logic easier to test and reason about without changing runtime semantics.
- Preserve all existing data keys, semantics and the `_CoordinatorCapabilitiesMixin` public surface while making the normalization code more maintainable.

### Description
- Added three pure helpers in `custom_components/thessla_green_modbus/coordinator/capabilities.py`: `_coerce_bypass_open`, `_clamp_percentage`, and `_flow_balance_status`.
- Replaced inline normalization/branching inside `_post_process_data` to delegate bypass detection, efficiency clamping and flow-balance labeling to the new helpers.
- Added focused unit tests in `tests/test_coordinator_update.py` (`test_flow_balance_status_helper`, `test_clamp_percentage_helper`, `test_coerce_bypass_open_helper`) to lock the extracted behavior.
- Kept the `_CoordinatorCapabilitiesMixin` API and `_post_process_data` external behavior unchanged.

### Testing
- Ran lint and static checks via `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed.
- Ran repository validation gates `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both passed.
- Ran unit tests `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` and full test suite `pytest tests/ -q`, and all tests passed (with existing skips).
- Ran entity mappings validation `python tools/validate_entity_mappings.py` and the coordinator package API audit (`__all__` assertion), both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f392cfb63c8326a137966771aaf2ce)