### PR TITLE
refactor: decompose config flow validation result handling

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow_device_validation.py
+++ b/custom_components/thessla_green_modbus/config_flow_device_validation.py
@@ -80,6 +80,26 @@ def _validate_scan_result(scan_result: Any) -> dict[str, Any]:
     return scan_result
 
 
+def _build_validation_result(
+    *,
+    name: str,
+    scan_result: dict[str, Any],
+    capabilities_cls: type,
+    process_scan_capabilities: Callable[[dict[str, Any], type], dict[str, Any]],
+) -> dict[str, Any]:
+    """Attach normalized capabilities and build final payload."""
+    scan_result["capabilities"] = process_scan_capabilities(scan_result, capabilities_cls)
+    return _build_success_payload(name, scan_result)
+
+
+def _require_verify_connection(scanner: Any) -> Callable[[], Any]:
+    """Return scanner verify callback or raise when missing."""
+    verify_cb = getattr(scanner, "verify_connection", None)
+    if not callable(verify_cb):
+        raise AttributeError("verify_connection")
+    return verify_cb
+
+
 def _build_timeout_runner(
     *,
     run_with_retry: Callable[[Callable[[], Awaitable[Any]], int, float], Awaitable[Any]],
@@ -115,9 +135,7 @@ async def _run_scanner_validation(
 ) -> dict[str, Any]:
     """Run connection verification and device scan."""
     short_timeout = max(2, timeout)
-    verify_cb = getattr(scanner, "verify_connection", None)
-    if not callable(verify_cb):
-        raise AttributeError("verify_connection")
+    verify_cb = _require_verify_connection(scanner)
     await run_scanner_call(verify_cb, short_timeout)
     return _validate_scan_result(await run_scanner_call(scanner.scan_device, timeout))
 
@@ -283,9 +301,12 @@ async def validate_input_impl(
             run_scanner_call=run_scanner_call,
         )
 
-        caps_dict = process_scan_capabilities(scan_result, capabilities_cls)
-        scan_result["capabilities"] = caps_dict
-        return _build_success_payload(params["name"], scan_result)
+        return _build_validation_result(
+            name=params["name"],
+            scan_result=scan_result,
+            capabilities_cls=capabilities_cls,
+            process_scan_capabilities=process_scan_capabilities,
+        )
     except asyncio.CancelledError:
         raise
     except CannotConnect:

--- a/tests/test_config_flow_runtime_validation.py
+++ b/tests/test_config_flow_runtime_validation.py
@@ -1,5 +1,10 @@
 """Runtime helper behavior tests for config flow validation."""
 
+import pytest
+from custom_components.thessla_green_modbus.config_flow_device_validation import (
+    _build_validation_result,
+    _require_verify_connection,
+)
 from custom_components.thessla_green_modbus.scanner.core import DeviceCapabilities
 
 
@@ -13,3 +18,28 @@ def test_device_capabilities_serialization():
     assert list(caps.keys()) == list(serialized.keys())
     assert list(caps.items()) == list(serialized.items())
     assert list(caps.values()) == list(serialized.values())
+
+
+def test_require_verify_connection_rejects_missing_method():
+    with pytest.raises(AttributeError, match="verify_connection"):
+        _require_verify_connection(object())
+
+
+def test_build_validation_result_attaches_capabilities():
+    scan_result = {"device_info": {"model": "x"}}
+
+    def _fake_caps(result, cls):
+        assert result is scan_result
+        assert cls is DeviceCapabilities
+        return {"basic_control": True}
+
+    payload = _build_validation_result(
+        name="Test Device",
+        scan_result=scan_result,
+        capabilities_cls=DeviceCapabilities,
+        process_scan_capabilities=_fake_caps,
+    )
+
+    assert payload["title"] == "Test Device"
+    assert payload["device_info"] == {"model": "x"}
+    assert payload["scan_result"]["capabilities"] == {"basic_control": True}


### PR DESCRIPTION
### Motivation
- Further decompose config-flow device validation to isolate success-payload construction and scanner precondition checks used by `validate_input_impl` while preserving existing behaviour and error mapping.

### Description
- Extracted `_build_validation_result` to centralize capabilities normalization and success payload construction while preserving the returned shape (`title`, `device_info`, `scan_result`).
- Extracted `_require_verify_connection` to validate the scanner `verify_connection` precondition and reused it inside `_run_scanner_validation` to preserve the same `AttributeError("verify_connection")` path.
- Replaced inline capability attachment in `validate_input_impl` with a call to `_build_validation_result` so the flow semantics remain unchanged.
- Added focused tests in `tests/test_config_flow_runtime_validation.py` that assert missing `verify_connection` is rejected and capabilities are attached to the validation payload.

### Testing
- Ran linting with `ruff check custom_components tests tools` and code compilation with `python -m compileall -q custom_components/thessla_green_modbus tests tools` and fixed reported import ordering; checks passed after fixes.
- Ran `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py` and the maintainability gate passed.
- Ran `pytest -q tests/test_config_flow*.py` and `pytest tests/ -q` and all tests passed (with 4 skipped), and `python tools/validate_entity_mappings.py` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a50bd4488326856fac0a7ada22e1)