### PR TITLE
refactor: decompose modbus call helper logic

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -336,6 +336,36 @@ def _log_modbus_response(func_name: str, response: Any) -> None:
         _LOGGER.debug("Modbus response: %s", _mask_frame(encoded))
 
 
+def _calculate_batch_size(kwargs: dict[str, Any]) -> int:
+    """Calculate batch size metadata for request logging."""
+    return kwargs.get("count") or len(kwargs.get("values", [])) or 1
+
+
+def _classify_modbus_exception(err: Exception) -> str:
+    """Return exception class for Modbus call logging."""
+    if isinstance(err, ModbusIOException) and "request cancelled" in str(err).lower():
+        return "cancelled"
+    return "failed"
+
+
+async def _dispatch_modbus_call(
+    func: Callable[..., Awaitable[Any]],
+    positional: list[Any],
+    kwargs: dict[str, Any],
+    kwarg: str,
+    slave_id: int,
+    timeout: float | None,
+) -> Any:
+    """Dispatch a Modbus callable with optional external timeout."""
+
+    async def _invoke() -> Any:
+        return await _invoke_with_slave_kwarg(func, positional, kwargs, kwarg, slave_id)
+
+    if timeout is not None and _should_apply_external_timeout(func):
+        return await asyncio.wait_for(_invoke(), timeout=timeout)
+    return await _invoke()
+
+
 async def _call_modbus(
     func: Callable[..., Awaitable[Any]],
     slave_id: int,
@@ -363,7 +393,7 @@ async def _call_modbus(
     kwarg = _resolve_slave_kwarg(func, params, signature)
 
     func_name = getattr(func, "__name__", repr(func))
-    batch_size = kwargs.get("count") or len(kwargs.get("values", [])) or 1
+    batch_size = _calculate_batch_size(kwargs)
 
     delay = 0.0
     if apply_backoff:
@@ -401,14 +431,15 @@ async def _call_modbus(
         kwargs=kwargs,
     )
 
-    async def _invoke() -> Any:
-        return await _invoke_with_slave_kwarg(func, positional, kwargs, kwarg, slave_id)
-
     try:
-        if timeout is not None and _should_apply_external_timeout(func):
-            response = await asyncio.wait_for(_invoke(), timeout=timeout)
-        else:
-            response = await _invoke()
+        response = await _dispatch_modbus_call(
+            func=func,
+            positional=positional,
+            kwargs=kwargs,
+            kwarg=kwarg,
+            slave_id=slave_id,
+            timeout=timeout,
+        )
     except TimeoutError as err:
         _LOGGER.debug("Call to %s timed out on attempt %s/%s", func_name, attempt, max_attempts)
         raise TimeoutError("Modbus request timed out") from err
@@ -423,7 +454,8 @@ async def _call_modbus(
         TypeError,
         ValueError,
     ) as err:
-        if isinstance(err, ModbusIOException) and "request cancelled" in str(err).lower():
+        classification = _classify_modbus_exception(err)
+        if classification == "cancelled":
             _LOGGER.debug("Call to %s cancelled on attempt %s/%s", func_name, attempt, max_attempts)
         else:
             _LOGGER.debug("Call to %s failed on attempt %s/%s", func_name, attempt, max_attempts)

--- a/tests/test_modbus_helpers.py
+++ b/tests/test_modbus_helpers.py
@@ -25,10 +25,13 @@ sys.modules["custom_components.thessla_green_modbus.registers"] = types.SimpleNa
     get_registers_by_function=loader_stub.get_registers_by_function,
 )
 
+from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
 from custom_components.thessla_green_modbus.modbus_helpers import (
     _KWARG_CACHE,
     _SIG_CACHE,
+    _calculate_batch_size,
     _call_modbus,
+    _classify_modbus_exception,
     async_close_client,
     group_reads,
 )
@@ -319,6 +322,32 @@ def test_calculate_backoff_jitter_float():
 
     delay = _calculate_backoff_delay(base=1.0, attempt=2, jitter=0.5)
     assert delay >= 1.0
+
+
+def test_calculate_batch_size_prefers_count():
+    """Count keyword takes precedence for logging batch size."""
+    assert _calculate_batch_size({"count": 7, "values": [1, 2]}) == 7
+
+
+def test_calculate_batch_size_uses_values_length():
+    """Values length is used when count is absent."""
+    assert _calculate_batch_size({"values": [1, 2, 3]}) == 3
+
+
+def test_calculate_batch_size_defaults_to_one():
+    """Empty kwargs defaults to one request item."""
+    assert _calculate_batch_size({}) == 1
+
+
+def test_classify_modbus_exception_cancelled():
+    """Cancelled request exceptions are classified as cancelled."""
+    err = ModbusIOException("Request cancelled by remote peer")
+    assert _classify_modbus_exception(err) == "cancelled"
+
+
+def test_classify_modbus_exception_failed():
+    """Non-cancelled exceptions are classified as failed."""
+    assert _classify_modbus_exception(ValueError("bad")) == "failed"
 
 
 def test_calculate_backoff_no_jitter_zero_attempt():


### PR DESCRIPTION
### Motivation
- Reduce complexity inside `_call_modbus` by extracting narrow helpers for clearer responsibilities and easier testing.
- Keep Modbus behavior, timeout/cancellation, and retry/backoff semantics unchanged while improving readability and testability.

### Description
- Added `_calculate_batch_size`, `_dispatch_modbus_call`, and `_classify_modbus_exception` to encapsulate batch-size metadata, timeout-aware dispatch, and exception classification respectively.
- Updated `_call_modbus` to delegate batch-size computation, call dispatch, and exception classification to the new helpers while preserving signature normalization, logging, backoff sleeps, and exception propagation.
- Added focused unit tests in `tests/test_modbus_helpers.py` to validate batch-size rules and exception classification behavior.
- Changed files: `custom_components/thessla_green_modbus/modbus_helpers.py` and `tests/test_modbus_helpers.py`.

### Testing
- Ran `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed.
- Ran repository validation scripts `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both passed.
- Ran targeted tests `pytest -q tests/test_modbus_helpers.py tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py` which passed.
- Ran full test suite `pytest tests/ -q` which passed with 4 skipped, and `python tools/validate_entity_mappings.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a505938c8326afae5b0b4a6e517b)