### PR TITLE
refactor: extract per-target runner to shrink maintenance handler breadth

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import datetime as _dt
 
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -60,22 +61,36 @@ def _maintenance_registrations():
     ]
 
 
+async def _run_for_targets(
+    hass: HomeAssistant,
+    call: ServiceCall,
+    deps: ServiceHandlerDeps,
+    action: Callable[[str, object], Awaitable[bool]],
+) -> None:
+    """Run a maintenance action for each targeted coordinator."""
+    for entity_id, coordinator in _iter_targets(hass, call, deps):
+        await action(entity_id, coordinator)
+
+
 def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
     """Register maintenance services."""
 
     async def reset_filters(call: ServiceCall) -> None:
         filter_value = filter_reset_value(deps.normalize_option, call.data["filter_type"])
-        for entity_id, coordinator in _iter_targets(hass, call, deps):
+        async def _reset_filters_for_target(entity_id: str, coordinator: object) -> bool:
             if not await deps.write_register(coordinator, "filter_change", filter_value, entity_id, "reset filters"):
                 deps.logger.error("Failed to reset filters for %s", entity_id)
-                continue
+                return False
             await refresh_and_log_success(coordinator, deps.logger, "Reset filters for %s", entity_id)
+            return True
+
+        await _run_for_targets(hass, call, deps, _reset_filters_for_target)
 
     async def reset_settings(call: ServiceCall) -> None:
         reset_type = deps.normalize_option(call.data["reset_type"])
         registers = reset_settings_registers(reset_type)
 
-        for entity_id, coordinator in _iter_targets(hass, call, deps):
+        async def _reset_settings_for_target(entity_id: str, coordinator: object) -> bool:
             if not await write_register_batch(
                 coordinator,
                 registers,
@@ -88,13 +103,16 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                     "hard_reset_schedule": "Failed to reset schedule settings for %s",
                 },
             ):
-                continue
+                return False
             await refresh_and_log_success(
                 coordinator, deps.logger, "Reset settings (%s) for %s", reset_type, entity_id
             )
+            return True
+
+        await _run_for_targets(hass, call, deps, _reset_settings_for_target)
 
     async def start_pressure_test(call: ServiceCall) -> None:
-        for entity_id, coordinator in _iter_targets(hass, call, deps):
+        async def _start_pressure_test_for_target(entity_id: str, coordinator: object) -> bool:
             if not await write_register_batch(
                 coordinator,
                 pressure_test_payload(deps.dt_now()),
@@ -107,15 +125,17 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                     "pres_check_time_2": "Failed to start pressure test for %s",
                 },
             ):
-                continue
+                return False
             await refresh_and_log_success(coordinator, deps.logger, "Started pressure test for %s", entity_id)
+            return True
+
+        await _run_for_targets(hass, call, deps, _start_pressure_test_for_target)
 
     async def set_modbus_parameters(call: ServiceCall) -> None:
         port, baud_rate, parity, stop_bits = normalize_modbus_options(deps.normalize_option, call.data)
 
-        for entity_id, coordinator in _iter_targets(hass, call, deps):
+        async def _set_modbus_parameters_for_target(entity_id: str, coordinator: object) -> bool:
             writes = iter_modbus_parameter_writes(port, baud_rate, parity, stop_bits)
-            failed = False
             for register_name, option_value, option_map, error_message in writes:
                 if not await write_mapped_optional_register(
                     coordinator,
@@ -128,15 +148,15 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                     deps.write_register,
                     deps.logger,
                 ):
-                    failed = True
-                    break
-            if failed:
-                continue
+                    return False
             await refresh_and_log_success(coordinator, deps.logger, "Set Modbus parameters for %s", entity_id)
+            return True
+
+        await _run_for_targets(hass, call, deps, _set_modbus_parameters_for_target)
 
     async def set_device_name(call: ServiceCall) -> None:
         device_name = call.data["device_name"]
-        for entity_id, coordinator in _iter_targets(hass, call, deps):
+        async def _set_device_name_for_target(entity_id: str, coordinator: object) -> bool:
             try:
                 if len(device_name) >= 16:
                     success = await coordinator.async_write_register("device_name", device_name, refresh=False)
@@ -148,16 +168,19 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                     )
                 if not success:
                     deps.logger.error("Failed to set device name for %s", entity_id)
-                    continue
+                    return False
             except (ModbusException, ConnectionException) as err:
                 deps.logger.error("Failed to set device name for %s: %s", entity_id, err)
-                continue
+                return False
             await refresh_and_log_success(
                 coordinator, deps.logger, "Set device name to '%s' for %s", device_name, entity_id
             )
+            return True
+
+        await _run_for_targets(hass, call, deps, _set_device_name_for_target)
 
     async def sync_time(call: ServiceCall) -> None:
-        for entity_id, coordinator in _iter_targets(hass, call, deps):
+        async def _sync_time_for_target(entity_id: str, coordinator: object) -> bool:
             now = _dt.now()
             try:
                 success = await coordinator.async_write_registers(
@@ -171,6 +194,9 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                     deps.logger.error("Failed to sync clock for %s", entity_id)
             except (ModbusException, ConnectionException) as err:
                 deps.logger.error("Failed to sync clock for %s: %s", entity_id, err)
+            return True
+
+        await _run_for_targets(hass, call, deps, _sync_time_for_target)
 
     handlers = {
         "reset_filters": reset_filters,


### PR DESCRIPTION
### Motivation
- Reduce breadth and duplication in maintenance service handlers by centralizing the coordinator/target iteration pattern. 
- Improve testability and readability while preserving existing service behavior, schemas, and logging/error handling. 

### Description
- Added a reusable helper `async def _run_for_targets(hass, call, deps, action)` to centralize iterating `deps.iter_target_coordinators` in `custom_components/thessla_green_modbus/services_handlers_maintenance.py`. 
- Refactored each maintenance handler (`reset_filters`, `reset_settings`, `start_pressure_test`, `set_modbus_parameters`, `set_device_name`, `sync_time`) to build a per-target async closure and invoke it via `_run_for_targets`, keeping all original write/refresh/error/log paths intact. 
- Did not change service names, registration rows returned by `_maintenance_registrations()`, schemas, or logging semantics. 

### Testing
- Ran lint and formatting checks with `ruff check custom_components tests tools` and applied the auto-fix; the check passed. 
- Verified bytecode compilation with `python -m compileall -q custom_components/thessla_green_modbus tests tools`, which passed. 
- Ran register consistency with `python tools/compare_registers_with_reference.py`, which ran and reported existing expected diffs (integration extras/name mismatches) but completed successfully. 
- Ran maintainability gate with `python tools/check_maintainability.py`, which passed. 
- Executed focused handler tests with `pytest -q tests/test_services*.py tests/test_services_handlers_*.py`, which passed. 
- Executed full test suite with `pytest tests/ -q`, which passed (4 skipped). 
- Validated entity mappings with `python tools/validate_entity_mappings.py`, which passed. 

Additional notes: changed file `custom_components/thessla_green_modbus/services_handlers_maintenance.py` only; commit hash is `5844fb94`. All automated checks and tests listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a4fd82548326a1521d7746e2345d)