### PR TITLE
refactor: extract shared mapping payload helpers

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -28,6 +28,9 @@ from ._mapping_classification import (
 from ._mapping_classification import (
     classify_min_max_mapping as _classify_min_max_mapping,
 )
+from ._mapping_payloads import (
+    parse_info_states as _parse_info_states,
+)
 
 _TIME_ENTITY_PREFIXES = (
     "schedule_",
@@ -53,21 +56,6 @@ def _is_mapped_as_binary_source(register: str, binary_mappings: dict[str, dict[s
 def _is_problem_register(register: str) -> bool:
     """Return True for diagnostic/problem registers handled as binary sensors."""
     return register in {"alarm", "error"} or register.startswith(("s_", "e_", "f_"))
-
-
-def _parse_info_states(info_text: str) -> dict[str, int]:
-    """Parse '0 - foo; 1 - bar' style info text into state mapping."""
-    states: dict[str, int] = {}
-    for part in info_text.split(";"):
-        part = part.strip()
-        if " - " not in part:
-            continue
-        val_str, label = part.split(" - ", 1)
-        try:
-            states[_to_snake_case(label)] = int(val_str.strip())
-        except ValueError:
-            continue
-    return states
 
 
 def _is_register_mapped_anywhere(register: str, mappings: tuple[dict[str, Any], ...]) -> bool:
@@ -103,36 +91,6 @@ def _build_season_setting_mapping(register: str) -> dict[str, Any]:
         "icon": "mdi:fan",
         "register_type": "holding_registers",
         "states": PERCENT_10_SELECT_STATES,
-    }
-
-
-def _build_switch_mapping(register: str) -> dict[str, Any]:
-    """Return standard mapping payload for writable on/off style registers."""
-    return {
-        "icon": "mdi:toggle-switch",
-        "register": register,
-        "register_type": "holding_registers",
-        "category": None,
-        "translation_key": register,
-    }
-
-
-def _build_binary_toggle_mapping(register: str) -> dict[str, Any]:
-    """Return standard mapping payload for read-only on/off style registers."""
-    return {
-        "translation_key": register,
-        "icon": "mdi:checkbox-marked-circle-outline",
-        "register_type": "holding_registers",
-    }
-
-
-def _build_select_mapping(register: str, states: dict[str, int]) -> dict[str, Any]:
-    """Return standard mapping payload for select entities based on states."""
-    return {
-        "icon": "mdi:format-list-bulleted",
-        "translation_key": register,
-        "states": states,
-        "register_type": "holding_registers",
     }
 
 

--- a/custom_components/thessla_green_modbus/mappings/_mapping_classification.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_classification.py
@@ -6,47 +6,18 @@ from typing import Any
 
 from ..utils import _to_snake_case
 from ._helpers import _infer_icon
-
-
-def _build_switch_mapping(register: str) -> dict[str, Any]:
-    return {
-        "icon": "mdi:toggle-switch",
-        "register": register,
-        "register_type": "holding_registers",
-        "category": None,
-        "translation_key": register,
-    }
-
-
-def _build_binary_toggle_mapping(register: str) -> dict[str, Any]:
-    return {
-        "translation_key": register,
-        "icon": "mdi:checkbox-marked-circle-outline",
-        "register_type": "holding_registers",
-    }
-
-
-def _build_select_mapping(register: str, states: dict[str, int]) -> dict[str, Any]:
-    return {
-        "icon": "mdi:format-list-bulleted",
-        "translation_key": register,
-        "states": states,
-        "register_type": "holding_registers",
-    }
-
-
-def _parse_info_states(info_text: str) -> dict[str, int]:
-    states: dict[str, int] = {}
-    for part in info_text.split(";"):
-        part = part.strip()
-        if " - " not in part:
-            continue
-        val_str, label = part.split(" - ", 1)
-        try:
-            states[_to_snake_case(label)] = int(val_str.strip())
-        except ValueError:
-            continue
-    return states
+from ._mapping_payloads import (
+    build_binary_toggle_mapping as _build_binary_toggle_mapping,
+)
+from ._mapping_payloads import (
+    build_select_mapping as _build_select_mapping,
+)
+from ._mapping_payloads import (
+    build_switch_mapping as _build_switch_mapping,
+)
+from ._mapping_payloads import (
+    parse_info_states as _parse_info_states,
+)
 
 
 def classify_enum_mapping(

--- a/custom_components/thessla_green_modbus/mappings/_mapping_payloads.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_payloads.py
@@ -1,0 +1,52 @@
+"""Shared payload and parsing helpers for mapping classification/builders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..utils import _to_snake_case
+
+
+def build_switch_mapping(register: str) -> dict[str, Any]:
+    """Return standard mapping payload for writable on/off style registers."""
+    return {
+        "icon": "mdi:toggle-switch",
+        "register": register,
+        "register_type": "holding_registers",
+        "category": None,
+        "translation_key": register,
+    }
+
+
+def build_binary_toggle_mapping(register: str) -> dict[str, Any]:
+    """Return standard mapping payload for read-only on/off style registers."""
+    return {
+        "translation_key": register,
+        "icon": "mdi:checkbox-marked-circle-outline",
+        "register_type": "holding_registers",
+    }
+
+
+def build_select_mapping(register: str, states: dict[str, int]) -> dict[str, Any]:
+    """Return standard mapping payload for select entities based on states."""
+    return {
+        "icon": "mdi:format-list-bulleted",
+        "translation_key": register,
+        "states": states,
+        "register_type": "holding_registers",
+    }
+
+
+def parse_info_states(info_text: str) -> dict[str, int]:
+    """Parse '0 - foo; 1 - bar' style info text into state mapping."""
+    states: dict[str, int] = {}
+    for part in info_text.split(";"):
+        part = part.strip()
+        if " - " not in part:
+            continue
+        val_str, label = part.split(" - ", 1)
+        try:
+            states[_to_snake_case(label)] = int(val_str.strip())
+        except ValueError:
+            continue
+    return states

--- a/tests/test_entity_mappings_helpers.py
+++ b/tests/test_entity_mappings_helpers.py
@@ -3,18 +3,26 @@
 from types import SimpleNamespace
 
 from custom_components.thessla_green_modbus.mappings._mapping_builders import (
-    _build_binary_toggle_mapping,
     _build_problem_binary_mapping,
-    _build_select_mapping,
-    _build_switch_mapping,
     _build_time_like_mapping,
     _is_already_mapped,
     _is_mapped_as_binary_source,
     _is_problem_register,
     _is_register_mapped_anywhere,
     _is_unmappable_holding_register,
-    _parse_info_states,
     _route_enum_or_min_max_mapping,
+)
+from custom_components.thessla_green_modbus.mappings._mapping_payloads import (
+    build_binary_toggle_mapping as _build_binary_toggle_mapping,
+)
+from custom_components.thessla_green_modbus.mappings._mapping_payloads import (
+    build_select_mapping as _build_select_mapping,
+)
+from custom_components.thessla_green_modbus.mappings._mapping_payloads import (
+    build_switch_mapping as _build_switch_mapping,
+)
+from custom_components.thessla_green_modbus.mappings._mapping_payloads import (
+    parse_info_states as _parse_info_states,
 )
 from custom_components.thessla_green_modbus.mappings._static_discrete import (
     _select_payload,


### PR DESCRIPTION
### Motivation

- Reduce duplication and further decompose the large `_mapping_builders.py` by extracting repeated payload construction and state-parsing logic into a single helper module. 
- Make enum/min-max classification and mapping builders reuse the same payload constructors to keep entity mapping output stable while simplifying maintenance.

### Description

- Added `custom_components/thessla_green_modbus/mappings/_mapping_payloads.py` with shared helpers `build_switch_mapping`, `build_binary_toggle_mapping`, `build_select_mapping`, and `parse_info_states` to centralize payload construction and parsing. 
- Updated `custom_components/thessla_green_modbus/mappings/_mapping_classification.py` to import and use the new payload helpers instead of keeping duplicate implementations. 
- Updated `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` to import `parse_info_states` from the new module and removed the duplicated parsing/build payload code there. 
- Adjusted `tests/test_entity_mappings_helpers.py` to validate the extracted helpers and preserve the exact mapping payload shapes asserted by tests.

### Testing

- Ran lint and formatting with `ruff check custom_components tests tools` which passed after automatic fixes. 
- Compiled sources with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed. 
- Ran reference checks with `python tools/compare_registers_with_reference.py` which completed (reported integration extras/mismatches but unchanged by this refactor). 
- Maintainability gate `python tools/check_maintainability.py` passed. 
- Entity mapping validation `python tools/validate_entity_mappings.py` passed: `OK: 366 entities validated`. 
- Unit tests: `pytest -q tests/test_entity_mappings*.py` and full `pytest tests/ -q` both passed in this environment with 4 skipped. 

Commit: `c52756c4a083a0f79d80e5237caf9100b02dcb1a`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a4eee06083269fd5a297d4439ee2)