### PR TITLE
refactor: extract coordinator connection state helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/connection_state.py
+++ b/custom_components/thessla_green_modbus/coordinator/connection_state.py
@@ -1,0 +1,22 @@
+"""Connection state transitions for coordinator runtime bookkeeping."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any
+
+
+def mark_connection_established(*, offline_state_setter: Any) -> None:
+    """Mark coordinator runtime as connected."""
+    offline_state_setter(False)
+
+
+def mark_connection_failure(*, statistics: MutableMapping[str, Any], offline_state_setter: Any) -> None:
+    """Record connection failure counters and switch coordinator offline."""
+    statistics["connection_errors"] += 1
+    offline_state_setter(True)
+
+
+def mark_connection_disconnected(*, offline_state_setter: Any) -> None:
+    """Mark coordinator runtime as disconnected."""
+    offline_state_setter(True)

--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -116,6 +116,15 @@ from .connection import (
 from .connection import (
     setup_client_with_retry as _setup_client_with_retry_impl,
 )
+from .connection_state import (
+    mark_connection_disconnected as _mark_connection_disconnected_impl,
+)
+from .connection_state import (
+    mark_connection_established as _mark_connection_established_impl,
+)
+from .connection_state import (
+    mark_connection_failure as _mark_connection_failure_impl,
+)
 from .io import _ModbusIOMixin
 from .lifecycle import async_setup as _async_setup_impl
 from .models import CoordinatorConfig
@@ -710,20 +719,26 @@ class ThesslaGreenModbusCoordinator(
                     client=self.client,
                 )
                 _LOGGER.debug("Modbus connection established")
-                self.offline_state = False
+                _mark_connection_established_impl(offline_state_setter=lambda value: setattr(self, "offline_state", value))
             except (ModbusException, ConnectionException) as exc:
-                self.statistics["connection_errors"] += 1
-                self.offline_state = True
+                _mark_connection_failure_impl(
+                    statistics=self.statistics,
+                    offline_state_setter=lambda value: setattr(self, "offline_state", value),
+                )
                 _LOGGER.exception("Failed to establish connection: %s", exc)
                 raise
             except TimeoutError as exc:
-                self.statistics["connection_errors"] += 1
-                self.offline_state = True
+                _mark_connection_failure_impl(
+                    statistics=self.statistics,
+                    offline_state_setter=lambda value: setattr(self, "offline_state", value),
+                )
                 _LOGGER.warning("Connection attempt timed out: %s", exc)
                 raise
             except OSError as exc:
-                self.statistics["connection_errors"] += 1
-                self.offline_state = True
+                _mark_connection_failure_impl(
+                    statistics=self.statistics,
+                    offline_state_setter=lambda value: setattr(self, "offline_state", value),
+                )
                 _LOGGER.exception("Unexpected error establishing connection: %s", exc)
                 raise
 
@@ -757,7 +772,9 @@ class ThesslaGreenModbusCoordinator(
             await self._close_client_connection()
 
         self.client = None
-        self.offline_state = True
+        _mark_connection_disconnected_impl(
+            offline_state_setter=lambda value: setattr(self, "offline_state", value)
+        )
         _LOGGER.debug("Disconnected from Modbus device")
 
     async def _close_client_connection(self) -> None:

--- a/tests/test_coordinator_connection_state.py
+++ b/tests/test_coordinator_connection_state.py
@@ -1,0 +1,40 @@
+"""Tests for coordinator connection state bookkeeping helpers."""
+
+from __future__ import annotations
+
+from custom_components.thessla_green_modbus.coordinator.connection_state import (
+    mark_connection_disconnected,
+    mark_connection_established,
+    mark_connection_failure,
+)
+
+
+def test_mark_connection_established_sets_online() -> None:
+    holder = {"offline": True}
+
+    mark_connection_established(offline_state_setter=lambda value: holder.__setitem__("offline", value))
+
+    assert holder["offline"] is False
+
+
+def test_mark_connection_failure_increments_counter_and_sets_offline() -> None:
+    holder = {"offline": False}
+    statistics = {"connection_errors": 2}
+
+    mark_connection_failure(
+        statistics=statistics,
+        offline_state_setter=lambda value: holder.__setitem__("offline", value),
+    )
+
+    assert statistics["connection_errors"] == 3
+    assert holder["offline"] is True
+
+
+def test_mark_connection_disconnected_sets_offline() -> None:
+    holder = {"offline": False}
+
+    mark_connection_disconnected(
+        offline_state_setter=lambda value: holder.__setitem__("offline", value)
+    )
+
+    assert holder["offline"] is True


### PR DESCRIPTION
### Motivation

- Reduce complexity in `ThesslaGreenModbusCoordinator` by extracting connection-state bookkeeping into a focused helper so the coordinator keeps HA-facing orchestration only while preserving runtime behavior.  
- Isolate connection-related state transitions (online/offline flag and connection error counter) to make the coordinator easier to test and maintain.  

### Description

- Added `custom_components/thessla_green_modbus/coordinator/connection_state.py` implementing `mark_connection_established`, `mark_connection_failure`, and `mark_connection_disconnected`.  
- Updated `custom_components/thessla_green_modbus/coordinator/coordinator.py` to import and delegate connection-state transitions in `_ensure_connected` exception handlers and `_disconnect_locked` to the new helper functions.  
- Added unit tests `tests/test_coordinator_connection_state.py` that validate online transition, failure counter increment + offline transition, and disconnect offline transition.  
- Commit created: `ee544e72`, and the coordinator package-root API was preserved (`__all__` unchanged).  

### Testing

- Ran `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed.  
- Ran `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both passed.  
- Ran `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` and `pytest tests/ -q`, and all tests passed (full pytest passed with 4 skipped).  
- Ran `python tools/validate_entity_mappings.py` and the coordinator `__all__` audit, both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a4e8022083268caebe4822a6cede)