### PR TITLE
refactor: decompose scanner input read path

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -191,6 +191,47 @@ def _should_skip_holding_range(scanner: Any, start: int, end: int, skip_cache: b
     return True, cached_failed_range[0], cached_failed_range[1]
 
 
+def _prepare_input_read(scanner: Any, start: int, end: int, skip_cache: bool) -> bool:
+    """Return True when input read should short-circuit as failed/unsupported."""
+    should_skip, skip_start, skip_end = _should_skip_input_range(scanner, start, end, skip_cache)
+    if not should_skip:
+        return False
+    if (skip_start, skip_end) != (start, end) and (skip_start, skip_end) not in scanner._input_skip_log_ranges:
+        _LOGGER.debug("Skipping cached failed input registers %d-%d", skip_start, skip_end)
+        scanner._input_skip_log_ranges.add((skip_start, skip_end))
+    _handle_terminal_read_failure(scanner, "input_registers", skip_start, skip_end)
+    return True
+
+
+def _handle_input_read_exception(
+    scanner: Any,
+    exc: Exception,
+    *,
+    start: int,
+    end: int,
+    address: int,
+    count: int,
+    attempt: int,
+) -> tuple[bool, bool]:
+    """Handle input read exception.
+
+    Returns (abort_transiently, stop_retries).
+    """
+    if isinstance(exc, ModbusIOException):
+        if _should_abort_input_exception(exc):
+            return True, True
+        track_input_failure(scanner, count, address)
+        return False, False
+    if isinstance(exc, TimeoutError):
+        return True, True
+    if isinstance(exc, OSError):
+        return False, True
+    if isinstance(exc, (ModbusException, ConnectionException)):
+        track_input_failure(scanner, count, address)
+        return False, False
+    raise exc
+
+
 async def read_input(
     scanner: Any,
     client_or_address: AsyncModbusTcpClient | AsyncModbusSerialClientType | int,
@@ -204,12 +245,7 @@ async def read_input(
     start = address
     end = address + count - 1
 
-    should_skip, skip_start, skip_end = _should_skip_input_range(scanner, start, end, skip_cache)
-    if should_skip:
-        if (skip_start, skip_end) != (start, end) and (skip_start, skip_end) not in scanner._input_skip_log_ranges:
-            _LOGGER.debug("Skipping cached failed input registers %d-%d", skip_start, skip_end)
-            scanner._input_skip_log_ranges.add((skip_start, skip_end))
-        _handle_terminal_read_failure(scanner, "input_registers", skip_start, skip_end)
+    if _prepare_input_read(scanner, start, end, skip_cache):
         return None
 
     transport, client = resolve_transport_and_client(scanner, client)
@@ -258,10 +294,18 @@ async def read_input(
                 exc=exc,
                 backoff=scanner.backoff,
             )
-            if _should_abort_input_exception(exc):
-                aborted_transiently = True
+            aborted, stop = _handle_input_read_exception(
+                scanner,
+                exc,
+                start=start,
+                end=end,
+                address=address,
+                count=count,
+                attempt=attempt,
+            )
+            aborted_transiently = aborted_transiently or aborted
+            if stop:
                 break
-            track_input_failure(scanner, count, address)
         except (TimeoutError, OSError) as exc:
             log_scanner_retry(
                 operation=f"read_input:{start}-{end}",
@@ -270,8 +314,18 @@ async def read_input(
                 exc=exc,
                 backoff=scanner.backoff,
             )
-            aborted_transiently = isinstance(exc, TimeoutError)
-            break
+            aborted, stop = _handle_input_read_exception(
+                scanner,
+                exc,
+                start=start,
+                end=end,
+                address=address,
+                count=count,
+                attempt=attempt,
+            )
+            aborted_transiently = aborted_transiently or aborted
+            if stop:
+                break
         except (ModbusException, ConnectionException) as exc:
             log_scanner_retry(
                 operation=f"read_input:{start}-{end}",
@@ -280,7 +334,18 @@ async def read_input(
                 exc=exc,
                 backoff=scanner.backoff,
             )
-            track_input_failure(scanner, count, address)
+            aborted, stop = _handle_input_read_exception(
+                scanner,
+                exc,
+                start=start,
+                end=end,
+                address=address,
+                count=count,
+                attempt=attempt,
+            )
+            aborted_transiently = aborted_transiently or aborted
+            if stop:
+                break
 
         await _sleep_retry_backoff(
             backoff=scanner.backoff,


### PR DESCRIPTION
### Motivation

- Reduce complexity in the `read_input` flow by extracting preconditions and exception classification to small helpers for clearer control flow.
- Centralize skip-cache / unsupported-range short-circuit and skip-range debug logging for input reads so behavior is consistent with holding-path refactors.
- Preserve Modbus read semantics (retry/backoff, unsupported-range behavior, skip-cache and failure tracking) while keeping scanner code HA-independent and avoiding changes to orchestration/core.

### Description

- Added `_prepare_input_read(scanner, start, end, skip_cache)` to centralize unsupported/cached-failure short-circuiting and skip-range debug logging for input reads.
- Added `_handle_input_read_exception(scanner, exc, *, start, end, address, count, attempt)` which returns `(abort_transiently, stop_retries)` and classifies `ModbusIOException`, `TimeoutError`, `OSError`, `ModbusException`, and `ConnectionException` while delegating failure counting to `track_input_failure` as appropriate.
- Simplified `read_input(...)` to delegate pre-read checks and exception handling to the new helpers while preserving retry/backoff loops, terminal failure marking, and logging; modified file `custom_components/thessla_green_modbus/scanner/io_read.py` and committed as `4423a1a1e77b6daf458f71caad27e054dc552d83`.

### Testing

- Ran `ruff check custom_components tests tools` which passed.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed.
- Ran `pytest -q tests/test_scanner_io.py tests/test_scanner_io_coverage.py tests/test_scanner*.py` which passed for those test files.
- Ran the full suite `pytest tests/ -q` which passed (4 skipped), and maintainability validation `python tools/check_maintainability.py` and entity validation `python tools/validate_entity_mappings.py` which also passed; `python tools/compare_registers_with_reference.py` executed and reported expected reference mismatches for vendor verification but completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a4f77fcc8326a0fc6ff985a9923c)