### PR TITLE
refactor: extract coordinator connection orchestration helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/connection.py
+++ b/custom_components/thessla_green_modbus/coordinator/connection.py
@@ -219,3 +219,55 @@ async def connect_transport_or_client(
     if client is None:
         raise ConnectionException("Modbus transport is not available")
     return client
+
+
+async def ensure_connected_runtime(
+    *,
+    current_transport: BaseModbusTransport | None,
+    current_client: Any,
+    reconnect_client_if_needed_fn: Callable[[Any], Awaitable[bool]],
+    disconnect_locked_fn: Callable[[], Awaitable[None]],
+    get_runtime_state_fn: Callable[[], tuple[BaseModbusTransport | None, Any]],
+    ensure_transport_selected_fn: Callable[
+        [], Awaitable[tuple[BaseModbusTransport | None, str | None]]
+    ],
+    connect_transport_or_client_fn: Callable[..., Awaitable[Any]],
+    mark_connection_established_fn: Callable[[], None],
+    mark_connection_failure_fn: Callable[[], None],
+    logger: logging.Logger,
+) -> tuple[BaseModbusTransport | None, Any, str | None]:
+    """Orchestrate coordinator connection/reconnect transitions."""
+
+    if current_transport is not None and current_transport.is_connected():
+        return current_transport, current_client, None
+
+    if current_transport is None and current_client is not None:
+        if await reconnect_client_if_needed_fn(current_client):
+            return current_transport, current_client, None
+
+    if current_transport is not None or current_client is not None:
+        await disconnect_locked_fn()
+        current_transport, current_client = get_runtime_state_fn()
+
+    try:
+        selected_transport, selected_mode = await ensure_transport_selected_fn()
+        current_transport, current_client = get_runtime_state_fn()
+        if selected_transport is not None:
+            current_transport = selected_transport
+
+        current_client = await connect_transport_or_client_fn(
+            transport=current_transport,
+            client=current_client,
+        )
+        logger.debug("Modbus connection established")
+        mark_connection_established_fn()
+        return current_transport, current_client, selected_mode
+    except (ModbusException, ConnectionException):
+        mark_connection_failure_fn()
+        raise
+    except TimeoutError:
+        mark_connection_failure_fn()
+        raise
+    except OSError:
+        mark_connection_failure_fn()
+        raise

--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -108,6 +108,9 @@ from .connection import (
     connect_transport_or_client as _connect_transport_or_client_impl,
 )
 from .connection import (
+    ensure_connected_runtime as _ensure_connected_runtime_impl,
+)
+from .connection import (
     ensure_transport_selected as _ensure_transport_selected_impl,
 )
 from .connection import (
@@ -661,84 +664,71 @@ class ThesslaGreenModbusCoordinator(
         """Ensure Modbus connection is established using the shared client."""
 
         async with self._client_lock:
-            if self._transport is not None and self._transport.is_connected():
-                return
-            if self._transport is None and self.client is not None:
-                if await _reconnect_client_if_needed_impl(self.client):
-                    return
-            if self._transport is not None or self.client is not None:
-                await self._disconnect_locked()
-
+            parity = SERIAL_PARITY_MAP.get(self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
+            stop_bits = SERIAL_STOP_BITS_MAP.get(
+                self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
+            )
             try:
-                parity = SERIAL_PARITY_MAP.get(
-                    self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY]
-                )
-                stop_bits = SERIAL_STOP_BITS_MAP.get(
-                    self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
-                )
-                selected_transport, selected_mode = await _ensure_transport_selected_impl(
+                transport, client, selected_mode = await _ensure_connected_runtime_impl(
                     current_transport=self._transport,
-                    connection_type=self.config.connection_type,
-                    connection_mode=self.config.connection_mode,
-                    host=self.config.host,
-                    port=self.config.port,
-                    serial_port=self.config.serial_port,
-                    baudrate=self.config.baud_rate,
-                    parity=parity,
-                    stopbits=stop_bits,
-                    retry=self.retry,
-                    backoff=self.backoff,
-                    max_backoff=DEFAULT_MAX_BACKOFF,
-                    timeout=self.timeout,
-                    offline_state=self.offline_state,
-                    connection_type_rtu=CONNECTION_TYPE_RTU,
-                    connection_mode_auto=CONNECTION_MODE_AUTO,
-                    connection_mode_tcp=CONNECTION_MODE_TCP,
-                    build_rtu_transport_fn=_build_rtu_transport_impl,
-                    build_tcp_transport_fn=self._build_tcp_transport,
-                    select_auto_transport_fn=lambda: _select_auto_transport_impl(
-                        resolved_connection_mode=self._resolved_connection_mode,
-                        build_tcp_transport=self._build_tcp_transport,
-                        try_direct_client_connect=lambda allow_parameterless_ctor: self._try_direct_client_connect(
-                            allow_parameterless_ctor=allow_parameterless_ctor
-                        ),
-                        port=self.config.port,
-                        timeout=self.timeout,
-                        slave_id=self.config.slave_id,
+                    current_client=self.client,
+                    reconnect_client_if_needed_fn=_reconnect_client_if_needed_impl,
+                    disconnect_locked_fn=self._disconnect_locked,
+                    get_runtime_state_fn=lambda: (self._transport, self.client),
+                    ensure_transport_selected_fn=lambda: _ensure_transport_selected_impl(
+                        current_transport=self._transport,
+                        connection_type=self.config.connection_type,
+                        connection_mode=self.config.connection_mode,
                         host=self.config.host,
-                        logger=_LOGGER,
+                        port=self.config.port,
+                        serial_port=self.config.serial_port,
+                        baudrate=self.config.baud_rate,
+                        parity=parity,
+                        stopbits=stop_bits,
+                        retry=self.retry,
+                        backoff=self.backoff,
+                        max_backoff=DEFAULT_MAX_BACKOFF,
+                        timeout=self.timeout,
+                        offline_state=self.offline_state,
+                        connection_type_rtu=CONNECTION_TYPE_RTU,
+                        connection_mode_auto=CONNECTION_MODE_AUTO,
+                        connection_mode_tcp=CONNECTION_MODE_TCP,
+                        build_rtu_transport_fn=_build_rtu_transport_impl,
+                        build_tcp_transport_fn=self._build_tcp_transport,
+                        select_auto_transport_fn=lambda: _select_auto_transport_impl(
+                            resolved_connection_mode=self._resolved_connection_mode,
+                            build_tcp_transport=self._build_tcp_transport,
+                            try_direct_client_connect=lambda allow_parameterless_ctor: self._try_direct_client_connect(
+                                allow_parameterless_ctor=allow_parameterless_ctor
+                            ),
+                            port=self.config.port,
+                            timeout=self.timeout,
+                            slave_id=self.config.slave_id,
+                            host=self.config.host,
+                            logger=_LOGGER,
+                        ),
                     ),
+                    connect_transport_or_client_fn=_connect_transport_or_client_impl,
+                    mark_connection_established_fn=lambda: _mark_connection_established_impl(
+                        offline_state_setter=lambda value: setattr(self, "offline_state", value)
+                    ),
+                    mark_connection_failure_fn=lambda: _mark_connection_failure_impl(
+                        statistics=self.statistics,
+                        offline_state_setter=lambda value: setattr(self, "offline_state", value),
+                    ),
+                    logger=_LOGGER,
                 )
-                if selected_transport is not None:
-                    self._transport = selected_transport
+                self._transport = transport
+                self.client = client
                 if selected_mode is not None:
                     self._resolved_connection_mode = selected_mode
-
-                self.client = await _connect_transport_or_client_impl(
-                    transport=self._transport,
-                    client=self.client,
-                )
-                _LOGGER.debug("Modbus connection established")
-                _mark_connection_established_impl(offline_state_setter=lambda value: setattr(self, "offline_state", value))
             except (ModbusException, ConnectionException) as exc:
-                _mark_connection_failure_impl(
-                    statistics=self.statistics,
-                    offline_state_setter=lambda value: setattr(self, "offline_state", value),
-                )
                 _LOGGER.exception("Failed to establish connection: %s", exc)
                 raise
             except TimeoutError as exc:
-                _mark_connection_failure_impl(
-                    statistics=self.statistics,
-                    offline_state_setter=lambda value: setattr(self, "offline_state", value),
-                )
                 _LOGGER.warning("Connection attempt timed out: %s", exc)
                 raise
             except OSError as exc:
-                _mark_connection_failure_impl(
-                    statistics=self.statistics,
-                    offline_state_setter=lambda value: setattr(self, "offline_state", value),
-                )
                 _LOGGER.exception("Unexpected error establishing connection: %s", exc)
                 raise
 

--- a/tests/test_coordinator_connection_helpers.py
+++ b/tests/test_coordinator_connection_helpers.py
@@ -14,6 +14,7 @@ from custom_components.thessla_green_modbus.coordinator.connection import (
     build_tcp_transport,
     connect_direct_tcp_client,
     connect_transport_or_client,
+    ensure_connected_runtime,
     ensure_transport_selected,
     setup_client_with_retry,
 )
@@ -250,3 +251,73 @@ def test_connect_transport_or_client_with_transport() -> None:
 def test_connect_transport_or_client_requires_client_or_transport() -> None:
     with pytest.raises(ConnectionException):
         asyncio.run(connect_transport_or_client(transport=None, client=None))
+
+
+def test_ensure_connected_runtime_disconnects_before_reselect() -> None:
+    class _Transport:
+        def is_connected(self) -> bool:
+            return False
+
+    disconnected = {"called": False}
+    established = {"called": False}
+
+    async def _disconnect() -> None:
+        disconnected["called"] = True
+
+    async def _select() -> tuple[object, str]:
+        return object(), "tcp"
+
+    async def _connect(*, transport: object, client: object | None) -> object:
+        assert transport is not None
+        assert client is None
+        return object()
+
+    transport, client, mode = asyncio.run(
+        ensure_connected_runtime(
+            current_transport=_Transport(),
+            current_client=object(),
+            reconnect_client_if_needed_fn=lambda _client: asyncio.sleep(0, result=False),
+            disconnect_locked_fn=_disconnect,
+            get_runtime_state_fn=lambda: (None, None),
+            ensure_transport_selected_fn=_select,
+            connect_transport_or_client_fn=_connect,
+            mark_connection_established_fn=lambda: established.__setitem__("called", True),
+            mark_connection_failure_fn=lambda: None,
+            logger=logging.getLogger("test.ensure_connected_runtime"),
+        )
+    )
+    assert disconnected["called"] is True
+    assert established["called"] is True
+    assert transport is not None
+    assert client is not None
+    assert mode == "tcp"
+
+
+def test_ensure_connected_runtime_marks_failure_on_timeout() -> None:
+    failures = {"count": 0}
+
+    async def _select() -> tuple[object, str]:
+        return object(), "tcp"
+
+    async def _connect(*, transport: object, client: object | None) -> object:
+        raise TimeoutError("timed out")
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(
+            ensure_connected_runtime(
+                current_transport=None,
+                current_client=None,
+                reconnect_client_if_needed_fn=lambda _client: asyncio.sleep(0, result=False),
+                disconnect_locked_fn=lambda: asyncio.sleep(0),
+                get_runtime_state_fn=lambda: (None, None),
+                ensure_transport_selected_fn=_select,
+                connect_transport_or_client_fn=_connect,
+                mark_connection_established_fn=lambda: None,
+                mark_connection_failure_fn=lambda: failures.__setitem__(
+                    "count", failures["count"] + 1
+                ),
+                logger=logging.getLogger("test.ensure_connected_runtime.error"),
+            )
+        )
+
+    assert failures["count"] == 1


### PR DESCRIPTION
### Motivation
- Reduce the size and runtime responsibility of `ThesslaGreenModbusCoordinator` by extracting a cohesive orchestration block handling connection/reconnect transitions.
- Move concrete runtime control-flow (reconnect, disconnect-before-reselect, transport selection, connect, and success/failure hooks) into a focused helper so the coordinator remains the HA-facing adapter.

### Description
- Added `ensure_connected_runtime(...)` to `custom_components/thessla_green_modbus/coordinator/connection.py`, implementing the extracted connection/reconnect orchestration logic and invoking injected callables for selection, connect, disconnect and state marking.
- Updated `ThesslaGreenModbusCoordinator._ensure_connected` in `custom_components/thessla_green_modbus/coordinator/coordinator.py` to delegate orchestration to the new helper and to retain logging/error handling and runtime state updates.
- Added tests in `tests/test_coordinator_connection_helpers.py` covering the disconnect-before-reselect path and failure-marking on timeout for the new helper.
- Kept package-root public API unchanged and did not add any shims or proxies; preserved behavior for AUTO mode and existing exception handling.

### Testing
- Ran lint/format checks and compile: `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` (passed).
- Ran repository validation scripts: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py` (passed; register comparison shows expected vendor differences unrelated to this change).
- Ran unit tests: `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` and then full test suite `pytest tests/ -q` (all tests passed, one test file had 4 skipped tests as expected).
- Ran entity mapping validation: `python tools/validate_entity_mappings.py` (passed).
- Confirmed coordinator package API audit assertion (export list equals `CoordinatorConfig`, `ThesslaGreenModbusCoordinator`) and that no coordinator top-level shim was reintroduced (both checks passed).
- Commit created: `7cf704f3` (PR creation was invoked by the internal mechanism in this environment but no external PR URL was returned).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ca2f96088326b3ab23b7ac8f9423)