### PR TITLE
refactor: extract multi-register chunk executor from coordinator schedule

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -77,6 +77,17 @@ class _CoordinatorScheduleMixin:
             attempt=attempt,
         )
 
+    async def _execute_multi_register_chunks(
+        self, chunks: list[tuple[int, list[int]]], attempt: int
+    ) -> tuple[Any, bool]:
+        """Execute a prepared list of multi-register write chunks."""
+        response = None
+        for chunk_start, chunk in chunks:
+            response = await self._write_registers_payload(chunk_start, chunk, attempt)
+            if not self._write_response_ok(response):
+                return response, False
+        return response, True
+
     def _encode_write_value(
         self,
         register_name: str,
@@ -371,17 +382,12 @@ class _CoordinatorScheduleMixin:
 
                 for attempt in range(1, self.retry + 1):
                     try:
-                        success = True
-                        response = None
-                        for chunk_start, chunk in self._plan_multi_register_chunks(
-                            start_address, values, require_single_request
-                        ):
-                            response = await self._write_registers_payload(
-                                chunk_start, chunk, attempt
-                            )
-                            if not self._write_response_ok(response):
-                                success = False
-                                break
+                        response, success = await self._execute_multi_register_chunks(
+                            self._plan_multi_register_chunks(
+                                start_address, values, require_single_request
+                            ),
+                            attempt,
+                        )
                         if not success:
                             if attempt == self.retry:
                                 _LOGGER.error(

--- a/tests/test_multi_register_write.py
+++ b/tests/test_multi_register_write.py
@@ -82,6 +82,37 @@ async def test_async_write_registers_passes_attempt():
 
 
 @pytest.mark.asyncio
+async def test_async_write_registers_retries_from_first_chunk_after_chunk_error():
+    hass = MagicMock()
+    coordinator = ThesslaGreenModbusCoordinator.from_params(
+        hass=hass,
+        host="localhost",
+        port=502,
+        slave_id=1,
+        name="test",
+        retry=2,
+    )
+    coordinator._ensure_connection = AsyncMock()
+    coordinator._disconnect = AsyncMock()
+    coordinator.effective_batch = 2
+
+    response_error = MagicMock()
+    response_error.isError.return_value = True
+    response_ok = MagicMock()
+    response_ok.isError.return_value = False
+    transport = MagicMock()
+    transport.is_connected.return_value = True
+    transport.write_registers = AsyncMock(
+        side_effect=[response_error, response_ok, response_ok]
+    )
+    coordinator._transport = transport
+
+    assert await coordinator.async_write_registers(100, [1, 2, 3]) is True
+    addresses = [call.args[1] for call in transport.write_registers.await_args_list]
+    assert addresses == [100, 100, 102]
+
+
+@pytest.mark.asyncio
 async def test_async_write_registers_single_request_override():
     """Temporary writes should bypass chunking to keep 3-register atomicity."""
     hass = MagicMock()


### PR DESCRIPTION
### Motivation
- Reduce complexity in `coordinator/schedule.py` by isolating remaining write-path execution logic into a small, testable helper.
- Make the multi-register write retry and chunking behavior easier to reason about and reuse without changing external behavior.
- Prepare the codebase for further coordinator write-path decomposition while preserving Modbus semantics and retry logic.

### Description
- Added a new helper `async def _execute_multi_register_chunks(self, chunks: list[tuple[int, list[int]]], attempt: int) -> tuple[Any, bool]` in `custom_components/thessla_green_modbus/coordinator/schedule.py` that executes prepared chunk plans and evaluates responses.
- Replaced the inline chunking loop inside `async_write_registers` with a call to `_execute_multi_register_chunks`, preserving the existing retry, disconnect, logging, and refresh semantics.
- Added a focused regression test `test_async_write_registers_retries_from_first_chunk_after_chunk_error` to `tests/test_multi_register_write.py` that verifies retry behavior when the first chunk fails and ensures the next attempt restarts from the first chunk.

### Testing
- Ran linting and static checks with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, which passed.
- Ran repository validation scripts `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both of which passed (maintainability gate passed).
- Ran unit tests with `pytest -q tests/test_coordinator_register_writes.py tests/test_multi_register_write.py tests/test_force_full_register_list.py tests/test_logging.py tests/test_coordinator*.py` and then the full suite `pytest tests/ -q`, which passed (test run completed; some unrelated tests were skipped as expected).
- Ran `python tools/validate_entity_mappings.py` which passed, and code searches for forbidden shims returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ca3b73e88326bab33c38ab8ef440)