### PR TITLE
refactor: extract scanner core state helper

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/core.py
+++ b/custom_components/thessla_green_modbus/scanner/core.py
@@ -19,8 +19,9 @@ from ..const import (
     DEFAULT_STOP_BITS,
     HOLDING_BATCH_BOUNDARIES,
     KNOWN_MISSING_REGISTERS,
-    SERIAL_PARITY_MAP,
-    SERIAL_STOP_BITS_MAP,
+)
+from ..const import (
+    SERIAL_STOP_BITS_MAP as _SERIAL_STOP_BITS_MAP,
 )
 from ..modbus_helpers import async_maybe_await_close
 from ..modbus_helpers import group_reads as _group_reads
@@ -38,13 +39,6 @@ from ..scanner_helpers import (
 from ..scanner_helpers import (
     SAFE_REGISTERS as _SAFE_REGISTERS,
 )
-from ..scanner_register_maps import (
-    COIL_REGISTERS,
-    DISCRETE_INPUT_REGISTERS,
-    HOLDING_REGISTERS,
-    INPUT_REGISTERS,
-    MULTI_REGISTER_SIZES,
-)
 from ..utils import (
     resolve_connection_settings,
 )
@@ -56,12 +50,19 @@ from . import register_map_runtime as scanner_register_map_runtime
 from . import registers as scanner_registers
 from . import selection as scanner_selection
 from . import setup as scanner_setup
+from . import state as scanner_state
 
 asdict = _dataclasses_asdict
 
 _LOGGER = logging.getLogger(__name__)
 REGISTER_DEFINITIONS = _register_maps.REGISTER_DEFINITIONS
+INPUT_REGISTERS = _register_maps.INPUT_REGISTERS
+HOLDING_REGISTERS = _register_maps.HOLDING_REGISTERS
+COIL_REGISTERS = _register_maps.COIL_REGISTERS
+DISCRETE_INPUT_REGISTERS = _register_maps.DISCRETE_INPUT_REGISTERS
+MULTI_REGISTER_SIZES = _register_maps.MULTI_REGISTER_SIZES
 SAFE_REGISTERS = _SAFE_REGISTERS
+SERIAL_STOP_BITS_MAP = _SERIAL_STOP_BITS_MAP
 __all__ = [
     "DeviceCapabilities",
     "ThesslaGreenDeviceScanner",
@@ -168,33 +169,25 @@ class ThesslaGreenDeviceScanner(
             connection_mode,
             port,
         )
-        self.connection_type = resolved_type
-        self.connection_mode = resolved_mode
-        self._resolved_connection_mode: str | None = resolved_fixed_mode
-        self.serial_port = serial_port or DEFAULT_SERIAL_PORT
-        try:
-            self.baud_rate = int(baud_rate)
-        except (TypeError, ValueError):
-            self.baud_rate = DEFAULT_BAUD_RATE
-        parity_norm = str(parity or DEFAULT_PARITY).lower()
-        if parity_norm not in SERIAL_PARITY_MAP:
-            parity_norm = DEFAULT_PARITY
-        self.parity = parity_norm
-        self.stop_bits = SERIAL_STOP_BITS_MAP.get(
-            stop_bits,
-            SERIAL_STOP_BITS_MAP.get(str(stop_bits), DEFAULT_STOP_BITS),
+        scanner_state.apply_connection_state(
+            self,
+            scanner_state.build_connection_state(
+                connection_type=resolved_type,
+                connection_mode=resolved_mode,
+                resolved_connection_mode=resolved_fixed_mode,
+                serial_port=serial_port,
+                baud_rate=baud_rate,
+                parity=parity,
+                stop_bits=stop_bits,
+            ),
         )
-        if self.stop_bits not in (1, 2):
-            self.stop_bits = DEFAULT_STOP_BITS
         self._hass = hass
 
         scanner_setup.initialize_runtime_collections(self, DeviceCapabilities)
-        self._input_register_map = INPUT_REGISTERS
-        self._holding_register_map = HOLDING_REGISTERS
-        self._coil_register_map = COIL_REGISTERS
-        self._discrete_input_register_map = DISCRETE_INPUT_REGISTERS
-        self._known_missing_registers = KNOWN_MISSING_REGISTERS
-        self._multi_register_sizes = MULTI_REGISTER_SIZES
+        scanner_state.apply_register_defaults(
+            self,
+            known_missing_registers=KNOWN_MISSING_REGISTERS,
+        )
 
         self._populate_known_missing_addresses()
 

--- a/custom_components/thessla_green_modbus/scanner/state.py
+++ b/custom_components/thessla_green_modbus/scanner/state.py
@@ -1,1 +1,99 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Scanner core state initialization helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..const import (
+    CONNECTION_MODE_AUTO,
+    DEFAULT_BAUD_RATE,
+    DEFAULT_PARITY,
+    DEFAULT_SERIAL_PORT,
+    DEFAULT_STOP_BITS,
+    SERIAL_PARITY_MAP,
+    SERIAL_STOP_BITS_MAP,
+)
+from ..scanner_register_maps import (
+    COIL_REGISTERS,
+    DISCRETE_INPUT_REGISTERS,
+    HOLDING_REGISTERS,
+    INPUT_REGISTERS,
+    MULTI_REGISTER_SIZES,
+)
+
+
+@dataclass(frozen=True)
+class ScannerConnectionState:
+    """Resolved scanner connection state normalized from raw init parameters."""
+
+    connection_type: str
+    connection_mode: str
+    resolved_connection_mode: str | None
+    serial_port: str
+    baud_rate: int
+    parity: str
+    stop_bits: int
+
+
+def build_connection_state(
+    *,
+    connection_type: str,
+    connection_mode: str,
+    resolved_connection_mode: str | None,
+    serial_port: str,
+    baud_rate: int,
+    parity: str,
+    stop_bits: int,
+) -> ScannerConnectionState:
+    """Normalize and freeze scanner connection parameters."""
+    try:
+        normalized_baud_rate = int(baud_rate)
+    except (TypeError, ValueError):
+        normalized_baud_rate = DEFAULT_BAUD_RATE
+
+    normalized_parity = str(parity or DEFAULT_PARITY).lower()
+    if normalized_parity not in SERIAL_PARITY_MAP:
+        normalized_parity = DEFAULT_PARITY
+
+    normalized_stop_bits = SERIAL_STOP_BITS_MAP.get(
+        stop_bits,
+        SERIAL_STOP_BITS_MAP.get(str(stop_bits), DEFAULT_STOP_BITS),
+    )
+    if normalized_stop_bits not in (1, 2):
+        normalized_stop_bits = DEFAULT_STOP_BITS
+
+    fixed_mode = resolved_connection_mode
+    if connection_mode == CONNECTION_MODE_AUTO:
+        fixed_mode = None
+
+    return ScannerConnectionState(
+        connection_type=connection_type,
+        connection_mode=connection_mode,
+        resolved_connection_mode=fixed_mode,
+        serial_port=serial_port or DEFAULT_SERIAL_PORT,
+        baud_rate=normalized_baud_rate,
+        parity=normalized_parity,
+        stop_bits=normalized_stop_bits,
+    )
+
+
+def apply_connection_state(scanner: Any, state: ScannerConnectionState) -> None:
+    """Apply normalized connection state to scanner instance."""
+    scanner.connection_type = state.connection_type
+    scanner.connection_mode = state.connection_mode
+    scanner._resolved_connection_mode = state.resolved_connection_mode
+    scanner.serial_port = state.serial_port
+    scanner.baud_rate = state.baud_rate
+    scanner.parity = state.parity
+    scanner.stop_bits = state.stop_bits
+
+
+def apply_register_defaults(scanner: Any, *, known_missing_registers: dict[str, dict[str, Any]]) -> None:
+    """Apply default scanner register maps and known-missing metadata."""
+    scanner._input_register_map = INPUT_REGISTERS
+    scanner._holding_register_map = HOLDING_REGISTERS
+    scanner._coil_register_map = COIL_REGISTERS
+    scanner._discrete_input_register_map = DISCRETE_INPUT_REGISTERS
+    scanner._known_missing_registers = known_missing_registers
+    scanner._multi_register_sizes = MULTI_REGISTER_SIZES

--- a/tests/test_scanner_state.py
+++ b/tests/test_scanner_state.py
@@ -1,0 +1,78 @@
+"""Tests for scanner state initialization helper."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.thessla_green_modbus.const import (
+    CONNECTION_MODE_AUTO,
+    CONNECTION_MODE_TCP,
+    DEFAULT_BAUD_RATE,
+    DEFAULT_PARITY,
+    DEFAULT_SERIAL_PORT,
+    DEFAULT_STOP_BITS,
+)
+from custom_components.thessla_green_modbus.scanner import state as scanner_state
+
+
+def test_build_connection_state_normalizes_serial_settings() -> None:
+    state = scanner_state.build_connection_state(
+        connection_type="rtu",
+        connection_mode=CONNECTION_MODE_TCP,
+        resolved_connection_mode=CONNECTION_MODE_TCP,
+        serial_port="",
+        baud_rate="bad",
+        parity="invalid",
+        stop_bits=99,
+    )
+
+    assert state.serial_port == DEFAULT_SERIAL_PORT
+    assert state.baud_rate == DEFAULT_BAUD_RATE
+    assert state.parity == DEFAULT_PARITY
+    assert state.stop_bits == DEFAULT_STOP_BITS
+
+
+def test_build_connection_state_clears_fixed_mode_for_auto() -> None:
+    state = scanner_state.build_connection_state(
+        connection_type="tcp",
+        connection_mode=CONNECTION_MODE_AUTO,
+        resolved_connection_mode=CONNECTION_MODE_TCP,
+        serial_port="/dev/ttyUSB0",
+        baud_rate=19200,
+        parity="e",
+        stop_bits=2,
+    )
+
+    assert state.resolved_connection_mode is None
+
+
+def test_apply_connection_state_assigns_scanner_attributes() -> None:
+    scanner = SimpleNamespace()
+    state = scanner_state.build_connection_state(
+        connection_type="tcp",
+        connection_mode=CONNECTION_MODE_TCP,
+        resolved_connection_mode=CONNECTION_MODE_TCP,
+        serial_port="/dev/ttyS0",
+        baud_rate=9600,
+        parity="n",
+        stop_bits=1,
+    )
+
+    scanner_state.apply_connection_state(scanner, state)
+
+    assert scanner.connection_type == "tcp"
+    assert scanner.connection_mode == CONNECTION_MODE_TCP
+    assert scanner._resolved_connection_mode == CONNECTION_MODE_TCP
+    assert scanner.serial_port == "/dev/ttyS0"
+
+
+def test_apply_register_defaults_assigns_maps() -> None:
+    scanner = SimpleNamespace()
+    scanner_state.apply_register_defaults(scanner, known_missing_registers={"input": {}})
+
+    assert scanner._known_missing_registers == {"input": {}}
+    assert isinstance(scanner._input_register_map, dict)
+    assert isinstance(scanner._holding_register_map, dict)
+    assert isinstance(scanner._coil_register_map, dict)
+    assert isinstance(scanner._discrete_input_register_map, dict)
+    assert isinstance(scanner._multi_register_sizes, dict)


### PR DESCRIPTION
### Motivation

- Reduce complexity in `scanner/core.py` by extracting connection and register state bookkeeping into a focused helper module.
- Centralize connection normalization and default register-map assignment to make scanner setup clearer and easier to refactor further.
- Preserve scanner independence from Home Assistant and keep existing scan/autodetect/RTU-TCP behavior intact.

### Description

- Add `custom_components/thessla_green_modbus/scanner/state.py` implementing `ScannerConnectionState`, `build_connection_state`, `apply_connection_state`, and `apply_register_defaults` to encapsulate connection normalization and register defaults.
- Update `custom_components/thessla_green_modbus/scanner/core.py` to delegate connection-state normalization and register default assignments to the new `scanner.state` helpers while preserving module-level register-map exports used by the rest of the codebase and tests.
- Add `tests/test_scanner_state.py` with focused unit tests that validate serial/connection normalization and application of register defaults.
- No changes were made to IO, transport, coordinator, register JSONs, mappings, or CI configuration, and no Home Assistant imports were added to the scanner package.

### Testing

- Ran `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed.
- Ran `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, which both passed.
- Ran scanner-focused tests with `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` and full suite `pytest tests/ -q`, and the test suite passed (with the same skips previously observed).
- Ran `python tools/validate_entity_mappings.py` and audit greps for `homeassistant` imports and shim/proxy keywords in scanner code, which returned no violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ca54e8b8832685475bcd2aa6a180)