### PR TITLE
refactor: extract temperature sensor mappings into focused module

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_static_sensor_temperatures.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_sensor_temperatures.py
@@ -1,0 +1,120 @@
+"""Static temperature sensor mapping groups for ThesslaGreen entities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfTemperature
+
+INPUT_TEMPERATURE_SENSOR_MAPPINGS: dict[str, dict[str, Any]] = {
+    "outside_temperature": {
+        "translation_key": "outside_temperature",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "input_registers",
+    },
+    "supply_temperature": {
+        "translation_key": "supply_temperature",
+        "icon": "mdi:thermometer-plus",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "input_registers",
+    },
+    "exhaust_temperature": {
+        "translation_key": "exhaust_temperature",
+        "icon": "mdi:thermometer-minus",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "input_registers",
+    },
+    "fpx_temperature": {
+        "translation_key": "fpx_temperature",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "input_registers",
+    },
+    "duct_supply_temperature": {
+        "translation_key": "duct_supply_temperature",
+        "icon": "mdi:thermometer-plus",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "input_registers",
+    },
+    "gwc_temperature": {
+        "translation_key": "gwc_temperature",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "input_registers",
+    },
+    "ambient_temperature": {
+        "translation_key": "ambient_temperature",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "input_registers",
+    },
+    "heating_temperature": {
+        "translation_key": "heating_temperature",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "input_registers",
+    },
+}
+
+HOLDING_TEMPERATURE_SENSOR_MAPPINGS: dict[str, dict[str, Any]] = {
+    "supply_air_temperature_manual": {
+        "translation_key": "supply_air_temperature_manual",
+        "icon": "mdi:thermometer-plus",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "holding_registers",
+    },
+    "min_bypass_temperature": {
+        "translation_key": "min_bypass_temperature",
+        "icon": "mdi:thermometer-low",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "holding_registers",
+    },
+    "air_temperature_summer_free_heating": {
+        "translation_key": "air_temperature_summer_free_heating",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "holding_registers",
+    },
+    "air_temperature_summer_free_cooling": {
+        "translation_key": "air_temperature_summer_free_cooling",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "holding_registers",
+    },
+    "required_temperature": {
+        "translation_key": "required_temperature",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+        "register_type": "holding_registers",
+    },
+}
+
+__all__ = ["HOLDING_TEMPERATURE_SENSOR_MAPPINGS", "INPUT_TEMPERATURE_SENSOR_MAPPINGS"]

--- a/custom_components/thessla_green_modbus/mappings/_static_sensors.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_sensors.py
@@ -15,6 +15,11 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.entity import EntityCategory
 
+from ._static_sensor_temperatures import (
+    HOLDING_TEMPERATURE_SENSOR_MAPPINGS,
+    INPUT_TEMPERATURE_SENSOR_MAPPINGS,
+)
+
 
 def _diagnostic_sensor_payload(
     translation_key: str,
@@ -33,70 +38,7 @@ def _diagnostic_sensor_payload(
 
 SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     # Temperature sensors (Input Registers)
-    "outside_temperature": {
-        "translation_key": "outside_temperature",
-        "icon": "mdi:thermometer",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "supply_temperature": {
-        "translation_key": "supply_temperature",
-        "icon": "mdi:thermometer-plus",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "exhaust_temperature": {
-        "translation_key": "exhaust_temperature",
-        "icon": "mdi:thermometer-minus",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "fpx_temperature": {
-        "translation_key": "fpx_temperature",
-        "icon": "mdi:thermometer",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "duct_supply_temperature": {
-        "translation_key": "duct_supply_temperature",
-        "icon": "mdi:thermometer-plus",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "gwc_temperature": {
-        "translation_key": "gwc_temperature",
-        "icon": "mdi:thermometer",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "ambient_temperature": {
-        "translation_key": "ambient_temperature",
-        "icon": "mdi:thermometer",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
-    "heating_temperature": {
-        "translation_key": "heating_temperature",
-        "icon": "mdi:thermometer",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "input_registers",
-    },
+    **INPUT_TEMPERATURE_SENSOR_MAPPINGS,
     # Air flow sensors
     "supply_flow_rate": {
         "translation_key": "supply_flow_rate_m3h",
@@ -259,38 +201,7 @@ SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
         "register_type": "holding_registers",
     },
     # Configuration sensors from holding registers
-    "supply_air_temperature_manual": {
-        "translation_key": "supply_air_temperature_manual",
-        "icon": "mdi:thermometer-plus",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "holding_registers",
-    },
-    "min_bypass_temperature": {
-        "translation_key": "min_bypass_temperature",
-        "icon": "mdi:thermometer-low",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "holding_registers",
-    },
-    "air_temperature_summer_free_heating": {
-        "translation_key": "air_temperature_summer_free_heating",
-        "icon": "mdi:thermometer",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "holding_registers",
-    },
-    "air_temperature_summer_free_cooling": {
-        "translation_key": "air_temperature_summer_free_cooling",
-        "icon": "mdi:thermometer",
-        "device_class": SensorDeviceClass.TEMPERATURE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfTemperature.CELSIUS,
-        "register_type": "holding_registers",
-    },
+    **HOLDING_TEMPERATURE_SENSOR_MAPPINGS,
     # lock_date — product-key expiry year (BCD-encoded, read-only)
     "lock_date": {
         "translation_key": "lock_date",

--- a/tests/test_entity_mappings_static_groups.py
+++ b/tests/test_entity_mappings_static_groups.py
@@ -1,0 +1,38 @@
+"""Focused tests for extracted static mapping groups."""
+
+from custom_components.thessla_green_modbus.mappings._static_sensor_temperatures import (
+    HOLDING_TEMPERATURE_SENSOR_MAPPINGS,
+    INPUT_TEMPERATURE_SENSOR_MAPPINGS,
+)
+from custom_components.thessla_green_modbus.mappings._static_sensors import SENSOR_ENTITY_MAPPINGS
+
+
+def test_input_temperature_group_keys_stable() -> None:
+    assert set(INPUT_TEMPERATURE_SENSOR_MAPPINGS) == {
+        "outside_temperature",
+        "supply_temperature",
+        "exhaust_temperature",
+        "fpx_temperature",
+        "duct_supply_temperature",
+        "gwc_temperature",
+        "ambient_temperature",
+        "heating_temperature",
+    }
+
+
+def test_holding_temperature_group_keys_stable() -> None:
+    assert set(HOLDING_TEMPERATURE_SENSOR_MAPPINGS) == {
+        "supply_air_temperature_manual",
+        "min_bypass_temperature",
+        "air_temperature_summer_free_heating",
+        "air_temperature_summer_free_cooling",
+        "required_temperature",
+    }
+
+
+def test_extracted_group_payloads_match_exported_sensor_mappings() -> None:
+    for key, payload in {
+        **INPUT_TEMPERATURE_SENSOR_MAPPINGS,
+        **HOLDING_TEMPERATURE_SENSOR_MAPPINGS,
+    }.items():
+        assert SENSOR_ENTITY_MAPPINGS[key] == payload


### PR DESCRIPTION
### Motivation
- Reduce size and improve organization of the static mapping modules by extracting a coherent group (temperature sensors) into a focused module.  
- Make future mapping splits simpler while preserving exact exported mapping behaviour and test coverage.  

### Description
- Added `custom_components/thessla_green_modbus/mappings/_static_sensor_temperatures.py` containing `INPUT_TEMPERATURE_SENSOR_MAPPINGS` and `HOLDING_TEMPERATURE_SENSOR_MAPPINGS`.  
- Updated `custom_components/thessla_green_modbus/mappings/_static_sensors.py` to import and compose `SENSOR_ENTITY_MAPPINGS` via `**INPUT_TEMPERATURE_SENSOR_MAPPINGS` and `**HOLDING_TEMPERATURE_SENSOR_MAPPINGS`, preserving original payloads and keys.  
- Added focused tests `tests/test_entity_mappings_static_groups.py` that assert key-set stability for the extracted groups and payload equality between the extracted groups and the exported `SENSOR_ENTITY_MAPPINGS`.  
- Preserved all entity unique IDs, names, domains and translation payloads; mapping outputs are unchanged by design.  

### Testing
- Ran dependency/install and validation commands: `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, all succeeded (a minor `__all__` ordering issue from `ruff` was fixed as part of the change).  
- Ran mapping/reference and maintainability checks: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both passed (reference check reports expected extras/mismatches to verify with vendor).  
- Ran entity mapping validation: `python tools/validate_entity_mappings.py` which passed with `OK: 366 entities validated`.  
- Ran tests: `pytest -q tests/test_entity_mappings*.py` and `pytest tests/ -q`, both passed (some existing tests are skipped as before); the new focused tests pass and confirm payload stability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ca62f25c8326ba469c236c3df318)