### PR TITLE
refactor: extract exception-function classifier in RawRtuOverTcpTransport

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_transport_raw.py
+++ b/custom_components/thessla_green_modbus/modbus_transport_raw.py
@@ -160,11 +160,16 @@ class RawRtuOverTcpTransport(BaseModbusTransport):
 
         if resp_slave != (slave_id & 0xFF):
             raise ModbusIOException("Unexpected slave ID in RTU response")
-        if resp_func & 0x80:
-            return resp_func
-        if resp_func != (function & 0xFF):
+        if resp_func != (function & 0xFF) and not RawRtuOverTcpTransport._is_exception_function(
+            resp_func, expected_function=function
+        ):
             raise ModbusIOException("Unexpected function code in RTU response")
         return resp_func
+
+    @staticmethod
+    def _is_exception_function(resp_func: int, *, expected_function: int) -> bool:
+        """Return True when ``resp_func`` is a Modbus exception response for the request."""
+        return (resp_func & 0x80) != 0 and (resp_func & 0x7F) == (expected_function & 0xFF)
 
     async def _read_exception_response(self, header: bytes, *, function: int) -> bytes:
         exception_code = await self._read_exactly(1)
@@ -193,7 +198,7 @@ class RawRtuOverTcpTransport(BaseModbusTransport):
         header = await self._read_exactly(2)
         resp_func = self._validate_response_header(header, slave_id=slave_id, function=function)
 
-        if resp_func & 0x80:
+        if self._is_exception_function(resp_func, expected_function=function):
             return await self._read_exception_response(header, function=resp_func)
         if function in (3, 4):
             return await self._read_register_data_response(header)

--- a/tests/test_modbus_transport_raw.py
+++ b/tests/test_modbus_transport_raw.py
@@ -175,6 +175,18 @@ def test_validate_response_header_wrong_function():
 def test_validate_response_header_exception_function_passthrough():
     t = _make_raw_tcp()
     assert t._validate_response_header(bytes([1, 0x84]), slave_id=1, function=4) == 0x84
+
+
+def test_is_exception_function_matches_request_function():
+    t = _make_raw_tcp()
+    assert t._is_exception_function(0x84, expected_function=4)
+    assert not t._is_exception_function(0x83, expected_function=4)
+
+
+def test_validate_response_header_rejects_mismatched_exception_function():
+    t = _make_raw_tcp()
+    with pytest.raises(ModbusIOException, match="function code"):
+        t._validate_response_header(bytes([1, 0x83]), slave_id=1, function=4)
 def test_build_write_multiple_frame_structure():
     """_build_write_multiple_frame produces correct write multiple frame."""
     from custom_components.thessla_green_modbus.modbus_transport import RawRtuOverTcpTransport
@@ -454,5 +466,4 @@ async def test_raw_tcp_write_registers_invalid_length():
         with patch.object(t, "ensure_connected", new=AsyncMock()):
             with pytest.raises(ModbusIOException, match="length"):
                 await t.write_registers(1, 100, values=[1, 2])
-
 


### PR DESCRIPTION
### Motivation
- Continue the Modbus transport/helper decomposition by extracting a narrow responsibility for classifying Modbus exception function codes, making response-header validation clearer and easier to test.
- Preserve existing Modbus wire/CRC/framing, retry, and timeout semantics while tightening validation to reject exception frames that do not match the requested function.

### Description
- Added `_is_exception_function(resp_func, expected_function)` to `RawRtuOverTcpTransport` to centralize exception-function detection and document the 0x80-bit + base-function match rule.
- Updated `_validate_response_header` to use the new helper so exception responses are accepted only when they correspond to the requested function, and kept existing slave-id and function-code error semantics.
- Updated `_read_response` to use the helper for consistent exception dispatching.
- Added focused unit tests in `tests/test_modbus_transport_raw.py` that assert positive and negative matches for exception-function classification and that header validation rejects mismatched exception functions.

### Testing
- Ran lint/compile/maintainability and unit tests via: `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, and `python tools/validate_entity_mappings.py`, all of which passed.
- Ran the relevant pytest subsets and full test suite: `pytest -q tests/test_modbus_helpers.py tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py` and `pytest tests/ -q`, and all tests passed (with the existing skips reported by the suite).
- Maintainability gate passed (`python tools/check_maintainability.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ca716a088326b9b14541208e6d43)