### PR TITLE
refactor: extract maintenance service registration helper

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -61,6 +61,12 @@ def _maintenance_registrations():
     ]
 
 
+def _iter_maintenance_service_bindings(handlers: dict[str, object]):
+    """Yield maintenance registration rows with bound handlers."""
+    for service, schema in _maintenance_registrations():
+        yield service, schema, handlers[service]
+
+
 async def _run_for_targets(
     hass: HomeAssistant,
     call: ServiceCall,
@@ -206,5 +212,5 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
         "set_device_name": set_device_name,
         "sync_time": sync_time,
     }
-    for service, schema in _maintenance_registrations():
-        hass.services.async_register(deps.domain, service, handlers[service], schema)
+    for service, schema, handler in _iter_maintenance_service_bindings(handlers):
+        hass.services.async_register(deps.domain, service, handler, schema)

--- a/tests/test_services_handlers_maintenance.py
+++ b/tests/test_services_handlers_maintenance.py
@@ -13,7 +13,16 @@ from custom_components.thessla_green_modbus.services import (
     async_setup_services,
 )
 from custom_components.thessla_green_modbus.services_handlers_maintenance import (
+    _iter_maintenance_service_bindings,
     _maintenance_registrations,
+)
+from custom_components.thessla_green_modbus.services_schema import (
+    RESET_FILTERS_SCHEMA,
+    RESET_SETTINGS_SCHEMA,
+    SET_DEVICE_NAME_SCHEMA,
+    SET_MODBUS_PARAMETERS_SCHEMA,
+    START_PRESSURE_TEST_SCHEMA,
+    SYNC_TIME_SCHEMA,
 )
 
 # ---------------------------------------------------------------------------
@@ -286,6 +295,27 @@ def test_maintenance_registrations_service_order_and_schema_count():
         "set_modbus_parameters",
         "set_device_name",
         "sync_time",
+    ]
+
+
+def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
+    """Service binding helper keeps registration order and uses matching handler names."""
+    handlers = {
+        "reset_filters": object(),
+        "reset_settings": object(),
+        "start_pressure_test": object(),
+        "set_modbus_parameters": object(),
+        "set_device_name": object(),
+        "sync_time": object(),
+    }
+
+    assert list(_iter_maintenance_service_bindings(handlers)) == [
+        ("reset_filters", RESET_FILTERS_SCHEMA, handlers["reset_filters"]),
+        ("reset_settings", RESET_SETTINGS_SCHEMA, handlers["reset_settings"]),
+        ("start_pressure_test", START_PRESSURE_TEST_SCHEMA, handlers["start_pressure_test"]),
+        ("set_modbus_parameters", SET_MODBUS_PARAMETERS_SCHEMA, handlers["set_modbus_parameters"]),
+        ("set_device_name", SET_DEVICE_NAME_SCHEMA, handlers["set_device_name"]),
+        ("sync_time", SYNC_TIME_SCHEMA, handlers["sync_time"]),
     ]
 
 


### PR DESCRIPTION
### Motivation
- Reduce the breadth of `register_maintenance_services` by isolating the service/schema/handler binding logic into a focused helper. 
- Make the maintenance registration responsibility a smaller, testable slice to aid future decomposition and readability. 
- Preserve existing runtime behaviour, logging, error handling and registration order while narrowing the function surface.

### Description
- Added `_iter_maintenance_service_bindings(handlers: dict[str, object])` to `custom_components/thessla_green_modbus/services_handlers_maintenance.py` which yields `(service, schema, handler)` tuples bound from the existing registration table. 
- Updated `register_maintenance_services` to consume the new iterator and register services via the bound `(service, schema, handler)` tuples instead of directly indexing the handler map during table iteration. 
- Kept the `_maintenance_registrations()` table and its order unchanged and left all service names and schemas intact. 
- Added unit test `test_iter_maintenance_service_bindings_keeps_order_and_schema_binding` in `tests/test_services_handlers_maintenance.py` to assert order and schema-to-handler binding.

### Testing
- Created commit `b6e546b6` and modified `custom_components/thessla_green_modbus/services_handlers_maintenance.py` and `tests/test_services_handlers_maintenance.py`. 
- Ran lint and static validation with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed. 
- Ran targeted tests with `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` and full test suite with `pytest tests/ -q`, both completed successfully (full pytest passed with a small number of skips). 
- Ran repository validation scripts `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, and `python tools/validate_entity_mappings.py`, all of which passed as shown in the validation output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ca6a35e883268e9ba7fec29221bd)