### PR TITLE
refactor: extract shared register read failure finalizer in scanner I/O

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -159,6 +159,28 @@ def _handle_terminal_read_failure(scanner: Any, register_type: str, start: int, 
     _mark_failed_addresses(scanner, register_type, start, end)
 
 
+def _finalize_register_read_failure(
+    scanner: Any,
+    *,
+    register_type: str,
+    start: int,
+    end: int,
+    retry: int,
+    attempted_reads: int,
+    aborted_transiently: bool,
+) -> None:
+    """Finalize shared failure state/logging for input/holding read loops."""
+    kind = "input" if register_type == "input_registers" else "holding"
+    if aborted_transiently:
+        _log_read_abort(kind, start, end, attempted_reads, retry)
+        if register_type == "holding_registers":
+            _log_read_failure(kind, start, end, retry)
+        return
+
+    _log_read_failure(kind, start, end, retry)
+    _handle_terminal_read_failure(scanner, register_type, start, end)
+
+
 def _should_skip_input_range(scanner: Any, start: int, end: int, skip_cache: bool) -> tuple[bool, int, int]:
     """Return (skip, mark_start, mark_end) for unsupported/cached input ranges."""
     if skip_cache:
@@ -354,12 +376,15 @@ async def read_input(
             retry=scanner.retry,
         )
 
-    if aborted_transiently:
-        _log_read_abort("input", start, end, attempted_reads, scanner.retry)
-        return None
-
-    _handle_terminal_read_failure(scanner, "input_registers", start, end)
-    _log_read_failure("input", start, end, scanner.retry)
+    _finalize_register_read_failure(
+        scanner,
+        register_type="input_registers",
+        start=start,
+        end=end,
+        retry=scanner.retry,
+        attempted_reads=attempted_reads,
+        aborted_transiently=aborted_transiently,
+    )
     return None
 
 
@@ -537,13 +562,15 @@ async def read_holding(
             retry=scanner.retry,
         )
 
-    if aborted_transiently:
-        _log_read_abort("holding", start, end, attempted_reads, scanner.retry)
-        _log_read_failure("holding", start, end, scanner.retry)
-        return None
-
-    _log_read_failure("holding", start, end, scanner.retry)
-    _handle_terminal_read_failure(scanner, "holding_registers", start, end)
+    _finalize_register_read_failure(
+        scanner,
+        register_type="holding_registers",
+        start=start,
+        end=end,
+        retry=scanner.retry,
+        attempted_reads=attempted_reads,
+        aborted_transiently=aborted_transiently,
+    )
     return None
 
 

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner.io_read import _finalize_register_read_failure
 
 pytestmark = pytest.mark.asyncio
 
@@ -184,3 +185,44 @@ async def test_read_holding_cancelled_modbusio_stops_retry_loop():
     assert result is None
     assert call_mock.await_count == 1
     sleep_mock.assert_not_called()
+
+
+def test_finalize_register_read_failure_input_aborted_logs_abort_only(caplog):
+    """Input aborted transiently should not mark failed range or emit terminal failure."""
+    scanner = MagicMock()
+    scanner.failed_addresses = {"modbus_exceptions": {"input_registers": set(), "holding_registers": set()}}
+
+    with caplog.at_level(logging.WARNING):
+        _finalize_register_read_failure(
+            scanner,
+            register_type="input_registers",
+            start=4,
+            end=5,
+            retry=3,
+            attempted_reads=1,
+            aborted_transiently=True,
+        )
+
+    assert scanner.failed_addresses["modbus_exceptions"]["input_registers"] == set()
+    assert "Aborted reading input registers 4-5" in caplog.text
+    assert "Failed to read input registers 4-5" not in caplog.text
+
+
+def test_finalize_register_read_failure_holding_non_aborted_marks_and_logs(caplog):
+    """Holding terminal failure should mark full range and emit error log."""
+    scanner = MagicMock()
+    scanner.failed_addresses = {"modbus_exceptions": {"input_registers": set(), "holding_registers": set()}}
+
+    with caplog.at_level(logging.ERROR):
+        _finalize_register_read_failure(
+            scanner,
+            register_type="holding_registers",
+            start=10,
+            end=12,
+            retry=2,
+            attempted_reads=2,
+            aborted_transiently=False,
+        )
+
+    assert scanner.failed_addresses["modbus_exceptions"]["holding_registers"] == {10, 11, 12}
+    assert "Failed to read holding registers 10-12 after 2 retries" in caplog.text


### PR DESCRIPTION
### Motivation

- Reduce duplicated tail logic in scanner read paths by centralizing terminal/aborted failure finalization for input and holding register reads.

### Description

- Added `_finalize_register_read_failure(...)` in `custom_components/thessla_green_modbus/scanner/io_read.py` to consolidate abort vs terminal-failure logging and failed-range marking.
- Replaced duplicated tail logic in `read_input` and `read_holding` to call the new helper while preserving retry/backoff, unsupported-range, skip-cache, and failure-tracking semantics.
- Added two focused unit tests in `tests/test_scanner_io.py` that validate the helper: one for aborted input-path logging without marking failures and one for holding terminal-failure marking and error logging.
- No Home Assistant imports were introduced and scanner I/O remains HA-independent.

### Testing

- Ran lint/type/format checks and static compilation with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed.
- Ran repository validation with `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both passed (maintainability gate passed).
- Ran focused scanner tests with `pytest -q tests/test_scanner_io.py tests/test_scanner_io_coverage.py tests/test_scanner*.py tests/test_device_scanner*.py`, and then full test suite with `pytest tests/ -q`, both completed successfully (with the repository's known skips).
- Ran entity mappings validation with `python tools/validate_entity_mappings.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ca4cbaf0832697d98013830617b2)