### PR TITLE
refactor: extract reauth helpers from config flow

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -60,8 +60,10 @@ from .config_flow_runtime import (
 from .config_flow_runtime import run_with_retry as _run_with_retry_impl
 from .config_flow_schema import build_connection_schema as _build_connection_schema_impl
 from .config_flow_steps import extract_discovered_state as _extract_discovered_state_impl
+from .config_flow_steps import initialize_reauth_state as _initialize_reauth_state_impl
 from .config_flow_steps import merge_options_payload as _merge_options_payload_impl
 from .config_flow_steps import resolve_reauth_defaults as _resolve_reauth_defaults_impl
+from .config_flow_steps import resolve_reauth_entry as _resolve_reauth_entry_impl
 from .config_flow_steps import validate_options_submission as _validate_options_submission_impl
 from .config_flow_user_submit import process_user_submission as _process_user_submission_impl
 from .config_flow_validation import process_scan_capabilities as _process_scan_capabilities_impl
@@ -406,23 +408,24 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
     async def async_step_reauth(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle reauthentication by collecting updated connection details."""
         errors: dict[str, str] = {}
-        entry = None
-
-        if self.hass is not None:
-            entry_id = self.context.get("entry_id")
-            if entry_id:
-                entry = self.hass.config_entries.async_get_entry(entry_id)
+        entry = _resolve_reauth_entry_impl(self.hass, self.context)
 
         defaults: dict[str, Any] = {}
         if entry is not None:
             defaults = _resolve_reauth_defaults_impl(entry.data, entry.options)
 
-        if self._tg_flow_reauth_entry_id is None:
-            self._tg_flow_reauth_entry_id = entry.entry_id if entry else None
-            self._tg_flow_reauth_existing_data = defaults
+        should_initialize, reauth_entry_id, reauth_defaults = _initialize_reauth_state_impl(
+            active_entry_id=self._tg_flow_reauth_entry_id,
+            entry=entry,
+            defaults=defaults,
+        )
+
+        if should_initialize:
+            self._tg_flow_reauth_entry_id = reauth_entry_id
+            self._tg_flow_reauth_existing_data = reauth_defaults
             return self.async_show_form(
                 step_id="reauth",
-                data_schema=self._build_connection_schema(defaults),
+                data_schema=self._build_connection_schema(reauth_defaults),
                 errors=errors,
             )
 

--- a/custom_components/thessla_green_modbus/config_flow_steps.py
+++ b/custom_components/thessla_green_modbus/config_flow_steps.py
@@ -41,3 +41,25 @@ def resolve_reauth_defaults(
 ) -> dict[str, Any]:
     """Build reauth defaults from config entry payloads."""
     return {**(entry_options or {}), **(entry_data or {})}
+
+
+def resolve_reauth_entry(hass: Any, context: dict[str, Any]) -> Any | None:
+    """Resolve current reauth config entry from flow context."""
+    if hass is None:
+        return None
+    entry_id = context.get("entry_id")
+    if not entry_id:
+        return None
+    return hass.config_entries.async_get_entry(entry_id)
+
+
+def initialize_reauth_state(
+    *,
+    active_entry_id: str | None,
+    entry: Any | None,
+    defaults: dict[str, Any],
+) -> tuple[bool, str | None, dict[str, Any]]:
+    """Return initialization state and normalized reauth state payload."""
+    if active_entry_id is None:
+        return True, (entry.entry_id if entry else None), dict(defaults)
+    return False, active_entry_id, dict(defaults)

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -19,7 +19,9 @@ from custom_components.thessla_green_modbus.config_flow_schema import (
 )
 from custom_components.thessla_green_modbus.config_flow_steps import (
     extract_discovered_state,
+    initialize_reauth_state,
     resolve_reauth_defaults,
+    resolve_reauth_entry,
 )
 from custom_components.thessla_green_modbus.errors import CannotConnect
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
@@ -314,6 +316,24 @@ def test_resolve_reauth_defaults_options_overridden_by_data():
     assert defaults == {"host": "from_data", "slave_id": 3, "deep_scan": True}
 
 
+def test_resolve_reauth_entry_without_hass_returns_none():
+    assert resolve_reauth_entry(None, {"entry_id": "x"}) is None
+
+
+def test_initialize_reauth_state_initializes_from_entry():
+    class Entry:
+        entry_id = "entry-1"
+
+    should_init, entry_id, defaults = initialize_reauth_state(
+        active_entry_id=None,
+        entry=Entry(),
+        defaults={"host": "10.0.0.10"},
+    )
+    assert should_init is True
+    assert entry_id == "entry-1"
+    assert defaults == {"host": "10.0.0.10"}
+
+
 def test_vol_invalid_no_path():
     """VOL_INVALID without explicit path should keep empty path."""
     import custom_components.thessla_green_modbus.config_flow as cf_mod
@@ -454,5 +474,4 @@ async def test_call_with_optional_timeout_sync_function():
 # ---------------------------------------------------------------------------
 # Pass 16 — lines 425-428: RTU validation success path
 # ---------------------------------------------------------------------------
-
 


### PR DESCRIPTION
### Motivation
- Reduce config-flow complexity by extracting reauth context parsing and initialization logic into focused helpers to keep `ConfigFlow.async_step_reauth` readable while preserving existing behavior.

### Description
- Added `resolve_reauth_entry(hass, context)` to `custom_components/thessla_green_modbus/config_flow_steps.py` to encapsulate lookup of the reauth `config_entry` from flow context.
- Added `initialize_reauth_state(*, active_entry_id, entry, defaults)` to `config_flow_steps.py` to centralize first-step initialization and normalization of reauth state.
- Updated `custom_components/thessla_green_modbus/config_flow.py` to delegate reauth entry resolution and initialization branching to the new helpers and to use the normalized `reauth_defaults` when showing the initial reauth form.
- Added unit tests in `tests/test_config_flow_helpers.py` to cover the new helpers and adjusted imports accordingly.

### Testing
- Ran lint and static checks with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both of which passed.
- Ran auxiliary validation with `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both of which passed.
- Ran unit tests for config flow with `pytest -q tests/test_config_flow*.py` and full test suite with `pytest tests/ -q`, and all tests passed (only existing skips remained); the new tests `test_resolve_reauth_entry_without_hass_returns_none` and `test_initialize_reauth_state_initializes_from_entry` passed.
- Ran entity mappings validation with `python tools/validate_entity_mappings.py`, which passed.
- Maintainability gate passed and overall CI-equivalent validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4497e99e48326980c9d851ef931c8)