### PR TITLE
refactor: extract coordinator disconnect orchestration helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -128,6 +128,8 @@ from .connection_state import (
 from .connection_state import (
     mark_connection_failure as _mark_connection_failure_impl,
 )
+from .disconnect import close_client_connection as _close_client_connection_impl
+from .disconnect import disconnect_locked as _disconnect_locked_impl
 from .io import _ModbusIOMixin
 from .lifecycle import async_setup as _async_setup_impl
 from .models import CoordinatorConfig
@@ -751,37 +753,20 @@ class ThesslaGreenModbusCoordinator(
     async def _disconnect_locked(self) -> None:
         """Disconnect from Modbus device without acquiring locks."""
 
-        if self._transport is not None:
-            try:
-                await self._transport.close()
-            except (ModbusException, ConnectionException):
-                _LOGGER.debug("Error disconnecting", exc_info=True)
-            except OSError:
-                _LOGGER.exception("Unexpected error disconnecting")
-        elif self.client is not None:
-            await self._close_client_connection()
-
-        self.client = None
-        _mark_connection_disconnected_impl(
-            offline_state_setter=lambda value: setattr(self, "offline_state", value)
+        await _disconnect_locked_impl(
+            transport=self._transport,
+            client=self.client,
+            close_client_connection_fn=_close_client_connection_impl,
+            mark_connection_disconnected_fn=lambda: _mark_connection_disconnected_impl(
+                offline_state_setter=lambda value: setattr(self, "offline_state", value)
+            ),
+            logger=_LOGGER,
         )
-        _LOGGER.debug("Disconnected from Modbus device")
+        self.client = None
 
     async def _close_client_connection(self) -> None:
         """Close client object safely for sync or async close implementations."""
-        try:
-            close = getattr(self.client, "close", None)
-            if callable(close):
-                if inspect.iscoroutinefunction(close):
-                    await close()
-                else:
-                    result = close()
-                    if inspect.isawaitable(result):
-                        await result
-        except (ModbusException, ConnectionException):
-            _LOGGER.debug("Error disconnecting", exc_info=True)
-        except OSError:
-            _LOGGER.exception("Unexpected error disconnecting")
+        await _close_client_connection_impl(client=self.client, logger=_LOGGER)
 
     async def _disconnect(self) -> None:
         """Disconnect from Modbus device."""

--- a/custom_components/thessla_green_modbus/coordinator/disconnect.py
+++ b/custom_components/thessla_green_modbus/coordinator/disconnect.py
@@ -1,0 +1,50 @@
+"""Coordinator disconnect orchestration helpers."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from ..modbus_exceptions import ConnectionException, ModbusException
+
+
+async def close_client_connection(*, client: Any, logger: logging.Logger) -> None:
+    """Close client object safely for sync or async close implementations."""
+    try:
+        close = getattr(client, "close", None)
+        if callable(close):
+            if inspect.iscoroutinefunction(close):
+                await close()
+            else:
+                result = close()
+                if inspect.isawaitable(result):
+                    await result
+    except (ModbusException, ConnectionException):
+        logger.debug("Error disconnecting", exc_info=True)
+    except OSError:
+        logger.exception("Unexpected error disconnecting")
+
+
+async def disconnect_locked(
+    *,
+    transport: Any,
+    client: Any,
+    close_client_connection_fn: Callable[..., Any],
+    mark_connection_disconnected_fn: Callable[[], None],
+    logger: logging.Logger,
+) -> None:
+    """Disconnect from Modbus device without acquiring locks."""
+    if transport is not None:
+        try:
+            await transport.close()
+        except (ModbusException, ConnectionException):
+            logger.debug("Error disconnecting", exc_info=True)
+        except OSError:
+            logger.exception("Unexpected error disconnecting")
+    elif client is not None:
+        await close_client_connection_fn(client=client, logger=logger)
+
+    mark_connection_disconnected_fn()
+    logger.debug("Disconnected from Modbus device")

--- a/tests/test_coordinator_disconnect.py
+++ b/tests/test_coordinator_disconnect.py
@@ -1,0 +1,39 @@
+"""Tests for coordinator disconnect helper module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus.coordinator import disconnect
+
+
+@pytest.mark.asyncio
+async def test_disconnect_locked_uses_close_client_helper():
+    """disconnect_locked delegates client-close branch to helper callback."""
+    close_client = AsyncMock()
+    mark_disconnected = MagicMock()
+
+    await disconnect.disconnect_locked(
+        transport=None,
+        client=MagicMock(),
+        close_client_connection_fn=close_client,
+        mark_connection_disconnected_fn=mark_disconnected,
+        logger=MagicMock(),
+    )
+
+    close_client.assert_awaited_once()
+    mark_disconnected.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_close_client_connection_awaits_awaitable_close_result():
+    """close_client_connection awaits an awaitable returned from sync close()."""
+    client = MagicMock()
+
+    async def _close_coro():
+        return None
+
+    client.close = MagicMock(return_value=_close_coro())
+    await disconnect.close_client_connection(client=client, logger=MagicMock())
+    client.close.assert_called_once()


### PR DESCRIPTION
### Motivation

- Reduce the size and responsibilities of `ThesslaGreenModbusCoordinator` by moving disconnect/teardown logic into a focused implementation module.  
- Isolate transport/client close-path complexity (sync/async/awaitable close, Modbus/connection exceptions) so the coordinator remains the Home Assistant-facing orchestrator.  
- Preserve runtime behavior and the coordinator package-root public API while enabling future decomposition of other coordinator responsibilities.

### Description

- Added `custom_components/thessla_green_modbus/coordinator/disconnect.py` implementing real disconnect logic with `close_client_connection(...)` and `disconnect_locked(...)`.  
- Updated `ThesslaGreenModbusCoordinator` to delegate `_disconnect_locked` and `_close_client_connection` to the new helper implementations while preserving the same state transitions and logging.  
- Added unit tests `tests/test_coordinator_disconnect.py` covering delegation and awaitable-close handling for the extracted helpers.  
- Ensured the new module is an implementation (not a shim) and kept the coordinator package-root API unchanged (`CoordinatorConfig`, `ThesslaGreenModbusCoordinator`).

### Testing

- Ran lint and static checks: `ruff check custom_components tests tools` succeeded.  
- Verified Python compilation: `python -m compileall -q custom_components/thessla_green_modbus tests tools` succeeded.  
- Ran repository validation gates: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py` succeeded.  
- Ran unit tests: `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` passed, and a full `pytest tests/ -q` run passed (with repository-expected skips).  
- Ran entity mappings validation: `python tools/validate_entity_mappings.py` succeeded.  
- Confirmed coordinator package API assertion (`__all__ == ['CoordinatorConfig', 'ThesslaGreenModbusCoordinator']`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f452d2957c8326ade2ecae31474abb)