### PR TITLE
refactor: extract scanner read batching helper

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -92,6 +92,21 @@ def _normalize_register_result(response: Any) -> list[int]:
     return cast(list[int], response.registers)
 
 
+def _build_register_chunks(scanner: Any, start: int, count: int) -> list[tuple[int, int]]:
+    """Build contiguous chunk plan for a register range."""
+    return list(chunk_register_range(start, count, scanner.effective_batch))
+
+
+def _extend_or_abort_register_results(
+    results: list[int], block: list[int] | None
+) -> tuple[bool, list[int] | None]:
+    """Append block values and indicate whether read batching should continue."""
+    if block is None:
+        return False, None
+    results.extend(block)
+    return True, results
+
+
 def _process_register_response(
     scanner: Any,
     *,
@@ -410,15 +425,15 @@ async def read_register_block(
 
     results: list[int] = []
     active_client = client or scanner._client
-    for chunk_start, chunk_count in chunk_register_range(start, count, scanner.effective_batch):
+    for chunk_start, chunk_count in _build_register_chunks(scanner, start, count):
         block = await (
             read_fn(chunk_start, chunk_count)
             if active_client is None
             else read_fn(active_client, chunk_start, chunk_count)
         )
-        if block is None:
+        can_continue, _ = _extend_or_abort_register_results(results, block)
+        if not can_continue:
             return None
-        results.extend(block)
     return results
 
 

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
-from custom_components.thessla_green_modbus.scanner.io_read import _finalize_register_read_failure
+from custom_components.thessla_green_modbus.scanner.io_read import (
+    _build_register_chunks,
+    _extend_or_abort_register_results,
+    _finalize_register_read_failure,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -226,3 +230,22 @@ def test_finalize_register_read_failure_holding_non_aborted_marks_and_logs(caplo
 
     assert scanner.failed_addresses["modbus_exceptions"]["holding_registers"] == {10, 11, 12}
     assert "Failed to read holding registers 10-12 after 2 retries" in caplog.text
+
+
+def test_build_register_chunks_uses_effective_batch():
+    """Chunk construction should respect effective batch size boundaries."""
+    scanner = MagicMock()
+    scanner.effective_batch = 2
+    assert _build_register_chunks(scanner, 10, 5) == [(10, 2), (12, 2), (14, 1)]
+
+
+def test_extend_or_abort_register_results_handles_none_and_appends():
+    """Result helper should abort on None and append successful blocks."""
+    results = [1]
+    can_continue, payload = _extend_or_abort_register_results(results, None)
+    assert (can_continue, payload) == (False, None)
+    assert results == [1]
+
+    can_continue, payload = _extend_or_abort_register_results(results, [2, 3])
+    assert can_continue is True
+    assert payload == [1, 2, 3]


### PR DESCRIPTION
### Motivation

- Reduce duplication and complexity in `custom_components/thessla_green_modbus/scanner/io_read.py` by extracting shared logic that builds read batches and assembles chunked read results.

### Description

- Add `_build_register_chunks(scanner, start, count)` to centralize chunk plan construction using the scanner `effective_batch`.
- Add `_extend_or_abort_register_results(results, block)` to centralize normalized chunk result assembly and early-abort semantics when a chunk returns `None`.
- Refactor `read_register_block` to use the new helpers and preserve existing semantics (abort on any failed chunk, return concatenated results on success) by delegating chunking and result handling to the helpers.
- Add focused unit tests for the new helpers in `tests/test_scanner_io.py` verifying chunk boundaries and abort/append behavior.
- No changes to `scanner/core.py`, transport, coordinator, mappings, or Home Assistant dependencies; scanner remains HA-independent.

### Testing

- Ran lint and compile gates: `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` (passed).
- Ran maintainability and reference checks: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py` (passed).
- Ran targeted and full tests: `pytest -q tests/test_scanner_io.py tests/test_scanner_io_coverage.py tests/test_scanner*.py tests/test_device_scanner*.py` and `pytest tests/ -q` (all passed with expected skips).
- Ran entity mapping validation: `python tools/validate_entity_mappings.py` (passed).
- Files changed: `custom_components/thessla_green_modbus/scanner/io_read.py` and `tests/test_scanner_io.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f452c1c5888326b45586a340df3e9c)