### PR TITLE
refactor: continue scanner runtime decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/custom_scan.py
+++ b/custom_components/thessla_green_modbus/scanner/custom_scan.py
@@ -1,0 +1,47 @@
+"""Custom scan runtime helpers for scanner orchestration."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from ..scanner_device_info import DeviceCapabilities, ScannerDeviceInfo
+
+
+def uses_custom_scan_impl(scanner: Any) -> bool:
+    """Return True when scanner.scan is overridden outside scanner.core."""
+    scan_method = scanner.scan
+    base_scan = getattr(type(scanner), "scan", None)
+    return getattr(scan_method, "__func__", None) is not base_scan or getattr(
+        base_scan, "__module__", ""
+    ) != "custom_components.thessla_green_modbus.scanner.core"
+
+
+def normalize_custom_scan_result(scanner: Any, scan_result: Any) -> dict[str, Any]:
+    """Normalize custom scan return shapes to a scan payload."""
+    if (
+        isinstance(scan_result, tuple)
+        and len(scan_result) >= 2
+        and isinstance(scan_result[0], ScannerDeviceInfo)
+        and isinstance(scan_result[1], DeviceCapabilities)
+    ):
+        device, caps = scan_result[0], scan_result[1]
+        unknown = scan_result[2] if len(scan_result) > 2 and isinstance(scan_result[2], dict) else {}
+        return {
+            "available_registers": {k: sorted(v) for k, v in scanner.available_registers.items()},
+            "device_info": device.as_dict(),
+            "capabilities": caps.as_dict(),
+            "register_count": sum(len(v) for v in scanner.available_registers.values()),
+            "unknown_registers": unknown,
+        }
+    if isinstance(scan_result, dict):
+        return scan_result
+    raise TypeError("scan() must return a dict")
+
+
+async def run_custom_scan(scanner: Any) -> dict[str, Any]:
+    """Run overridden scan implementation and normalize result."""
+    scan_result: Any = scanner.scan()
+    if inspect.isawaitable(scan_result):
+        scan_result = await scan_result
+    return normalize_custom_scan_result(scanner, scan_result)

--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 import time
 from typing import Any
@@ -21,6 +20,7 @@ from ..modbus_exceptions import ConnectionException, ModbusException, ModbusIOEx
 from ..modbus_helpers import group_reads as _group_reads
 from ..modbus_transport import RtuModbusTransport
 from ..scanner_device_info import DeviceCapabilities, ScannerDeviceInfo
+from . import custom_scan as scanner_custom_scan
 from .io import is_request_cancelled_error
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,47 +92,6 @@ def _build_scan_result(scanner: Any, *, device: ScannerDeviceInfo, caps: DeviceC
         result["raw_registers"] = raw_registers
         result["total_addresses_scanned"] = len(raw_registers)
     return result
-
-
-def _uses_custom_scan_impl(scanner: Any) -> bool:
-    """Return True when scanner.scan is overridden outside scanner.core."""
-    scan_method = scanner.scan
-    base_scan = getattr(type(scanner), "scan", None)
-    return getattr(scan_method, "__func__", None) is not base_scan or getattr(
-        base_scan, "__module__", ""
-    ) != "custom_components.thessla_green_modbus.scanner.core"
-
-
-def _normalize_custom_scan_result(scanner: Any, scan_result: Any) -> dict[str, Any]:
-    """Normalize custom scan return shapes to a scan payload."""
-    if (
-        isinstance(scan_result, tuple)
-        and len(scan_result) >= 2
-        and isinstance(scan_result[0], ScannerDeviceInfo)
-        and isinstance(scan_result[1], DeviceCapabilities)
-    ):
-        device, caps = scan_result[0], scan_result[1]
-        unknown = scan_result[2] if len(scan_result) > 2 and isinstance(scan_result[2], dict) else {}
-        return {
-            "available_registers": {
-                k: sorted(v) for k, v in scanner.available_registers.items()
-            },
-            "device_info": device.as_dict(),
-            "capabilities": caps.as_dict(),
-            "register_count": sum(len(v) for v in scanner.available_registers.values()),
-            "unknown_registers": unknown,
-        }
-    if isinstance(scan_result, dict):
-        return scan_result
-    raise TypeError("scan() must return a dict")
-
-
-async def _run_custom_scan(scanner: Any) -> dict[str, Any]:
-    """Run overridden scan implementation and normalize result."""
-    scan_result: Any = scanner.scan()
-    if inspect.isawaitable(scan_result):
-        scan_result = await scan_result
-    return _normalize_custom_scan_result(scanner, scan_result)
 
 
 async def _auto_detect_tcp_transport(scanner: Any) -> None:
@@ -428,9 +387,9 @@ async def scan(scanner: Any) -> dict[str, Any]:
 
 async def scan_device(scanner: Any) -> dict[str, Any]:
     """Open the Modbus connection, perform a scan and close the client."""
-    if _uses_custom_scan_impl(scanner):
+    if scanner_custom_scan.uses_custom_scan_impl(scanner):
         try:
-            return await _run_custom_scan(scanner)
+            return await scanner_custom_scan.run_custom_scan(scanner)
         finally:
             await scanner.close()
     await _prepare_scan_transport(scanner)

--- a/tests/test_scanner_custom_scan.py
+++ b/tests/test_scanner_custom_scan.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import pytest
+from custom_components.thessla_green_modbus.scanner import custom_scan
+from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner_device_info import (
+    DeviceCapabilities,
+    ScannerDeviceInfo,
+)
+
+
+def test_uses_custom_scan_impl_detects_bound_override() -> None:
+    scanner = SimpleNamespace()
+
+    async def fake_scan() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    scanner.scan = fake_scan
+    assert custom_scan.uses_custom_scan_impl(scanner) is True
+
+
+def test_normalize_custom_scan_result_tuple_shape() -> None:
+    scanner = SimpleNamespace(
+        available_registers={
+            "input_registers": {"outside_temperature"},
+            "holding_registers": {"mode"},
+        }
+    )
+    device = ScannerDeviceInfo(model="AirPack")
+    caps = DeviceCapabilities(basic_control=True)
+
+    result = custom_scan.normalize_custom_scan_result(
+        scanner,
+        (device, caps, {"input_registers": {10: 1}}),
+    )
+
+    assert result["register_count"] == 2
+    assert result["capabilities"]["basic_control"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_custom_scan_awaits_coroutine() -> None:
+    async def fake_scan() -> dict[str, str]:
+        return {"ready": "ok"}
+
+    scanner = SimpleNamespace(scan=fake_scan)
+    result = await custom_scan.run_custom_scan(scanner)
+    assert result == {"ready": "ok"}
+
+
+def test_uses_custom_scan_impl_false_for_core_impl() -> None:
+    scanner = ThesslaGreenDeviceScanner("127.0.0.1", 502, registers_ready=True)
+    assert custom_scan.uses_custom_scan_impl(scanner) is False


### PR DESCRIPTION
### Motivation
- Reduce complexity in scanner orchestration by extracting the custom-scan detection/normalization/runtime concern into a single focused helper so `scan_device` has fewer responsibilities while preserving behavior.

### Description
- Added `custom_components/thessla_green_modbus/scanner/custom_scan.py` which implements detection of bound/overridden `scan` implementations, normalization of legacy tuple/dict scan results, and asynchronous execution of custom scans.
- Updated `custom_components/thessla_green_modbus/scanner/orchestration.py` to delegate custom-scan handling to the new `custom_scan` helper and removed the inlined custom-scan logic.
- Added `tests/test_scanner_custom_scan.py` with focused unit tests covering override detection, tuple normalization, coroutine execution, and default/core implementation detection.

### Testing
- Ran `ruff check custom_components tests tools` and automatic import-fix, which passed; `python -m compileall -q custom_components/thessla_green_modbus tests tools` passed.
- Ran `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both passed; repository maintainability checks passed.
- Executed `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` and full `pytest tests/ -q`, and all tests passed (existing skips unchanged); newly added tests passed.
- Ran `python tools/validate_entity_mappings.py` and repository grep audits for HA imports/shims, all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f452ba8ccc83268183af6f731f9d6b)