### PR TITLE
refactor: extract options form payload builder

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -36,16 +36,7 @@ from .config_flow_options import normalize_baud_rate as _normalize_baud_rate_imp
 from .config_flow_options import normalize_parity as _normalize_parity_impl
 from .config_flow_options import normalize_stop_bits as _normalize_stop_bits_impl
 from .config_flow_options import strip_translation_prefix as _strip_translation_prefix_impl
-from .config_flow_options_form import (
-    build_options_defaults as _build_options_defaults,
-)
-from .config_flow_options_form import (
-    build_options_description_placeholders as _build_options_description_placeholders,
-)
-from .config_flow_options_form import build_options_schema as _build_options_schema
-from .config_flow_options_form import (
-    build_transport_description as _build_transport_description,
-)
+from .config_flow_options_form import build_options_form_payload as _build_options_form_payload
 from .config_flow_payloads import caps_to_dict as _caps_to_dict_impl
 from .config_flow_payloads import normalize_connection_type as _normalize_connection_type_impl
 from .config_flow_reauth import process_reauth_submission as _process_reauth_submission_impl
@@ -511,9 +502,10 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         entry_data = getattr(self.config_entry, "data", {}) or {}
         entry_options = getattr(self.config_entry, "options", {}) or {}
-        values = _build_options_defaults(entry_data, entry_options)
-        transport_label, transport_details = _build_transport_description(values)
-        data_schema = _build_options_schema(values)
+        data_schema, description_placeholders = _build_options_form_payload(
+            entry_data,
+            entry_options,
+        )
 
         # IMPORTANT: do NOT expose CONF_CONNECTION_MODE here (prevents duplicate GUI fields)
 
@@ -521,9 +513,5 @@ class OptionsFlow(config_entries.OptionsFlow):
             step_id="init",
             data_schema=data_schema,
             errors=errors,
-            description_placeholders=_build_options_description_placeholders(
-                values,
-                transport_label=transport_label,
-                transport_details=transport_details,
-            ),
+            description_placeholders=description_placeholders,
         )

--- a/custom_components/thessla_green_modbus/config_flow_options_form.py
+++ b/custom_components/thessla_green_modbus/config_flow_options_form.py
@@ -203,3 +203,17 @@ def build_options_description_placeholders(
         "transport_label": transport_label,
         "transport_details": transport_details,
     }
+
+
+def build_options_form_payload(
+    entry_data: dict[str, Any],
+    entry_options: dict[str, Any],
+) -> tuple[vol.Schema, dict[str, str]]:
+    """Build options form schema and description placeholders."""
+    values = build_options_defaults(entry_data, entry_options)
+    transport_label, transport_details = build_transport_description(values)
+    return build_options_schema(values), build_options_description_placeholders(
+        values,
+        transport_label=transport_label,
+        transport_details=transport_details,
+    )

--- a/tests/test_config_flow_options.py
+++ b/tests/test_config_flow_options.py
@@ -8,6 +8,9 @@ from custom_components.thessla_green_modbus.config_flow import (
     ConfigFlow,
     OptionsFlow,
 )
+from custom_components.thessla_green_modbus.config_flow_options_form import (
+    build_options_form_payload,
+)
 from custom_components.thessla_green_modbus.const import (
     CONF_CONNECTION_TYPE,
     CONF_MAX_REGISTERS_PER_REQUEST,
@@ -145,3 +148,18 @@ async def test_options_flow_max_registers_per_request_validated():
     assert result["type"] == "form"
     assert result["errors"][CONF_MAX_REGISTERS_PER_REQUEST] == "max_registers_range"
 
+
+
+@pytest.mark.asyncio
+async def test_build_options_form_payload_includes_transport_placeholders():
+    """Options form payload builder returns schema and placeholders."""
+    data_schema, placeholders = build_options_form_payload(
+        {CONF_CONNECTION_TYPE: CONNECTION_TYPE_TCP, CONF_PORT: 502},
+        {},
+    )
+
+    schema_keys = {
+        key.schema if hasattr(key, "schema") else key for key in data_schema.schema
+    }
+    assert CONF_MAX_REGISTERS_PER_REQUEST in schema_keys
+    assert placeholders["transport_label"] in {"Modbus TCP", "Modbus TCP (Auto)", "Modbus TCP RTU"}


### PR DESCRIPTION
### Motivation
- Reduce `config_flow.py` complexity by centralizing the options-flow form schema and description placeholder assembly into a single helper so the HA flow entry points stay smaller and easier to test while preserving user-visible behavior.

### Description
- Add `build_options_form_payload(entry_data, entry_options)` in `custom_components/thessla_green_modbus/config_flow_options_form.py` to return the options `data_schema` and `description_placeholders` in one call.
- Simplify `OptionsFlow.async_step_init` in `custom_components/thessla_green_modbus/config_flow.py` to call the new helper instead of assembling `values`, `transport_label`, `transport_details`, `data_schema`, and placeholders inline.
- Add a focused test `test_build_options_form_payload_includes_transport_placeholders` in `tests/test_config_flow_options.py` that asserts the schema contains `CONF_MAX_REGISTERS_PER_REQUEST` and that the transport placeholder is one of the expected labels.

### Testing
- Ran `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, `pytest -q tests/test_config_flow*.py`, `pytest tests/ -q`, and `python tools/validate_entity_mappings.py`; all checks completed successfully and pytest passed (with expected skips reported by the suite).
- The updated config-flow tests including the new helper test (`tests/test_config_flow_options.py`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f452aca94c8326bd870e25303ff391)