### PR TITLE
refactor: extract discrete mapping loader from mapping builders

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -28,8 +28,11 @@ from ._mapping_classification import (
 from ._mapping_classification import (
     classify_min_max_mapping as _classify_min_max_mapping,
 )
-from ._mapping_payloads import (
-    classify_discrete_holding_payload as _classify_discrete_holding_payload,
+from ._mapping_discrete_loader import (
+    add_binary_mappings_for_boolean_registers as _add_binary_mappings_for_boolean_registers,
+)
+from ._mapping_discrete_loader import (
+    classify_discrete_holding_registers as _classify_discrete_holding_registers,
 )
 from ._mapping_payloads import (
     parse_info_states as _parse_info_states,
@@ -495,37 +498,20 @@ def _load_discrete_mappings() -> tuple[
     discrete_regs = _discrete_regs()
     holding_regs = _holding_regs()
 
-    for reg in coil_regs:
-        if reg not in binary_keys:
-            continue
-        binary_configs[reg] = _build_base_translation_mapping(reg, "coil_registers")
-    for reg in discrete_regs:
-        if reg not in binary_keys:
-            continue
-        binary_configs[reg] = _build_base_translation_mapping(reg, "discrete_inputs")
+    _add_binary_mappings_for_boolean_registers(binary_configs, coil_regs, binary_keys, "coil_registers")
+    _add_binary_mappings_for_boolean_registers(binary_configs, discrete_regs, binary_keys, "discrete_inputs")
 
-    for reg in holding_regs:
-        info = _get_info(reg)
-        if not info:
-            continue
-        states = _parse(info.get("unit"))
-        if not states:
-            continue
-        access = (info.get("access") or "").upper()
-        target, payload = _classify_discrete_holding_payload(
-            register=reg,
-            access=access,
-            states=states,
-            switch_keys=switch_keys,
-            binary_keys=binary_keys,
-            select_keys=select_keys,
-        )
-        if target == "switch" and payload:
-            switch_configs[reg] = payload
-        elif target == "binary" and payload:
-            binary_configs[reg] = payload
-        elif target == "select" and payload:
-            select_configs[reg] = payload
+    holding_binary, holding_switch, holding_select = _classify_discrete_holding_registers(
+        holding_regs=holding_regs,
+        get_info=_get_info,
+        parse_states=_parse,
+        switch_keys=switch_keys,
+        binary_keys=binary_keys,
+        select_keys=select_keys,
+    )
+    binary_configs.update(holding_binary)
+    switch_configs.update(holding_switch)
+    select_configs.update(holding_select)
 
     _apply_diagnostic_binary_overrides(
         _diag_register_candidates(holding_regs),
@@ -635,13 +621,14 @@ def _extend_entity_mappings_from_registers() -> None:
 
 __all__ = [
     "_TIME_ENTITY_PREFIXES",
+    "_add_binary_mappings_for_boolean_registers",
     "_apply_diagnostic_binary_overrides",
     "_build_base_translation_mapping",
     "_build_problem_binary_mapping",
     "_build_season_setting_mapping",
     "_build_sensor_season_setting_mapping",
     "_build_time_like_mapping",
-    "_classify_discrete_holding_payload",
+    "_classify_discrete_holding_registers",
     "_classify_enum_mapping",
     "_classify_min_max_mapping",
     "_diag_register_candidates",

--- a/custom_components/thessla_green_modbus/mappings/_mapping_discrete_loader.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_discrete_loader.py
@@ -1,0 +1,68 @@
+"""Discrete mapping loader helpers extracted from mapping builders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._mapping_payloads import classify_discrete_holding_payload
+
+
+def add_binary_mappings_for_boolean_registers(
+    binary_configs: dict[str, dict[str, Any]],
+    registers: set[str],
+    binary_keys: set[str],
+    register_type: str,
+) -> None:
+    """Populate binary configs with translation/register type for matching registers."""
+    for reg in registers:
+        if reg not in binary_keys:
+            continue
+        binary_configs[reg] = {
+            "translation_key": reg,
+            "register_type": register_type,
+        }
+
+
+def classify_discrete_holding_registers(
+    holding_regs: set[str],
+    get_info: Any,
+    parse_states: Any,
+    switch_keys: set[str],
+    binary_keys: set[str],
+    select_keys: set[str],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Classify holding discrete registers into switch/binary/select payload buckets."""
+    binary_configs: dict[str, dict[str, Any]] = {}
+    switch_configs: dict[str, dict[str, Any]] = {}
+    select_configs: dict[str, dict[str, Any]] = {}
+
+    for reg in holding_regs:
+        info = get_info(reg)
+        if not info:
+            continue
+        states = parse_states(info.get("unit"))
+        if not states:
+            continue
+        access = (info.get("access") or "").upper()
+        target, payload = classify_discrete_holding_payload(
+            register=reg,
+            access=access,
+            states=states,
+            switch_keys=switch_keys,
+            binary_keys=binary_keys,
+            select_keys=select_keys,
+        )
+        if target == "switch" and payload:
+            switch_configs[reg] = payload
+        elif target == "binary" and payload:
+            binary_configs[reg] = payload
+        elif target == "select" and payload:
+            select_configs[reg] = payload
+
+    return binary_configs, switch_configs, select_configs
+
+
+__all__ = [
+    "add_binary_mappings_for_boolean_registers",
+    "classify_discrete_holding_registers",
+]

--- a/tests/test_entity_mappings_builder_transformations.py
+++ b/tests/test_entity_mappings_builder_transformations.py
@@ -16,6 +16,10 @@ from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _route_problem_mapping,
     _route_time_and_season_mappings,
 )
+from custom_components.thessla_green_modbus.mappings._mapping_discrete_loader import (
+    add_binary_mappings_for_boolean_registers,
+    classify_discrete_holding_registers,
+)
 from custom_components.thessla_green_modbus.mappings._mapping_payloads import (
     classify_discrete_holding_payload,
 )
@@ -301,4 +305,67 @@ def test_classify_discrete_holding_payload_routes_binary_switch_and_select() -> 
         "translation_key": "mode",
         "register_type": "holding_registers",
         "states": {"auto": 0, "manual": 1, "boost": 2},
+    }
+
+
+def test_add_binary_mappings_for_boolean_registers_filters_by_translation() -> None:
+    binary: dict[str, dict[str, object]] = {}
+    add_binary_mappings_for_boolean_registers(
+        binary_configs=binary,
+        registers={"reg_a", "reg_b"},
+        binary_keys={"reg_b"},
+        register_type="coil_registers",
+    )
+    assert binary == {"reg_b": {"translation_key": "reg_b", "register_type": "coil_registers"}}
+
+
+def test_classify_discrete_holding_registers_splits_targets() -> None:
+    info_by_reg = {
+        "fan_enable": {"unit": "0-off;1-on", "access": "RW"},
+        "filter_dirty": {"unit": "0-off;1-on", "access": "R"},
+        "mode": {"unit": "0-auto;1-manual;2-boost", "access": "RW"},
+        "skip": {"unit": None, "access": "RW"},
+    }
+
+    def _get_info(name: str):
+        return info_by_reg.get(name)
+
+    def _parse_states(unit: str | None):
+        if not unit:
+            return {}
+        out = {}
+        for part in unit.split(";"):
+            val, label = part.split("-", 1)
+            out[label] = int(val)
+        return out
+
+    binary, switch, select = classify_discrete_holding_registers(
+        holding_regs={"fan_enable", "filter_dirty", "mode", "skip"},
+        get_info=_get_info,
+        parse_states=_parse_states,
+        switch_keys={"fan_enable"},
+        binary_keys={"filter_dirty"},
+        select_keys={"mode"},
+    )
+
+    assert switch == {
+        "fan_enable": {
+            "translation_key": "fan_enable",
+            "register_type": "holding_registers",
+            "register": "fan_enable",
+            "icon": "mdi:toggle-switch",
+        }
+    }
+    assert binary == {
+        "filter_dirty": {
+            "translation_key": "filter_dirty",
+            "register_type": "holding_registers",
+        }
+    }
+    assert select == {
+        "mode": {
+            "translation_key": "mode",
+            "register_type": "holding_registers",
+            "states": {"auto": 0, "manual": 1, "boost": 2},
+        }
     }


### PR DESCRIPTION
### Motivation
- Continue decomposition of `mappings` by isolating discrete/boolean register classification and boolean binary population to reduce complexity in `_mapping_builders.py`.

### Description
- Extracted discrete mapping helpers into a new module `custom_components/thessla_green_modbus/mappings/_mapping_discrete_loader.py` implementing `add_binary_mappings_for_boolean_registers` and `classify_discrete_holding_registers`.
- Updated `_load_discrete_mappings` in `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` to call the new helpers while preserving diagnostic overrides, bitmask handling, and resulting payload shapes.
- Added focused tests in `tests/test_entity_mappings_builder_transformations.py` to validate `add_binary_mappings_for_boolean_registers` and `classify_discrete_holding_registers`, and updated exported symbols to expose the new helpers.
- Commit hash for this change is `7e58c2aa`.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt` and `ruff check custom_components tests tools`, which completed successfully.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` and `python tools/compare_registers_with_reference.py` which completed successfully.
- Ran `python tools/check_maintainability.py` which passed the maintainability gate.
- Ran `python tools/validate_entity_mappings.py` which reported `OK: 366 entities validated` and passed.
- Ran `pytest -q tests/test_entity_mappings*.py` and `pytest tests/ -q` and the full test suite passed (existing skips remained).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f452b2856c8326b885d892f7bbbead)