### PR TITLE
docs: add staged non-disruptive CI hardening plan to maintainability audit

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -101,3 +101,34 @@ Interpretation: the largest remaining production hotspots are coordinator orches
 
 - Full pytest: **passed** (4 skipped).
 - Maintainability gate: **passed**.
+
+## 9) Safe CI hardening plan (staged, non-disruptive)
+
+As of this audit, CI-required gates remain intentionally limited to Ruff linting, compile checks, register/reference comparison, maintainability checks, pytest+coverage, and entity mapping validation. The following staged plan can increase quality signal **without** re-introducing previously excluded blocking checks (`black`, `isort`, `mypy`, `hassfest`, HACS validation):
+
+### Stage A (documentation + local developer workflow only)
+
+1. Keep CI required jobs unchanged.
+2. Encourage local informational checks for:
+   - `ruff format --check custom_components tests tools`
+   - `ruff check --select I custom_components tests tools`
+3. Treat these as local feedback only until file churn drops; do not auto-format in broad sweep PRs.
+
+### Stage B (optional informational CI job, non-blocking)
+
+If desired, add a separate workflow job that runs the two checks above and is explicitly marked non-blocking (for example, `continue-on-error: true`). This job should:
+
+- avoid touching required branch protection gates,
+- avoid secrets and external services,
+- only report drift trend.
+
+### Stage C (targeted adoption after convergence)
+
+When `ruff format --check` and import-order checks are routinely clean on active files, enforce them incrementally by path or module group in small PRs, never as a one-shot repository-wide rewrite.
+
+### Current readiness snapshot
+
+- `ruff format --check custom_components tests tools`: **fails** currently (94 files would be reformatted).
+- `ruff check --select I custom_components tests tools`: **passes** currently.
+
+Conclusion: repository is ready for import-order enforcement (already clean), but not ready for mandatory format enforcement without a dedicated formatting campaign.


### PR DESCRIPTION
### Motivation

- Document a safe, staged plan to harden CI quality signals without re-introducing previously excluded blocking checks such as `black`, `isort`, `mypy`, `hassfest`, or HACS validation.
- Preserve the current CI gate posture while providing guidance for local developer workflows and optional non-blocking CI signals.
- Record the repository readiness snapshot for format and import-order checks to support incremental adoption planning.

### Description

- Added a new "Safe CI hardening plan" section to `docs/maintainability_audit.md` that outlines Stage A (local checks), Stage B (optional non-blocking CI job), and Stage C (targeted enforcement after convergence).
- Documented current readiness: `ruff format --check` would reformat 94 files (fails), while `ruff check --select I` (import-order) passes.
- Confirmed the change is docs-only and does not modify production code, tests, or required CI gates. 

### Testing

- Ran the validation suite including `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, `pytest tests/ -q`, and `python tools/validate_entity_mappings.py`, all of which succeeded. 
- Observed `ruff format --check custom_components tests tools` reports 94 files would be reformatted (informational failure) and `ruff check --select I custom_components tests tools` passes (import-order clean). 
- Maintainability gate passed and full pytest passed (4 skipped); register comparison reported extras/name mismatches to verify with vendor. 
- Change committed (commit `546d59ab`) and no CI gates were added, removed, or weakened.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4528797d88326961cd107f155f120)