### PR TITLE
refactor: extract parameter service registration table

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_parameters.py
+++ b/custom_components/thessla_green_modbus/services_handlers_parameters.py
@@ -19,6 +19,7 @@ from .services_validation import BYPASS_MODE_MAP, GWC_MODE_MAP
 
 WriteStep = tuple[str, object | None, bool, str]
 ServiceHandler = Callable[[ServiceCall], object]
+Registration = tuple[str, ServiceHandler, vol.Schema]
 
 
 def _build_step_handler(
@@ -48,8 +49,10 @@ def _build_step_handler(
     return _handler
 
 
-def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
-    """Register parameter/configuration services."""
+def _parameter_registrations(
+    hass: HomeAssistant, deps: ServiceHandlerDeps
+) -> tuple[Registration, ...]:
+    """Build parameter service registrations with handlers and schemas."""
     set_bypass_parameters = _build_step_handler(
         hass,
         deps,
@@ -127,11 +130,15 @@ def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -
         ],
     )
 
-    registrations: tuple[tuple[str, ServiceHandler, vol.Schema], ...] = (
+    return (
         ("set_bypass_parameters", set_bypass_parameters, SET_BYPASS_PARAMETERS_SCHEMA),
         ("set_gwc_parameters", set_gwc_parameters, SET_GWC_PARAMETERS_SCHEMA),
         ("set_air_quality_thresholds", set_air_quality_thresholds, SET_AIR_QUALITY_THRESHOLDS_SCHEMA),
         ("set_temperature_curve", set_temperature_curve, SET_TEMPERATURE_CURVE_SCHEMA),
     )
-    for service_name, handler, schema in registrations:
+
+
+def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
+    """Register parameter/configuration services."""
+    for service_name, handler, schema in _parameter_registrations(hass, deps):
         hass.services.async_register(deps.domain, service_name, handler, schema)

--- a/tests/test_services_handlers_parameters_registration.py
+++ b/tests/test_services_handlers_parameters_registration.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 from custom_components.thessla_green_modbus.services_handler_deps import ServiceHandlerDeps
 from custom_components.thessla_green_modbus.services_handlers_parameters import (
+    _parameter_registrations,
     register_parameter_services,
 )
 from custom_components.thessla_green_modbus.services_schema import (
@@ -56,3 +57,29 @@ def test_register_parameter_services_preserves_order_and_schema() -> None:
     ]
     assert len(hass.services.calls) == len(expected)
     assert [(service, schema) for service, _handler, schema in hass.services.calls] == expected
+
+
+def test_parameter_registrations_service_names_and_order() -> None:
+    hass = SimpleNamespace(services=_Services())
+
+    registrations = _parameter_registrations(hass, _deps())
+
+    assert [service for service, _handler, _schema in registrations] == [
+        "set_bypass_parameters",
+        "set_gwc_parameters",
+        "set_air_quality_thresholds",
+        "set_temperature_curve",
+    ]
+
+
+def test_parameter_registrations_schema_binding() -> None:
+    hass = SimpleNamespace(services=_Services())
+
+    registrations = _parameter_registrations(hass, _deps())
+
+    assert [(service, schema) for service, _handler, schema in registrations] == [
+        ("set_bypass_parameters", SET_BYPASS_PARAMETERS_SCHEMA),
+        ("set_gwc_parameters", SET_GWC_PARAMETERS_SCHEMA),
+        ("set_air_quality_thresholds", SET_AIR_QUALITY_THRESHOLDS_SCHEMA),
+        ("set_temperature_curve", SET_TEMPERATURE_CURVE_SCHEMA),
+    ]


### PR DESCRIPTION
### Motivation
- Continue decomposing service handler responsibilities by isolating the construction of the parameter service registration table to make the registration mapping testable and reduce the surface of `register_parameter_services` while preserving existing behavior and schemas.

### Description
- Add `Registration` type alias and new helper ` _parameter_registrations(hass, deps)` in `custom_components/thessla_green_modbus/services_handlers_parameters.py` that returns the parameter service tuples `(service_name, handler, schema)`. 
- Keep `register_parameter_services` as the simple registration loop that iterates over `_parameter_registrations`, preserving service names, schemas, registration order, logging, and runtime semantics. 
- Add tests `test_parameter_registrations_service_names_and_order` and `test_parameter_registrations_schema_binding` in `tests/test_services_handlers_parameters_registration.py` to assert exact service ordering and schema binding. 
- Files changed: `custom_components/thessla_green_modbus/services_handlers_parameters.py` and `tests/test_services_handlers_parameters_registration.py` (commit `67e4d25c9a666a0297ea6d16a9909ce4c2621fe3`).

### Testing
- Ran lint and compilation with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed. 
- Ran targeted unit tests with `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` and the full test suite `pytest tests/ -q`, both passed (some expected skips reported). 
- Ran repository validation tools `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, and `python tools/validate_entity_mappings.py`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4529711a08326891fe7f987301d98)