### PR TITLE
refactor: extract RTU exception response payload parser

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_transport_raw.py
+++ b/custom_components/thessla_green_modbus/modbus_transport_raw.py
@@ -171,12 +171,22 @@ class RawRtuOverTcpTransport(BaseModbusTransport):
         """Return True when ``resp_func`` is a Modbus exception response for the request."""
         return (resp_func & 0x80) != 0 and (resp_func & 0x7F) == (expected_function & 0xFF)
 
+    @staticmethod
+    def _parse_exception_response_payload(payload: bytes, *, function: int) -> int:
+        """Validate and parse an exception response payload."""
+        if len(payload) != 3:
+            raise ModbusIOException("Invalid exception response payload length")
+        if payload[1] != (function & 0xFF):
+            raise ModbusIOException("Unexpected function code in exception RTU response")
+        return payload[2]
+
     async def _read_exception_response(self, header: bytes, *, function: int) -> bytes:
         exception_code = await self._read_exactly(1)
         crc_bytes = await self._read_exactly(2)
         payload = header + exception_code
         self._validate_crc(payload, crc_bytes)
-        raise ModbusException(f"Modbus exception {exception_code[0]} for function {function}")
+        parsed_exception = self._parse_exception_response_payload(payload, function=function)
+        raise ModbusException(f"Modbus exception {parsed_exception} for function {function}")
 
     async def _read_register_data_response(self, header: bytes) -> bytes:
         byte_count_raw = await self._read_exactly(1)

--- a/tests/test_modbus_transport_raw.py
+++ b/tests/test_modbus_transport_raw.py
@@ -187,6 +187,25 @@ def test_validate_response_header_rejects_mismatched_exception_function():
     t = _make_raw_tcp()
     with pytest.raises(ModbusIOException, match="function code"):
         t._validate_response_header(bytes([1, 0x83]), slave_id=1, function=4)
+
+
+def test_parse_exception_response_payload_returns_exception_code():
+    t = _make_raw_tcp()
+    assert t._parse_exception_response_payload(bytes([1, 0x84, 2]), function=0x84) == 2
+
+
+def test_parse_exception_response_payload_rejects_invalid_length():
+    t = _make_raw_tcp()
+    with pytest.raises(ModbusIOException, match="payload length"):
+        t._parse_exception_response_payload(bytes([1, 0x84]), function=0x84)
+
+
+def test_parse_exception_response_payload_rejects_wrong_function():
+    t = _make_raw_tcp()
+    with pytest.raises(ModbusIOException, match="function code"):
+        t._parse_exception_response_payload(bytes([1, 0x83, 2]), function=0x84)
+
+
 def test_build_write_multiple_frame_structure():
     """_build_write_multiple_frame produces correct write multiple frame."""
     from custom_components.thessla_green_modbus.modbus_transport import RawRtuOverTcpTransport
@@ -466,4 +485,3 @@ async def test_raw_tcp_write_registers_invalid_length():
         with patch.object(t, "ensure_connected", new=AsyncMock()):
             with pytest.raises(ModbusIOException, match="length"):
                 await t.write_registers(1, 100, values=[1, 2])
-


### PR DESCRIPTION
### Motivation
- Continue decomposition of Modbus transport helpers by isolating exception response payload validation and parsing to a narrow, testable helper while preserving existing RTU framing and CRC behavior.

### Description
- Add `RawRtuOverTcpTransport._parse_exception_response_payload(payload, *, function)` to validate exception payload length and function byte and return the Modbus exception code.
- Update `_read_exception_response` to delegate payload validation/parsing to the new helper after CRC verification.
- Add unit tests in `tests/test_modbus_transport_raw.py` covering successful parse, invalid payload length, and mismatched exception function code.

### Testing
- Ran `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, and `python tools/check_maintainability.py`, which all passed.
- Ran targeted pytest (`pytest -q tests/test_modbus_helpers.py tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py`) and full test suite (`pytest tests/ -q`), and `python tools/validate_entity_mappings.py`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4529d94a483269c13acfc78090e73)