### PR TITLE
refactor: extract register loader helper

### DIFF
--- a/custom_components/thessla_green_modbus/registers/load_cache_helpers.py
+++ b/custom_components/thessla_green_modbus/registers/load_cache_helpers.py
@@ -1,0 +1,47 @@
+"""Helpers for cached register file loading."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TypeVar
+
+from .cache import get_cached_file_info, get_cached_registers, set_cached_registers
+from .register_def import RegisterDef
+
+T = TypeVar("T")
+
+
+def resolve_cached_registers(
+    path: Path,
+    file_hash: str,
+    load_when_missing: Callable[[], list[RegisterDef]],
+) -> list[RegisterDef]:
+    """Return cached register definitions or load and cache them."""
+    mtime = _get_cached_mtime(path)
+    regs = get_cached_registers(file_hash, mtime)
+    if regs is None:
+        regs = load_when_missing()
+        set_cached_registers(file_hash, mtime, regs)
+    return regs
+
+
+async def async_resolve_cached_registers(
+    path: Path,
+    file_hash: str,
+    load_when_missing: Callable[[], Awaitable[list[RegisterDef]]],
+) -> list[RegisterDef]:
+    """Asynchronous variant of :func:`resolve_cached_registers`."""
+    mtime = _get_cached_mtime(path)
+    regs = get_cached_registers(file_hash, mtime)
+    if regs is None:
+        regs = await load_when_missing()
+        set_cached_registers(file_hash, mtime, regs)
+    return regs
+
+
+def _get_cached_mtime(path: Path) -> float:
+    cached = get_cached_file_info(path)
+    if cached is None:
+        raise RuntimeError(f"Missing cache metadata for register file: {path}")
+    return cached[0]

--- a/custom_components/thessla_green_modbus/registers/loader.py
+++ b/custom_components/thessla_green_modbus/registers/loader.py
@@ -7,17 +7,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from .cache import (
-    async_registers_sha256,
-    get_cached_file_info,
-    get_cached_registers,
-    registers_sha256,
-    set_cached_registers,
-)
+from .cache import async_registers_sha256, registers_sha256
 from .cache import (
     clear_cache as _clear_register_cache,
 )
 from .definition import ReadPlan
+from .load_cache_helpers import async_resolve_cached_registers, resolve_cached_registers
 from .loader_helpers import (
     build_register_map,
     filter_registers_by_function,
@@ -44,15 +39,11 @@ def load_registers(json_path: Path | str | None = None) -> list[RegisterDef]:
     """Return cached register definitions, reloading if file changed."""
     path = resolve_registers_path(_REGISTERS_PATH, json_path)
     file_hash = registers_sha256(path)
-    cached = get_cached_file_info(path)
-    if cached is None:
-        raise RuntimeError(f"Missing cache metadata for register file: {path}")
-    mtime = cached[0]
-    regs = get_cached_registers(file_hash, mtime)
-    if regs is None:
-        regs = load_registers_from_file(path)
-        set_cached_registers(file_hash, mtime, regs)
-    return regs
+    return resolve_cached_registers(
+        path,
+        file_hash,
+        lambda: load_registers_from_file(path),
+    )
 
 
 async def async_load_registers(
@@ -61,15 +52,11 @@ async def async_load_registers(
     """Return cached register definitions asynchronously."""
     path = resolve_registers_path(_REGISTERS_PATH, json_path)
     file_hash = await async_registers_sha256(hass, path)
-    cached = get_cached_file_info(path)
-    if cached is None:
-        raise RuntimeError(f"Missing cache metadata for register file: {path}")
-    mtime = cached[0]
-    regs = get_cached_registers(file_hash, mtime)
-    if regs is None:
-        regs = await async_load_registers_from_file(hass, path)
-        set_cached_registers(file_hash, mtime, regs)
-    return regs
+    return await async_resolve_cached_registers(
+        path,
+        file_hash,
+        lambda: async_load_registers_from_file(hass, path),
+    )
 
 
 def clear_cache() -> None:  # pragma: no cover


### PR DESCRIPTION
### Motivation
- Reduce complexity and duplication in the register loader by isolating cache/hash resolution and cache-population logic into a focused helper, while preserving the existing loader API and behavior.
- Make async and sync register-loading paths share the same cache-resolution flow to simplify branching and future maintenance.

### Description
- Added `custom_components/thessla_green_modbus/registers/load_cache_helpers.py` which implements `resolve_cached_registers`, `async_resolve_cached_registers`, and `_get_cached_mtime` to encapsulate cached file-mtime lookup, cache-hit retrieval, and cache population logic.
- Updated `custom_components/thessla_green_modbus/registers/loader.py` to delegate sync/async cache orchestration to the new helpers and removed inline duplication in `load_registers` and `async_load_registers`, keeping public functions and `_register_map` behavior unchanged.
- No register JSON files, register addresses/names, codec logic, or lookup semantics were modified by this change.

### Testing
- Ran lint and compile checks with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both of which passed.
- Verified register reference consistency with `python tools/compare_registers_with_reference.py` and maintainability with `python tools/check_maintainability.py`, both passing.
- Executed unit and integration tests with `pytest tests/ -q` (including the focused test suite `pytest -q tests/test_register_loader.py tests/unit/test_register_*.py tests/test_airflow_unit.py tests/unit/test_register_loader_cache_async.py`), and the full test run passed with 4 skipped tests.
- Ran entity mappings validation with `python tools/validate_entity_mappings.py` and repository scans for forbidden shims/imports, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f452a550f88326b0ea045f0e0a8821)