### PR TITLE
refactor: extract fan entity helper

### DIFF
--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -72,6 +72,13 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
     """
 
     _MODE_MAP: ClassVar[dict[int, str]] = {0: "auto", 1: "manual", 2: "temporary"}
+    _FLOW_REGISTERS: ClassVar[tuple[str, ...]] = (
+        "supply_air_flow",
+        "supply_flow_rate",
+        "supply_percentage",
+        "air_flow_rate_manual",
+        "air_flow_rate_temporary_2",
+    )
 
     def __init__(self, coordinator: ThesslaGreenModbusCoordinator) -> None:
         """Initialize the fan entity."""
@@ -123,15 +130,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
     def _get_current_flow_rate(self) -> float | None:
         """Get current flow rate from available registers."""
         # Priority order for reading current flow rate
-        flow_registers = [
-            "supply_air_flow",  # Supply air flow rate
-            "supply_flow_rate",  # CF measured supply flow rate
-            "supply_percentage",  # Supply air percentage
-            "air_flow_rate_manual",  # Manual flow rate setting
-            "air_flow_rate_temporary_2",  # Temporary flow rate setting
-        ]
-
-        for register in flow_registers:
+        for register in self._FLOW_REGISTERS:
             if register in self.coordinator.data:
                 value = self.coordinator.data[register]
                 if value is not None and isinstance(value, int | float):
@@ -148,8 +147,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         """Turn on the fan."""
         try:
             # First ensure system is on
-            holding_regs = self.coordinator.available_registers.get("holding_registers", set())
-            if "on_off_panel_mode" in holding_registers() and "on_off_panel_mode" in holding_regs:
+            if self._is_writable_holding_register("on_off_panel_mode"):
                 await self._write_register("on_off_panel_mode", 1)
 
             # Set flow rate
@@ -168,8 +166,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         try:
-            holding_regs = self.coordinator.available_registers.get("holding_registers", set())
-            if "on_off_panel_mode" in holding_registers() and "on_off_panel_mode" in holding_regs:
+            if self._is_writable_holding_register("on_off_panel_mode"):
                 # If system power control is available, use it to turn off
                 await self._write_register("on_off_panel_mode", 0)
                 self.coordinator.data["on_off_panel_mode"] = 0
@@ -181,7 +178,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                     if current_mode == "manual" or not current_mode
                     else "air_flow_rate_temporary_2"
                 )
-                if register in holding_registers() and register in holding_regs:
+                if self._is_writable_holding_register(register):
                     await self._write_register(register, 0)
                     self.coordinator.data[register] = 0
 
@@ -209,16 +206,11 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
 
             # Determine which register to write based on current mode
             current_mode = self._get_current_mode()
-            holding_regs = self.coordinator.available_registers.get("holding_registers", set())
-
             if current_mode == "manual" or not current_mode:
                 # Set manual mode and flow rate
-                if "mode" in holding_registers() and "mode" in holding_regs:
+                if self._is_writable_holding_register("mode"):
                     await self._write_register("mode", 1)  # Manual mode
-                if (
-                    "air_flow_rate_manual" in holding_registers()
-                    and "air_flow_rate_manual" in holding_regs
-                ):
+                if self._is_writable_holding_register("air_flow_rate_manual"):
                     await self._write_register("air_flow_rate_manual", actual_percentage)
             else:
                 # Temporary mode - must use 3-register write block
@@ -230,10 +222,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                         raise RuntimeError("Failed to write temporary airflow block")
                     await self.coordinator.async_request_refresh()
                     return
-                if (
-                    "air_flow_rate_temporary_2" in holding_registers()
-                    and "air_flow_rate_temporary_2" in holding_regs
-                ):
+                if self._is_writable_holding_register("air_flow_rate_temporary_2"):
                     await self._write_register("air_flow_rate_temporary_2", actual_percentage)
 
             _LOGGER.debug("Set fan speed to %d%%", actual_percentage)
@@ -272,6 +261,12 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
             offset=offset,
             refresh=refresh,
             include_offset=include_offset,
+        )
+
+    def _is_writable_holding_register(self, register_name: str) -> bool:
+        """Return True if a register is writable and available on this device."""
+        return register_name in holding_registers() and register_name in self.coordinator.available_registers.get(
+            "holding_registers", set()
         )
 
     @property

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -239,3 +239,16 @@ def test_fan_write_register_not_in_available_skips(mock_coordinator):
     fan = ThesslaGreenFan(mock_coordinator)
     asyncio.run(fan._write_register("air_flow_rate_manual", 50))
     mock_coordinator.async_write_register.assert_not_called()
+
+
+def test_is_writable_holding_register_true(mock_coordinator):
+    """Helper reports True when a register is writable and discovered."""
+    fan = ThesslaGreenFan(mock_coordinator)
+    assert fan._is_writable_holding_register("air_flow_rate_manual") is True  # nosec B101
+
+
+def test_is_writable_holding_register_false_when_missing(mock_coordinator):
+    """Helper reports False when register was not discovered on the device."""
+    mock_coordinator.available_registers["holding_registers"].discard("air_flow_rate_manual")
+    fan = ThesslaGreenFan(mock_coordinator)
+    assert fan._is_writable_holding_register("air_flow_rate_manual") is False  # nosec B101


### PR DESCRIPTION
### Motivation
- Reduce complexity and duplication in the fan entity by centralizing register availability and flow-register logic into small helpers.  
- Keep Home Assistant behavior, entity IDs, names, domains, mappings, and register JSON unchanged while improving readability and maintainability.

### Description
- Added a class-level `_FLOW_REGISTERS` tuple and replaced inline flow-register lists with this constant in `_get_current_flow_rate` to centralize priority logic.  
- Introduced `_is_writable_holding_register` on `ThesslaGreenFan` and switched existing writable/availability checks in `async_turn_on`, `async_turn_off`, and `async_set_percentage` to use it.  
- Kept the existing `_write_register` semantics and entity schema intact; only `custom_components/thessla_green_modbus/fan.py` and `tests/test_fan.py` were modified.  
- Commit: `1b9434dd` (files changed: `custom_components/thessla_green_modbus/fan.py`, `tests/test_fan.py`) and added focused tests covering the new helper.

### Testing
- Ran `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed.  
- Ran `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, and `python tools/validate_entity_mappings.py` which completed successfully and reported entity mapping validation as OK (`OK: 366 entities validated`) and maintainability gate passed.  
- Ran unit tests with `pytest -q tests/test_fan*.py tests/test_entity*.py tests/test_entity_data_correctness*.py` and `pytest tests/ -q`, which completed successfully (existing/skipped tests remained skipped); all relevant fan and entity tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afa39cb883268b4edab03032b095)