### PR TITLE
refactor: continue register loader decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/registers/parse_file_helpers.py
+++ b/custom_components/thessla_green_modbus/registers/parse_file_helpers.py
@@ -1,0 +1,30 @@
+"""Helpers for reading register JSON files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .cache import _async_executor
+
+
+def read_registers_json(path: Path) -> Any:
+    """Read and decode register definitions JSON file."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as err:  # pragma: no cover
+        raise RuntimeError(f"Register definition file missing: {path}") from err
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as err:  # pragma: no cover
+        raise RuntimeError(f"Failed to read register definitions from {path}") from err
+
+
+async def async_read_registers_json(hass: Any | None, path: Path) -> Any:
+    """Asynchronously read and decode register definitions JSON file."""
+    try:
+        raw_text = await _async_executor(hass, path.read_text, encoding="utf-8")
+        return json.loads(raw_text)
+    except FileNotFoundError as err:  # pragma: no cover
+        raise RuntimeError(f"Register definition file missing: {path}") from err
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as err:  # pragma: no cover
+        raise RuntimeError(f"Failed to read register definitions from {path}") from err

--- a/custom_components/thessla_green_modbus/registers/parser.py
+++ b/custom_components/thessla_green_modbus/registers/parser.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import Any, cast
 
-from .cache import _async_executor
+from .parse_file_helpers import async_read_registers_json, read_registers_json
 from .register_def import RegisterDef
 from .schema import RegisterList, _normalise_function, _normalise_name
 
@@ -93,23 +93,10 @@ def register_from_parsed(parsed: Any) -> RegisterDef:
 
 def load_registers_from_file(path: Path) -> list[RegisterDef]:
     """Load and parse register definitions from file path."""
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError as err:  # pragma: no cover
-        raise RuntimeError(f"Register definition file missing: {path}") from err
-    except (OSError, TypeError, ValueError, json.JSONDecodeError) as err:  # pragma: no cover
-        raise RuntimeError(f"Failed to read register definitions from {path}") from err
-    return parse_registers(raw)
+    return parse_registers(read_registers_json(path))
 
 
 async def async_load_registers_from_file(hass: Any | None, path: Path) -> list[RegisterDef]:
     """Load and parse register definitions asynchronously."""
-    try:
-        raw_text = await _async_executor(hass, path.read_text, encoding="utf-8")
-        raw = json.loads(raw_text)
-    except FileNotFoundError as err:  # pragma: no cover
-        raise RuntimeError(f"Register definition file missing: {path}") from err
-    except (OSError, TypeError, ValueError, json.JSONDecodeError) as err:  # pragma: no cover
-        raise RuntimeError(f"Failed to read register definitions from {path}") from err
-    return parse_registers(raw)
+    return parse_registers(await async_read_registers_json(hass, path))
 

--- a/tests/unit/test_register_parse_file_helpers.py
+++ b/tests/unit/test_register_parse_file_helpers.py
@@ -1,0 +1,22 @@
+"""Tests for register file parsing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from custom_components.thessla_green_modbus.registers.parse_file_helpers import (
+    async_read_registers_json,
+    read_registers_json,
+)
+
+
+def test_read_registers_json_file_missing(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Register definition file missing"):
+        read_registers_json(tmp_path / "missing.json")
+
+
+@pytest.mark.asyncio
+async def test_async_read_registers_json_file_missing(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Register definition file missing"):
+        await async_read_registers_json(None, tmp_path / "missing.json")


### PR DESCRIPTION
### Motivation
- Reduce complexity in the register loader/parser by extracting file I/O (JSON read/decode) into a focused helper so the parser can concentrate on schema parsing and RegisterDef construction.

### Description
- Added `custom_components/thessla_green_modbus/registers/parse_file_helpers.py` exposing `read_registers_json` and `async_read_registers_json` with consistent error handling for missing/invalid files.
- Updated `custom_components/thessla_green_modbus/registers/parser.py` so `load_registers_from_file` and `async_load_registers_from_file` delegate JSON reading to the new helpers and retain all parsing/normalisation logic.
- Added unit tests `tests/unit/test_register_parse_file_helpers.py` covering missing-file error behavior for both sync and async helpers.
- No register JSON files, addresses, names, codecs, or lookup semantics were changed and public loader APIs remain stable.

### Testing
- Ran linting and static checks with `ruff check custom_components tests tools` which passed. 
- Compiled modules with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed. 
- Executed `python tools/compare_registers_with_reference.py` and observed expected reference/integration results (no missing reference entries affecting behavior). 
- Ran unit and integration tests with `pytest -q tests/test_register_loader.py tests/unit/test_register_*.py tests/test_airflow_unit.py tests/unit/test_register_loader_cache_async.py` and `pytest tests/ -q`, and the test suite passed (some tests were skipped as expected). 
- Maintainability checks via `python tools/check_maintainability.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afab1ca08326b4019b9d301688a0)