### PR TITLE
refactor: extract unique id migration helpers

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import asyncio
-import re
 from functools import cache, lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from .registers.loader import get_registers_by_function
+from .unique_id_migration import (
+    device_unique_id_prefix as _device_unique_id_prefix_impl,
+)
+from .unique_id_migration import (
+    migrate_unique_id as _migrate_unique_id_impl,
+)
 
 try:
     from homeassistant.const import Platform as _HAPlatform
@@ -262,39 +267,6 @@ PLATFORMS: list[Any] = [
 _ENTITY_LOOKUP: dict[str, tuple[str, str | None, int | None]] | None = None
 
 
-def _sanitize_identifier(value: str) -> str:
-    """Sanitize identifier components used inside unique IDs."""
-
-    sanitized = re.sub(r"[^0-9A-Za-z_-]", "-", value)
-    sanitized = re.sub(r"-{2,}", "-", sanitized)
-    sanitized = re.sub(r"_{2,}", "_", sanitized)
-    return sanitized.strip("-_")
-
-
-def device_unique_id_prefix(
-    serial_number: str | None,
-    host: str,
-    port: int,
-) -> str:
-    """Return the device specific prefix used in entity unique IDs."""
-
-    if serial_number:
-        serial_token = _sanitize_identifier(serial_number)
-        if serial_token:
-            return serial_token
-
-    host_part = _sanitize_identifier(host.replace(":", "-")) if host else ""
-    port_part = _sanitize_identifier(str(port)) if port is not None else ""
-
-    if host_part and port_part:
-        return f"{host_part}-{port_part}"
-    if host_part:
-        return host_part
-    if port_part:
-        return f"device-{port_part}"
-    return "device"
-
-
 def _build_entity_lookup() -> dict[str, tuple[str, str | None, int | None]]:
     """Build mapping of entity keys to register info."""
     global _ENTITY_LOOKUP
@@ -310,6 +282,16 @@ def _build_entity_lookup() -> dict[str, tuple[str, str | None, int | None]]:
     return _ENTITY_LOOKUP
 
 
+
+
+def device_unique_id_prefix(
+    serial_number: str | None,
+    host: str,
+    port: int,
+) -> str:
+    """Return the device specific prefix used in entity unique IDs."""
+
+    return _device_unique_id_prefix_impl(serial_number, host, port)
 def migrate_unique_id(
     unique_id: str,
     *,
@@ -320,96 +302,20 @@ def migrate_unique_id(
 ) -> str:
     """Migrate a historical unique_id to the current format."""
 
-    uid = unique_id.replace(":", "-")
-    prefix = device_unique_id_prefix(serial_number, host, port)
-
-    for unit in (AIRFLOW_UNIT_M3H, AIRFLOW_UNIT_PERCENTAGE):
-        suffix = f"_{unit}"
-        if uid.endswith(suffix):
-            uid = uid[: -len(suffix)]
-            break
-
-    pattern_new = rf"{re.escape(prefix)}_{slave_id}_[^_]+_\d+(?:_bit\d+)?$"
-    if re.fullmatch(pattern_new, uid):
-        return uid
-
-    uid_no_domain = uid[len(DOMAIN) + 1 :] if uid.startswith(f"{DOMAIN}_") else uid
-
-    lookup = _build_entity_lookup()
-
-    def _bit_index(bit: int | None) -> int | None:
-        return bit.bit_length() - 1 if bit is not None else None
-
-    def _register_address(register: str, register_type: str | None) -> int | None:
-        if register_type == "holding_registers":
-            return holding_registers().get(register)
-        if register_type == "input_registers":
-            return input_registers().get(register)
-        if register_type == "coil_registers":
-            return coil_registers().get(register)
-        if register_type == "discrete_inputs":
-            return discrete_input_registers().get(register)
-        return None
-
-    reverse_by_address: dict[tuple[int, int | None], str] = {}
-    register_to_key: dict[str, str] = {}
-
-    for mapping_key, (mapped_register_name, mapped_register_type, bit) in lookup.items():
-        register_to_key.setdefault(mapped_register_name, mapping_key)
-        address = _register_address(mapped_register_name, mapped_register_type)
-        if address is None:
-            continue
-        reverse_by_address.setdefault((address, _bit_index(bit)), mapping_key)
-
-    match = re.match(rf".*_{slave_id}_(.+)", uid_no_domain)
-    remainder = match.group(1) if match else None
-
-    base_uid: str | None = None
-
-    if remainder:
-        match_address = re.fullmatch(r"(\d+)(?:_bit(\d+))?", remainder)
-        if match_address:
-            address = int(match_address.group(1))
-            bit_index = int(match_address.group(2)) if match_address.group(2) else None
-            resolved_key = reverse_by_address.get((address, bit_index)) or reverse_by_address.get(
-                (address, None)
-            )
-            if resolved_key:
-                bit_suffix = f"_bit{bit_index}" if bit_index is not None else ""
-                base_uid = f"{slave_id}_{resolved_key}_{address}{bit_suffix}"
-        else:
-            resolved_key = None
-            matched_register_name: str | None = None
-            matched_register_type: str | None = None
-            matched_bit_index: int | None = None
-
-            if remainder in lookup:
-                resolved_key = remainder
-                matched_register_name, matched_register_type, bit = lookup[resolved_key]
-                matched_bit_index = _bit_index(bit)
-            elif remainder in register_to_key:
-                resolved_key = register_to_key[remainder]
-                matched_register_name, matched_register_type, bit = lookup[resolved_key]
-                matched_bit_index = _bit_index(bit)
-
-            if matched_register_name:
-                address = _register_address(matched_register_name, matched_register_type)
-                if address is not None:
-                    bit_suffix = f"_bit{matched_bit_index}" if matched_bit_index is not None else ""
-                    base_uid = f"{slave_id}_{resolved_key}_{address}{bit_suffix}"
-            elif remainder == "fan":
-                base_uid = f"{slave_id}_fan_0"
-
-    if base_uid is None:
-        fallback = uid_no_domain
-        if not fallback.startswith(f"{prefix}_"):
-            fallback = f"{prefix}_{fallback}"
-        return fallback
-
-    if base_uid.startswith(prefix):
-        return base_uid
-
-    return f"{prefix}_{base_uid}"
+    return _migrate_unique_id_impl(
+        unique_id,
+        serial_number=serial_number,
+        host=host,
+        port=port,
+        slave_id=slave_id,
+        domain=DOMAIN,
+        airflow_units=(AIRFLOW_UNIT_M3H, AIRFLOW_UNIT_PERCENTAGE),
+        get_entity_lookup=_build_entity_lookup,
+        holding_registers=holding_registers,
+        input_registers=input_registers,
+        coil_registers=coil_registers,
+        discrete_input_registers=discrete_input_registers,
+    )
 
 
 # Aggregated entity mappings for all platforms.  Additional platforms can be

--- a/custom_components/thessla_green_modbus/unique_id_migration.py
+++ b/custom_components/thessla_green_modbus/unique_id_migration.py
@@ -1,0 +1,151 @@
+"""Unique-id migration helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+EntityLookup = dict[str, tuple[str, str | None, int | None]]
+RegisterGetter = Callable[[], dict[str, int]]
+
+
+def sanitize_identifier(value: str) -> str:
+    """Sanitize identifier components used inside unique IDs."""
+
+    sanitized = re.sub(r"[^0-9A-Za-z_-]", "-", value)
+    sanitized = re.sub(r"-{2,}", "-", sanitized)
+    sanitized = re.sub(r"_{2,}", "_", sanitized)
+    return sanitized.strip("-_")
+
+
+def device_unique_id_prefix(
+    serial_number: str | None,
+    host: str,
+    port: int | None,
+) -> str:
+    """Return the device specific prefix used in entity unique IDs."""
+
+    if serial_number:
+        serial_token = sanitize_identifier(serial_number)
+        if serial_token:
+            return serial_token
+
+    host_part = sanitize_identifier(host.replace(":", "-")) if host else ""
+    port_part = sanitize_identifier(str(port)) if port is not None else ""
+
+    if host_part and port_part:
+        return f"{host_part}-{port_part}"
+    if host_part:
+        return host_part
+    if port_part:
+        return f"device-{port_part}"
+    return "device"
+
+
+def migrate_unique_id(
+    unique_id: str,
+    *,
+    serial_number: str | None,
+    host: str,
+    port: int,
+    slave_id: int,
+    domain: str,
+    airflow_units: tuple[str, str],
+    get_entity_lookup: Callable[[], EntityLookup],
+    holding_registers: RegisterGetter,
+    input_registers: RegisterGetter,
+    coil_registers: RegisterGetter,
+    discrete_input_registers: RegisterGetter,
+) -> str:
+    """Migrate a historical unique_id to the current format."""
+
+    uid = unique_id.replace(":", "-")
+    prefix = device_unique_id_prefix(serial_number, host, port)
+
+    for unit in airflow_units:
+        suffix = f"_{unit}"
+        if uid.endswith(suffix):
+            uid = uid[: -len(suffix)]
+            break
+
+    pattern_new = rf"{re.escape(prefix)}_{slave_id}_[^_]+_\d+(?:_bit\d+)?$"
+    if re.fullmatch(pattern_new, uid):
+        return uid
+
+    uid_no_domain = uid[len(domain) + 1 :] if uid.startswith(f"{domain}_") else uid
+
+    lookup = get_entity_lookup()
+
+    def _bit_index(bit: int | None) -> int | None:
+        return bit.bit_length() - 1 if bit is not None else None
+
+    def _register_address(register: str, register_type: str | None) -> int | None:
+        if register_type == "holding_registers":
+            return holding_registers().get(register)
+        if register_type == "input_registers":
+            return input_registers().get(register)
+        if register_type == "coil_registers":
+            return coil_registers().get(register)
+        if register_type == "discrete_inputs":
+            return discrete_input_registers().get(register)
+        return None
+
+    reverse_by_address: dict[tuple[int, int | None], str] = {}
+    register_to_key: dict[str, str] = {}
+
+    for mapping_key, (mapped_register_name, mapped_register_type, bit) in lookup.items():
+        register_to_key.setdefault(mapped_register_name, mapping_key)
+        address = _register_address(mapped_register_name, mapped_register_type)
+        if address is None:
+            continue
+        reverse_by_address.setdefault((address, _bit_index(bit)), mapping_key)
+
+    match = re.match(rf".*_{slave_id}_(.+)", uid_no_domain)
+    remainder = match.group(1) if match else None
+
+    base_uid: str | None = None
+
+    if remainder:
+        match_address = re.fullmatch(r"(\d+)(?:_bit(\d+))?", remainder)
+        if match_address:
+            address = int(match_address.group(1))
+            bit_index = int(match_address.group(2)) if match_address.group(2) else None
+            resolved_key = reverse_by_address.get((address, bit_index)) or reverse_by_address.get(
+                (address, None)
+            )
+            if resolved_key:
+                bit_suffix = f"_bit{bit_index}" if bit_index is not None else ""
+                base_uid = f"{slave_id}_{resolved_key}_{address}{bit_suffix}"
+        else:
+            resolved_key = None
+            matched_register_name: str | None = None
+            matched_register_type: str | None = None
+            matched_bit_index: int | None = None
+
+            if remainder in lookup:
+                resolved_key = remainder
+                matched_register_name, matched_register_type, bit = lookup[resolved_key]
+                matched_bit_index = _bit_index(bit)
+            elif remainder in register_to_key:
+                resolved_key = register_to_key[remainder]
+                matched_register_name, matched_register_type, bit = lookup[resolved_key]
+                matched_bit_index = _bit_index(bit)
+
+            if matched_register_name:
+                address = _register_address(matched_register_name, matched_register_type)
+                if address is not None:
+                    bit_suffix = f"_bit{matched_bit_index}" if matched_bit_index is not None else ""
+                    base_uid = f"{slave_id}_{resolved_key}_{address}{bit_suffix}"
+            elif remainder == "fan":
+                base_uid = f"{slave_id}_fan_0"
+
+    if base_uid is None:
+        fallback = uid_no_domain
+        if not fallback.startswith(f"{prefix}_"):
+            fallback = f"{prefix}_{fallback}"
+        return fallback
+
+    if base_uid.startswith(prefix):
+        return base_uid
+
+    return f"{prefix}_{base_uid}"

--- a/tests/test_unique_id_migration_helpers.py
+++ b/tests/test_unique_id_migration_helpers.py
@@ -1,0 +1,14 @@
+"""Focused tests for unique-id migration helper module."""
+
+from custom_components.thessla_green_modbus.unique_id_migration import (
+    device_unique_id_prefix,
+    sanitize_identifier,
+)
+
+
+def test_sanitize_identifier_replaces_invalid_chars() -> None:
+    assert sanitize_identifier("a::b  c") == "a-b-c"
+
+
+def test_device_unique_id_prefix_falls_back_to_device() -> None:
+    assert device_unique_id_prefix(None, "", None) == "device"


### PR DESCRIPTION
### Motivation
- Reduce size and responsibility of `const.py` by isolating unique-id migration logic into a focused implementation module. 
- Improve testability and clarity of migration helpers (sanitization, prefix generation, and legacy-to-current unique-id resolution). 
- Keep public migration API stable so existing entity unique IDs and migration behaviour remain unchanged.

### Description
- Added `custom_components/thessla_green_modbus/unique_id_migration.py` implementing `sanitize_identifier`, `device_unique_id_prefix`, and the full `migrate_unique_id` migration algorithm parameterized with entity lookup and register getters. 
- Updated `custom_components/thessla_green_modbus/const.py` to delegate `device_unique_id_prefix` and `migrate_unique_id` to the new implementation while retaining `_build_entity_lookup` and register accessor usage to preserve behaviour. 
- Kept the public API and call-sites intact so entity unique IDs, translations, and migration outputs are not changed. 
- Added focused unit tests in `tests/test_unique_id_migration_helpers.py` to cover identifier sanitization and prefix fallback behaviour.

### Testing
- Ran dependency install and linting with `python -m pip install -q -r requirements-dev.txt` and `ruff check custom_components tests tools`, both passing. 
- Compiled sources with `python -m compileall -q custom_components/thessla_green_modbus tests tools` and ran maintainability checks with `python tools/check_maintainability.py`, both passing. 
- Validated entity mappings with `python tools/validate_entity_mappings.py` which reported `OK: 366 entities validated`. 
- Ran targeted and full test suites with `pytest -q tests/test_entity_data_correctness*.py tests/test_entity_mappings*.py` and `pytest tests/ -q`, and all tests passed (some tests skipped as expected). 
- Additional checks `python tools/compare_registers_with_reference.py` ran (reported vendor mismatches informationally) and `rg "compat|shim|proxy|re-export|legacy" ...` returned no forbidden shim/proxy matches for the touched files. 

Files changed: `custom_components/thessla_green_modbus/const.py`, `custom_components/thessla_green_modbus/unique_id_migration.py`, and `tests/test_unique_id_migration_helpers.py`.

Commit hash: `0c81203bdbac291698e2ac447edd1bc20799b0e2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afb44ecc8326bd11b675a62c59ab)