### PR TITLE
refactor: extract _read_response_payload in RawRtuOverTcpTransport

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_transport_raw.py
+++ b/custom_components/thessla_green_modbus/modbus_transport_raw.py
@@ -188,21 +188,21 @@ class RawRtuOverTcpTransport(BaseModbusTransport):
         parsed_exception = self._parse_exception_response_payload(payload, function=function)
         raise ModbusException(f"Modbus exception {parsed_exception} for function {function}")
 
-    async def _read_register_data_response(self, header: bytes) -> bytes:
-        byte_count_raw = await self._read_exactly(1)
-        byte_count = byte_count_raw[0]
-        data = await self._read_exactly(byte_count)
-        crc_bytes = await self._read_exactly(2)
-        payload = header + byte_count_raw + data
-        self._validate_crc(payload, crc_bytes)
-        return data
-
-    async def _read_write_body_response(self, header: bytes) -> bytes:
-        body = await self._read_exactly(4)
+    async def _read_response_payload(self, header: bytes, body_length: int) -> bytes:
+        body = await self._read_exactly(body_length)
         crc_bytes = await self._read_exactly(2)
         payload = header + body
         self._validate_crc(payload, crc_bytes)
         return body
+
+    async def _read_register_data_response(self, header: bytes) -> bytes:
+        byte_count_raw = await self._read_exactly(1)
+        byte_count = byte_count_raw[0]
+        data = await self._read_response_payload(header + byte_count_raw, byte_count)
+        return data
+
+    async def _read_write_body_response(self, header: bytes) -> bytes:
+        return await self._read_response_payload(header, 4)
 
     async def _read_response(self, slave_id: int, function: int) -> bytes:
         header = await self._read_exactly(2)

--- a/tests/test_modbus_transport_raw.py
+++ b/tests/test_modbus_transport_raw.py
@@ -217,6 +217,33 @@ def test_build_write_multiple_frame_structure():
     assert frame[1] == 16  # function code 0x10
 
 
+@pytest.mark.asyncio
+async def test_read_response_payload_reads_body_and_validates_crc():
+    t = _make_raw_tcp()
+    t._read_exactly = AsyncMock(side_effect=[b"\x10\x20", b"\xaa\xbb"])
+    t._validate_crc = MagicMock()
+
+    payload = await t._read_response_payload(b"\x01\x04", 2)
+
+    assert payload == b"\x10\x20"
+    t._read_exactly.assert_any_await(2)
+    t._read_exactly.assert_any_await(2)
+    t._validate_crc.assert_called_once_with(b"\x01\x04\x10\x20", b"\xaa\xbb")
+
+
+@pytest.mark.asyncio
+async def test_read_register_data_response_uses_payload_helper():
+    t = _make_raw_tcp()
+    t._read_exactly = AsyncMock(return_value=b"\x04")
+    t._read_response_payload = AsyncMock(return_value=b"\x00\x01\x00\x02")
+
+    payload = await t._read_register_data_response(b"\x01\x04")
+
+    assert payload == b"\x00\x01\x00\x02"
+    t._read_response_payload.assert_awaited_once_with(b"\x01\x04\x04", 4)
+
+
+
 # ---------------------------------------------------------------------------
 # _read_response paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Reduce duplicated logic for reading response bodies and CRC validation in the RTU-over-TCP transport by centralizing "read body + read CRC + validate CRC" behavior in a single helper.

### Description
- Add `RawRtuOverTcpTransport._read_response_payload(header: bytes, body_length: int)` and reuse it from `._read_register_data_response` and `._read_write_body_response` to remove duplicated CRC/body parsing logic.
- Add two focused tests in `tests/test_modbus_transport_raw.py` that validate the new helper and verify that `_read_register_data_response` delegates to it with the expected header/body-length composition.

### Testing
- Lint and compile checks were run with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, and both passed.
- Register comparison and maintainability gates were run with `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, and both passed.
- Targeted unit tests were run with `pytest -q tests/test_modbus_helpers.py tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py` and the full test suite was run with `pytest tests/ -q`, and all tests passed (existing skips reported); the added tests passed.
- Entity mappings validation `python tools/validate_entity_mappings.py` passed; the change was committed as `a363105a41dd8e8723e14e5d897ba5c75bbc1472`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afbb58708326a2f69970656c52f4)