### PR TITLE
refactor: extract reauth form defaults helper

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -50,6 +50,7 @@ from .config_flow_runtime import (
 )
 from .config_flow_runtime import run_with_retry as _run_with_retry_impl
 from .config_flow_schema import build_connection_schema as _build_connection_schema_impl
+from .config_flow_steps import build_reauth_form_defaults as _build_reauth_form_defaults_impl
 from .config_flow_steps import extract_discovered_state as _extract_discovered_state_impl
 from .config_flow_steps import initialize_reauth_state as _initialize_reauth_state_impl
 from .config_flow_steps import merge_options_payload as _merge_options_payload_impl
@@ -436,7 +437,10 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
         return self.async_show_form(
             step_id="reauth",
             data_schema=self._build_connection_schema(
-                user_input or self._tg_flow_reauth_existing_data
+                _build_reauth_form_defaults_impl(
+                    user_input=user_input,
+                    existing_data=self._tg_flow_reauth_existing_data,
+                )
             ),
             errors=errors,
         )

--- a/custom_components/thessla_green_modbus/config_flow_steps.py
+++ b/custom_components/thessla_green_modbus/config_flow_steps.py
@@ -63,3 +63,12 @@ def initialize_reauth_state(
     if active_entry_id is None:
         return True, (entry.entry_id if entry else None), dict(defaults)
     return False, active_entry_id, dict(defaults)
+
+
+def build_reauth_form_defaults(
+    *,
+    user_input: dict[str, Any] | None,
+    existing_data: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build defaults for rendering the reauth form."""
+    return dict(user_input or existing_data or {})

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -18,6 +18,7 @@ from custom_components.thessla_green_modbus.config_flow_schema import (
     _build_serial_defaults_and_validators,
 )
 from custom_components.thessla_green_modbus.config_flow_steps import (
+    build_reauth_form_defaults,
     extract_discovered_state,
     initialize_reauth_state,
     resolve_reauth_defaults,
@@ -334,6 +335,22 @@ def test_initialize_reauth_state_initializes_from_entry():
     assert defaults == {"host": "10.0.0.10"}
 
 
+def test_build_reauth_form_defaults_prefers_user_input():
+    defaults = build_reauth_form_defaults(
+        user_input={"host": "from_user"},
+        existing_data={"host": "from_existing"},
+    )
+    assert defaults == {"host": "from_user"}
+
+
+def test_build_reauth_form_defaults_falls_back_to_existing():
+    defaults = build_reauth_form_defaults(
+        user_input=None,
+        existing_data={"host": "from_existing"},
+    )
+    assert defaults == {"host": "from_existing"}
+
+
 def test_vol_invalid_no_path():
     """VOL_INVALID without explicit path should keep empty path."""
     import custom_components.thessla_green_modbus.config_flow as cf_mod
@@ -474,4 +491,3 @@ async def test_call_with_optional_timeout_sync_function():
 # ---------------------------------------------------------------------------
 # Pass 16 — lines 425-428: RTU validation success path
 # ---------------------------------------------------------------------------
-


### PR DESCRIPTION
### Motivation
- Reduce branching complexity in the config flow reauth step by centralizing the logic that chooses form defaults for rendering.
- Make the defaults construction easier to test and maintain while preserving existing reauth behavior and semantics.

### Description
- Add `build_reauth_form_defaults` to `custom_components/thessla_green_modbus/config_flow_steps.py` which returns the `user_input` when present or falls back to stored reauth data.
- Update `ConfigFlow.async_step_reauth` to use the new helper when building the connection schema defaults instead of inlining `user_input or self._tg_flow_reauth_existing_data`.
- Add unit tests in `tests/test_config_flow_helpers.py` to validate that the helper prefers `user_input` and falls back to existing data.
- Tidy an import ordering in `config_flow.py` to satisfy linter checks.

### Testing
- Ran `ruff check custom_components tests tools` and it passed.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` and it passed.
- Ran `pytest -q tests/test_config_flow*.py` and `pytest tests/ -q` and tests completed successfully with the new tests passing and only expected skips elsewhere.
- Ran `python tools/check_maintainability.py`, `python tools/compare_registers_with_reference.py`, and `python tools/validate_entity_mappings.py`; maintainability passed and the other validation scripts completed (register comparison reported informational name/extras output from vendor data).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afc39ee48326a6c602bb5d8faf74)