### PR TITLE
refactor: extract maintenance handler map helper

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -67,6 +67,25 @@ def _iter_maintenance_service_bindings(handlers: dict[str, object]):
         yield service, schema, handlers[service]
 
 
+def _maintenance_handlers(
+    reset_filters: object,
+    reset_settings: object,
+    start_pressure_test: object,
+    set_modbus_parameters: object,
+    set_device_name: object,
+    sync_time: object,
+) -> dict[str, object]:
+    """Return maintenance service handlers keyed by service name."""
+    return {
+        "reset_filters": reset_filters,
+        "reset_settings": reset_settings,
+        "start_pressure_test": start_pressure_test,
+        "set_modbus_parameters": set_modbus_parameters,
+        "set_device_name": set_device_name,
+        "sync_time": sync_time,
+    }
+
+
 async def _run_for_targets(
     hass: HomeAssistant,
     call: ServiceCall,
@@ -204,13 +223,13 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
 
         await _run_for_targets(hass, call, deps, _sync_time_for_target)
 
-    handlers = {
-        "reset_filters": reset_filters,
-        "reset_settings": reset_settings,
-        "start_pressure_test": start_pressure_test,
-        "set_modbus_parameters": set_modbus_parameters,
-        "set_device_name": set_device_name,
-        "sync_time": sync_time,
-    }
+    handlers = _maintenance_handlers(
+        reset_filters,
+        reset_settings,
+        start_pressure_test,
+        set_modbus_parameters,
+        set_device_name,
+        sync_time,
+    )
     for service, schema, handler in _iter_maintenance_service_bindings(handlers):
         hass.services.async_register(deps.domain, service, handler, schema)

--- a/tests/test_services_handlers_maintenance.py
+++ b/tests/test_services_handlers_maintenance.py
@@ -14,6 +14,7 @@ from custom_components.thessla_green_modbus.services import (
 )
 from custom_components.thessla_green_modbus.services_handlers_maintenance import (
     _iter_maintenance_service_bindings,
+    _maintenance_handlers,
     _maintenance_registrations,
 )
 from custom_components.thessla_green_modbus.services_schema import (
@@ -297,6 +298,38 @@ def test_maintenance_registrations_service_order_and_schema_count():
         "sync_time",
     ]
 
+
+
+
+def test_maintenance_handlers_keys_stable_and_bound():
+    """Handler map helper returns expected keys and handler bindings."""
+    handlers = {name: object() for name in [
+        "reset_filters",
+        "reset_settings",
+        "start_pressure_test",
+        "set_modbus_parameters",
+        "set_device_name",
+        "sync_time",
+    ]}
+
+    bound = _maintenance_handlers(
+        handlers["reset_filters"],
+        handlers["reset_settings"],
+        handlers["start_pressure_test"],
+        handlers["set_modbus_parameters"],
+        handlers["set_device_name"],
+        handlers["sync_time"],
+    )
+
+    assert list(bound) == [
+        "reset_filters",
+        "reset_settings",
+        "start_pressure_test",
+        "set_modbus_parameters",
+        "set_device_name",
+        "sync_time",
+    ]
+    assert bound == handlers
 
 def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
     """Service binding helper keeps registration order and uses matching handler names."""


### PR DESCRIPTION
### Motivation

- Reduce breadth of `register_maintenance_services` by extracting the construction of the maintenance handler map into a small dedicated helper. 
- Improve testability and make the registration wiring explicit while preserving existing service schemas, names, logging, and error handling.

### Description

- Added a `_maintenance_handlers(...)` helper in `custom_components/thessla_green_modbus/services_handlers_maintenance.py` that returns the maintenance handler dict keyed by service name. 
- Updated `register_maintenance_services` to consume `_maintenance_handlers(...)` (no behavior or registration order changes). 
- Added `test_maintenance_handlers_keys_stable_and_bound` in `tests/test_services_handlers_maintenance.py` to assert the handler key order and exact bindings remain stable.

### Testing

- Ran lint/compile and validation commands: `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both succeeded. 
- Ran register/maintainability checks: `python tools/compare_registers_with_reference.py` (reports extras to review but completed) and `python tools/check_maintainability.py`, both completed successfully. 
- Ran unit tests `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` and `pytest tests/ -q`, and all executed tests passed. 
- Commit created: `89863808` and changed files: `custom_components/thessla_green_modbus/services_handlers_maintenance.py`, `tests/test_services_handlers_maintenance.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afca2de88326b6631e69feb803e6)