### PR TITLE
refactor: extract bitmask binary-entry helper from mapping builders

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_bitmask.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_bitmask.py
@@ -1,0 +1,50 @@
+"""Helpers for deriving binary mappings from bitmask register definitions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..utils import _to_snake_case
+
+
+def iter_bitmask_binary_entries(reg: Any) -> list[tuple[str, dict[str, Any]]]:
+    """Build binary mapping entries derived from a bitmask register definition."""
+    func_map = {
+        1: "coil_registers",
+        2: "discrete_inputs",
+        3: "holding_registers",
+        4: "input_registers",
+    }
+    register_type = func_map.get(reg.function)
+    if not register_type:
+        return []
+
+    bits = reg.bits or []
+    entries: list[tuple[str, dict[str, Any]]] = []
+    unnamed_bit = False
+    for idx, bit_def in enumerate(bits):
+        bit_name = bit_def.get("name") if isinstance(bit_def, dict) else (str(bit_def) if bit_def is not None else None)
+        if bit_name:
+            key = f"{reg.name}_{_to_snake_case(bit_name)}"
+            entries.append(
+                (
+                    key,
+                    {
+                        "translation_key": key,
+                        "register_type": register_type,
+                        "register": reg.name,
+                        "bit": 1 << idx,
+                    },
+                )
+            )
+        else:
+            unnamed_bit = True
+
+    if not bits or unnamed_bit:
+        entries.append(
+            (
+                reg.name,
+                {"translation_key": reg.name, "register_type": register_type, "bitmask": True},
+            )
+        )
+    return entries

--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -15,13 +15,14 @@ from ..const import (
     holding_registers,
 )
 from ..registers.loader import get_all_registers
-from ..utils import BCD_TIME_PREFIXES, _to_snake_case
+from ..utils import BCD_TIME_PREFIXES
 from ._helpers import (
     _get_register_info,
     _load_translation_keys,
     _number_translation_keys,
     _parse_states,
 )
+from ._mapping_bitmask import iter_bitmask_binary_entries as _iter_bitmask_binary_entries
 from ._mapping_classification import (
     classify_enum_mapping as _classify_enum_mapping,
 )
@@ -139,49 +140,6 @@ def _apply_diagnostic_binary_overrides(
         }
         switch_configs.pop(reg, None)
         select_configs.pop(reg, None)
-
-def _iter_bitmask_binary_entries(reg: Any) -> list[tuple[str, dict[str, Any]]]:
-    """Build binary mapping entries derived from a bitmask register definition."""
-    func_map = {
-        1: "coil_registers",
-        2: "discrete_inputs",
-        3: "holding_registers",
-        4: "input_registers",
-    }
-    register_type = func_map.get(reg.function)
-    if not register_type:
-        return []
-
-    bits = reg.bits or []
-    entries: list[tuple[str, dict[str, Any]]] = []
-    unnamed_bit = False
-    for idx, bit_def in enumerate(bits):
-        bit_name = bit_def.get("name") if isinstance(bit_def, dict) else (str(bit_def) if bit_def is not None else None)
-        if bit_name:
-            key = f"{reg.name}_{_to_snake_case(bit_name)}"
-            entries.append(
-                (
-                    key,
-                    {
-                        "translation_key": key,
-                        "register_type": register_type,
-                        "register": reg.name,
-                        "bit": 1 << idx,
-                    },
-                )
-            )
-        else:
-            unnamed_bit = True
-
-    if not bits or unnamed_bit:
-        entries.append(
-            (
-                reg.name,
-                {"translation_key": reg.name, "register_type": register_type, "bitmask": True},
-            )
-        )
-    return entries
-
 
 def _route_enum_mapping(
     target: str | None,

--- a/tests/test_entity_mappings_builder_transformations.py
+++ b/tests/test_entity_mappings_builder_transformations.py
@@ -1,5 +1,8 @@
 """Tests for extracted transformation helpers in mapping builders."""
 
+from custom_components.thessla_green_modbus.mappings._mapping_bitmask import (
+    iter_bitmask_binary_entries as _iter_bitmask_binary_entries,
+)
 from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _apply_diagnostic_binary_overrides,
     _build_base_translation_mapping,
@@ -8,7 +11,6 @@ from custom_components.thessla_green_modbus.mappings._mapping_builders import (
     _classify_min_max_mapping,
     _diag_register_candidates,
     _is_binary_state_pair,
-    _iter_bitmask_binary_entries,
     _register_context,
     _resolve_parent_child_mappings,
     _route_enum_mapping,


### PR DESCRIPTION
### Motivation
- Reduce branching and size in `mappings/_mapping_builders.py` by isolating the bitmask→binary mapping logic into a single-purpose helper module.
- Keep mapping semantics and exported mapping dictionaries stable while improving module-level responsibility and testability.

### Description
- Add new helper module `custom_components/thessla_green_modbus/mappings/_mapping_bitmask.py` that defines `iter_bitmask_binary_entries` and implements the previous bitmask-to-binary-entry construction logic.
- Update `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` to import and use `iter_bitmask_binary_entries` and remove the in-file implementation.
- Update `tests/test_entity_mappings_builder_transformations.py` to import the extracted helper and retain all existing assertions validating key names and payload shapes.
- Preserve all mapping outputs and entity-level identifiers, names, and domains so external behavior is unchanged.

### Testing
- Ran lint and static checks with `ruff check custom_components tests tools` which passed after organizing imports automatically with `ruff --fix`.
- Compiled sources with `python -m compileall -q custom_components/thessla_green_modbus tests tools` and ran `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, all of which completed (the register-compare reports expected extras to verify with vendor but did not block changes).
- Validated mappings with `python tools/validate_entity_mappings.py` which passed with `OK: 366 entities validated` indicating no change in entity outputs.
- Executed unit tests with `pytest -q tests/test_entity_mappings*.py` and `pytest tests/ -q`, with the full test suite passing (4 expected skips).
- Commit created: `f3ca7025`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afd302388326857752b3a00563a1)