### PR TITLE
refactor: continue scanner orchestration decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/full_scan_phase.py
+++ b/custom_components/thessla_green_modbus/scanner/full_scan_phase.py
@@ -1,0 +1,44 @@
+"""Helpers for normalizing full-scan register phase results."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def apply_word_register_block(
+    scanner: Any,
+    *,
+    function: int,
+    register_group: str,
+    start: int,
+    count: int,
+    data: list[int],
+    unknown_registers: dict[str, dict[int, Any]],
+) -> None:
+    """Apply full-scan results for input/holding registers."""
+    available = scanner.available_registers[register_group]
+    invalid_addresses = scanner.failed_addresses["invalid_values"][register_group]
+    register_map = scanner._registers.get(function, {})
+
+    for offset in range(count):
+        addr = start + offset
+        reg_name = register_map.get(addr)
+        if offset >= len(data):
+            if reg_name is None:
+                base = data[0] if data else start
+                unknown_registers[register_group][addr] = int(base) + offset
+            continue
+
+        value = data[offset]
+        if reg_name and scanner._is_valid_register_value(reg_name, value):
+            names = scanner._alias_names(function, addr)
+            if names:
+                available.update(names)
+            else:
+                available.add(reg_name)
+            continue
+
+        unknown_registers[register_group][addr] = value
+        if reg_name:
+            invalid_addresses.add(addr)
+            scanner._log_invalid_value(reg_name, value)

--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -21,6 +21,7 @@ from ..modbus_helpers import group_reads as _group_reads
 from ..modbus_transport import RtuModbusTransport
 from ..scanner_device_info import DeviceCapabilities, ScannerDeviceInfo
 from . import custom_scan as scanner_custom_scan
+from .full_scan_phase import apply_word_register_block
 from .io import is_request_cancelled_error
 
 _LOGGER = logging.getLogger(__name__)
@@ -185,26 +186,15 @@ async def run_full_scan(
                 range(start, start + count)
             )
             continue
-        for offset in range(count):
-            addr = start + offset
-            if offset >= len(input_data):
-                if scanner._registers.get(4, {}).get(addr) is None:
-                    base = input_data[0] if input_data else start
-                    unknown_registers["input_registers"][addr] = int(base) + offset
-                continue
-            value = input_data[offset]
-            reg_name = scanner._registers.get(4, {}).get(addr)
-            if reg_name and scanner._is_valid_register_value(reg_name, value):
-                names = scanner._alias_names(4, addr)
-                if names:
-                    scanner.available_registers["input_registers"].update(names)
-                else:
-                    scanner.available_registers["input_registers"].add(reg_name)
-            else:
-                unknown_registers["input_registers"][addr] = value
-                if reg_name:
-                    scanner.failed_addresses["invalid_values"]["input_registers"].add(addr)
-                    scanner._log_invalid_value(reg_name, value)
+        apply_word_register_block(
+            scanner,
+            function=4,
+            register_group="input_registers",
+            start=start,
+            count=count,
+            data=input_data,
+            unknown_registers=unknown_registers,
+        )
 
     for start, count in _group_reads(
         range(holding_max + 1), max_block_size=scanner.effective_batch
@@ -220,26 +210,15 @@ async def run_full_scan(
                 range(start, start + count)
             )
             continue
-        for offset in range(count):
-            addr = start + offset
-            if offset >= len(holding_data):
-                if scanner._registers.get(3, {}).get(addr) is None:
-                    base = holding_data[0] if holding_data else start
-                    unknown_registers["holding_registers"][addr] = int(base) + offset
-                continue
-            value = holding_data[offset]
-            reg_name = scanner._registers.get(3, {}).get(addr)
-            if reg_name and scanner._is_valid_register_value(reg_name, value):
-                names = scanner._alias_names(3, addr)
-                if names:
-                    scanner.available_registers["holding_registers"].update(names)
-                else:
-                    scanner.available_registers["holding_registers"].add(reg_name)
-            else:
-                unknown_registers["holding_registers"][addr] = value
-                if reg_name:
-                    scanner.failed_addresses["invalid_values"]["holding_registers"].add(addr)
-                    scanner._log_invalid_value(reg_name, value)
+        apply_word_register_block(
+            scanner,
+            function=3,
+            register_group="holding_registers",
+            start=start,
+            count=count,
+            data=holding_data,
+            unknown_registers=unknown_registers,
+        )
 
     for start, count in _group_reads(range(coil_max + 1), max_block_size=scanner.effective_batch):
         scanned_registers["coil_registers"] += count

--- a/tests/test_scanner_full_scan_phase.py
+++ b/tests/test_scanner_full_scan_phase.py
@@ -1,0 +1,49 @@
+"""Tests for full scan phase helpers."""
+
+from __future__ import annotations
+
+from custom_components.thessla_green_modbus.scanner.full_scan_phase import (
+    apply_word_register_block,
+)
+
+
+class _DummyScanner:
+    def __init__(self) -> None:
+        self.available_registers = {"input_registers": set(), "holding_registers": set()}
+        self.failed_addresses = {
+            "invalid_values": {"input_registers": set(), "holding_registers": set()}
+        }
+        self._registers = {4: {0: "reg_ok", 1: "reg_bad"}, 3: {}}
+        self.invalid_logged: list[tuple[str, int]] = []
+
+    def _is_valid_register_value(self, reg_name: str, value: int) -> bool:
+        return reg_name != "reg_bad" and value < 100
+
+    def _alias_names(self, function: int, address: int) -> set[str]:
+        if function == 4 and address == 0:
+            return {"reg_ok", "reg_ok_alias"}
+        return set()
+
+    def _log_invalid_value(self, reg_name: str, value: int) -> None:
+        self.invalid_logged.append((reg_name, value))
+
+
+def test_apply_word_register_block_normalizes_alias_invalid_and_unknown() -> None:
+    scanner = _DummyScanner()
+    unknown_registers = {"input_registers": {}, "holding_registers": {}}
+
+    apply_word_register_block(
+        scanner,
+        function=4,
+        register_group="input_registers",
+        start=0,
+        count=3,
+        data=[10, 200],
+        unknown_registers=unknown_registers,
+    )
+
+    assert scanner.available_registers["input_registers"] == {"reg_ok", "reg_ok_alias"}
+    assert unknown_registers["input_registers"][1] == 200
+    assert unknown_registers["input_registers"][2] == 12
+    assert scanner.failed_addresses["invalid_values"]["input_registers"] == {1}
+    assert scanner.invalid_logged == [("reg_bad", 200)]


### PR DESCRIPTION
### Motivation
- Reduce branching and duplication in scanner orchestration by extracting the per-block normalization logic used during full-register scans. 
- Centralize alias expansion, invalid-value tracking/logging, and truncated-block unknown-address handling so `run_full_scan` focuses on I/O flow.

### Description
- Add `custom_components/thessla_green_modbus/scanner/full_scan_phase.py` implementing `apply_word_register_block(...)` to normalize input/holding register blocks. 
- Replace duplicated per-block logic in `custom_components/thessla_green_modbus/scanner/orchestration.py::run_full_scan` with calls to `apply_word_register_block(...)`. 
- Add `tests/test_scanner_full_scan_phase.py` with a focused unit test covering alias expansion, invalid-value handling, and short-response unknown-address normalization. 
- Preserved behavior and boundaries: no changes to `scanner/io_read.py`, no Home Assistant imports introduced, and transport/coordinator/registers were not modified.

### Testing
- Ran lint and validation: `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed. 
- Ran repository validation scripts: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py` which passed (reference checks reported existing extras/mismatches as before). 
- Ran unit tests: `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` and `pytest tests/ -q` which passed (test suite completed with the existing skips reported by the suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afd9f3e083268190a38579957889)