### PR TITLE
refactor: continue scanner input read decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -269,6 +269,38 @@ def _handle_input_read_exception(
     raise exc
 
 
+def _handle_input_attempt_exception(
+    scanner: Any,
+    exc: Exception,
+    *,
+    start: int,
+    end: int,
+    address: int,
+    count: int,
+    attempt: int,
+) -> tuple[bool, bool]:
+    """Log and normalize input-read attempt failures.
+
+    Returns (abort_transiently, stop_retries).
+    """
+    log_scanner_retry(
+        operation=f"read_input:{start}-{end}",
+        attempt=attempt,
+        max_attempts=scanner.retry,
+        exc=exc,
+        backoff=scanner.backoff,
+    )
+    return _handle_input_read_exception(
+        scanner,
+        exc,
+        start=start,
+        end=end,
+        address=address,
+        count=count,
+        attempt=attempt,
+    )
+
+
 async def read_input(
     scanner: Any,
     client_or_address: AsyncModbusTcpClient | AsyncModbusSerialClientType | int,
@@ -324,14 +356,7 @@ async def read_input(
                     _LOGGER.debug("Read input registers %d-%d: %s", start, end, payload)
                 return payload
         except ModbusIOException as exc:
-            log_scanner_retry(
-                operation=f"read_input:{start}-{end}",
-                attempt=attempt,
-                max_attempts=scanner.retry,
-                exc=exc,
-                backoff=scanner.backoff,
-            )
-            aborted, stop = _handle_input_read_exception(
+            aborted, stop = _handle_input_attempt_exception(
                 scanner,
                 exc,
                 start=start,
@@ -344,14 +369,7 @@ async def read_input(
             if stop:
                 break
         except (TimeoutError, OSError) as exc:
-            log_scanner_retry(
-                operation=f"read_input:{start}-{end}",
-                attempt=attempt,
-                max_attempts=scanner.retry,
-                exc=exc,
-                backoff=scanner.backoff,
-            )
-            aborted, stop = _handle_input_read_exception(
+            aborted, stop = _handle_input_attempt_exception(
                 scanner,
                 exc,
                 start=start,
@@ -364,14 +382,7 @@ async def read_input(
             if stop:
                 break
         except (ModbusException, ConnectionException) as exc:
-            log_scanner_retry(
-                operation=f"read_input:{start}-{end}",
-                attempt=attempt,
-                max_attempts=scanner.retry,
-                exc=exc,
-                backoff=scanner.backoff,
-            )
-            aborted, stop = _handle_input_read_exception(
+            aborted, stop = _handle_input_attempt_exception(
                 scanner,
                 exc,
                 start=start,

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -10,6 +10,7 @@ from custom_components.thessla_green_modbus.scanner.io_read import (
     _build_register_chunks,
     _extend_or_abort_register_results,
     _finalize_register_read_failure,
+    _handle_input_attempt_exception,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -189,6 +190,40 @@ async def test_read_holding_cancelled_modbusio_stops_retry_loop():
     assert result is None
     assert call_mock.await_count == 1
     sleep_mock.assert_not_called()
+
+
+def test_handle_input_attempt_exception_logs_retry_and_delegates():
+    """Input-attempt helper should centralize retry logging and delegation."""
+    scanner = MagicMock(retry=3, backoff=0.1)
+    exc = TimeoutError("timeout")
+    with (
+        patch(
+            "custom_components.thessla_green_modbus.scanner.io_read.log_scanner_retry"
+        ) as retry_log,
+        patch(
+            "custom_components.thessla_green_modbus.scanner.io_read._handle_input_read_exception",
+            return_value=(True, True),
+        ) as delegate,
+    ):
+        aborted, stop = _handle_input_attempt_exception(
+            scanner,
+            exc,
+            start=10,
+            end=11,
+            address=10,
+            count=2,
+            attempt=2,
+        )
+
+    assert (aborted, stop) == (True, True)
+    retry_log.assert_called_once_with(
+        operation="read_input:10-11",
+        attempt=2,
+        max_attempts=3,
+        exc=exc,
+        backoff=0.1,
+    )
+    delegate.assert_called_once()
 
 
 def test_finalize_register_read_failure_input_aborted_logs_abort_only(caplog):


### PR DESCRIPTION
### Motivation
- Reduce duplication in the `read_input` retry loop by centralizing per-attempt retry logging and exception normalization so the input-read path is simpler to reason about and easier to further decompose.

### Description
- Add `_handle_input_attempt_exception(...)` to `custom_components/thessla_green_modbus/scanner/io_read.py` which logs the retry via `log_scanner_retry` then delegates to the existing `_handle_input_read_exception` to normalize abort/stop decisions.
- Replace repeated `log_scanner_retry` + `_handle_input_read_exception` branches in `read_input` with calls to the new helper so control flow, retries, backoff, and finalization are unchanged.
- Add `test_handle_input_attempt_exception_logs_retry_and_delegates` to `tests/test_scanner_io.py` to verify the helper emits the retry log and delegates to the original exception handler.

### Testing
- Ran `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, and full `pytest tests/ -q`; all checks passed and pytest completed with the existing skips.
- Changes committed as `cf057130` and a PR was created via the internal Codex PR mechanism.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afe154f4832690f1b1f53049f2e3)