### PR TITLE
refactor: reduce coordinator retry capability complexity

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/retry.py
+++ b/custom_components/thessla_green_modbus/coordinator/retry.py
@@ -141,6 +141,47 @@ async def disconnect_and_reconnect_for_retry(
     return None
 
 
+async def _handle_retry_exception(
+    owner: Any,
+    *,
+    register_type: str,
+    start_address: int,
+    attempt: int,
+    exc: Exception,
+    reconnect: bool,
+    timeout: bool = False,
+) -> Exception:
+    """Handle retryable read exception and return the most recent error."""
+    if attempt >= owner.retry:
+        raise exc
+
+    if reconnect:
+        reconnect_error = await disconnect_and_reconnect_for_retry(
+            owner,
+            register_type=register_type,
+            start_address=start_address,
+            attempt=attempt,
+        )
+        if reconnect_error is not None:
+            return reconnect_error
+
+    log_coordinator_retry(
+        operation=f"read:{register_type}:{start_address}",
+        attempt=attempt,
+        max_attempts=owner.retry,
+        exc=exc,
+        backoff=getattr(owner, "backoff", 0.0),
+    )
+    owner._log_read_retry(
+        register_type=register_type,
+        start_address=start_address,
+        attempt=attempt,
+        exc=exc,
+        timeout=timeout,
+    )
+    return exc
+
+
 async def read_with_retry(
     owner: Any,
     read_method: Any,
@@ -172,76 +213,33 @@ async def read_with_retry(
         except _PermanentModbusError:
             raise
         except TimeoutError as exc:
-            last_error = exc
-            if attempt >= owner.retry:
-                raise  # pragma: no cover
-            reconnect_error = await disconnect_and_reconnect_for_retry(
+            last_error = await _handle_retry_exception(
                 owner,
                 register_type=register_type,
                 start_address=start_address,
                 attempt=attempt,
-            )
-            if reconnect_error is not None:
-                last_error = reconnect_error
-                continue
-            log_coordinator_retry(
-                operation=f"read:{register_type}:{start_address}",
-                attempt=attempt,
-                max_attempts=owner.retry,
                 exc=exc,
-                backoff=getattr(owner, "backoff", 0.0),
-            )
-            owner._log_read_retry(
-                register_type=register_type,
-                start_address=start_address,
-                attempt=attempt,
-                exc=exc,
+                reconnect=True,
                 timeout=True,
             )
         except (ModbusIOException, ConnectionException, OSError) as exc:
-            last_error = exc
-            if attempt >= owner.retry:
-                raise
-            reconnect_error = await disconnect_and_reconnect_for_retry(
+            last_error = await _handle_retry_exception(
                 owner,
                 register_type=register_type,
                 start_address=start_address,
                 attempt=attempt,
-            )
-            if reconnect_error is not None:
-                last_error = reconnect_error
-                continue
-            log_coordinator_retry(
-                operation=f"read:{register_type}:{start_address}",
-                attempt=attempt,
-                max_attempts=owner.retry,
                 exc=exc,
-                backoff=getattr(owner, "backoff", 0.0),
-            )
-            owner._log_read_retry(
-                register_type=register_type,
-                start_address=start_address,
-                attempt=attempt,
-                exc=exc,
+                reconnect=True,
             )
         except ModbusException as exc:
-            last_error = exc
-            if attempt >= owner.retry:
-                raise
-            log_coordinator_retry(
-                operation=f"read:{register_type}:{start_address}",
-                attempt=attempt,
-                max_attempts=owner.retry,
-                exc=exc,
-                backoff=getattr(owner, "backoff", 0.0),
-            )
-            owner._log_read_retry(
+            last_error = await _handle_retry_exception(
+                owner,
                 register_type=register_type,
                 start_address=start_address,
                 attempt=attempt,
                 exc=exc,
+                reconnect=False,
             )
-            continue
     if last_error is not None:  # pragma: no cover
         raise last_error  # pragma: no cover
     raise ModbusException(


### PR DESCRIPTION
### Motivation
- Reduce branching and duplicated logic in the coordinator retry path by extracting the common exception-handling/reconnect/logging responsibilities into a focused helper. 
- Keep the coordinator orchestration and schedule/write paths untouched while tightening retry-related code quality. 
- Preserve existing retry/backoff, error classification, and logging semantics required by the coordinator layer.

### Description
- Added a new helper `_handle_retry_exception` in `custom_components/thessla_green_modbus/coordinator/retry.py` that centralizes retry-limit checks, optional disconnect-and-reconnect before retry, and standardized retry logging. 
- Simplified `read_with_retry` to delegate timeout/transport/ModbusException branches to the new helper while preserving the original control flow and raising behavior for permanent errors. 
- No public coordinator package API was changed and no other coordinator modules were modified.

### Testing
- Ran the full validation pipeline: `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, and `python tools/check_maintainability.py`, all of which passed. 
- Ran unit and integration tests: `pytest -q tests/test_coordinator*.py tests/test_error_contract.py tests/unit/test_errors.py` and `pytest tests/ -q`, and the test suites passed (with existing skips). 
- Ran entity mappings validation: `python tools/validate_entity_mappings.py` and coordinator package API assertion; both passed. 
- Changed files: `custom_components/thessla_green_modbus/coordinator/retry.py` (refactor only). 
- Commit: `7050d421`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afe9e314832686de03d7d0205c58)