### PR TITLE
refactor: extract write-attempt exception handler from coordinator schedule

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -243,6 +243,53 @@ class _CoordinatorScheduleMixin:
         _LOGGER.info(retry_message)
         return True
 
+
+    async def _handle_write_attempt_exception(
+        self,
+        *,
+        register_name: str,
+        attempt: int,
+        exc: Exception,
+        timed_out_message: str,
+        persistent_timeout_message: str,
+        failed_message: str,
+        retry_message: str,
+        unexpected_message: str,
+    ) -> bool:
+        """Handle write attempt exception paths.
+
+        Returns True when caller should retry, False when operation must stop.
+        """
+        if isinstance(exc, (ModbusException, ConnectionException)):
+            await self._disconnect()
+            if attempt == self.retry:
+                _LOGGER.error(failed_message, register_name, exc_info=True)
+                return False
+            _LOGGER.info(retry_message, register_name, exc)
+            return True
+
+        if isinstance(exc, TimeoutError):
+            if self._transport is not None:
+                await self._disconnect()
+            _LOGGER.warning(
+                timed_out_message,
+                register_name,
+                attempt,
+                self.retry,
+                exc_info=True,
+            )
+            if attempt == self.retry:
+                _LOGGER.error(persistent_timeout_message, register_name)
+                return False
+            return True
+
+        if isinstance(exc, OSError):
+            await self._disconnect()
+            _LOGGER.exception(unexpected_message, register_name)
+            return False
+
+        raise exc
+
     async def _finalize_write_result(self, refresh_after_write: bool) -> bool:
         """Finish write operation with optional refresh."""
         if refresh_after_write:
@@ -340,42 +387,20 @@ class _CoordinatorScheduleMixin:
                             register_name,
                         )
                         break
-                    except (ModbusException, ConnectionException) as exc:
-                        await self._disconnect()
-                        if attempt == self.retry:
-                            _LOGGER.error(
-                                "Failed to write register %s",
-                                register_name,
-                                exc_info=True,
-                            )
-                            return False
-                        _LOGGER.info(
-                            "Retrying write to register %s after error: %s",
-                            register_name,
-                            exc,
+                    except (ModbusException, ConnectionException, TimeoutError, OSError) as exc:
+                        should_retry = await self._handle_write_attempt_exception(
+                            register_name=register_name,
+                            attempt=attempt,
+                            exc=exc,
+                            timed_out_message="Writing register %s timed out (attempt %d/%d)",
+                            persistent_timeout_message="Persistent timeout writing register %s",
+                            failed_message="Failed to write register %s",
+                            retry_message="Retrying write to register %s after error: %s",
+                            unexpected_message="Unexpected error writing register %s",
                         )
-                        continue
-                    except TimeoutError:
-                        if self._transport is not None:
-                            await self._disconnect()
-                        _LOGGER.warning(
-                            "Writing register %s timed out (attempt %d/%d)",
-                            register_name,
-                            attempt,
-                            self.retry,
-                            exc_info=True,
-                        )
-                        if attempt == self.retry:
-                            _LOGGER.error(
-                                "Persistent timeout writing register %s",
-                                register_name,
-                            )
+                        if not should_retry:
                             return False
                         continue
-                    except OSError:
-                        await self._disconnect()
-                        _LOGGER.exception("Unexpected error writing register %s", register_name)
-                        return False
 
             except (ModbusException, ConnectionException):  # pragma: no cover - safety
                 _LOGGER.exception("Failed to write register %s", register_name)
@@ -430,42 +455,20 @@ class _CoordinatorScheduleMixin:
                             start_address,
                         )
                         break
-                    except (ModbusException, ConnectionException) as exc:
-                        await self._disconnect()
-                        if attempt == self.retry:
-                            _LOGGER.error(
-                                "Failed to write registers at %s",
-                                start_address,
-                                exc_info=True,
-                            )
-                            return False
-                        _LOGGER.info(
-                            "Retrying multi-register write at %s after error: %s",
-                            start_address,
-                            exc,
+                    except (ModbusException, ConnectionException, TimeoutError, OSError) as exc:
+                        should_retry = await self._handle_write_attempt_exception(
+                            register_name=str(start_address),
+                            attempt=attempt,
+                            exc=exc,
+                            timed_out_message="Writing registers at %s timed out (attempt %d/%d)",
+                            persistent_timeout_message="Persistent timeout writing registers at %s",
+                            failed_message="Failed to write registers at %s",
+                            retry_message="Retrying multi-register write at %s after error: %s",
+                            unexpected_message="Unexpected error writing registers at %s",
                         )
-                        continue
-                    except TimeoutError:
-                        if self._transport is not None:
-                            await self._disconnect()
-                        _LOGGER.warning(
-                            "Writing registers at %s timed out (attempt %d/%d)",
-                            start_address,
-                            attempt,
-                            self.retry,
-                            exc_info=True,
-                        )
-                        if attempt == self.retry:
-                            _LOGGER.error(
-                                "Persistent timeout writing registers at %s",
-                                start_address,
-                            )
+                        if not should_retry:
                             return False
                         continue
-                    except OSError:
-                        await self._disconnect()
-                        _LOGGER.exception("Unexpected error writing registers at %s", start_address)
-                        return False
 
             except (ModbusException, ConnectionException):  # pragma: no cover - safety
                 _LOGGER.exception("Failed to write registers at %s", start_address)

--- a/tests/test_coordinator_register_writes.py
+++ b/tests/test_coordinator_register_writes.py
@@ -144,3 +144,52 @@ def test_handle_write_response_failure_logs_error(coordinator, caplog):
     )
     assert should_retry is False
     assert "Error writing to register mode: err" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_write_attempt_exception_timeout_disconnects_transport(coordinator, caplog):
+    """Timeout should disconnect transport, log warning, and request retry."""
+    coordinator.retry = 3
+    coordinator._transport = MagicMock()
+    coordinator._disconnect = AsyncMock()
+
+    caplog.set_level("WARNING")
+    should_retry = await coordinator._handle_write_attempt_exception(
+        register_name="mode",
+        attempt=1,
+        exc=TimeoutError("late"),
+        timed_out_message="Writing register %s timed out (attempt %d/%d)",
+        persistent_timeout_message="Persistent timeout writing register %s",
+        failed_message="Failed to write register %s",
+        retry_message="Retrying write to register %s after error: %s",
+        unexpected_message="Unexpected error writing register %s",
+    )
+
+    assert should_retry is True
+    coordinator._disconnect.assert_awaited_once()
+    assert "Writing register mode timed out (attempt 1/3)" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_write_attempt_exception_final_modbus_failure(coordinator, caplog):
+    """Final Modbus/connection failure should stop retries."""
+    from custom_components.thessla_green_modbus.modbus_exceptions import ModbusException
+
+    coordinator.retry = 2
+    coordinator._disconnect = AsyncMock()
+    caplog.set_level("ERROR")
+
+    should_retry = await coordinator._handle_write_attempt_exception(
+        register_name="100",
+        attempt=2,
+        exc=ModbusException("boom"),
+        timed_out_message="Writing registers at %s timed out (attempt %d/%d)",
+        persistent_timeout_message="Persistent timeout writing registers at %s",
+        failed_message="Failed to write registers at %s",
+        retry_message="Retrying multi-register write at %s after error: %s",
+        unexpected_message="Unexpected error writing registers at %s",
+    )
+
+    assert should_retry is False
+    coordinator._disconnect.assert_awaited_once()
+    assert "Failed to write registers at 100" in caplog.text


### PR DESCRIPTION
### Motivation
- Reduce duplication and complexity in `coordinator/schedule.py` by extracting the repeated per-attempt exception/retry/disconnect/log branch. 
- Continue the ongoing coordinator write-path decomposition to make write-path responsibilities easier to test and maintain.

### Description
- Add a new helper `async def _handle_write_attempt_exception(...)` in `custom_components/thessla_green_modbus/coordinator/schedule.py` that centralizes handling for `(ModbusException, ConnectionException, TimeoutError, OSError)` and returns whether the caller should retry. 
- Update `async_write_register(...)` and `async_write_registers(...)` to delegate exception-path handling to the new helper and pass operation-specific message templates to preserve existing logging and retry semantics. 
- Add two focused tests in `tests/test_coordinator_register_writes.py` to cover the timeout + disconnect retry path and the final Modbus failure stop path for the new helper.

### Testing
- Ran lint/compile checks with `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both of which passed. 
- Ran register/reference and maintainability gates with `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both of which passed (reference check reports expected extras). 
- Ran focused tests with `pytest -q tests/test_coordinator_register_writes.py tests/test_multi_register_write.py tests/test_force_full_register_list.py tests/test_logging.py tests/test_coordinator*.py`, and then the full test suite with `pytest tests/ -q`, and both runs passed (with pre-existing skips). 
- Ran entity mappings validation with `python tools/validate_entity_mappings.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7aff15a548326900666c1ceb6dc1e)