### PR TITLE
refactor: extract coordinator runtime state helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/update.py
+++ b/custom_components/thessla_green_modbus/coordinator/update.py
@@ -14,6 +14,7 @@ from ..modbus_exceptions import ConnectionException
 from ..utils import utcnow as _utcnow
 from .errors import handle_update_error
 from .update_result import apply_success_result
+from .update_state import begin_update_cycle, finish_update_cycle
 
 if TYPE_CHECKING:
     from .coordinator import ThesslaGreenModbusCoordinator
@@ -49,12 +50,9 @@ async def async_update_data(coordinator: ThesslaGreenModbusCoordinator) -> dict[
     """Fetch data from device and handle failures consistently."""
     start_time = _utcnow()
 
-    if coordinator._update_in_progress:
-        _LOGGER.debug("Data update already running; skipping duplicate task")
-        return coordinator.data or {}
-
-    coordinator._update_in_progress = True
-    coordinator._failed_registers = set()
+    prepared_data = begin_update_cycle(coordinator)
+    if prepared_data is not None:
+        return prepared_data
 
     async with coordinator._write_lock:
         try:
@@ -92,4 +90,4 @@ async def async_update_data(coordinator: ThesslaGreenModbusCoordinator) -> dict[
                 use_helper=False,
             ) from exc
         finally:
-            coordinator._update_in_progress = False
+            finish_update_cycle(coordinator)

--- a/custom_components/thessla_green_modbus/coordinator/update_state.py
+++ b/custom_components/thessla_green_modbus/coordinator/update_state.py
@@ -1,0 +1,27 @@
+"""Coordinator runtime update-state helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .coordinator import ThesslaGreenModbusCoordinator
+
+_LOGGER = logging.getLogger(__name__.rsplit(".", maxsplit=1)[0])
+
+
+def begin_update_cycle(coordinator: ThesslaGreenModbusCoordinator) -> dict[str, Any] | None:
+    """Prepare runtime state for an update cycle or return cached data when already running."""
+    if coordinator._update_in_progress:
+        _LOGGER.debug("Data update already running; skipping duplicate task")
+        return coordinator.data or {}
+
+    coordinator._update_in_progress = True
+    coordinator._failed_registers = set()
+    return None
+
+
+def finish_update_cycle(coordinator: ThesslaGreenModbusCoordinator) -> None:
+    """Reset runtime update flag after a cycle completes or fails."""
+    coordinator._update_in_progress = False

--- a/tests/test_coordinator_update_state.py
+++ b/tests/test_coordinator_update_state.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.thessla_green_modbus.coordinator.update_state import (
+    begin_update_cycle,
+    finish_update_cycle,
+)
+
+
+def test_begin_update_cycle_returns_existing_data_when_already_running() -> None:
+    coordinator = MagicMock()
+    coordinator._update_in_progress = True
+    coordinator.data = {"temperature": 21}
+
+    result = begin_update_cycle(coordinator)
+
+    assert result == {"temperature": 21}
+
+
+def test_begin_update_cycle_initializes_runtime_flags() -> None:
+    coordinator = MagicMock()
+    coordinator._update_in_progress = False
+    coordinator._failed_registers = {"legacy"}
+
+    result = begin_update_cycle(coordinator)
+
+    assert result is None
+    assert coordinator._update_in_progress is True
+    assert coordinator._failed_registers == set()
+
+
+def test_finish_update_cycle_resets_runtime_flag() -> None:
+    coordinator = MagicMock()
+    coordinator._update_in_progress = True
+
+    finish_update_cycle(coordinator)
+
+    assert coordinator._update_in_progress is False


### PR DESCRIPTION
### Motivation
- Reduce size and surface area of the large coordinator implementation by extracting a single cohesive runtime responsibility from the update path. 
- Keep runtime behavior identical while making the coordinator easier to reason about and test.

### Description
- Add `coordinator/update_state.py` with real implementation logic: `begin_update_cycle` and `finish_update_cycle` to manage the `_update_in_progress` guard and `_failed_registers` initialization. 
- Replace inline runtime-flag handling in `coordinator/update.py` with calls to `begin_update_cycle` and `finish_update_cycle`. 
- Add focused unit tests in `tests/test_coordinator_update_state.py` covering already-running short-circuit, initialization, and teardown behavior. 
- Verified the coordinator package-root API remains minimal and unchanged (`CoordinatorConfig`, `ThesslaGreenModbusCoordinator`).

### Testing
- Ran style and static checks with `ruff check custom_components tests tools` which passed. 
- Verified byte-compile with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed. 
- Ran integration consistency with `python tools/compare_registers_with_reference.py` which completed (reported expected extras/mismatches unrelated to this change). 
- Ran maintainability check with `python tools/check_maintainability.py` which passed. 
- Ran targeted tests with `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` which passed, and ran full test suite with `pytest tests/ -q` which passed (with the repository's existing skips). 
- Ran entity mapping validation with `python tools/validate_entity_mappings.py` which passed and verified package API audit asserting `__all__` contains only `CoordinatorConfig` and `ThesslaGreenModbusCoordinator`. 
- Commit created: `5931808b`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7aff7bf78832697292ac4ec76e583)