### PR TITLE
chore: stage ruff formatting and import-order hardening

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,3 +123,39 @@ jobs:
 
       - name: Validate entity mappings
         run: python tools/validate_entity_mappings.py
+
+  ruff-adoption-signal:
+    name: Ruff formatting/import-order signal (non-blocking)
+    runs-on: ubuntu-latest
+    needs: lint
+    continue-on-error: true
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+        ha-version: ["2026.2.3"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+            constraints.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
+          python -m pip install homeassistant==${{ matrix.ha-version }} hacs
+
+      - name: Ruff import order (informational)
+        run: ruff check --select I custom_components tests tools
+
+      - name: Ruff format drift (informational)
+        run: ruff format --check custom_components tests tools

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,6 +1,6 @@
 # Maintainability audit
 
-Date: 2026-05-01
+Date: 2026-05-03
 
 ## Inputs and checks
 
@@ -122,19 +122,19 @@ As of this audit, CI-required gates remain intentionally limited to Ruff linting
 
 ### Stage B (optional informational CI job, non-blocking)
 
-If desired, add a separate workflow job that runs the two checks above and is explicitly marked non-blocking (for example, `continue-on-error: true`). This job should:
+Implemented in CI as `ruff-adoption-signal`: a separate workflow job that runs the two checks above and is explicitly marked non-blocking via `continue-on-error: true`. This job:
 
 - avoid touching required branch protection gates,
 - avoid secrets and external services,
-- only report drift trend.
+- only reports drift trend.
 
 ### Stage C (targeted adoption after convergence)
 
 When `ruff format --check` and import-order checks are routinely clean on active files, enforce them incrementally by path or module group in small PRs, never as a one-shot repository-wide rewrite.
 
-### Current readiness snapshot
+### Current readiness snapshot (2026-05-03)
 
-- `ruff format --check custom_components tests tools`: **fails** currently (94 files would be reformatted).
+- `ruff format --check custom_components tests tools`: **fails** currently (99 files would be reformatted).
 - `ruff check --select I custom_components tests tools`: **passes** currently.
 
 Conclusion: repository is ready for import-order enforcement (already clean), but not ready for mandatory format enforcement without a dedicated formatting campaign.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-01.
+Last reviewed: 2026-05-03.
 
 Related document:
 
@@ -41,3 +41,11 @@ Dedicated migration PR completed. Current canonical state:
 - Keep architecture docs aligned with real repository state.
 - Do not document unsupported devices or speculative features.
 - Do not create migration guides unless real migration code exists.
+
+## CI hardening status (safe staged adoption)
+
+- Required CI gates remain unchanged: lint, tests, and entity mappings validation.
+- A non-blocking informational CI job (`ruff-adoption-signal`) now reports:
+  - `ruff check --select I custom_components tests tools`
+  - `ruff format --check custom_components tests tools`
+- This preserves branch-protection stability while exposing formatting/import-order drift trends.


### PR DESCRIPTION
### Motivation
- Provide visibility into Ruff import-order and formatting drift without weakening existing branch-protection gates. 
- Stage a gradual adoption path so import-order can be enforced earlier while full repository formatting remains a future targeted effort. 
- Keep CI stable by adding only a non-blocking informational signal that surfaces drift trends for developers. 

### Description
- Add a new non-blocking CI job `ruff-adoption-signal` to `.github/workflows/ci.yaml` that runs `ruff check --select I custom_components tests tools` and `ruff format --check custom_components tests tools` with `continue-on-error: true`. 
- Update `docs/maintainability_audit.md` to reflect the implemented Stage B signal, bump the audit date, and update the reported format-drift count to 99 files. 
- Update `docs/refactor_status.md` to set the review date and document the CI hardening status, while preserving existing required CI jobs unchanged. 

### Testing
- Ran `ruff check custom_components tests tools` and `ruff check --select I custom_components tests tools`, both of which passed. 
- Ran `ruff format --check custom_components tests tools`, which is informational and reported drift (99 files would be reformatted). 
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, and `python tools/check_maintainability.py`, all of which passed (the register comparison reported extra entries/name mismatches for vendor verification). 
- Ran `pytest tests/ -q` which passed (with 4 skipped) and `python tools/validate_entity_mappings.py` which passed (366 entities validated). 
- Changes were committed (commit `b173474557eeec9b2575f42080a6427bd5a17eb3`) and no production code or tests were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b2cd2fcc83268871c4cd504c61ee)