### PR TITLE
refactor: extract scanner creation from config flow validation

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow_device_validation.py
+++ b/custom_components/thessla_green_modbus/config_flow_device_validation.py
@@ -140,6 +140,39 @@ async def _run_scanner_validation(
     return _validate_scan_result(await run_scanner_call(scanner.scan_device, timeout))
 
 
+async def _create_scanner(
+    *,
+    scanner_cls: Any,
+    hass: Any,
+    params: dict[str, Any],
+    default_retry: int,
+    config_flow_backoff: float,
+    run_with_retry: Callable[[Callable[[], Awaitable[Any]], int, float], Awaitable[Any]],
+) -> Any:
+    """Create scanner instance using normalized connection parameters."""
+    return await run_with_retry(
+        lambda: scanner_cls.create(
+            host=params["host"],
+            port=params["port"],
+            slave_id=params["slave_id"],
+            timeout=params["timeout"],
+            retry=default_retry,
+            backoff=config_flow_backoff,
+            deep_scan=params["deep_scan"],
+            connection_type=params["connection_type"],
+            connection_mode=params["connection_mode"],
+            serial_port=params["serial_port"],
+            baud_rate=params["baud_rate"],
+            parity=params["parity"],
+            stop_bits=params["stop_bits"],
+            hass=hass,
+        ),
+        default_retry,
+        config_flow_backoff,
+    )
+
+
+
 def _map_validation_exception(
     exc: BaseException,
     *,
@@ -268,25 +301,13 @@ async def validate_input_impl(
         *timeout_exceptions,
     )
     try:
-        scanner = await run_with_retry(
-            lambda: scanner_cls.create(
-                host=params["host"],
-                port=params["port"],
-                slave_id=params["slave_id"],
-                timeout=params["timeout"],
-                retry=default_retry,
-                backoff=config_flow_backoff,
-                deep_scan=params["deep_scan"],
-                connection_type=params["connection_type"],
-                connection_mode=params["connection_mode"],
-                serial_port=params["serial_port"],
-                baud_rate=params["baud_rate"],
-                parity=params["parity"],
-                stop_bits=params["stop_bits"],
-                hass=hass,
-            ),
-            default_retry,
-            config_flow_backoff,
+        scanner = await _create_scanner(
+            scanner_cls=scanner_cls,
+            hass=hass,
+            params=params,
+            default_retry=default_retry,
+            config_flow_backoff=config_flow_backoff,
+            run_with_retry=run_with_retry,
         )
 
         run_scanner_call = _build_timeout_runner(

--- a/tests/test_config_flow_runtime_validation.py
+++ b/tests/test_config_flow_runtime_validation.py
@@ -3,6 +3,7 @@
 import pytest
 from custom_components.thessla_green_modbus.config_flow_device_validation import (
     _build_validation_result,
+    _create_scanner,
     _require_verify_connection,
 )
 from custom_components.thessla_green_modbus.scanner.core import DeviceCapabilities
@@ -43,3 +44,50 @@ def test_build_validation_result_attaches_capabilities():
     assert payload["title"] == "Test Device"
     assert payload["device_info"] == {"model": "x"}
     assert payload["scan_result"]["capabilities"] == {"basic_control": True}
+
+
+@pytest.mark.asyncio
+async def test_create_scanner_uses_normalized_params():
+    recorded: dict[str, object] = {}
+
+    class _FakeScanner:
+        async def verify_connection(self):
+            return None
+
+        async def scan_device(self):
+            return {"device_info": {"model": "ok"}}
+
+    class _FakeScannerCls:
+        @staticmethod
+        async def create(**kwargs):
+            recorded.update(kwargs)
+            return _FakeScanner()
+
+    async def _run_with_retry(func, retries, backoff):
+        return await func()
+
+    scanner = await _create_scanner(
+        scanner_cls=_FakeScannerCls,
+        hass=object(),
+        params={
+            "host": "127.0.0.1",
+            "port": 502,
+            "slave_id": 10,
+            "timeout": 5.0,
+            "deep_scan": True,
+            "connection_type": "tcp",
+            "connection_mode": None,
+            "serial_port": None,
+            "baud_rate": None,
+            "parity": "N",
+            "stop_bits": 1,
+        },
+        default_retry=3,
+        config_flow_backoff=0.1,
+        run_with_retry=_run_with_retry,
+    )
+
+    assert scanner is not None
+    assert recorded["host"] == "127.0.0.1"
+    assert recorded["port"] == 502
+    assert recorded["slave_id"] == 10


### PR DESCRIPTION
### Motivation
- Reduce branching and inline setup complexity inside the large `validate_input_impl` validation flow by isolating the scanner instantiation concern. 
- Create a focused, testable boundary for scanner creation so future decomposition of `config_flow_device_validation.py` is easier while preserving existing behavior.

### Description
- Added a new helper `_create_scanner(...)` in `custom_components/thessla_green_modbus/config_flow_device_validation.py` that encapsulates the `scanner_cls.create(...)` call and its retry parameters. 
- Replaced the inline scanner-instantiation block inside `validate_input_impl` with a call to `_create_scanner(...)`, preserving the retry/backoff semantics and subsequent validation flow. 
- Added a unit test `test_create_scanner_uses_normalized_params` in `tests/test_config_flow_runtime_validation.py` to assert normalized connection parameters are forwarded to scanner creation unchanged.

### Testing
- Ran `ruff check custom_components tests tools` and it passed. 
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` and it passed. 
- Ran `python tools/compare_registers_with_reference.py` and it executed (reported integration reference diffs unrelated to this change). 
- Ran `python tools/check_maintainability.py`, `pytest -q tests/test_config_flow*.py`, and `pytest tests/ -q` and all tests passed (with the existing skips), and `python tools/validate_entity_mappings.py` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f861647c588326aa90a1e978758672)