### PR TITLE
refactor: continue service handler decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_parameters.py
+++ b/custom_components/thessla_green_modbus/services_handlers_parameters.py
@@ -15,7 +15,7 @@ from .services_schema import (
     SET_GWC_PARAMETERS_SCHEMA,
     SET_TEMPERATURE_CURVE_SCHEMA,
 )
-from .services_validation import BYPASS_MODE_MAP, GWC_MODE_MAP
+from .services_validation import BYPASS_MODE_MAP, GWC_MODE_MAP, iter_air_quality_writes
 
 WriteStep = tuple[str, object | None, bool, str]
 ServiceHandler = Callable[[ServiceCall], object]
@@ -95,17 +95,13 @@ def _parameter_registrations(
         ],
     )
 
-    async def set_air_quality_thresholds(call: ServiceCall) -> None:
-        for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            success = True
-            for param in ["co2_low", "co2_medium", "co2_high", "humidity_target"]:
-                value = call.data.get(param)
-                if value is not None and not await deps.write_register(coordinator, deps.air_quality_register_map[param], value, entity_id, "set air quality thresholds"):
-                    deps.logger.error("Failed to set %s for %s", param, entity_id)
-                    success = False
-                    break
-            if success:
-                await refresh_and_log_success(coordinator, deps.logger, "Set air quality thresholds for %s", entity_id)
+    set_air_quality_thresholds = _build_step_handler(
+        hass,
+        deps,
+        context="set air quality thresholds",
+        success_log="Set air quality thresholds for %s",
+        step_builder=lambda call: list(iter_air_quality_writes(call.data, deps.air_quality_register_map)),
+    )
 
     set_temperature_curve = _build_step_handler(
         hass,

--- a/custom_components/thessla_green_modbus/services_validation.py
+++ b/custom_components/thessla_green_modbus/services_validation.py
@@ -109,6 +109,18 @@ def iter_modbus_parameter_writes(
     ]
 
 
+
+def iter_air_quality_writes(
+    data: dict[str, Any],
+    register_map: dict[str, str],
+) -> list[tuple[str, object | None, bool, str]]:
+    """Build optional write steps for air quality thresholds."""
+    fields = ("co2_low", "co2_medium", "co2_high", "humidity_target")
+    return [
+        (register_map[field], data.get(field), True, f"Failed to set {field} for %s")
+        for field in fields
+    ]
+
 def filter_reset_value(normalize: Any, raw_filter_type: str) -> int:
     """Map filter reset option payload to register value."""
     return FILTER_TYPE_MAP[normalize(raw_filter_type)]

--- a/tests/test_services_dispatch_validation.py
+++ b/tests/test_services_dispatch_validation.py
@@ -18,6 +18,7 @@ from custom_components.thessla_green_modbus.services_dispatch import (
 from custom_components.thessla_green_modbus.services_validation import (
     BAUD_MAP,
     filter_reset_value,
+    iter_air_quality_writes,
     normalize_modbus_options,
     normalize_option,
     pressure_test_payload,
@@ -187,3 +188,22 @@ async def test_write_device_name_chunks_writes_offsets():
     assert coordinator.async_write_register.await_count == 2
     coordinator.async_write_register.assert_any_await("device_name", "ABCD", refresh=False, offset=0)
     coordinator.async_write_register.assert_any_await("device_name", "EFGH", refresh=False, offset=2)
+
+
+def test_iter_air_quality_writes_builds_optional_steps_with_register_map():
+    steps = iter_air_quality_writes(
+        {"co2_low": 500, "co2_medium": None, "co2_high": 1000, "humidity_target": 45},
+        {
+            "co2_low": "co2_low_reg",
+            "co2_medium": "co2_medium_reg",
+            "co2_high": "co2_high_reg",
+            "humidity_target": "humidity_target_reg",
+        },
+    )
+
+    assert steps == [
+        ("co2_low_reg", 500, True, "Failed to set co2_low for %s"),
+        ("co2_medium_reg", None, True, "Failed to set co2_medium for %s"),
+        ("co2_high_reg", 1000, True, "Failed to set co2_high for %s"),
+        ("humidity_target_reg", 45, True, "Failed to set humidity_target for %s"),
+    ]


### PR DESCRIPTION
### Motivation
- Reduce duplication in parameter service handlers by unifying air-quality threshold writes into the shared step-handler flow to keep handler wiring consistent and simplify payload→write-step construction.

### Description
- Replaced the inline `set_air_quality_thresholds` implementation with a `_build_step_handler` call that reuses the established step-writing flow in `custom_components/thessla_green_modbus/services_handlers_parameters.py`.
- Extracted `iter_air_quality_writes(...)` into `custom_components/thessla_green_modbus/services_validation.py` to produce `(register, value, optional, error_message)` write-step tuples for air-quality fields.
- Updated imports and added a unit test exercising `iter_air_quality_writes` in `tests/test_services_dispatch_validation.py` to assert mapping, optional handling, and error-message formatting.
- Files changed: `custom_components/thessla_green_modbus/services_handlers_parameters.py`, `custom_components/thessla_green_modbus/services_validation.py`, and `tests/test_services_dispatch_validation.py`.

### Testing
- Ran linter and static checks with `ruff check custom_components tests tools` which passed.
- Verified bytecode compilation with `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed.
- Ran register comparison with `python tools/compare_registers_with_reference.py` which completed (reported integration extras but ran successfully).
- Ran maintainability check with `python tools/check_maintainability.py` which passed.
- Ran targeted service tests with `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` which passed.
- Ran full test suite with `pytest tests/ -q` which passed (with 4 skips reported).
- Ran entity mappings validation with `python tools/validate_entity_mappings.py` which passed.
- Commit created: `fd24c32b` and PR created via internal mechanism with title `refactor: continue service handler decomposition`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8615ca30c83269ac82d38b94f0c8e)