### PR TITLE
refactor: extract airflow sensor mappings helper

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_static_sensors.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_sensors.py
@@ -36,42 +36,49 @@ def _diagnostic_sensor_payload(
     }
 
 
+def _airflow_sensor_mappings() -> dict[str, dict[str, Any]]:
+    """Return static airflow-related sensor mappings."""
+    return {
+        "supply_flow_rate": {
+            "translation_key": "supply_flow_rate_m3h",
+            "icon": "mdi:fan-plus",
+            "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+            "register_type": "input_registers",
+        },
+        "exhaust_flow_rate": {
+            "translation_key": "exhaust_flow_rate_m3h",
+            "icon": "mdi:fan-minus",
+            "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+            "register_type": "input_registers",
+        },
+        "supply_air_flow": {
+            "translation_key": "supply_air_flow",
+            "icon": "mdi:fan-plus",
+            "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+            "register_type": "holding_registers",
+        },
+        "exhaust_air_flow": {
+            "translation_key": "exhaust_air_flow",
+            "icon": "mdi:fan-minus",
+            "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+            "register_type": "holding_registers",
+        },
+    }
+
+
 SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     # Temperature sensors (Input Registers)
     **INPUT_TEMPERATURE_SENSOR_MAPPINGS,
     # Air flow sensors
-    "supply_flow_rate": {
-        "translation_key": "supply_flow_rate_m3h",
-        "icon": "mdi:fan-plus",
-        "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "input_registers",
-    },
-    "exhaust_flow_rate": {
-        "translation_key": "exhaust_flow_rate_m3h",
-        "icon": "mdi:fan-minus",
-        "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "input_registers",
-    },
-    "supply_air_flow": {
-        "translation_key": "supply_air_flow",
-        "icon": "mdi:fan-plus",
-        "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "holding_registers",
-    },
-    "exhaust_air_flow": {
-        "translation_key": "exhaust_air_flow",
-        "icon": "mdi:fan-minus",
-        "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
-        "state_class": SensorStateClass.MEASUREMENT,
-        "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        "register_type": "holding_registers",
-    },
+    **_airflow_sensor_mappings(),
     # Percentage sensors
     "supply_percentage": {
         "translation_key": "supply_percentage",

--- a/tests/test_entity_mappings_helpers.py
+++ b/tests/test_entity_mappings_helpers.py
@@ -29,6 +29,7 @@ from custom_components.thessla_green_modbus.mappings._static_discrete import (
     _weekday_states,
 )
 from custom_components.thessla_green_modbus.mappings._static_sensors import (
+    _airflow_sensor_mappings,
     _diagnostic_sensor_payload,
 )
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -240,4 +241,41 @@ def test_diagnostic_sensor_payload_defaults_and_overrides() -> None:
         "icon": "mdi:information-outline",
         "register_type": "holding_registers",
         "entity_category": EntityCategory.DIAGNOSTIC,
+    }
+
+
+def test_airflow_sensor_mappings_payload_stability() -> None:
+    assert _airflow_sensor_mappings() == {
+        "supply_flow_rate": {
+            "translation_key": "supply_flow_rate_m3h",
+            "icon": "mdi:fan-plus",
+            "device_class": "volume_flow_rate",
+            "state_class": "measurement",
+            "unit": "m³/h",
+            "register_type": "input_registers",
+        },
+        "exhaust_flow_rate": {
+            "translation_key": "exhaust_flow_rate_m3h",
+            "icon": "mdi:fan-minus",
+            "device_class": "volume_flow_rate",
+            "state_class": "measurement",
+            "unit": "m³/h",
+            "register_type": "input_registers",
+        },
+        "supply_air_flow": {
+            "translation_key": "supply_air_flow",
+            "icon": "mdi:fan-plus",
+            "device_class": "volume_flow_rate",
+            "state_class": "measurement",
+            "unit": "m³/h",
+            "register_type": "holding_registers",
+        },
+        "exhaust_air_flow": {
+            "translation_key": "exhaust_air_flow",
+            "icon": "mdi:fan-minus",
+            "device_class": "volume_flow_rate",
+            "state_class": "measurement",
+            "unit": "m³/h",
+            "register_type": "holding_registers",
+        },
     }


### PR DESCRIPTION
### Motivation
- Reduce inline bulk in the static sensor mappings by extracting the cohesive airflow/fan sensor group into a dedicated helper while preserving exact entity outputs.

### Description
- Add `_airflow_sensor_mappings()` to `custom_components/thessla_green_modbus/mappings/_static_sensors.py` and replace the previous inline airflow entries with `**_airflow_sensor_mappings()`; add `test_airflow_sensor_mappings_payload_stability` to `tests/test_entity_mappings_helpers.py` to assert payload/key stability.

### Testing
- Ran `ruff check custom_components tests tools` (passed), `python -m compileall -q custom_components/thessla_green_modbus tests tools` (passed), `python tools/compare_registers_with_reference.py` (reported the same integration extras/name mismatches as before), `python tools/check_maintainability.py` (passed), `python tools/validate_entity_mappings.py` (OK: 366 entities validated), and `pytest tests/ -q` (passed with existing skips).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8615301448326926890abc6bc58e0)