### PR TITLE
refactor: continue scanner runtime decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -19,8 +19,9 @@ from ..const import (
 from ..modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
 from ..modbus_helpers import group_reads as _group_reads
 from ..modbus_transport import RtuModbusTransport
-from ..scanner_device_info import DeviceCapabilities, ScannerDeviceInfo
+from ..scanner_device_info import ScannerDeviceInfo
 from . import custom_scan as scanner_custom_scan
+from . import scan_runtime
 from .full_scan_phase import apply_word_register_block
 from .io import is_request_cancelled_error
 
@@ -65,34 +66,6 @@ async def _accumulate_raw_registers(scanner: Any) -> dict[int, int]:
         for offset, value in enumerate(data):
             raw_registers[start + offset] = value
     return raw_registers
-
-
-def _build_scan_result(scanner: Any, *, device: ScannerDeviceInfo, caps: DeviceCapabilities, available_registers: dict[str, set[str]], unknown_registers: dict[str, dict[int, Any]], scanned_registers: dict[str, int], scan_blocks: dict[str, list[tuple[int, int]]], missing_registers: dict[str, dict[str, int]], scan_started: float, raw_registers: dict[int, int]) -> dict[str, Any]:
-    """Assemble the scan result payload."""
-    result: dict[str, Any] = {
-        "available_registers": available_registers,
-        "device_info": device.as_dict(),
-        "capabilities": caps.as_dict(),
-        "register_count": sum(len(v) for v in available_registers.values()),
-        "scan_blocks": scan_blocks,
-        "unknown_registers": unknown_registers,
-        "scanned_registers": scanned_registers,
-        "missing_registers": missing_registers,
-        "failed_addresses": {
-            "modbus_exceptions": {k: sorted(v) for k, v in scanner.failed_addresses["modbus_exceptions"].items() if v},
-            "invalid_values": {k: sorted(v) for k, v in scanner.failed_addresses["invalid_values"].items() if v},
-        },
-        "resolved_connection_mode": scanner._resolved_connection_mode,
-        "scan_stats": {
-            "total_attempts": sum(scanned_registers.values()),
-            "successful_reads": sum(len(v) for v in available_registers.values()),
-            "scan_duration": max(0.0001, time.monotonic() - scan_started),
-        },
-    }
-    if scanner.deep_scan:
-        result["raw_registers"] = raw_registers
-        result["total_addresses_scanned"] = len(raw_registers)
-    return result
 
 
 async def _auto_detect_tcp_transport(scanner: Any) -> None:
@@ -337,19 +310,10 @@ async def scan(scanner: Any) -> dict[str, Any]:
         input_registers, holding_registers, coil_registers, discrete_registers
     )
 
-    if missing_registers:
-        details = []
-        for reg_type, regs in missing_registers.items():
-            formatted = ", ".join(
-                f"{name}={addr}" for name, addr in sorted(regs.items(), key=lambda item: item[1])
-            )
-            details.append(f"{reg_type}: {formatted}")
-        _LOGGER.warning(
-            "The following registers were not found during scan: %s", "; ".join(details)
-        )
+    scan_runtime.log_missing_registers(missing_registers)
 
     available_registers = {key: set(value) for key, value in scanner.available_registers.items()}
-    return _build_scan_result(
+    return scan_runtime.build_scan_result(
         scanner,
         device=device,
         caps=caps,

--- a/custom_components/thessla_green_modbus/scanner/scan_runtime.py
+++ b/custom_components/thessla_green_modbus/scanner/scan_runtime.py
@@ -1,0 +1,70 @@
+"""Scan runtime result helpers for scanner orchestration."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from ..scanner_device_info import DeviceCapabilities, ScannerDeviceInfo
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def log_missing_registers(missing_registers: dict[str, dict[str, int]]) -> None:
+    """Log missing registers summary when expected addresses were not read."""
+    if not missing_registers:
+        return
+    details = []
+    for reg_type, regs in missing_registers.items():
+        formatted = ", ".join(
+            f"{name}={addr}" for name, addr in sorted(regs.items(), key=lambda item: item[1])
+        )
+        details.append(f"{reg_type}: {formatted}")
+    _LOGGER.warning("The following registers were not found during scan: %s", "; ".join(details))
+
+
+def build_scan_result(
+    scanner: Any,
+    *,
+    device: ScannerDeviceInfo,
+    caps: DeviceCapabilities,
+    available_registers: dict[str, set[str]],
+    unknown_registers: dict[str, dict[int, Any]],
+    scanned_registers: dict[str, int],
+    scan_blocks: dict[str, list[tuple[int, int]]],
+    missing_registers: dict[str, dict[str, int]],
+    scan_started: float,
+    raw_registers: dict[int, int],
+) -> dict[str, Any]:
+    """Assemble canonical scan result payload from runtime state."""
+    result: dict[str, Any] = {
+        "available_registers": available_registers,
+        "device_info": device.as_dict(),
+        "capabilities": caps.as_dict(),
+        "register_count": sum(len(v) for v in available_registers.values()),
+        "scan_blocks": scan_blocks,
+        "unknown_registers": unknown_registers,
+        "scanned_registers": scanned_registers,
+        "missing_registers": missing_registers,
+        "failed_addresses": {
+            "modbus_exceptions": {
+                k: sorted(v)
+                for k, v in scanner.failed_addresses["modbus_exceptions"].items()
+                if v
+            },
+            "invalid_values": {
+                k: sorted(v) for k, v in scanner.failed_addresses["invalid_values"].items() if v
+            },
+        },
+        "resolved_connection_mode": scanner._resolved_connection_mode,
+        "scan_stats": {
+            "total_attempts": sum(scanned_registers.values()),
+            "successful_reads": sum(len(v) for v in available_registers.values()),
+            "scan_duration": max(0.0001, time.monotonic() - scan_started),
+        },
+    }
+    if scanner.deep_scan:
+        result["raw_registers"] = raw_registers
+        result["total_addresses_scanned"] = len(raw_registers)
+    return result

--- a/tests/test_scanner_scan_runtime.py
+++ b/tests/test_scanner_scan_runtime.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from custom_components.thessla_green_modbus.scanner import scan_runtime
+from custom_components.thessla_green_modbus.scanner_device_info import (
+    DeviceCapabilities,
+    ScannerDeviceInfo,
+)
+
+
+def test_log_missing_registers_emits_warning(caplog) -> None:
+    missing = {"input_registers": {"temp": 10, "rpm": 3}}
+
+    with caplog.at_level(logging.WARNING):
+        scan_runtime.log_missing_registers(missing)
+
+    assert "input_registers: rpm=3, temp=10" in caplog.text
+
+
+def test_build_scan_result_includes_deep_scan_payload() -> None:
+    scanner = SimpleNamespace(
+        failed_addresses={
+            "modbus_exceptions": {"input_registers": {2}, "holding_registers": set()},
+            "invalid_values": {"input_registers": {4}, "holding_registers": set()},
+        },
+        _resolved_connection_mode="tcp",
+        deep_scan=True,
+    )
+    device = ScannerDeviceInfo()
+    caps = DeviceCapabilities()
+
+    result = scan_runtime.build_scan_result(
+        scanner,
+        device=device,
+        caps=caps,
+        available_registers={"input_registers": {"a"}, "holding_registers": set()},
+        unknown_registers={"input_registers": {0: 7}},
+        scanned_registers={"input_registers": 5},
+        scan_blocks={"input_registers": [(0, 4)]},
+        missing_registers={},
+        scan_started=0.0,
+        raw_registers={0: 1, 1: 2},
+    )
+
+    assert result["failed_addresses"]["modbus_exceptions"]["input_registers"] == [2]
+    assert result["failed_addresses"]["invalid_values"]["input_registers"] == [4]
+    assert result["resolved_connection_mode"] == "tcp"
+    assert result["total_addresses_scanned"] == 2
+    assert result["raw_registers"] == {0: 1, 1: 2}


### PR DESCRIPTION
### Motivation

- Reduce complexity in `scanner/orchestration.py` by isolating the scan result assembly and missing-register logging responsibilities. 
- Improve testability of scanner runtime result normalization and preserve existing scan behavior and logging semantics.

### Description

- Extracted scan result assembly and missing-register warning formatting into a new helper module `custom_components/thessla_green_modbus/scanner/scan_runtime.py` implementing `build_scan_result` and `log_missing_registers`.
- Updated `custom_components/thessla_green_modbus/scanner/orchestration.py` to delegate final result construction and missing-register logging to the new `scan_runtime` helper, preserving orchestration flow and transport handling.
- Added focused unit tests in `tests/test_scanner_scan_runtime.py` to validate missing-register log formatting and deep-scan payload composition.
- Ran automatic import formatting fixes (ruff) on the modified orchestration file to keep import ordering consistent.

### Testing

- `ruff check custom_components tests tools` — passed after fixes.
- `python -m compileall -q custom_components/thessla_green_modbus tests tools` — passed.
- `python tools/compare_registers_with_reference.py` — executed (script returned expected report with extras/mismatches to verify), script completed.
- `python tools/check_maintainability.py` — passed.
- `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` — passed.
- `pytest -q tests/` — full test suite passed (with the same skips present prior to this change).
- `python tools/validate_entity_mappings.py` — passed.
- Repository scan for Home Assistant imports in scanner returned no matches, confirming the scanner remains HA-independent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86149c208832680540041a3c08a28)