### PR TITLE
refactor: continue scanner optimized read decomposition

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, cast
+from typing import Any
 
 from pymodbus.client import AsyncModbusTcpClient
 
@@ -21,6 +21,13 @@ from .io_core import (
     track_holding_failure,
     track_input_failure,
     unpack_read_args,
+)
+from .io_read_helpers import (
+    append_read_block,
+    build_read_attempt_meta,
+    build_success_result,
+    iter_grouped_read_chunks,
+    normalize_bit_read_result,
 )
 
 try:
@@ -87,23 +94,24 @@ def _log_read_failure(kind: str, start: int, end: int, retry: int) -> None:
     _LOGGER.error("Failed to read %s registers %d-%d after %d retries", kind, start, end, retry)
 
 
-def _normalize_register_result(response: Any) -> list[int]:
-    """Normalize a successful register response payload."""
-    return cast(list[int], response.registers)
-
-
 def _build_register_chunks(scanner: Any, start: int, count: int) -> list[tuple[int, int]]:
     """Build contiguous chunk plan for a register range."""
-    return list(chunk_register_range(start, count, scanner.effective_batch))
+    return iter_grouped_read_chunks(
+        start,
+        count,
+        lambda chunk_start, chunk_count: chunk_register_range(
+            chunk_start, chunk_count, scanner.effective_batch
+        ),
+    )
 
 
 def _extend_or_abort_register_results(
     results: list[int], block: list[int] | None
 ) -> tuple[bool, list[int] | None]:
     """Append block values and indicate whether read batching should continue."""
-    if block is None:
+    can_continue = append_read_block(results, block)
+    if not can_continue:
         return False, None
-    results.extend(block)
     return True, results
 
 
@@ -166,7 +174,7 @@ def _process_register_response(
 
     if register_type == "holding_registers" and address in scanner._holding_failures:
         del scanner._holding_failures[address]
-    return True, _normalize_register_result(response)
+    return True, build_success_result(response)
 
 
 def _handle_terminal_read_failure(scanner: Any, register_type: str, start: int, end: int) -> None:
@@ -311,8 +319,9 @@ async def read_input(
 ) -> list[int] | None:
     """Read input registers with retry and backoff."""
     client, address, count = unpack_read_args(scanner, client_or_address, address_or_count, count)
-    start = address
-    end = address + count - 1
+    meta = build_read_attempt_meta(address, count)
+    start = meta.start
+    end = meta.end
 
     if _prepare_input_read(scanner, start, end, skip_cache):
         return None
@@ -523,8 +532,9 @@ async def read_holding(
 ) -> list[int] | None:
     """Read holding registers with retry, backoff and failure tracking."""
     client, address, count = unpack_read_args(scanner, client_or_address, address_or_count, count)
-    start = address
-    end = address + count - 1
+    meta = build_read_attempt_meta(address, count)
+    start = meta.start
+    end = meta.end
 
     if _prepare_holding_read(scanner, start, end, address, skip_cache):
         return None
@@ -643,8 +653,9 @@ async def read_bit_registers(
                 backoff=scanner.backoff,
                 backoff_jitter=scanner.backoff_jitter,
             )
-            if response is not None and not response.isError():
-                return cast(list[bool], response.bits[:count])
+            normalized_bits = normalize_bit_read_result(response, count)
+            if normalized_bits is not None:
+                return normalized_bits
         except TimeoutError:
             _LOGGER.warning(
                 "Timeout reading %s %d on attempt %d",

--- a/custom_components/thessla_green_modbus/scanner/io_read_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read_helpers.py
@@ -1,0 +1,46 @@
+"""Helper utilities for scanner register/bit read workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+
+@dataclass(frozen=True)
+class ReadAttemptMeta:
+    """Address metadata describing a single register-read attempt."""
+
+    start: int
+    end: int
+    address: int
+    count: int
+
+
+def build_read_attempt_meta(address: int, count: int) -> ReadAttemptMeta:
+    """Build normalized metadata for a register read attempt."""
+    return ReadAttemptMeta(start=address, end=address + count - 1, address=address, count=count)
+
+
+def iter_grouped_read_chunks(start: int, count: int, chunk_builder: Any) -> list[tuple[int, int]]:
+    """Create grouped chunk plan for optimized/batched reads."""
+    return list(chunk_builder(start, count))
+
+
+def append_read_block(results: list[int], block: list[int] | None) -> bool:
+    """Append a decoded block to results and report if read should continue."""
+    if block is None:
+        return False
+    results.extend(block)
+    return True
+
+
+def build_success_result(response: Any) -> list[int]:
+    """Build normalized register-read success payload from Modbus response."""
+    return cast(list[int], response.registers)
+
+
+def normalize_bit_read_result(response: Any, count: int) -> list[bool] | None:
+    """Normalize bit-read response payload for coils/discrete inputs."""
+    if response is None or response.isError():
+        return None
+    return cast(list[bool], response.bits[:count])

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -12,6 +12,10 @@ from custom_components.thessla_green_modbus.scanner.io_read import (
     _finalize_register_read_failure,
     _handle_input_attempt_exception,
 )
+from custom_components.thessla_green_modbus.scanner.io_read_helpers import (
+    build_read_attempt_meta,
+    normalize_bit_read_result,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -284,3 +288,21 @@ def test_extend_or_abort_register_results_handles_none_and_appends():
     can_continue, payload = _extend_or_abort_register_results(results, [2, 3])
     assert can_continue is True
     assert payload == [1, 2, 3]
+
+
+def test_build_read_attempt_meta_sets_expected_range():
+    """Read-attempt metadata should normalize start/end from address/count."""
+    meta = build_read_attempt_meta(30, 4)
+    assert (meta.start, meta.end, meta.address, meta.count) == (30, 33, 30, 4)
+
+
+def test_normalize_bit_read_result_handles_error_and_success():
+    """Bit-result normalizer should filter errors and truncate to count."""
+    error_response = MagicMock()
+    error_response.isError.return_value = True
+    assert normalize_bit_read_result(error_response, 2) is None
+
+    ok_response = MagicMock()
+    ok_response.isError.return_value = False
+    ok_response.bits = [True, False, True]
+    assert normalize_bit_read_result(ok_response, 2) == [True, False]


### PR DESCRIPTION
### Motivation
- Reduce complexity in `io_read.py` by extracting cohesive responsibilities for grouped read planning, normalized result assembly, read-attempt metadata, and bit-read normalization to enable safer decomposition and focused tests.
- Keep existing scanner I/O semantics (retry/backoff, unsupported-range, skip-cache, failure tracking) intact while making the code easier to reason about and test.
- Provide small, pure helpers to centralize common transformations used by input/holding/bit read paths.

### Description
- Add `custom_components/thessla_green_modbus/scanner/io_read_helpers.py` which provides `ReadAttemptMeta`, `build_read_attempt_meta`, `iter_grouped_read_chunks`, `append_read_block`, `build_success_result`, and `normalize_bit_read_result` to centralize read planning and normalization logic.
- Refactor `custom_components/thessla_green_modbus/scanner/io_read.py` to consume the new helpers for chunk planning, read-attempt metadata, successful register payload construction, result appending, and bit-read normalization while preserving all existing retry/backoff and failure semantics.
- Add focused unit tests in `tests/test_scanner_io.py` for `build_read_attempt_meta` and `normalize_bit_read_result`, and adjust imports to reference the helper module.

### Testing
- Ran `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools` and both passed.
- Ran repository validation tools `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, and both passed.
- Ran unit tests with `pytest -q tests/test_scanner_io.py tests/test_scanner_io_coverage.py tests/test_scanner*.py tests/test_device_scanner*.py` and a full `pytest tests/ -q`, and all tests passed (with existing skips).
- Ran `python tools/validate_entity_mappings.py` (passed) and verified scanner package contains no Home Assistant imports; maintainability gate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8613fd13c83269aa958ae5a6b9362)