### PR TITLE
refactor: extract coordinator capability post-processing helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/capabilities.py
+++ b/custom_components/thessla_green_modbus/coordinator/capabilities.py
@@ -33,6 +33,11 @@ def _coerce_bypass_open(raw_bypass: Any) -> bool:
     return raw_bypass in (1, 2)
 
 
+def _normalise_capability_flag(raw_value: Any) -> bool:
+    """Normalise capability-like values to a strict boolean."""
+    return bool(raw_value) if raw_value is not None else False
+
+
 class _CoordinatorCapabilitiesMixin:
     """Capability and derived-value logic for the coordinator."""
 
@@ -51,6 +56,73 @@ class _CoordinatorCapabilitiesMixin:
         }
     )
     _MODEL_FLOW_TOLERANCE = 15
+
+    def _apply_capability_result(
+        self, data: dict[str, Any], key: str, value: Any, capability_flag: Any
+    ) -> bool:
+        """Apply a derived value only when a capability flag is enabled."""
+        if not _normalise_capability_flag(capability_flag):
+            return False
+        data[key] = value
+        return True
+
+    def _calculate_heat_recovery_efficiency(self, data: dict[str, Any]) -> float | None:
+        """Calculate heat recovery efficiency percentage if inputs allow it."""
+        bypass_open = _coerce_bypass_open(data.get("bypass_mode"))
+        if bypass_open:
+            return None
+        if not all(
+            k in data for k in ("outside_temperature", "supply_temperature", "exhaust_temperature")
+        ):
+            return None
+        outside = float(data["outside_temperature"])
+        supply = float(data["supply_temperature"])
+        exhaust = float(data["exhaust_temperature"])
+        if exhaust - outside < 5.0:
+            return None
+        q_supply = data.get("supply_flow_rate")
+        q_exhaust = data.get("exhaust_flow_rate")
+        if q_supply is not None and q_exhaust is not None:
+            q_s = float(q_supply)
+            q_e = float(q_exhaust)
+            q_min = min(q_s, q_e)
+            raw = (
+                (q_s * (supply - outside)) / (q_min * (exhaust - outside))
+                if q_min > 0
+                else (supply - outside) / (exhaust - outside)
+            )
+        else:
+            raw = (supply - outside) / (exhaust - outside)
+        return _clamp_percentage(round(raw * 100, 1))
+
+    def _apply_post_process_derived_values(self, data: dict[str, Any]) -> None:
+        """Apply grouped derived metrics to mutable coordinator data."""
+        try:
+            efficiency = self._calculate_heat_recovery_efficiency(data)
+            if self._apply_capability_result(
+                data, "calculated_efficiency", efficiency, efficiency is not None
+            ):
+                data["heat_recovery_efficiency"] = data["calculated_efficiency"]
+        except (ZeroDivisionError, TypeError, ValueError) as exc:
+            _LOGGER.debug("Could not calculate efficiency: %s", exc)
+
+        if all(
+            k in data for k in ("supply_flow_rate", "outside_temperature", "supply_temperature")
+        ):
+            try:
+                flow = float(data["supply_flow_rate"])
+                delta_t = float(data["supply_temperature"]) - float(data["outside_temperature"])
+                data["heat_recovery_power"] = round(max(0.0, 0.335 * flow * delta_t), 1)
+            except (TypeError, ValueError) as exc:
+                _LOGGER.debug("Could not calculate heat recovery power: %s", exc)
+
+        if "supply_flow_rate" in data and "exhaust_flow_rate" in data:
+            try:
+                balance = float(data["supply_flow_rate"]) - float(data["exhaust_flow_rate"])
+                data["flow_balance"] = balance
+                data["flow_balance_status"] = _flow_balance_status(balance)
+            except (TypeError, ValueError) as exc:
+                _LOGGER.debug("Could not calculate flow balance: %s", exc)
     def _decode_device_clock(self, data: dict[str, Any]) -> str | None:
         """Decode device clock from packed BCD date/time registers."""
         raw_yymm = data.get("date_time")
@@ -168,68 +240,7 @@ class _CoordinatorCapabilitiesMixin:
         #     Note: this device exposes only 3 temperature sensors (TZ1, TN1, TP);
         #     the exhaust-outlet sensor TW is absent, so EN 308 η_exhaust and the
         #     Belgian mean-efficiency (η_epbd) cannot be computed.
-        bypass_open = _coerce_bypass_open(data.get("bypass_mode"))
-        if (
-            all(
-                k in data
-                for k in ["outside_temperature", "supply_temperature", "exhaust_temperature"]
-            )
-            and not bypass_open
-        ):
-            try:
-                outside = float(data["outside_temperature"])
-                supply = float(data["supply_temperature"])
-                exhaust = float(data["exhaust_temperature"])
-
-                # Heat recovery only makes sense in heating mode:
-                # outside must be colder than the room (exhaust > outside).
-                # In summer/freecooling the bypass should be open, but if the
-                # bypass register hasn't caught up yet, skip gracefully.
-                # EN 308 also requires ΔT ≥ 5 K for a statistically reliable
-                # measurement; below that threshold sensor noise dominates.
-                _MIN_DELTA_T = 5.0
-                if exhaust - outside >= _MIN_DELTA_T:
-                    q_supply = data.get("supply_flow_rate")
-                    q_exhaust = data.get("exhaust_flow_rate")
-                    if q_supply is not None and q_exhaust is not None:
-                        q_s = float(q_supply)
-                        q_e = float(q_exhaust)
-                        q_min = min(q_s, q_e)
-                        if q_min > 0:
-                            # ASHRAE 84 thermodynamic effectiveness (ε-NTU)
-                            raw = (q_s * (supply - outside)) / (q_min * (exhaust - outside))
-                        else:
-                            raw = (supply - outside) / (exhaust - outside)
-                    else:
-                        # EN 308 η_supply — 3-sensor fallback
-                        raw = (supply - outside) / (exhaust - outside)
-
-                    efficiency = round(raw * 100, 1)
-                    data["calculated_efficiency"] = _clamp_percentage(efficiency)
-                    data["heat_recovery_efficiency"] = data["calculated_efficiency"]
-            except (ZeroDivisionError, TypeError, ValueError) as exc:
-                _LOGGER.debug("Could not calculate efficiency: %s", exc)
-
-        # Calculate heat recovery power: P[W] = ρ·Cp·Q·ΔT
-        # ρ=1.2 kg/m³, Cp=1005 J/(kg·K) → coefficient = 1.2*1005/3600 ≈ 0.335 W/(m³/h·K)
-        if all(
-            k in data for k in ["supply_flow_rate", "outside_temperature", "supply_temperature"]
-        ):
-            try:
-                flow = float(data["supply_flow_rate"])
-                delta_t = float(data["supply_temperature"]) - float(data["outside_temperature"])
-                data["heat_recovery_power"] = round(max(0.0, 0.335 * flow * delta_t), 1)
-            except (TypeError, ValueError) as exc:
-                _LOGGER.debug("Could not calculate heat recovery power: %s", exc)
-
-        # Calculate flow balance
-        if "supply_flow_rate" in data and "exhaust_flow_rate" in data:
-            try:
-                balance = float(data["supply_flow_rate"]) - float(data["exhaust_flow_rate"])
-                data["flow_balance"] = balance
-                data["flow_balance_status"] = _flow_balance_status(balance)
-            except (TypeError, ValueError) as exc:
-                _LOGGER.debug("Could not calculate flow balance: %s", exc)
+        self._apply_post_process_derived_values(data)
         power = self.calculate_power_consumption(data)
         if power is not None:
             data["estimated_power"] = power

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -10,6 +10,7 @@ from custom_components.thessla_green_modbus.coordinator.capabilities import (
     _clamp_percentage,
     _coerce_bypass_open,
     _flow_balance_status,
+    _normalise_capability_flag,
 )
 
 
@@ -79,6 +80,13 @@ def test_coerce_bypass_open_helper():
     assert _coerce_bypass_open(2) is True
     assert _coerce_bypass_open(0) is False
     assert _coerce_bypass_open("1") is False
+
+
+def test_normalise_capability_flag_helper():
+    """Capability helper should coerce missing and truthy values predictably."""
+    assert _normalise_capability_flag(None) is False
+    assert _normalise_capability_flag(False) is False
+    assert _normalise_capability_flag(1) is True
 
 
 # ---------------------------------------------------------------------------
@@ -193,3 +201,13 @@ def test_post_process_data_naive_now_aware_last_ts():
         data = {"dac_supply": 3.0, "dac_exhaust": 3.0}
         result = coord._post_process_data(data)
     assert "estimated_power" in result
+
+
+def test_apply_capability_result_helper():
+    """Capability result helper applies value only when flag is enabled."""
+    coord = _make_coordinator()
+    data: dict[str, object] = {}
+    assert coord._apply_capability_result(data, "x", 1.0, None) is False
+    assert "x" not in data
+    assert coord._apply_capability_result(data, "x", 1.0, True) is True
+    assert data["x"] == 1.0


### PR DESCRIPTION
### Motivation
- Reduce branching and cognitive complexity inside `_post_process_data` in `coordinator/capabilities.py` by extracting cohesive helpers that group related capability normalization and derived-value application logic.
- Preserve all existing coordinator behavior, logging semantics, and public coordinator orchestration while making the post-processing logic easier to unit-test and maintain.

### Description
- Added `_normalise_capability_flag` to coerce capability-like values to a strict boolean and `_apply_capability_result` to conditionally apply derived values to the coordinator data only when a capability is present.
- Extracted the HEWR-specific branch into `_calculate_heat_recovery_efficiency` implementing the same EN308/ASHRAE logic and guards as before, and grouped heat-recovery, heat-recovery-power, and flow-balance mutations into `_apply_post_process_derived_values`.
- Replaced the original inline blocks in `_post_process_data` with a single call to `self._apply_post_process_derived_values(data)`, keeping the rest of `_post_process_data` (power estimation, energy accumulation, device clock decode, serial handling) unchanged.
- Added focused unit tests for the new helpers in `tests/test_coordinator_update.py` and adjusted imports to exercise the new helper functions; changes are limited to `custom_components/thessla_green_modbus/coordinator/capabilities.py` and `tests/test_coordinator_update.py`.

### Testing
- Ran development validation steps including `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, all of which passed.
- Ran targeted tests `pytest -q tests/test_coordinator*.py tests/test_error_contract.py tests/unit/test_errors.py`, and full test suite `pytest tests/ -q`, both of which passed (with existing skips reported by the suite).
- Ran repository gates `python tools/compare_registers_with_reference.py` (reports extras/mismatches as informational), `python tools/check_maintainability.py` (passed), and `python tools/validate_entity_mappings.py` (OK), all of which completed successfully.
- Confirmed coordinator package API invariant via a small assertion script and verified no forbidden shim/compat patterns were introduced; maintainability gate and full pytest passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86129a0e08326b6ad6235b02188ff)