### PR TITLE
refactor: extract single-register write success helper

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -296,6 +296,24 @@ class _CoordinatorScheduleMixin:
             await _safe_request_refresh(self)
         return True
 
+    def _handle_successful_single_register_write(
+        self,
+        *,
+        register_name: str,
+        original_value: float | str | list[int] | tuple[int, ...],
+        refresh: bool,
+    ) -> bool:
+        """Apply common success side effects for single-register write path."""
+        # Successful write: remove from failed set so the next
+        # poll doesn't skip this register's chunk entirely.
+        self._clear_register_failure(register_name)
+        _LOGGER.info(
+            "Successfully wrote %s to register %s",
+            original_value,
+            register_name,
+        )
+        return refresh
+
     def _write_response_ok(self, response: Any) -> bool:
         """Return True when a Modbus write response indicates success."""
         return response is not None and not response.isError()
@@ -377,14 +395,10 @@ class _CoordinatorScheduleMixin:
                                 return False
                             continue
 
-                        refresh_after_write = refresh
-                        # Successful write: remove from failed set so the next
-                        # poll doesn't skip this register's chunk entirely.
-                        self._clear_register_failure(register_name)
-                        _LOGGER.info(
-                            "Successfully wrote %s to register %s",
-                            original_value,
-                            register_name,
+                        refresh_after_write = self._handle_successful_single_register_write(
+                            register_name=register_name,
+                            original_value=original_value,
+                            refresh=refresh,
                         )
                         break
                     except (ModbusException, ConnectionException, TimeoutError, OSError) as exc:

--- a/tests/test_coordinator_register_writes.py
+++ b/tests/test_coordinator_register_writes.py
@@ -193,3 +193,33 @@ async def test_handle_write_attempt_exception_final_modbus_failure(coordinator, 
     assert should_retry is False
     coordinator._disconnect.assert_awaited_once()
     assert "Failed to write registers at 100" in caplog.text
+
+
+def test_handle_successful_single_register_write_with_refresh(coordinator, caplog):
+    """Single-register success helper should clear failure and request refresh."""
+    coordinator._clear_register_failure = MagicMock()
+    caplog.set_level("INFO")
+
+    refresh_after_write = coordinator._handle_successful_single_register_write(
+        register_name="mode",
+        original_value=1,
+        refresh=True,
+    )
+
+    assert refresh_after_write is True
+    coordinator._clear_register_failure.assert_called_once_with("mode")
+    assert "Successfully wrote 1 to register mode" in caplog.text
+
+
+def test_handle_successful_single_register_write_without_refresh(coordinator):
+    """Single-register success helper should preserve refresh=False."""
+    coordinator._clear_register_failure = MagicMock()
+
+    refresh_after_write = coordinator._handle_successful_single_register_write(
+        register_name="mode",
+        original_value=1,
+        refresh=False,
+    )
+
+    assert refresh_after_write is False
+    coordinator._clear_register_failure.assert_called_once_with("mode")


### PR DESCRIPTION
### Motivation
- Reduce complexity in `coordinator/schedule.py` by extracting the remaining single-register write success responsibilities into a focused helper. 
- Isolate success-side effects (failed-register clearing, logging, refresh propagation) so the write loop remains concise and easier to refactor further.

### Description
- Added `_handle_successful_single_register_write` to `custom_components/thessla_green_modbus/coordinator/schedule.py` to encapsulate single-register success side effects and return the refresh flag. 
- Replaced the inlined success block in `async_write_register` with a call to `_handle_successful_single_register_write`, preserving existing retry, error, and refresh semantics. 
- Added two focused unit tests to `tests/test_coordinator_register_writes.py` verifying the helper for `refresh=True` and `refresh=False`, including cleared failure set and success logging.

### Testing
- Ran lint/validation and byte-compile: `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both completed without errors. 
- Ran integration checks: `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, with the maintainability gate passing. 
- Ran unit tests: targeted coordinator write tests with `pytest -q tests/test_coordinator_register_writes.py tests/test_multi_register_write.py tests/test_force_full_register_list.py tests/test_logging.py tests/test_coordinator*.py` and the full test suite `pytest tests/ -q`, both completed successfully (the full run reported a small number of expected skips).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8613660ac8326860653f045c2839e)