### PR TITLE
refactor: extract runtime_state for coordinator failed-register tracking

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -134,6 +134,8 @@ from .io import _ModbusIOMixin
 from .lifecycle import async_setup as _async_setup_impl
 from .models import CoordinatorConfig
 from .retry import _PermanentModbusError
+from .runtime_state import clear_register_failure as _clear_register_failure_impl
+from .runtime_state import mark_registers_failed as _mark_registers_failed_impl
 from .scan import (
     apply_scan_cache as _apply_scan_cache_impl,
 )
@@ -569,14 +571,11 @@ class ThesslaGreenModbusCoordinator(
 
     def _mark_registers_failed(self, names: Iterable[str | None]) -> None:
         """Record registers that failed to read."""
-        failed: set[str] = getattr(self, "_failed_registers", set())
-        failed.update(name for name in names if name)
-        self._failed_registers = failed
+        _mark_registers_failed_impl(self, names)
 
     def _clear_register_failure(self, name: str) -> None:
         """Remove register from failed list on successful read."""
-        if hasattr(self, "_failed_registers"):
-            self._failed_registers.discard(name)
+        _clear_register_failure_impl(self, name)
 
     async def _test_connection(self) -> None:
         """Test initial connection to the device."""

--- a/custom_components/thessla_green_modbus/coordinator/runtime_state.py
+++ b/custom_components/thessla_green_modbus/coordinator/runtime_state.py
@@ -1,0 +1,28 @@
+"""Runtime state helpers for coordinator register failure tracking."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .coordinator import ThesslaGreenModbusCoordinator
+
+
+def mark_registers_failed(
+    coordinator: ThesslaGreenModbusCoordinator,
+    names: Iterable[str | None],
+) -> None:
+    """Record registers that failed to read in current runtime state."""
+    failed: set[str] = getattr(coordinator, "_failed_registers", set())
+    failed.update(name for name in names if name)
+    coordinator._failed_registers = failed
+
+
+def clear_register_failure(
+    coordinator: ThesslaGreenModbusCoordinator,
+    name: str,
+) -> None:
+    """Remove register from failed list after successful read/write."""
+    if hasattr(coordinator, "_failed_registers"):
+        coordinator._failed_registers.discard(name)

--- a/tests/test_coordinator_runtime_state.py
+++ b/tests/test_coordinator_runtime_state.py
@@ -1,0 +1,46 @@
+"""Tests for coordinator runtime-state helpers."""
+
+from __future__ import annotations
+
+from custom_components.thessla_green_modbus.coordinator.runtime_state import (
+    clear_register_failure,
+    mark_registers_failed,
+)
+
+
+class _CoordinatorStub:
+    pass
+
+
+def test_mark_registers_failed_creates_and_filters_none() -> None:
+    coordinator = _CoordinatorStub()
+
+    mark_registers_failed(coordinator, ["mode", None, "fan_speed"])
+
+    assert coordinator._failed_registers == {"mode", "fan_speed"}
+
+
+def test_mark_registers_failed_updates_existing_set() -> None:
+    coordinator = _CoordinatorStub()
+    coordinator._failed_registers = {"mode"}
+
+    mark_registers_failed(coordinator, ["fan_speed", "mode"])
+
+    assert coordinator._failed_registers == {"mode", "fan_speed"}
+
+
+def test_clear_register_failure_noop_without_state() -> None:
+    coordinator = _CoordinatorStub()
+
+    clear_register_failure(coordinator, "mode")
+
+    assert not hasattr(coordinator, "_failed_registers")
+
+
+def test_clear_register_failure_removes_requested_item() -> None:
+    coordinator = _CoordinatorStub()
+    coordinator._failed_registers = {"mode", "fan_speed"}
+
+    clear_register_failure(coordinator, "mode")
+
+    assert coordinator._failed_registers == {"fan_speed"}


### PR DESCRIPTION
### Motivation
- Reduce complexity in `ThesslaGreenModbusCoordinator` by moving a focused runtime/update-state responsibility into its own module to continue coordinator decomposition.
- Isolate failed-register tracking logic so the coordinator remains a Home Assistant-facing orchestrator and implementation details live in a dedicated module.

### Description
- Added `custom_components/thessla_green_modbus/coordinator/runtime_state.py` containing `mark_registers_failed` and `clear_register_failure` which mutate coordinator `_failed_registers` runtime state.
- Updated `custom_components/thessla_green_modbus/coordinator/coordinator.py` to delegate `_mark_registers_failed` and `_clear_register_failure` to the new helper implementations while preserving behavior and the package-root API.
- Added unit tests in `tests/test_coordinator_runtime_state.py` covering creation, update, and clear/no-op semantics of the failed-register state.
- No coordinator package-root API changes or compatibility shims were introduced and the coordinator remains the HA-facing adapter.

### Testing
- Ran linting and safety checks with `ruff check custom_components tests tools` and fixed one import ordering issue via `ruff --fix`, which completed successfully.
- Compiled sources with `python -m compileall -q custom_components/thessla_green_modbus tests tools` and ran `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, all of which passed.
- Executed targeted tests with `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py` and full test suite with `pytest tests/ -q`, both of which passed (4 tests skipped reported by the suite).
- Ran `python tools/validate_entity_mappings.py` and the package-root API audit asserting `__all__` contents, both of which passed.
- Commit created: `9d8473c3` and changed files: `coordinator/coordinator.py`, `coordinator/runtime_state.py`, and `tests/test_coordinator_runtime_state.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8612609188326be050b2e27377387)