### PR TITLE
refactor: continue modbus helper cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -341,6 +341,31 @@ def _calculate_batch_size(kwargs: dict[str, Any]) -> int:
     return kwargs.get("count") or len(kwargs.get("values", [])) or 1
 
 
+def _prepare_modbus_call(
+    func: Callable[..., Awaitable[Any]],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    attempt: int,
+    backoff: float,
+    backoff_jitter: float | tuple[float, float] | None,
+    apply_backoff: bool,
+) -> tuple[list[Any], str, str, int, float]:
+    """Prepare call metadata for ``_call_modbus`` without mutating behavior."""
+
+    signature = _get_signature(func)
+    positional, params = _normalize_positional_and_keyword_args(signature, args, kwargs)
+    kwarg = _resolve_slave_kwarg(func, params, signature)
+    func_name = getattr(func, "__name__", repr(func))
+    batch_size = _calculate_batch_size(kwargs)
+    delay = (
+        _calculate_backoff_delay(base=backoff, attempt=attempt, jitter=backoff_jitter)
+        if apply_backoff
+        else 0.0
+    )
+    return positional, kwarg, func_name, batch_size, delay
+
+
 def _classify_modbus_exception(err: Exception) -> str:
     """Return exception class for Modbus call logging."""
     if isinstance(err, ModbusIOException) and "request cancelled" in str(err).lower():
@@ -386,22 +411,15 @@ async def _call_modbus(
     (or lack thereof) is cached per callable for subsequent invocations.
     """
 
-    # Fetch and cache the function signature
-    signature = _get_signature(func)
-
-    positional, params = _normalize_positional_and_keyword_args(signature, args, kwargs)
-    kwarg = _resolve_slave_kwarg(func, params, signature)
-
-    func_name = getattr(func, "__name__", repr(func))
-    batch_size = _calculate_batch_size(kwargs)
-
-    delay = 0.0
-    if apply_backoff:
-        delay = _calculate_backoff_delay(
-            base=backoff,
-            attempt=attempt,
-            jitter=backoff_jitter,
-        )
+    positional, kwarg, func_name, batch_size, delay = _prepare_modbus_call(
+        func,
+        args,
+        kwargs,
+        attempt=attempt,
+        backoff=backoff,
+        backoff_jitter=backoff_jitter,
+        apply_backoff=apply_backoff,
+    )
 
     if delay > 0:
         _LOGGER.debug(

--- a/tests/test_modbus_helpers.py
+++ b/tests/test_modbus_helpers.py
@@ -32,6 +32,7 @@ from custom_components.thessla_green_modbus.modbus_helpers import (
     _calculate_batch_size,
     _call_modbus,
     _classify_modbus_exception,
+    _prepare_modbus_call,
     async_close_client,
     group_reads,
 )
@@ -216,6 +217,54 @@ def test_calculate_batch_size_uses_values_length():
 def test_calculate_batch_size_defaults_to_one():
     """Empty kwargs defaults to one request item."""
     assert _calculate_batch_size({}) == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_modbus_call_metadata_uses_detected_keyword():
+    """Prepared metadata should keep argument normalization and unit-detection."""
+
+    async def func(address, *, count, unit=None):
+        return address, count, unit
+
+    kwargs = {}
+    positional, kwarg, func_name, batch_size, delay = _prepare_modbus_call(
+        func,
+        (11, 5),
+        kwargs,
+        attempt=1,
+        backoff=0.1,
+        backoff_jitter=None,
+        apply_backoff=True,
+    )
+
+    assert positional == [11]
+    assert kwargs == {"count": 5}
+    assert kwarg == "unit"
+    assert func_name == "func"
+    assert batch_size == 5
+    assert delay == 0.0
+
+
+@pytest.mark.asyncio
+async def test_prepare_modbus_call_metadata_disables_backoff():
+    """Prepared metadata should skip delay when backoff is disabled."""
+
+    async def func(address, *, count, slave=None):
+        return address, count, slave
+
+    positional, kwarg, _func_name, _batch_size, delay = _prepare_modbus_call(
+        func,
+        (2, 3),
+        {},
+        attempt=3,
+        backoff=1.0,
+        backoff_jitter=None,
+        apply_backoff=False,
+    )
+
+    assert positional == [2]
+    assert kwarg == "slave"
+    assert delay == 0.0
 
 
 def test_classify_modbus_exception_cancelled():


### PR DESCRIPTION
### Motivation
- Reduce branching and setup logic inside `_call_modbus` by extracting narrow pre-call responsibilities into a focused helper to improve readability and enable further decomposition.
- Preserve existing Modbus behavior, timeouts, cancellation, backoff, and exception classification while moving purely preparatory work out of the main call path.

### Description
- Added `_prepare_modbus_call` in `custom_components/thessla_green_modbus/modbus_helpers.py` to encapsulate signature lookup, positional/keyword normalization, slave keyword detection (`unit`/`slave`/`device_id`), function/batch metadata, and backoff delay computation without changing behavior.
- Updated `_call_modbus` to call `_prepare_modbus_call` and consume the prepared metadata, removing duplicated inline orchestration logic.
- Added unit tests in `tests/test_modbus_helpers.py` to validate argument normalization, detected keyword usage, and backoff-disable behavior for the new helper.

### Testing
- Commands run: `python -m pip install -q -r requirements-dev.txt`, `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, `pytest -q tests/test_modbus_helpers.py tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py`, `pytest tests/ -q`, `python tools/validate_entity_mappings.py`, and repository grep checks for HA imports and shim keywords (all listed validation commands executed).
- Results: all listed lint/compile/maintainability/validation commands passed; pytest passed (full test suite passed with 4 skipped tests reported).
- Commit: `60e7e595`.
- Files changed: `custom_components/thessla_green_modbus/modbus_helpers.py`, `tests/test_modbus_helpers.py`.
- PR: created via the internal mechanism with title `refactor: continue modbus helper cleanup` (body documents the change and validation commands).
- Maintainability gate: passed (`python tools/check_maintainability.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86177f0e88326b9a773232bf4ed90)