### PR TITLE
refactor(scanner): extract input read retry loop and consolidate full-scan word phase

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -309,6 +309,104 @@ def _handle_input_attempt_exception(
     )
 
 
+async def _execute_word_read_attempt(
+    scanner: Any,
+    *,
+    transport: Any,
+    client: Any,
+    method_name: str,
+    address: int,
+    count: int,
+    attempt: int,
+) -> Any:
+    """Execute one word-register read attempt via transport or client fallback."""
+    if transport is not None:
+        return await getattr(transport, method_name)(scanner.slave_id, address, count=count)
+    return await _call_modbus_with_fallback(
+        scanner,
+        getattr(client, method_name),
+        scanner.slave_id,
+        address,
+        count=count,
+        attempt=attempt,
+        retry=scanner.retry,
+        timeout=scanner.timeout,
+        backoff=scanner.backoff,
+        backoff_jitter=scanner.backoff_jitter,
+    )
+
+
+async def _run_input_read_retry_loop(
+    scanner: Any,
+    *,
+    transport: Any,
+    client: Any,
+    address: int,
+    count: int,
+    start: int,
+    end: int,
+    skip_cache: bool,
+) -> list[int] | None:
+    """Run input read retry loop and finalize failure state when needed."""
+    attempted_reads = 0
+    aborted_transiently = False
+    for attempt in range(1, scanner.retry + 1):
+        attempted_reads = attempt
+        try:
+            response = await _execute_word_read_attempt(
+                scanner,
+                transport=transport,
+                client=client,
+                method_name="read_input_registers",
+                address=address,
+                count=count,
+                attempt=attempt,
+            )
+            done, payload = _process_register_response(
+                scanner,
+                response=response,
+                register_type="input_registers",
+                start=start,
+                end=end,
+                address=address,
+                count=count,
+                skip_cache=skip_cache,
+            )
+            if done:
+                if payload is not None:
+                    _LOGGER.debug("Read input registers %d-%d: %s", start, end, payload)
+                return payload
+        except (ModbusIOException, TimeoutError, OSError, ModbusException, ConnectionException) as exc:
+            aborted, stop = _handle_input_attempt_exception(
+                scanner,
+                exc,
+                start=start,
+                end=end,
+                address=address,
+                count=count,
+                attempt=attempt,
+            )
+            aborted_transiently = aborted_transiently or aborted
+            if stop:
+                break
+        await _sleep_retry_backoff(
+            backoff=scanner.backoff,
+            backoff_jitter=scanner.backoff_jitter,
+            attempt=attempt,
+            retry=scanner.retry,
+        )
+    _finalize_register_read_failure(
+        scanner,
+        register_type="input_registers",
+        start=start,
+        end=end,
+        retry=scanner.retry,
+        attempted_reads=attempted_reads,
+        aborted_transiently=aborted_transiently,
+    )
+    return None
+
+
 async def read_input(
     scanner: Any,
     client_or_address: AsyncModbusTcpClient | AsyncModbusSerialClientType | int,
@@ -328,99 +426,16 @@ async def read_input(
 
     transport, client = resolve_transport_and_client(scanner, client)
 
-    attempted_reads = 0
-    aborted_transiently = False
-    for attempt in range(1, scanner.retry + 1):
-        attempted_reads = attempt
-        try:
-            if transport is not None:
-                response = await transport.read_input_registers(
-                    scanner.slave_id, address, count=count
-                )
-            else:
-                response = await _call_modbus_with_fallback(
-                    scanner,
-                    client.read_input_registers,
-                    scanner.slave_id,
-                    address,
-                    count=count,
-                    attempt=attempt,
-                    retry=scanner.retry,
-                    timeout=scanner.timeout,
-                    backoff=scanner.backoff,
-                    backoff_jitter=scanner.backoff_jitter,
-                )
-            done, payload = _process_register_response(
-                scanner,
-                response=response,
-                register_type="input_registers",
-                start=start,
-                end=end,
-                address=address,
-                count=count,
-                skip_cache=skip_cache,
-            )
-            if done:
-                if payload is not None:
-                    _LOGGER.debug("Read input registers %d-%d: %s", start, end, payload)
-                return payload
-        except ModbusIOException as exc:
-            aborted, stop = _handle_input_attempt_exception(
-                scanner,
-                exc,
-                start=start,
-                end=end,
-                address=address,
-                count=count,
-                attempt=attempt,
-            )
-            aborted_transiently = aborted_transiently or aborted
-            if stop:
-                break
-        except (TimeoutError, OSError) as exc:
-            aborted, stop = _handle_input_attempt_exception(
-                scanner,
-                exc,
-                start=start,
-                end=end,
-                address=address,
-                count=count,
-                attempt=attempt,
-            )
-            aborted_transiently = aborted_transiently or aborted
-            if stop:
-                break
-        except (ModbusException, ConnectionException) as exc:
-            aborted, stop = _handle_input_attempt_exception(
-                scanner,
-                exc,
-                start=start,
-                end=end,
-                address=address,
-                count=count,
-                attempt=attempt,
-            )
-            aborted_transiently = aborted_transiently or aborted
-            if stop:
-                break
-
-        await _sleep_retry_backoff(
-            backoff=scanner.backoff,
-            backoff_jitter=scanner.backoff_jitter,
-            attempt=attempt,
-            retry=scanner.retry,
-        )
-
-    _finalize_register_read_failure(
+    return await _run_input_read_retry_loop(
         scanner,
-        register_type="input_registers",
+        transport=transport,
+        client=client,
+        address=address,
+        count=count,
         start=start,
         end=end,
-        retry=scanner.retry,
-        attempted_reads=attempted_reads,
-        aborted_transiently=aborted_transiently,
+        skip_cache=skip_cache,
     )
-    return None
 
 
 async def read_register_block(

--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -147,51 +147,39 @@ async def run_full_scan(
     scanned_registers: dict[str, int],
 ) -> None:
     """Scan all registers up to max known address (full_register_scan mode)."""
-    for start, count in _group_reads(range(input_max + 1), max_block_size=scanner.effective_batch):
-        scanned_registers["input_registers"] += count
-        input_data = (
-            await scanner._read_input(scanner._client, start, count, skip_cache=True)
-            if scanner._client is not None
-            else await scanner._read_input(None, start, count, skip_cache=True)
-        )
-        if input_data is None:
-            scanner.failed_addresses["modbus_exceptions"]["input_registers"].update(
-                range(start, start + count)
+    async def _run_word_phase(max_addr: int, scan_key: str, func: int, read_fn: Any) -> None:
+        for start, count in _group_reads(range(max_addr + 1), max_block_size=scanner.effective_batch):
+            scanned_registers[scan_key] += count
+            data = await read_fn(start, count)
+            if data is None:
+                scanner.failed_addresses["modbus_exceptions"][scan_key].update(range(start, start + count))
+                continue
+            apply_word_register_block(
+                scanner,
+                function=func,
+                register_group=scan_key,
+                start=start,
+                count=count,
+                data=data,
+                unknown_registers=unknown_registers,
             )
-            continue
-        apply_word_register_block(
-            scanner,
-            function=4,
-            register_group="input_registers",
-            start=start,
-            count=count,
-            data=input_data,
-            unknown_registers=unknown_registers,
-        )
 
-    for start, count in _group_reads(
-        range(holding_max + 1), max_block_size=scanner.effective_batch
-    ):
-        scanned_registers["holding_registers"] += count
-        holding_data = (
-            await scanner._read_holding(scanner._client, start, count, skip_cache=True)
-            if scanner._client is not None
-            else await scanner._read_holding(None, start, count, skip_cache=True)
-        )
-        if holding_data is None:
-            scanner.failed_addresses["modbus_exceptions"]["holding_registers"].update(
-                range(start, start + count)
-            )
-            continue
-        apply_word_register_block(
-            scanner,
-            function=3,
-            register_group="holding_registers",
-            start=start,
-            count=count,
-            data=holding_data,
-            unknown_registers=unknown_registers,
-        )
+    await _run_word_phase(
+        input_max,
+        "input_registers",
+        4,
+        lambda start, count: scanner._read_input(
+            scanner._client if scanner._client is not None else None, start, count, skip_cache=True
+        ),
+    )
+    await _run_word_phase(
+        holding_max,
+        "holding_registers",
+        3,
+        lambda start, count: scanner._read_holding(
+            scanner._client if scanner._client is not None else None, start, count, skip_cache=True
+        ),
+    )
 
     for start, count in _group_reads(range(coil_max + 1), max_block_size=scanner.effective_batch):
         scanned_registers["coil_registers"] += count


### PR DESCRIPTION
### Motivation
- Reduce complexity and size of the hot-path `read_input` logic by extracting cohesive helpers for read attempts and retry state.
- Remove duplicated full-scan word-register handling in `run_full_scan` and centralize the input/holding phases into a single reusable runner.
- Improve maintainability of bit-read handling while preserving existing two-argument/three-argument invocation compatibility and runtime behavior.

### Description
- Extracted `_execute_word_read_attempt(...)` to encapsulate a single word-register read via transport or client fallback and keep fallback/retry parameters centralized.
- Extracted `_run_input_read_retry_loop(...)` to contain the retry/backoff loop, exception handling, and final failure finalization previously embedded in `read_input`.
- Reworked `read_input` to be a thin orchestration layer that uses `unpack_read_args`, `build_read_attempt_meta`, `resolve_transport_and_client` and then delegates to `_run_input_read_retry_loop`.
- Consolidated duplicated input/holding phases in `run_full_scan` by adding an internal `_run_word_phase(...)` helper and replacing the prior duplicated loops with two calls that pass a small read lambda; coil/discrete phases remain unchanged.
- Preserved `read_bit_registers` argument compatibility and retry behavior (kept normalized bit decoding via `normalize_bit_read_result`).
- Files changed: `custom_components/thessla_green_modbus/scanner/io_read.py` and `custom_components/thessla_green_modbus/scanner/orchestration.py`.

### Testing
- Ran `ruff check custom_components tests tools` and `python -m compileall -q custom_components/thessla_green_modbus tests tools`, both passed.
- Ran `python tools/compare_registers_with_reference.py` and `python tools/check_maintainability.py`, both passed (informational differences in register reference remain unchanged).
- Ran targeted scanner tests `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` and full test suite `pytest -q tests/`, and all tests passed (some tests skipped as in baseline).
- Performed scanner package audits for HA imports and shim/proxy keywords and found no forbidden references; maintainability gate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87437ff848326986be89830ea96ed)