### PR TITLE
refactor: complete mapping maintainability cleanup batch

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -35,6 +35,8 @@ from ._mapping_discrete_loader import (
 from ._mapping_discrete_loader import (
     classify_discrete_holding_registers as _classify_discrete_holding_registers,
 )
+from ._mapping_domain_routes import route_enum_mapping as _route_enum_mapping_impl
+from ._mapping_domain_routes import route_min_max_mapping as _route_min_max_mapping_impl
 from ._mapping_payloads import (
     parse_info_states as _parse_info_states,
 )
@@ -141,6 +143,8 @@ def _apply_diagnostic_binary_overrides(
         switch_configs.pop(reg, None)
         select_configs.pop(reg, None)
 
+
+
 def _route_enum_mapping(
     target: str | None,
     register: str,
@@ -150,20 +154,15 @@ def _route_enum_mapping(
     switch_mappings: dict[str, Any],
     select_mappings: dict[str, Any],
 ) -> bool:
-    """Apply enum-classification result to mapping stores and return handled state."""
-    if target == "switch":
-        switch_mappings.setdefault(register, payload)
-        return True
-    if target == "binary":
-        binary_mappings.setdefault(register, payload)
-        return True
-    if target == "select":
-        select_mappings.setdefault(register, payload)
-        return True
-    if target == "sensor":
-        sensor_mappings.setdefault(register, payload)
-        return True
-    return False
+    return _route_enum_mapping_impl(
+        target,
+        register,
+        payload,
+        sensor_mappings=sensor_mappings,
+        binary_mappings=binary_mappings,
+        switch_mappings=switch_mappings,
+        select_mappings=select_mappings,
+    )
 
 
 def _route_min_max_mapping(
@@ -175,22 +174,15 @@ def _route_min_max_mapping(
     switch_mappings: dict[str, Any],
     select_mappings: dict[str, Any],
 ) -> bool:
-    """Apply min/max-classification result to mapping stores and return handled state."""
-    if target == "switch":
-        switch_mappings.setdefault(register, payload)
-        return True
-    if target == "binary":
-        binary_mappings.setdefault(register, payload)
-        return True
-    if target == "select":
-        select_mappings.setdefault(register, payload)
-        return True
-    if target == "number":
-        number_mappings.setdefault(register, payload)
-        return True
-    return False
-
-
+    return _route_min_max_mapping_impl(
+        target,
+        register,
+        payload,
+        number_mappings=number_mappings,
+        binary_mappings=binary_mappings,
+        switch_mappings=switch_mappings,
+        select_mappings=select_mappings,
+    )
 def _is_unmappable_holding_register(
     register: str,
     all_mappings: tuple[dict[str, Any], ...],

--- a/custom_components/thessla_green_modbus/mappings/_mapping_domain_routes.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_domain_routes.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def route_enum_mapping(target: str | None, register: str, payload: dict[str, Any] | None, *, sensor_mappings: dict[str, Any], binary_mappings: dict[str, Any], switch_mappings: dict[str, Any], select_mappings: dict[str, Any]) -> bool:
+    if target == "switch":
+        switch_mappings.setdefault(register, payload)
+        return True
+    if target == "binary":
+        binary_mappings.setdefault(register, payload)
+        return True
+    if target == "select":
+        select_mappings.setdefault(register, payload)
+        return True
+    if target == "sensor":
+        sensor_mappings.setdefault(register, payload)
+        return True
+    return False
+
+
+def route_min_max_mapping(target: str | None, register: str, payload: dict[str, Any] | None, *, number_mappings: dict[str, Any], binary_mappings: dict[str, Any], switch_mappings: dict[str, Any], select_mappings: dict[str, Any]) -> bool:
+    if target == "switch":
+        switch_mappings.setdefault(register, payload)
+        return True
+    if target == "binary":
+        binary_mappings.setdefault(register, payload)
+        return True
+    if target == "select":
+        select_mappings.setdefault(register, payload)
+        return True
+    if target == "number":
+        number_mappings.setdefault(register, payload)
+        return True
+    return False

--- a/custom_components/thessla_green_modbus/mappings/_static_sensor_groups.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_sensor_groups.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import (
+    UnitOfVolumeFlowRate,
+)
+from homeassistant.helpers.entity import EntityCategory
+
+
+def diagnostic_sensor_payload(translation_key: str, *, icon: str = "mdi:information", register_type: str = "input_registers") -> dict[str, Any]:
+    return {"translation_key": translation_key, "icon": icon, "register_type": register_type, "entity_category": EntityCategory.DIAGNOSTIC}
+
+
+def airflow_sensor_mappings() -> dict[str, dict[str, Any]]:
+    return {
+        "supply_flow_rate": {"translation_key": "supply_flow_rate_m3h", "icon": "mdi:fan-plus", "device_class": SensorDeviceClass.VOLUME_FLOW_RATE, "state_class": SensorStateClass.MEASUREMENT, "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "register_type": "input_registers"},
+        "exhaust_flow_rate": {"translation_key": "exhaust_flow_rate_m3h", "icon": "mdi:fan-minus", "device_class": SensorDeviceClass.VOLUME_FLOW_RATE, "state_class": SensorStateClass.MEASUREMENT, "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "register_type": "input_registers"},
+        "supply_air_flow": {"translation_key": "supply_air_flow", "icon": "mdi:fan-plus", "device_class": SensorDeviceClass.VOLUME_FLOW_RATE, "state_class": SensorStateClass.MEASUREMENT, "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "register_type": "holding_registers"},
+        "exhaust_air_flow": {"translation_key": "exhaust_air_flow", "icon": "mdi:fan-minus", "device_class": SensorDeviceClass.VOLUME_FLOW_RATE, "state_class": SensorStateClass.MEASUREMENT, "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "register_type": "holding_registers"},
+    }

--- a/custom_components/thessla_green_modbus/mappings/_static_sensors.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_sensors.py
@@ -15,6 +15,8 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.entity import EntityCategory
 
+from ._static_sensor_groups import airflow_sensor_mappings as _airflow_sensor_mappings_impl
+from ._static_sensor_groups import diagnostic_sensor_payload as _diagnostic_sensor_payload_impl
 from ._static_sensor_temperatures import (
     HOLDING_TEMPERATURE_SENSOR_MAPPINGS,
     INPUT_TEMPERATURE_SENSOR_MAPPINGS,
@@ -27,52 +29,11 @@ def _diagnostic_sensor_payload(
     icon: str = "mdi:information",
     register_type: str = "input_registers",
 ) -> dict[str, Any]:
-    """Build a standard diagnostic sensor payload."""
-    return {
-        "translation_key": translation_key,
-        "icon": icon,
-        "register_type": register_type,
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    }
+    return _diagnostic_sensor_payload_impl(translation_key, icon=icon, register_type=register_type)
 
 
 def _airflow_sensor_mappings() -> dict[str, dict[str, Any]]:
-    """Return static airflow-related sensor mappings."""
-    return {
-        "supply_flow_rate": {
-            "translation_key": "supply_flow_rate_m3h",
-            "icon": "mdi:fan-plus",
-            "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
-            "state_class": SensorStateClass.MEASUREMENT,
-            "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-            "register_type": "input_registers",
-        },
-        "exhaust_flow_rate": {
-            "translation_key": "exhaust_flow_rate_m3h",
-            "icon": "mdi:fan-minus",
-            "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
-            "state_class": SensorStateClass.MEASUREMENT,
-            "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-            "register_type": "input_registers",
-        },
-        "supply_air_flow": {
-            "translation_key": "supply_air_flow",
-            "icon": "mdi:fan-plus",
-            "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
-            "state_class": SensorStateClass.MEASUREMENT,
-            "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-            "register_type": "holding_registers",
-        },
-        "exhaust_air_flow": {
-            "translation_key": "exhaust_air_flow",
-            "icon": "mdi:fan-minus",
-            "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
-            "state_class": SensorStateClass.MEASUREMENT,
-            "unit": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-            "register_type": "holding_registers",
-        },
-    }
-
+    return _airflow_sensor_mappings_impl()
 
 SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     # Temperature sensors (Input Registers)


### PR DESCRIPTION
### Motivation
- Reduce branching and size of the large mapping builder hotspot to improve maintainability while preserving existing mapping outputs and tests.  
- Isolate small, well-scoped responsibilities (domain routing and sensor helper groups) so future phases can continue safely.  
- Keep public/internal loader APIs stable for tests by providing thin compatibility wrappers where needed.

### Description
- Extracted enum/min-max routing logic into a new module `custom_components/thessla_green_modbus/mappings/_mapping_domain_routes.py` with `route_enum_mapping` and `route_min_max_mapping`.  
- Kept `_mapping_builders.py` stable by delegating domain routing to the extracted module via thin wrapper functions (`_route_enum_mapping`, `_route_min_max_mapping`) so internal imports/tests remain unchanged.  
- Extracted sensor helper groups (airflow mappings and diagnostic payload builder) into `custom_components/thessla_green_modbus/mappings/_static_sensor_groups.py` and updated `_static_sensors.py` to delegate to these helpers.  
- Preserved mapping payloads and external behavior; no changes to entity unique IDs, names, domains, register JSON, or translations.

### Testing
- Ran lint and formatting checks with `ruff check custom_components tests tools` and applied small fixes; the check completed successfully.  
- Compiled sources with `python -m compileall -q custom_components/thessla_green_modbus tests tools` with no errors.  
- Ran mapping validation `python tools/validate_entity_mappings.py` which succeeded and reported `OK: 366 entities validated`.  
- Ran unit/test suite: `pytest -q tests/test_entity_mappings*.py tests/test_entity_data_correctness*.py` and `pytest tests/ -q`; all tests passed (with existing skips).  
- Maintained repository gates: `python tools/check_maintainability.py` and `python tools/compare_registers_with_reference.py` completed successfully (script output notes vendor-reference differences but returned success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87457521c832682998f0e0bd646ba)