### PR TITLE
refactor: modbus helpers, RTU response parsing, and register parser cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -8,6 +8,7 @@ import logging
 import random
 import weakref
 from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
 from typing import Any
 
 from . import const
@@ -341,6 +342,15 @@ def _calculate_batch_size(kwargs: dict[str, Any]) -> int:
     return kwargs.get("count") or len(kwargs.get("values", [])) or 1
 
 
+@dataclass(frozen=True, slots=True)
+class _PreparedCall:
+    positional: list[Any]
+    kwarg: str
+    func_name: str
+    batch_size: int
+    delay: float
+
+
 def _prepare_modbus_call(
     func: Callable[..., Awaitable[Any]],
     args: tuple[Any, ...],
@@ -421,48 +431,60 @@ async def _call_modbus(
         apply_backoff=apply_backoff,
     )
 
-    if delay > 0:
+    prepared = _PreparedCall(positional, kwarg, func_name, batch_size, delay)
+    if prepared.delay > 0:
         _LOGGER.debug(
-            "Delaying %.3fs before attempt %s/%s of %s", delay, attempt, max_attempts, func_name
+            "Delaying %.3fs before attempt %s/%s of %s",
+            prepared.delay,
+            attempt,
+            max_attempts,
+            prepared.func_name,
         )
         try:
-            await asyncio.sleep(delay)
+            await asyncio.sleep(prepared.delay)
         except asyncio.CancelledError:
             _LOGGER.debug(
-                "Sleep cancelled before calling %s attempt %s/%s", func_name, attempt, max_attempts
+                "Sleep cancelled before calling %s attempt %s/%s",
+                prepared.func_name,
+                attempt,
+                max_attempts,
             )
             raise
 
     _LOGGER.debug(
         "Calling %s on slave %s (batch=%s attempt %s/%s)",
-        func_name,
+        prepared.func_name,
         slave_id,
-        batch_size,
+        prepared.batch_size,
         attempt,
         max_attempts,
     )
 
     _log_modbus_request(
-        func_name=func_name,
+        func_name=prepared.func_name,
         slave_id=slave_id,
-        positional=positional,
+        positional=prepared.positional,
         kwargs=kwargs,
     )
 
     try:
         response = await _dispatch_modbus_call(
             func=func,
-            positional=positional,
+            positional=prepared.positional,
             kwargs=kwargs,
-            kwarg=kwarg,
+            kwarg=prepared.kwarg,
             slave_id=slave_id,
             timeout=timeout,
         )
     except TimeoutError as err:
-        _LOGGER.debug("Call to %s timed out on attempt %s/%s", func_name, attempt, max_attempts)
+        _LOGGER.debug(
+            "Call to %s timed out on attempt %s/%s", prepared.func_name, attempt, max_attempts
+        )
         raise TimeoutError("Modbus request timed out") from err
     except asyncio.CancelledError:
-        _LOGGER.debug("Call to %s cancelled on attempt %s/%s", func_name, attempt, max_attempts)
+        _LOGGER.debug(
+            "Call to %s cancelled on attempt %s/%s", prepared.func_name, attempt, max_attempts
+        )
         raise
     except (
         AttributeError,
@@ -474,12 +496,16 @@ async def _call_modbus(
     ) as err:
         classification = _classify_modbus_exception(err)
         if classification == "cancelled":
-            _LOGGER.debug("Call to %s cancelled on attempt %s/%s", func_name, attempt, max_attempts)
+            _LOGGER.debug(
+                "Call to %s cancelled on attempt %s/%s", prepared.func_name, attempt, max_attempts
+            )
         else:
-            _LOGGER.debug("Call to %s failed on attempt %s/%s", func_name, attempt, max_attempts)
+            _LOGGER.debug(
+                "Call to %s failed on attempt %s/%s", prepared.func_name, attempt, max_attempts
+            )
         raise
 
-    _log_modbus_response(func_name, response)
+    _log_modbus_response(prepared.func_name, response)
     return response
 
 

--- a/custom_components/thessla_green_modbus/modbus_transport_raw.py
+++ b/custom_components/thessla_green_modbus/modbus_transport_raw.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from typing import Any
 
 from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
@@ -21,6 +22,11 @@ from .modbus_transport_base import (
 
 class RawRtuOverTcpTransport(BaseModbusTransport):
     """RTU-over-TCP transport that sends raw Modbus RTU frames over TCP."""
+
+    @dataclass(frozen=True, slots=True)
+    class _ResponseHeader:
+        slave: int
+        function: int
 
     def __init__(
         self,
@@ -155,8 +161,22 @@ class RawRtuOverTcpTransport(BaseModbusTransport):
         return _append_crc(bytes(payload))
 
     @staticmethod
-    def _validate_response_header(header: bytes, *, slave_id: int, function: int) -> int:
-        resp_slave, resp_func = header
+    def _parse_response_header(header: bytes) -> _ResponseHeader:
+        if len(header) != 2:
+            raise ModbusIOException("Invalid RTU response header length")
+        return RawRtuOverTcpTransport._ResponseHeader(slave=header[0], function=header[1])
+
+    @staticmethod
+    def _validate_response_header(
+        header: bytes | _ResponseHeader, *, slave_id: int, function: int
+    ) -> int:
+        parsed = (
+            RawRtuOverTcpTransport._parse_response_header(header)
+            if isinstance(header, bytes)
+            else header
+        )
+        resp_slave = parsed.slave
+        resp_func = parsed.function
 
         if resp_slave != (slave_id & 0xFF):
             raise ModbusIOException("Unexpected slave ID in RTU response")
@@ -180,12 +200,16 @@ class RawRtuOverTcpTransport(BaseModbusTransport):
             raise ModbusIOException("Unexpected function code in exception RTU response")
         return payload[2]
 
+    @staticmethod
+    def _validate_exception_frame(payload: bytes, crc_bytes: bytes, *, function: int) -> int:
+        RawRtuOverTcpTransport._validate_crc(payload, crc_bytes)
+        return RawRtuOverTcpTransport._parse_exception_response_payload(payload, function=function)
+
     async def _read_exception_response(self, header: bytes, *, function: int) -> bytes:
         exception_code = await self._read_exactly(1)
         crc_bytes = await self._read_exactly(2)
         payload = header + exception_code
-        self._validate_crc(payload, crc_bytes)
-        parsed_exception = self._parse_exception_response_payload(payload, function=function)
+        parsed_exception = self._validate_exception_frame(payload, crc_bytes, function=function)
         raise ModbusException(f"Modbus exception {parsed_exception} for function {function}")
 
     async def _read_response_payload(self, header: bytes, body_length: int) -> bytes:
@@ -205,14 +229,17 @@ class RawRtuOverTcpTransport(BaseModbusTransport):
         return await self._read_response_payload(header, 4)
 
     async def _read_response(self, slave_id: int, function: int) -> bytes:
-        header = await self._read_exactly(2)
-        resp_func = self._validate_response_header(header, slave_id=slave_id, function=function)
+        raw_header = await self._read_exactly(2)
+        parsed_header = self._parse_response_header(raw_header)
+        resp_func = self._validate_response_header(
+            parsed_header, slave_id=slave_id, function=function
+        )
 
         if self._is_exception_function(resp_func, expected_function=function):
-            return await self._read_exception_response(header, function=resp_func)
+            return await self._read_exception_response(raw_header, function=resp_func)
         if function in (3, 4):
-            return await self._read_register_data_response(header)
-        return await self._read_write_body_response(header)
+            return await self._read_register_data_response(raw_header)
+        return await self._read_write_body_response(raw_header)
 
     async def _send_frame(self, frame: bytes, slave_id: int, function: int) -> bytes:
         async with self._request_lock:

--- a/custom_components/thessla_green_modbus/registers/parser.py
+++ b/custom_components/thessla_green_modbus/registers/parser.py
@@ -29,12 +29,14 @@ except (AttributeError, TypeError) as err:  # pragma: no cover
 
 def parse_registers(raw: Any) -> list[RegisterDef]:
     """Parse raw register definition data into RegisterDef objects."""
+    return [register_from_parsed(parsed) for parsed in _parse_schema_items(raw)]
+
+
+def _parse_schema_items(raw: Any) -> list[Any]:
     items = raw.get("registers", raw) if isinstance(raw, dict) else raw
     if hasattr(RegisterList, "model_validate"):
-        parsed_items = RegisterList.model_validate(items).registers
-    else:  # pragma: no cover
-        parsed_items = RegisterList.parse_obj(items).registers
-    return [register_from_parsed(parsed) for parsed in parsed_items]
+        return cast(list[Any], RegisterList.model_validate(items).registers)
+    return cast(list[Any], RegisterList.parse_obj(items).registers)  # pragma: no cover
 
 
 def normalise_enum_map(
@@ -99,4 +101,3 @@ def load_registers_from_file(path: Path) -> list[RegisterDef]:
 async def async_load_registers_from_file(hass: Any | None, path: Path) -> list[RegisterDef]:
     """Load and parse register definitions asynchronously."""
     return parse_registers(await async_read_registers_json(hass, path))
-


### PR DESCRIPTION
### Motivation
- Reduce complexity of Modbus call orchestration by centralizing prepared-call metadata and simplifying internal flow. 
- Extract and clarify RTU response/header and exception validation to shrink transport method branching and improve readability without changing protocol semantics. 
- Simplify register parsing flow by isolating schema-item extraction so parsing logic is easier to test and maintain.

### Description
- Introduced a frozen `_PreparedCall` dataclass and adjusted `_prepare_modbus_call` / `_call_modbus` to use structured metadata for delay, kwarg detection, logging, and invocation while preserving timeout/cancellation and exception semantics (`custom_components/thessla_green_modbus/modbus_helpers.py`).
- Added `_ResponseHeader` dataclass, `_parse_response_header`, and `_validate_exception_frame` helpers then updated the RTU-over-TCP read/response paths to use these helpers (no changes to CRC, framing, function codes or wire behavior) (`custom_components/thessla_green_modbus/modbus_transport_raw.py`).
- Extracted `_parse_schema_items` from `parse_registers` to centralize model parsing/compatibility handling and simplified `parse_registers` to map parsed items to `RegisterDef` objects (`custom_components/thessla_green_modbus/registers/parser.py`).
- All changes are internal refactors; register JSON data, addressing, CRC, codec behavior, retry/backoff and public loader APIs remain unchanged.

### Testing
- Ran style and static checks: `ruff check custom_components tests tools` (passed).
- Ran byte-compile: `python -m compileall -q custom_components/thessla_green_modbus tests tools` (passed).
- Ran register reference check: `python tools/compare_registers_with_reference.py` (passed with expected differences flagged as extras in integration but no missing entries).
- Ran maintainability audit: `python tools/check_maintainability.py` (passed).
- Ran targeted and full test suites: `pytest -q` for modified-target tests and `pytest tests/ -q` for full tests (all automated tests passed; some long-running/optional tests were skipped as expected).
- Ran `python tools/validate_entity_mappings.py` and repository audit `rg` checks for forbidden imports/terms (passed).

Files changed: `custom_components/thessla_green_modbus/modbus_helpers.py`, `custom_components/thessla_green_modbus/modbus_transport_raw.py`, `custom_components/thessla_green_modbus/registers/parser.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8746b86b08326b842e58911e57cf5)