### PR TITLE
refactor(coordinator): split capabilities post-processing and simplify write-path in schedule mixin

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/capabilities.py
+++ b/custom_components/thessla_green_modbus/coordinator/capabilities.py
@@ -217,54 +217,43 @@ class _CoordinatorCapabilitiesMixin:
 
     def _post_process_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Post-process data to calculate derived values."""
+        self._apply_serial_number_state(data)
+        self._apply_post_process_derived_values(data)
+        self._apply_power_and_energy_estimates(data)
+        self._apply_device_clock(data)
+        return data
+
+    def _apply_serial_number_state(self, data: dict[str, Any]) -> None:
+        """Expose known device serial number in coordinator data."""
         # Expose the full serial number (assembled from 6 registers by the scanner)
         # as a sensor value so the serial_number entity has a meaningful state.
         device_serial = (self.device_info or {}).get("serial_number")
         if device_serial and device_serial != "Unknown":
             data["serial_number"] = device_serial
 
-        # Calculate heat recovery efficiency.
-        # bypass_mode register 4330: 0=inactive (HX active), 1=freeheating, 2=freecooling.
-        # Both freeheating and freecooling open the bypass damper, routing air
-        # around the heat exchanger, so any temperature-based efficiency formula
-        # yields a meaningless result — skip for both active states.
-        #
-        # Formula selection (per EN 308 / ASHRAE Standard 84):
-        #   • With flow rates: thermodynamic effectiveness ε (ASHRAE 84 ε-NTU):
-        #       ε = Q_supply × (T_supply − T_outside) / (Q_min × (T_exhaust − T_outside))
-        #     where Q_min = min(Q_supply, Q_exhaust).
-        #     Correctly bounded [0, 1] even for unbalanced flows.
-        #   • Without flow rates: EN 308 supply-side temperature efficiency η_supply
-        #     (3-sensor formula, valid when flows are approximately balanced):
-        #       η = (T_supply − T_outside) / (T_exhaust − T_outside)
-        #     Note: this device exposes only 3 temperature sensors (TZ1, TN1, TP);
-        #     the exhaust-outlet sensor TW is absent, so EN 308 η_exhaust and the
-        #     Belgian mean-efficiency (η_epbd) cannot be computed.
-        self._apply_post_process_derived_values(data)
+    def _apply_power_and_energy_estimates(self, data: dict[str, Any]) -> None:
+        """Apply power estimate and accumulate total energy."""
         power = self.calculate_power_consumption(data)
-        if power is not None:
-            data["estimated_power"] = power
-            data["electrical_power"] = power
-            now = _utcnow()
-            last_ts = self._last_power_timestamp
-            if not isinstance(last_ts, datetime):
-                elapsed = 0.0
-            else:
-                if (
-                    getattr(now, "tzinfo", None) is not None
-                    and getattr(last_ts, "tzinfo", None) is None
-                ):
-                    last_ts = last_ts.replace(tzinfo=UTC)
-                elif (
-                    getattr(now, "tzinfo", None) is None
-                    and getattr(last_ts, "tzinfo", None) is not None
-                ):
-                    now = now.replace(tzinfo=UTC)
-                elapsed = (now - last_ts).total_seconds()
-            self._total_energy += power * elapsed / 3600000.0
-            data["total_energy"] = self._total_energy
-            self._last_power_timestamp = now
+        if power is None:
+            return
+        data["estimated_power"] = power
+        data["electrical_power"] = power
+        now = _utcnow()
+        last_ts = self._last_power_timestamp
+        if not isinstance(last_ts, datetime):
+            elapsed = 0.0
+        else:
+            if getattr(now, "tzinfo", None) is not None and getattr(last_ts, "tzinfo", None) is None:
+                last_ts = last_ts.replace(tzinfo=UTC)
+            elif getattr(now, "tzinfo", None) is None and getattr(last_ts, "tzinfo", None) is not None:
+                now = now.replace(tzinfo=UTC)
+            elapsed = (now - last_ts).total_seconds()
+        self._total_energy += power * elapsed / 3600000.0
+        data["total_energy"] = self._total_energy
+        self._last_power_timestamp = now
 
+    def _apply_device_clock(self, data: dict[str, Any]) -> None:
+        """Decode and store device clock when valid."""
         # Decode device clock from BCD registers 0-3
         try:
             device_clock = self._decode_device_clock(data)
@@ -272,5 +261,3 @@ class _CoordinatorCapabilitiesMixin:
                 data["device_clock"] = device_clock
         except (TypeError, ValueError, AttributeError) as exc:
             _LOGGER.debug("Failed to decode device clock: %s", exc)
-
-        return data

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -318,6 +318,50 @@ class _CoordinatorScheduleMixin:
         """Return True when a Modbus write response indicates success."""
         return response is not None and not response.isError()
 
+    async def _execute_single_register_write_attempt(
+        self,
+        *,
+        definition: Any,
+        register_name: str,
+        address: int,
+        encoded_values: list[int] | None,
+        scalar_value: Any,
+        attempt: int,
+    ) -> tuple[Any, bool]:
+        """Execute one write attempt and return (response, success)."""
+        if definition.function == 3:
+            response = await self._write_holding_attempt(
+                address=address,
+                encoded_values=encoded_values,
+                scalar_value=scalar_value,
+                attempt=attempt,
+            )
+        elif definition.function == 1:
+            response = await self._call_modbus(
+                self._get_client_method("write_coil"),
+                address=address,
+                value=bool(scalar_value),
+                attempt=attempt,
+            )
+        else:
+            _LOGGER.error("Register %s is not writable", register_name)
+            return None, False
+        return response, self._write_response_ok(response)
+
+    async def _write_holding_attempt(
+        self,
+        *,
+        address: int,
+        encoded_values: list[int] | None,
+        scalar_value: Any,
+        attempt: int,
+    ) -> Any:
+        """Write holding register(s) for one attempt and return response."""
+        if encoded_values is not None:
+            response, _success = await self._write_holding_multi(address, encoded_values, attempt)
+            return response
+        return await self._write_holding_single(address, scalar_value, attempt)
+
     async def async_write_register(
         self,
         register_name: str,
@@ -354,37 +398,15 @@ class _CoordinatorScheduleMixin:
 
                 for attempt in range(1, self.retry + 1):
                     try:
-                        if definition.function == 3:
-                            if encoded_values is not None:
-                                response, success = await self._write_holding_multi(
-                                    address, encoded_values, attempt
-                                )
-                                if not success:
-                                    should_retry = self._handle_write_response_failure(
-                                        is_final_attempt=attempt == self.retry,
-                                        final_error_message="Error writing to register %s: %s",
-                                        retry_message=f"Retrying write to register {register_name}",
-                                        error_args=(register_name, response),
-                                    )
-                                    if not should_retry:
-                                        return False
-                                    continue
-                            else:
-                                response = await self._write_holding_single(
-                                    address, scalar_value, attempt
-                                )
-                        elif definition.function == 1:
-                            response = await self._call_modbus(
-                                self._get_client_method("write_coil"),
-                                address=address,
-                                value=bool(scalar_value),
-                                attempt=attempt,
-                            )
-                        else:
-                            _LOGGER.error("Register %s is not writable", register_name)
-                            return False
-
-                        if not self._write_response_ok(response):
+                        response, success = await self._execute_single_register_write_attempt(
+                            definition=definition,
+                            register_name=register_name,
+                            address=address,
+                            encoded_values=encoded_values,
+                            scalar_value=scalar_value,
+                            attempt=attempt,
+                        )
+                        if not success:
                             should_retry = self._handle_write_response_failure(
                                 is_final_attempt=attempt == self.retry,
                                 final_error_message="Error writing to register %s: %s",


### PR DESCRIPTION
### Motivation
- Reduce complexity and cognitive load in coordinator mixins by extracting cohesive responsibilities from large methods. 
- Improve readability and maintainability of write-path logic while preserving existing retry, logging, and refresh semantics. 
- Group capability post-processing into smaller, testable steps (serial, derived metrics, power/energy, device clock) to make future changes safer. 

### Description
- Split `_post_process_data` in `coordinator/capabilities.py` into focused helpers: `_apply_serial_number_state`, `_apply_post_process_derived_values` (preserved), `_apply_power_and_energy_estimates`, and `_apply_device_clock`, and updated `_post_process_data` to call these helpers in sequence. (file: `custom_components/thessla_green_modbus/coordinator/capabilities.py`) 
- Extracted per-attempt write orchestration from the large `async_write_register` flow into `_execute_single_register_write_attempt` and `_write_holding_attempt`, reducing inline branching and simplifying success/failure handling while keeping behavior identical. (file: `custom_components/thessla_green_modbus/coordinator/schedule.py`) 
- Preserved public package-root API and runtime behavior; no coordinator package-root exports were changed. 

### Testing
- Ran lint/validation and maintainability gates: `ruff check custom_components tests tools` and `python tools/check_maintainability.py`, both passed. 
- Verified byte-compile: `python -m compileall -q custom_components/thessla_green_modbus tests tools` succeeded. 
- Ran register reference comparison: `python tools/compare_registers_with_reference.py` succeeded. 
- Ran targeted coordinator tests: `pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py tests/unit/test_errors.py`, all passed. 
- Ran full test suite: `pytest tests/ -q` and `python tools/validate_entity_mappings.py`, both passed (all automated checks green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8742fccbc83269daa02a9102bf82b)