### PR TITLE
Refactor service handlers and write-step flow to extract shared helpers

### DIFF
--- a/custom_components/thessla_green_modbus/services_dispatch.py
+++ b/custom_components/thessla_green_modbus/services_dispatch.py
@@ -110,12 +110,42 @@ async def write_register_steps(
     Optional values are skipped when ``value`` is ``None``.
     """
     for register_name, value, optional, error_message in steps:
-        if optional and value is None:
+        if not _should_write_step(optional, value):
             continue
-        if not await write_register_func(coordinator, register_name, value, entity_id, action):
-            logger.error(error_message, entity_id)
+        if not await _perform_step_write(
+            coordinator,
+            register_name,
+            value,
+            entity_id,
+            action,
+            error_message,
+            write_register_func,
+            logger,
+        ):
             return False
     return True
+
+
+def _should_write_step(optional: bool, value: object) -> bool:
+    """Return whether a write step should be executed."""
+    return not (optional and value is None)
+
+
+async def _perform_step_write(
+    coordinator: Any,
+    register_name: str,
+    value: object,
+    entity_id: str,
+    action: str,
+    error_message: str,
+    write_register_func: Any,
+    logger: Any,
+) -> bool:
+    """Execute one write step with common error translation."""
+    if await write_register_func(coordinator, register_name, value, entity_id, action):
+        return True
+    logger.error(error_message, entity_id)
+    return False
 
 
 async def write_device_name_chunks(coordinator: Any, device_name: str, batch: int) -> bool:

--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -86,6 +86,34 @@ def _maintenance_handlers(
     }
 
 
+async def _run_with_success_log(
+    coordinator: object,
+    deps: ServiceHandlerDeps,
+    success_message: str,
+    *args: object,
+) -> bool:
+    """Refresh and emit success message for a completed target action."""
+    await refresh_and_log_success(coordinator, deps.logger, success_message, *args)
+    return True
+
+
+def _register_maintenance_service(
+    hass: HomeAssistant,
+    deps: ServiceHandlerDeps,
+    service: str,
+    schema: object,
+    handler: object,
+) -> None:
+    """Register one maintenance service with schema."""
+    hass.services.async_register(deps.domain, service, handler, schema)
+
+
+def _register_maintenance_bindings(hass: HomeAssistant, deps: ServiceHandlerDeps, handlers: dict[str, object]) -> None:
+    """Finalize maintenance registration loop preserving order."""
+    for service, schema, handler in _iter_maintenance_service_bindings(handlers):
+        _register_maintenance_service(hass, deps, service, schema, handler)
+
+
 async def _run_for_targets(
     hass: HomeAssistant,
     call: ServiceCall,
@@ -106,8 +134,7 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
             if not await deps.write_register(coordinator, "filter_change", filter_value, entity_id, "reset filters"):
                 deps.logger.error("Failed to reset filters for %s", entity_id)
                 return False
-            await refresh_and_log_success(coordinator, deps.logger, "Reset filters for %s", entity_id)
-            return True
+            return await _run_with_success_log(coordinator, deps, "Reset filters for %s", entity_id)
 
         await _run_for_targets(hass, call, deps, _reset_filters_for_target)
 
@@ -129,10 +156,7 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                 },
             ):
                 return False
-            await refresh_and_log_success(
-                coordinator, deps.logger, "Reset settings (%s) for %s", reset_type, entity_id
-            )
-            return True
+            return await _run_with_success_log(coordinator, deps, "Reset settings (%s) for %s", reset_type, entity_id)
 
         await _run_for_targets(hass, call, deps, _reset_settings_for_target)
 
@@ -151,8 +175,7 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                 },
             ):
                 return False
-            await refresh_and_log_success(coordinator, deps.logger, "Started pressure test for %s", entity_id)
-            return True
+            return await _run_with_success_log(coordinator, deps, "Started pressure test for %s", entity_id)
 
         await _run_for_targets(hass, call, deps, _start_pressure_test_for_target)
 
@@ -174,8 +197,7 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
                     deps.logger,
                 ):
                     return False
-            await refresh_and_log_success(coordinator, deps.logger, "Set Modbus parameters for %s", entity_id)
-            return True
+            return await _run_with_success_log(coordinator, deps, "Set Modbus parameters for %s", entity_id)
 
         await _run_for_targets(hass, call, deps, _set_modbus_parameters_for_target)
 
@@ -197,10 +219,9 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
             except (ModbusException, ConnectionException) as err:
                 deps.logger.error("Failed to set device name for %s: %s", entity_id, err)
                 return False
-            await refresh_and_log_success(
-                coordinator, deps.logger, "Set device name to '%s' for %s", device_name, entity_id
+            return await _run_with_success_log(
+                coordinator, deps, "Set device name to '%s' for %s", device_name, entity_id
             )
-            return True
 
         await _run_for_targets(hass, call, deps, _set_device_name_for_target)
 
@@ -231,5 +252,4 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
         set_device_name,
         sync_time,
     )
-    for service, schema, handler in _iter_maintenance_service_bindings(handlers):
-        hass.services.async_register(deps.domain, service, handler, schema)
+    _register_maintenance_bindings(hass, deps, handlers)

--- a/custom_components/thessla_green_modbus/services_handlers_parameters.py
+++ b/custom_components/thessla_green_modbus/services_handlers_parameters.py
@@ -33,18 +33,8 @@ def _build_step_handler(
     """Create a parameter handler based on write steps."""
 
     async def _handler(call: ServiceCall) -> None:
-        steps = step_builder(call)
-        for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
-            if not await write_register_steps(
-                coordinator,
-                steps,
-                entity_id,
-                context,
-                deps.write_register,
-                deps.logger,
-            ):
-                continue
-            await refresh_and_log_success(coordinator, deps.logger, success_log, entity_id)
+        steps = list(step_builder(call))
+        await _run_parameter_steps(hass, call, deps, steps, context, success_log)
 
     return _handler
 
@@ -132,6 +122,28 @@ def _parameter_registrations(
         ("set_air_quality_thresholds", set_air_quality_thresholds, SET_AIR_QUALITY_THRESHOLDS_SCHEMA),
         ("set_temperature_curve", set_temperature_curve, SET_TEMPERATURE_CURVE_SCHEMA),
     )
+
+
+async def _run_parameter_steps(
+    hass: HomeAssistant,
+    call: ServiceCall,
+    deps: ServiceHandlerDeps,
+    steps: list[WriteStep],
+    context: str,
+    success_log: str,
+) -> None:
+    """Run shared write/refresh flow for parameter handlers."""
+    for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
+        if not await write_register_steps(
+            coordinator,
+            steps,
+            entity_id,
+            context,
+            deps.write_register,
+            deps.logger,
+        ):
+            continue
+        await refresh_and_log_success(coordinator, deps.logger, success_log, entity_id)
 
 
 def register_parameter_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:


### PR DESCRIPTION
### Motivation
- Reduce code duplication across maintenance and parameter service handlers by centralizing common write/refresh/log flows.
- Make step write logic clearer and safer by encapsulating optional-step checks and error translation.
- Simplify service registration and success logging to improve readability and maintainability.

### Description
- Extracted `_should_write_step` and `_perform_step_write` into `services_dispatch.py` and updated `write_register_steps` to use these helpers instead of inline checks and logging.
- Added `_run_with_success_log`, `_register_maintenance_service`, and `_register_maintenance_bindings` to `services_handlers_maintenance.py`, replacing repeated `refresh_and_log_success` calls and the direct registration loop with unified helper usage.
- Updated maintenance handlers to return the result of `_run_with_success_log` after successful writes, and consolidated service registration to use `_register_maintenance_bindings`.
- Added `_run_parameter_steps` to `services_handlers_parameters.py` and changed `_build_step_handler` to build a `list` of steps and delegate execution to the new helper, removing per-handler iteration duplication.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f874634c3883268b47ec0a1e470381)