### PR TITLE
refactor: finish services and config flow cleanup batch

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow_device_validation.py
+++ b/custom_components/thessla_green_modbus/config_flow_device_validation.py
@@ -265,9 +265,8 @@ async def validate_input_impl(
     timeout_exceptions: tuple[type[BaseException], ...],
 ) -> dict[str, Any]:
     """Validate user-provided connection data and return scan payload."""
-
-    params = _normalize_connection_params(
-        data,
+    params = _normalize_validation_inputs(
+        data=data,
         normalize_connection_type=normalize_connection_type,
         validate_slave_id=validate_slave_id,
         validate_tcp_config=validate_tcp_config,
@@ -282,11 +281,64 @@ async def validate_input_impl(
         default_stop_bits=default_stop_bits,
         connection_type_tcp=connection_type_tcp,
     )
+    scanner_cls, capabilities_cls = await _resolve_runtime_classes(
+        hass=hass,
+        load_scanner_module=load_scanner_module,
+        scanner_cls_override=scanner_cls_override,
+        capabilities_cls_override=capabilities_cls_override,
+    )
+    return await _execute_validation_flow(
+        hass=hass,
+        params=params,
+        scanner_cls=scanner_cls,
+        capabilities_cls=capabilities_cls,
+        run_with_retry=run_with_retry,
+        call_with_optional_timeout=call_with_optional_timeout,
+        process_scan_capabilities=process_scan_capabilities,
+        is_request_cancelled_error=is_request_cancelled_error,
+        classify_os_error=classify_os_error,
+        should_log_timeout_traceback=should_log_timeout_traceback,
+        logger=logger,
+        default_retry=default_retry,
+        config_flow_backoff=config_flow_backoff,
+        timeout_exceptions=timeout_exceptions,
+    )
 
+
+def _normalize_validation_inputs(**kwargs: Any) -> dict[str, Any]:
+    return _normalize_connection_params(**kwargs)
+
+
+async def _resolve_runtime_classes(
+    *,
+    hass: Any,
+    load_scanner_module: Callable[[Any], Awaitable[Any]],
+    scanner_cls_override: Any,
+    capabilities_cls_override: Any,
+) -> tuple[Any, Any]:
     module = await load_scanner_module(hass)
-    scanner_cls = scanner_cls_override or module.ThesslaGreenDeviceScanner
-    capabilities_cls = capabilities_cls_override or module.DeviceCapabilities
+    return (
+        scanner_cls_override or module.ThesslaGreenDeviceScanner,
+        capabilities_cls_override or module.DeviceCapabilities,
+    )
 
+async def _execute_validation_flow(
+    *,
+    hass: Any,
+    params: dict[str, Any],
+    scanner_cls: Any,
+    capabilities_cls: Any,
+    run_with_retry: Callable[[Callable[[], Awaitable[Any]], int, float], Awaitable[Any]],
+    call_with_optional_timeout: Callable[[Callable[[], Any], float], Awaitable[Any]],
+    process_scan_capabilities: Callable[[dict[str, Any], type], dict[str, Any]],
+    is_request_cancelled_error: Callable[[ModbusIOException], bool],
+    classify_os_error: Callable[[OSError], str],
+    should_log_timeout_traceback: Callable[[BaseException], bool],
+    logger: Any,
+    default_retry: int,
+    config_flow_backoff: float,
+    timeout_exceptions: tuple[type[BaseException], ...],
+) -> dict[str, Any]:
     scanner: Any | None = None
     handled_exceptions = (
         ConnectionException,

--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -114,30 +114,24 @@ def _register_maintenance_bindings(hass: HomeAssistant, deps: ServiceHandlerDeps
         _register_maintenance_service(hass, deps, service, schema, handler)
 
 
-async def _run_for_targets(
-    hass: HomeAssistant,
-    call: ServiceCall,
-    deps: ServiceHandlerDeps,
-    action: Callable[[str, object], Awaitable[bool]],
-) -> None:
-    """Run a maintenance action for each targeted coordinator."""
-    for entity_id, coordinator in _iter_targets(hass, call, deps):
-        await action(entity_id, coordinator)
-
-
-def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
-    """Register maintenance services."""
-
+def _build_reset_filters_handler(hass: HomeAssistant, deps: ServiceHandlerDeps):
     async def reset_filters(call: ServiceCall) -> None:
         filter_value = filter_reset_value(deps.normalize_option, call.data["filter_type"])
+
         async def _reset_filters_for_target(entity_id: str, coordinator: object) -> bool:
-            if not await deps.write_register(coordinator, "filter_change", filter_value, entity_id, "reset filters"):
+            if not await deps.write_register(
+                coordinator, "filter_change", filter_value, entity_id, "reset filters"
+            ):
                 deps.logger.error("Failed to reset filters for %s", entity_id)
                 return False
             return await _run_with_success_log(coordinator, deps, "Reset filters for %s", entity_id)
 
         await _run_for_targets(hass, call, deps, _reset_filters_for_target)
 
+    return reset_filters
+
+
+def _build_reset_settings_handler(hass: HomeAssistant, deps: ServiceHandlerDeps):
     async def reset_settings(call: ServiceCall) -> None:
         reset_type = deps.normalize_option(call.data["reset_type"])
         registers = reset_settings_registers(reset_type)
@@ -159,6 +153,25 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
             return await _run_with_success_log(coordinator, deps, "Reset settings (%s) for %s", reset_type, entity_id)
 
         await _run_for_targets(hass, call, deps, _reset_settings_for_target)
+
+    return reset_settings
+
+
+async def _run_for_targets(
+    hass: HomeAssistant,
+    call: ServiceCall,
+    deps: ServiceHandlerDeps,
+    action: Callable[[str, object], Awaitable[bool]],
+) -> None:
+    """Run a maintenance action for each targeted coordinator."""
+    for entity_id, coordinator in _iter_targets(hass, call, deps):
+        await action(entity_id, coordinator)
+
+
+def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
+    """Register maintenance services."""
+    reset_filters = _build_reset_filters_handler(hass, deps)
+    reset_settings = _build_reset_settings_handler(hass, deps)
 
     async def start_pressure_test(call: ServiceCall) -> None:
         async def _start_pressure_test_for_target(entity_id: str, coordinator: object) -> bool:

--- a/custom_components/thessla_green_modbus/services_handlers_parameters.py
+++ b/custom_components/thessla_green_modbus/services_handlers_parameters.py
@@ -48,41 +48,14 @@ def _parameter_registrations(
         deps,
         context="set bypass parameters",
         success_log="Set bypass parameters for %s",
-        step_builder=lambda call: [
-            (
-                "bypass_mode",
-                BYPASS_MODE_MAP[deps.normalize_option(call.data["mode"])],
-                False,
-                "Failed to set bypass mode for %s",
-            ),
-            (
-                "min_bypass_temperature",
-                call.data.get("min_outdoor_temperature"),
-                True,
-                "Failed to set bypass min temperature for %s",
-            ),
-        ],
+        step_builder=lambda call: _bypass_steps(call, deps),
     )
     set_gwc_parameters = _build_step_handler(
         hass,
         deps,
         context="set GWC parameters",
         success_log="Set GWC parameters for %s",
-        step_builder=lambda call: [
-            ("gwc_mode", GWC_MODE_MAP[deps.normalize_option(call.data["mode"])], False, "Failed to set GWC mode for %s"),
-            (
-                "min_gwc_air_temperature",
-                call.data.get("min_air_temperature"),
-                True,
-                "Failed to set GWC min air temperature for %s",
-            ),
-            (
-                "max_gwc_air_temperature",
-                call.data.get("max_air_temperature"),
-                True,
-                "Failed to set GWC max air temperature for %s",
-            ),
-        ],
+        step_builder=lambda call: _gwc_steps(call, deps),
     )
 
     set_air_quality_thresholds = _build_step_handler(
@@ -98,30 +71,38 @@ def _parameter_registrations(
         deps,
         context="set temperature curve",
         success_log="Set temperature curve for %s",
-        step_builder=lambda call: [
-            ("heating_curve_slope", call.data["slope"], False, "Failed to set heating curve slope for %s"),
-            ("heating_curve_offset", call.data["offset"], False, "Failed to set heating curve offset for %s"),
-            (
-                "max_supply_temperature",
-                call.data.get("max_supply_temp"),
-                True,
-                "Failed to set max supply temperature for %s",
-            ),
-            (
-                "min_supply_temperature",
-                call.data.get("min_supply_temp"),
-                True,
-                "Failed to set min supply temperature for %s",
-            ),
-        ],
+        step_builder=_temperature_curve_steps,
     )
-
     return (
         ("set_bypass_parameters", set_bypass_parameters, SET_BYPASS_PARAMETERS_SCHEMA),
         ("set_gwc_parameters", set_gwc_parameters, SET_GWC_PARAMETERS_SCHEMA),
         ("set_air_quality_thresholds", set_air_quality_thresholds, SET_AIR_QUALITY_THRESHOLDS_SCHEMA),
         ("set_temperature_curve", set_temperature_curve, SET_TEMPERATURE_CURVE_SCHEMA),
     )
+
+
+def _bypass_steps(call: ServiceCall, deps: ServiceHandlerDeps) -> list[WriteStep]:
+    return [
+        ("bypass_mode", BYPASS_MODE_MAP[deps.normalize_option(call.data["mode"])], False, "Failed to set bypass mode for %s"),
+        ("min_bypass_temperature", call.data.get("min_outdoor_temperature"), True, "Failed to set bypass min temperature for %s"),
+    ]
+
+
+def _gwc_steps(call: ServiceCall, deps: ServiceHandlerDeps) -> list[WriteStep]:
+    return [
+        ("gwc_mode", GWC_MODE_MAP[deps.normalize_option(call.data["mode"])], False, "Failed to set GWC mode for %s"),
+        ("min_gwc_air_temperature", call.data.get("min_air_temperature"), True, "Failed to set GWC min air temperature for %s"),
+        ("max_gwc_air_temperature", call.data.get("max_air_temperature"), True, "Failed to set GWC max air temperature for %s"),
+    ]
+
+
+def _temperature_curve_steps(call: ServiceCall) -> list[WriteStep]:
+    return [
+        ("heating_curve_slope", call.data["slope"], False, "Failed to set heating curve slope for %s"),
+        ("heating_curve_offset", call.data["offset"], False, "Failed to set heating curve offset for %s"),
+        ("max_supply_temperature", call.data.get("max_supply_temp"), True, "Failed to set max supply temperature for %s"),
+        ("min_supply_temperature", call.data.get("min_supply_temp"), True, "Failed to set min supply temperature for %s"),
+    ]
 
 
 async def _run_parameter_steps(


### PR DESCRIPTION
### Motivation
- Reduce breadth and improve maintainability of maintenance/parameter service handlers and config-flow device validation by extracting focused helper functions and isolating runtime orchestration, while preserving public behavior and schemas.

### Description
- Extracted maintenance handler factories `_build_reset_filters_handler` and `_build_reset_settings_handler` and simplified `register_maintenance_services` to keep registration wiring and order intact (no behavior change). 
- Pulled parameter write-step builders into `_bypass_steps`, `_gwc_steps`, and `_temperature_curve_steps` and simplified `_parameter_registrations` to return a concise registration tuple. 
- Decomposed `validate_input_impl` into `_normalize_validation_inputs`, `_resolve_runtime_classes`, and `_execute_validation_flow` to separate input normalization, runtime class resolution, and validation orchestration. 
- Changes are limited to three modules and are refactor-only: `custom_components/thessla_green_modbus/services_handlers_maintenance.py`, `custom_components/thessla_green_modbus/services_handlers_parameters.py`, and `custom_components/thessla_green_modbus/config_flow_device_validation.py`, and preserve all service names, schemas, config-flow error keys, and abort reasons.

### Testing
- Ran dependency import check with `python - <<'PY' ...` which succeeded (`dependency imports OK`).
- Ran targeted unit tests with `pytest -q tests/test_services*.py tests/test_services_handlers_*.py tests/test_config_flow*.py` and they passed.
- Ran the full test suite with `pytest tests/ -q` which passed (4 skipped).
- Ran CI-equivalent gates: `ruff check custom_components tests tools` (passed), `python -m compileall -q custom_components/thessla_green_modbus tests tools` (passed), `python tools/compare_registers_with_reference.py` (ran; reported extras but completed), `python tools/check_maintainability.py` (passed), and `python tools/validate_entity_mappings.py` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8982e016c8326ab9dad2ef03496d8)