### PR TITLE
refactor(services/config_flow): consolidate service handlers and split config-flow validation

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -391,11 +391,7 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
                 return await self.async_step_confirm()
             errors.update(submit_errors)
 
-        return self.async_show_form(
-            step_id="user",
-            data_schema=self._build_connection_schema(user_input or {}),
-            errors=errors,
-        )
+        return self._show_connection_form(step_id="user", defaults=user_input or {}, errors=errors)
 
     async def async_step_reauth(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle reauthentication by collecting updated connection details."""
@@ -415,11 +411,7 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
         if should_initialize:
             self._tg_flow_reauth_entry_id = reauth_entry_id
             self._tg_flow_reauth_existing_data = reauth_defaults
-            return self.async_show_form(
-                step_id="reauth",
-                data_schema=self._build_connection_schema(reauth_defaults),
-                errors=errors,
-            )
+            return self._show_connection_form(step_id="reauth", defaults=reauth_defaults, errors=errors)
 
         if user_input is not None:
             info, submit_errors = await _process_reauth_submission_impl(
@@ -434,14 +426,26 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
                 return await self.async_step_reauth_confirm()
             errors.update(submit_errors)
 
-        return self.async_show_form(
+        return self._show_connection_form(
             step_id="reauth",
-            data_schema=self._build_connection_schema(
-                _build_reauth_form_defaults_impl(
-                    user_input=user_input,
-                    existing_data=self._tg_flow_reauth_existing_data,
-                )
+            defaults=_build_reauth_form_defaults_impl(
+                user_input=user_input,
+                existing_data=self._tg_flow_reauth_existing_data,
             ),
+            errors=errors,
+        )
+
+    def _show_connection_form(
+        self,
+        *,
+        step_id: str,
+        defaults: dict[str, Any],
+        errors: dict[str, str],
+    ) -> ConfigFlowResult:
+        """Render connection-input form for user and reauth steps."""
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=self._build_connection_schema(defaults),
             errors=errors,
         )
 

--- a/custom_components/thessla_green_modbus/config_flow_device_validation.py
+++ b/custom_components/thessla_green_modbus/config_flow_device_validation.py
@@ -140,6 +140,30 @@ async def _run_scanner_validation(
     return _validate_scan_result(await run_scanner_call(scanner.scan_device, timeout))
 
 
+async def _run_full_scan(
+    *,
+    scanner: Any,
+    params: dict[str, Any],
+    default_retry: int,
+    config_flow_backoff: float,
+    run_with_retry: Callable[[Callable[[], Awaitable[Any]], int, float], Awaitable[Any]],
+    call_with_optional_timeout: Callable[[Callable[[], Any], float], Awaitable[Any]],
+) -> dict[str, Any]:
+    """Run complete scanner validation scan for an existing scanner."""
+    run_scanner_call = _build_timeout_runner(
+        run_with_retry=run_with_retry,
+        call_with_optional_timeout=call_with_optional_timeout,
+        retries=default_retry,
+        backoff=config_flow_backoff,
+    )
+    scan_result = await _run_scanner_validation(
+        scanner=scanner,
+        timeout=params["timeout"],
+        run_scanner_call=run_scanner_call,
+    )
+    return scan_result
+
+
 async def _create_scanner(
     *,
     scanner_cls: Any,
@@ -309,17 +333,13 @@ async def validate_input_impl(
             config_flow_backoff=config_flow_backoff,
             run_with_retry=run_with_retry,
         )
-
-        run_scanner_call = _build_timeout_runner(
+        scan_result = await _run_full_scan(
+            scanner=scanner,
+            params=params,
+            default_retry=default_retry,
+            config_flow_backoff=config_flow_backoff,
             run_with_retry=run_with_retry,
             call_with_optional_timeout=call_with_optional_timeout,
-            retries=default_retry,
-            backoff=config_flow_backoff,
-        )
-        scan_result = await _run_scanner_validation(
-            scanner=scanner,
-            timeout=params["timeout"],
-            run_scanner_call=run_scanner_call,
         )
 
         return _build_validation_result(

--- a/custom_components/thessla_green_modbus/services_dispatch.py
+++ b/custom_components/thessla_green_modbus/services_dispatch.py
@@ -109,9 +109,7 @@ async def write_register_steps(
     Each step is ``(register_name, value, optional, error_message)``.
     Optional values are skipped when ``value`` is ``None``.
     """
-    for register_name, value, optional, error_message in steps:
-        if not _should_write_step(optional, value):
-            continue
+    for register_name, value, _optional, error_message in _iter_executable_steps(steps):
         if not await _perform_step_write(
             coordinator,
             register_name,
@@ -124,6 +122,15 @@ async def write_register_steps(
         ):
             return False
     return True
+
+
+def _iter_executable_steps(
+    steps: list[tuple[str, object, bool, str]],
+):
+    """Yield only write steps that should be executed."""
+    for register_name, value, optional, error_message in steps:
+        if _should_write_step(optional, value):
+            yield register_name, value, optional, error_message
 
 
 def _should_write_step(optional: bool, value: object) -> bool:

--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -31,6 +31,8 @@ from .services_validation import (
     reset_settings_registers,
 )
 
+ServiceAction = Callable[[str, object], Awaitable[bool]]
+
 
 def _to_bcd(value: int) -> int:
     return ((value // 10) << 4) | (value % 10)
@@ -118,11 +120,26 @@ async def _run_for_targets(
     hass: HomeAssistant,
     call: ServiceCall,
     deps: ServiceHandlerDeps,
-    action: Callable[[str, object], Awaitable[bool]],
+    action: ServiceAction,
 ) -> None:
     """Run a maintenance action for each targeted coordinator."""
     for entity_id, coordinator in _iter_targets(hass, call, deps):
         await action(entity_id, coordinator)
+
+
+async def _write_then_refresh(
+    *,
+    coordinator: object,
+    entity_id: str,
+    deps: ServiceHandlerDeps,
+    success_message: str,
+    success_args: tuple[object, ...],
+    write_flow: Callable[[], Awaitable[bool]],
+) -> bool:
+    """Execute target write flow and common refresh/success logging."""
+    if not await write_flow():
+        return False
+    return await _run_with_success_log(coordinator, deps, success_message, *success_args)
 
 
 def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
@@ -131,10 +148,20 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
     async def reset_filters(call: ServiceCall) -> None:
         filter_value = filter_reset_value(deps.normalize_option, call.data["filter_type"])
         async def _reset_filters_for_target(entity_id: str, coordinator: object) -> bool:
-            if not await deps.write_register(coordinator, "filter_change", filter_value, entity_id, "reset filters"):
-                deps.logger.error("Failed to reset filters for %s", entity_id)
-                return False
-            return await _run_with_success_log(coordinator, deps, "Reset filters for %s", entity_id)
+            async def _write_flow() -> bool:
+                if not await deps.write_register(coordinator, "filter_change", filter_value, entity_id, "reset filters"):
+                    deps.logger.error("Failed to reset filters for %s", entity_id)
+                    return False
+                return True
+
+            return await _write_then_refresh(
+                coordinator=coordinator,
+                entity_id=entity_id,
+                deps=deps,
+                success_message="Reset filters for %s",
+                success_args=(entity_id,),
+                write_flow=_write_flow,
+            )
 
         await _run_for_targets(hass, call, deps, _reset_filters_for_target)
 
@@ -143,20 +170,25 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
         registers = reset_settings_registers(reset_type)
 
         async def _reset_settings_for_target(entity_id: str, coordinator: object) -> bool:
-            if not await write_register_batch(
-                coordinator,
-                registers,
-                entity_id,
-                "reset settings",
-                deps.write_register,
-                deps.logger,
-                {
-                    "hard_reset_settings": "Failed to reset user settings for %s",
-                    "hard_reset_schedule": "Failed to reset schedule settings for %s",
-                },
-            ):
-                return False
-            return await _run_with_success_log(coordinator, deps, "Reset settings (%s) for %s", reset_type, entity_id)
+            return await _write_then_refresh(
+                coordinator=coordinator,
+                entity_id=entity_id,
+                deps=deps,
+                success_message="Reset settings (%s) for %s",
+                success_args=(reset_type, entity_id),
+                write_flow=lambda: write_register_batch(
+                    coordinator,
+                    registers,
+                    entity_id,
+                    "reset settings",
+                    deps.write_register,
+                    deps.logger,
+                    {
+                        "hard_reset_settings": "Failed to reset user settings for %s",
+                        "hard_reset_schedule": "Failed to reset schedule settings for %s",
+                    },
+                ),
+            )
 
         await _run_for_targets(hass, call, deps, _reset_settings_for_target)
 

--- a/custom_components/thessla_green_modbus/services_handlers_parameters.py
+++ b/custom_components/thessla_green_modbus/services_handlers_parameters.py
@@ -33,10 +33,15 @@ def _build_step_handler(
     """Create a parameter handler based on write steps."""
 
     async def _handler(call: ServiceCall) -> None:
-        steps = list(step_builder(call))
+        steps = _normalize_steps(step_builder(call))
         await _run_parameter_steps(hass, call, deps, steps, context, success_log)
 
     return _handler
+
+
+def _normalize_steps(steps: Sequence[WriteStep]) -> list[WriteStep]:
+    """Normalize a write-step sequence into a concrete list."""
+    return list(steps)
 
 
 def _parameter_registrations(


### PR DESCRIPTION
### Motivation

- Reduce duplicated write/refresh logic across maintenance and parameter service handlers to improve readability and maintainability.
- Isolate step filtering/normalization and scanner orchestration to make the service dispatch and config-flow device validation flows easier to reason about.
- Preserve runtime behaviour, service names/schemas, registration order, and config-flow user-visible semantics while enabling future decomposition.

### Description

- Introduces a typed action and a shared write+refresh helper (`ServiceAction`, `_write_then_refresh`) and reuses it in maintenance target flows to centralize common success logging and refresh behaviour in `services_handlers_maintenance.py`.
- Adds `_normalize_steps` to parameter handlers and changes handlers to normalize step sequences before execution in `services_handlers_parameters.py` while keeping registration and schemas unchanged.
- Extracts optional-step filtering into `_iter_executable_steps` and simplifies `write_register_steps` iteration in `services_dispatch.py` to separate decision logic from write execution.
- Splits scanner orchestration in config-flow validation by extracting `_run_full_scan` and consolidates connection form rendering into `_show_connection_form` in `config_flow_device_validation.py` and `config_flow.py` respectively, preserving exception mapping, scanner lifecycle closure, error keys and reauth/reconfigure flows.

### Testing

- Ran dependency check: `python - <<'PY'\nimport pydantic, pytest, homeassistant\nprint('dependency imports OK')\nPY` which succeeded. 
- Ran targeted and full test suites: `pytest -q tests/test_services*.py tests/test_services_handlers_*.py tests/test_config_flow*.py` and `pytest tests/ -q`, both completed successfully with all assertions passing (4 tests skipped as expected). 
- Ran static and project gates: `ruff check custom_components tests tools`, `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, and `python tools/validate_entity_mappings.py`, all of which passed.
- Confirmed service names/schemas and config-flow error/abort keys and behavior were not changed by the refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89825772c8326bd1387cfcf211907)