### PR TITLE
refactor: scanner bit-read & full-scan orchestration cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -105,6 +105,31 @@ def _build_register_chunks(scanner: Any, start: int, count: int) -> list[tuple[i
     )
 
 
+def _normalize_bit_read_request(
+    scanner: Any,
+    client_or_address: AsyncModbusTcpClient | AsyncModbusSerialClientType | int,
+    address_or_count: int,
+    count: int | None,
+) -> tuple[Any, int, int]:
+    """Normalize bit-read call signatures to (client, address, count)."""
+    if count is None:
+        return scanner._client, int(client_or_address), address_or_count
+    if isinstance(client_or_address, int):
+        return scanner._client, client_or_address, address_or_count
+    return client_or_address, address_or_count, count
+
+
+def _resolve_bit_read_client(scanner: Any, client: Any) -> Any:
+    """Prefer transport client when available for bit reads."""
+    if client is None:
+        raise ConnectionException("Modbus client is not connected")
+    if client is scanner._client and scanner._transport is not None:
+        fresh = getattr(scanner._transport, "client", None)
+        if fresh is not None:
+            return fresh
+    return client
+
+
 def _extend_or_abort_register_results(
     results: list[int], block: list[int] | None
 ) -> tuple[bool, list[int] | None]:
@@ -635,24 +660,10 @@ async def read_bit_registers(
     count: int | None = None,
 ) -> list[bool] | None:
     """Shared implementation for coil/discrete reads with retry and backoff."""
-    if count is None:
-        address = int(client_or_address)
-        count = address_or_count
-        client = scanner._client
-    elif isinstance(client_or_address, int):
-        address = client_or_address
-        count = address_or_count
-        client = scanner._client
-    else:
-        client = client_or_address
-        address = address_or_count
-
-    if client is None:
-        raise ConnectionException("Modbus client is not connected")
-    if client is scanner._client and scanner._transport is not None:
-        fresh = getattr(scanner._transport, "client", None)
-        if fresh is not None:
-            client = fresh
+    client, address, count = _normalize_bit_read_request(
+        scanner, client_or_address, address_or_count, count
+    )
+    client = _resolve_bit_read_client(scanner, client)
 
     for attempt in range(1, scanner.retry + 1):
         try:
@@ -668,8 +679,7 @@ async def read_bit_registers(
                 backoff=scanner.backoff,
                 backoff_jitter=scanner.backoff_jitter,
             )
-            normalized_bits = normalize_bit_read_result(response, count)
-            if normalized_bits is not None:
+            if (normalized_bits := normalize_bit_read_result(response, count)) is not None:
                 return normalized_bits
         except TimeoutError:
             _LOGGER.warning(

--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -164,6 +164,26 @@ async def run_full_scan(
                 unknown_registers=unknown_registers,
             )
 
+    async def _run_bit_phase(
+        max_addr: int, scan_key: str, function: int, read_fn: Any
+    ) -> None:
+        for start, count in _group_reads(range(max_addr + 1), max_block_size=scanner.effective_batch):
+            scanned_registers[scan_key] += count
+            data = await read_fn(start, count)
+            if data is None:
+                scanner.failed_addresses["modbus_exceptions"][scan_key].update(range(start, start + count))
+                continue
+            for offset, value in enumerate(data):
+                addr = start + offset
+                if (reg_name := scanner._registers.get(function, {}).get(addr)) is not None:
+                    names = scanner._alias_names(function, addr)
+                    if names:
+                        scanner.available_registers[scan_key].update(names)
+                    else:
+                        scanner.available_registers[scan_key].add(reg_name)
+                else:
+                    unknown_registers[scan_key][addr] = value
+
     await _run_word_phase(
         input_max,
         "input_registers",
@@ -181,53 +201,22 @@ async def run_full_scan(
         ),
     )
 
-    for start, count in _group_reads(range(coil_max + 1), max_block_size=scanner.effective_batch):
-        scanned_registers["coil_registers"] += count
-        coil_data = (
-            await scanner._read_coil(scanner._client, start, count)
-            if scanner._client is not None
-            else await scanner._read_coil(start, count)
-        )
-        if coil_data is None:
-            scanner.failed_addresses["modbus_exceptions"]["coil_registers"].update(
-                range(start, start + count)
-            )
-            continue
-        for offset, value in enumerate(coil_data):
-            addr = start + offset
-            if (reg_name := scanner._registers.get(1, {}).get(addr)) is not None:
-                names = scanner._alias_names(1, addr)
-                if names:
-                    scanner.available_registers["coil_registers"].update(names)
-                else:
-                    scanner.available_registers["coil_registers"].add(reg_name)
-            else:
-                unknown_registers["coil_registers"][addr] = value
-
-    for start, count in _group_reads(
-        range(discrete_max + 1), max_block_size=scanner.effective_batch
-    ):
-        scanned_registers["discrete_inputs"] += count
-        discrete_data = (
-            await scanner._read_discrete(scanner._client, start, count)
-            if scanner._client is not None
-            else await scanner._read_discrete(start, count)
-        )
-        if discrete_data is None:
-            scanner.failed_addresses["modbus_exceptions"]["discrete_inputs"].update(
-                range(start, start + count)
-            )
-            continue
-        for offset, value in enumerate(discrete_data):
-            addr = start + offset
-            if (reg_name := scanner._registers.get(2, {}).get(addr)) is not None:
-                names = scanner._alias_names(2, addr)
-                if names:
-                    scanner.available_registers["discrete_inputs"].update(names)
-                else:
-                    scanner.available_registers["discrete_inputs"].add(reg_name)
-            else:
-                unknown_registers["discrete_inputs"][addr] = value
+    await _run_bit_phase(
+        coil_max,
+        "coil_registers",
+        1,
+        lambda start, count: scanner._read_coil(scanner._client, start, count)
+        if scanner._client is not None
+        else scanner._read_coil(start, count),
+    )
+    await _run_bit_phase(
+        discrete_max,
+        "discrete_inputs",
+        2,
+        lambda start, count: scanner._read_discrete(scanner._client, start, count)
+        if scanner._client is not None
+        else scanner._read_discrete(start, count),
+    )
 
 
 async def scan(scanner: Any) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation
- Improve maintainability of the scanner I/O and orchestration code by extracting focused helpers and reducing duplicated loop logic while preserving runtime and retry semantics.
- Make the bit-read flow clearer and centralize full-scan bit-phase behavior so future phases of the planned large refactor are easier to complete.

### Description
- Extracted request normalization and client resolution helpers in `custom_components/thessla_green_modbus/scanner/io_read.py` as ` _normalize_bit_read_request` and `_resolve_bit_read_client` and simplified `read_bit_registers` to delegate signature handling and client refresh logic to these helpers.
- Introduced a reusable `_run_bit_phase` helper in `custom_components/thessla_green_modbus/scanner/orchestration.py` and refactored `run_full_scan` to call `_run_word_phase` and `_run_bit_phase`, consolidating coil/discrete iteration, failure marking, alias handling, and unknown-register capture.
- Preserved behavior: retry/backoff, unsupported-range and skip-cache logic, failure tracking, transport/client refresh, and logging semantics were kept unchanged; bit-phase handling was intentionally implemented separately to avoid a `KeyError` regression when reusing the word-path helper.
- Files modified: `custom_components/thessla_green_modbus/scanner/io_read.py`, `custom_components/thessla_green_modbus/scanner/orchestration.py`.

### Testing
- Ran the initial dependency import check with `python - <<'PY' ...` which printed `dependency imports OK`.
- Ran linters and static/maintainability checks with `ruff check`, `python -m compileall -q`, `python tools/compare_registers_with_reference.py`, and `python tools/check_maintainability.py` and they all passed.
- Ran targeted and full test suites with `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` and `pytest tests/ -q`, and all tests passed (expected skips remained unchanged).
- Ran `python tools/validate_entity_mappings.py` and `rg` checks used to confirm no Home Assistant imports or compatibility shims were introduced; these validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89815006c83269f1565ff63ae8e00)