### PR TITLE
refactor: extract connection lifecycle and write-path orchestration from coordinator

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/connection_lifecycle.py
+++ b/custom_components/thessla_green_modbus/coordinator/connection_lifecycle.py
@@ -1,0 +1,49 @@
+"""Connection lifecycle orchestration for coordinator runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ..modbus_exceptions import ConnectionException, ModbusException
+
+
+async def ensure_connected_lifecycle(
+    coordinator: Any,
+    *,
+    ensure_connected_runtime_fn: Callable[..., Any],
+    reconnect_client_if_needed_fn: Callable[..., Any],
+    ensure_transport_selected_fn_factory: Callable[[], Callable[..., Any]],
+    connect_transport_or_client_fn: Callable[..., Any],
+    mark_connection_established_fn: Callable[[], None],
+    mark_connection_failure_fn: Callable[[], None],
+    logger: Any,
+) -> None:
+    """Drive connection establishment and state updates for coordinator."""
+    async with coordinator._client_lock:
+        try:
+            transport, client, selected_mode = await ensure_connected_runtime_fn(
+                current_transport=coordinator._transport,
+                current_client=coordinator.client,
+                reconnect_client_if_needed_fn=reconnect_client_if_needed_fn,
+                disconnect_locked_fn=coordinator._disconnect_locked,
+                get_runtime_state_fn=lambda: (coordinator._transport, coordinator.client),
+                ensure_transport_selected_fn=ensure_transport_selected_fn_factory(),
+                connect_transport_or_client_fn=connect_transport_or_client_fn,
+                mark_connection_established_fn=mark_connection_established_fn,
+                mark_connection_failure_fn=mark_connection_failure_fn,
+                logger=logger,
+            )
+            coordinator._transport = transport
+            coordinator.client = client
+            if selected_mode is not None:
+                coordinator._resolved_connection_mode = selected_mode
+        except (ModbusException, ConnectionException) as exc:
+            logger.exception("Failed to establish connection: %s", exc)
+            raise
+        except TimeoutError as exc:
+            logger.warning("Connection attempt timed out: %s", exc)
+            raise
+        except OSError as exc:
+            logger.exception("Unexpected error establishing connection: %s", exc)
+            raise

--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -81,7 +81,7 @@ from ..coordinator_state import (
 from ..coordinator_state import normalize_serial_settings as _normalize_serial_settings_impl
 from ..coordinator_state import resolve_effective_batch as _resolve_effective_batch_impl
 from ..errors import CannotConnect
-from ..modbus_exceptions import ConnectionException, ModbusException
+from ..modbus_exceptions import ConnectionException
 from ..modbus_helpers import group_reads
 from ..modbus_transport import (
     BaseModbusTransport,
@@ -119,6 +119,7 @@ from .connection import (
 from .connection import (
     setup_client_with_retry as _setup_client_with_retry_impl,
 )
+from .connection_lifecycle import ensure_connected_lifecycle as _ensure_connected_lifecycle_impl
 from .connection_state import (
     mark_connection_disconnected as _mark_connection_disconnected_impl,
 )
@@ -664,74 +665,61 @@ class ThesslaGreenModbusCoordinator(
     async def _ensure_connected(self) -> None:
         """Ensure Modbus connection is established using the shared client."""
 
-        async with self._client_lock:
-            parity = SERIAL_PARITY_MAP.get(self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
-            stop_bits = SERIAL_STOP_BITS_MAP.get(
-                self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
-            )
-            try:
-                transport, client, selected_mode = await _ensure_connected_runtime_impl(
-                    current_transport=self._transport,
-                    current_client=self.client,
-                    reconnect_client_if_needed_fn=_reconnect_client_if_needed_impl,
-                    disconnect_locked_fn=self._disconnect_locked,
-                    get_runtime_state_fn=lambda: (self._transport, self.client),
-                    ensure_transport_selected_fn=lambda: _ensure_transport_selected_impl(
-                        current_transport=self._transport,
-                        connection_type=self.config.connection_type,
-                        connection_mode=self.config.connection_mode,
-                        host=self.config.host,
-                        port=self.config.port,
-                        serial_port=self.config.serial_port,
-                        baudrate=self.config.baud_rate,
-                        parity=parity,
-                        stopbits=stop_bits,
-                        retry=self.retry,
-                        backoff=self.backoff,
-                        max_backoff=DEFAULT_MAX_BACKOFF,
-                        timeout=self.timeout,
-                        offline_state=self.offline_state,
-                        connection_type_rtu=CONNECTION_TYPE_RTU,
-                        connection_mode_auto=CONNECTION_MODE_AUTO,
-                        connection_mode_tcp=CONNECTION_MODE_TCP,
-                        build_rtu_transport_fn=_build_rtu_transport_impl,
-                        build_tcp_transport_fn=self._build_tcp_transport,
-                        select_auto_transport_fn=lambda: _select_auto_transport_impl(
-                            resolved_connection_mode=self._resolved_connection_mode,
-                            build_tcp_transport=self._build_tcp_transport,
-                            try_direct_client_connect=lambda allow_parameterless_ctor: self._try_direct_client_connect(
-                                allow_parameterless_ctor=allow_parameterless_ctor
-                            ),
-                            port=self.config.port,
-                            timeout=self.timeout,
-                            slave_id=self.config.slave_id,
-                            host=self.config.host,
-                            logger=_LOGGER,
-                        ),
+        parity = SERIAL_PARITY_MAP.get(self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
+        stop_bits = SERIAL_STOP_BITS_MAP.get(
+            self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
+        )
+
+        def _ensure_transport_selected() -> Any:
+            return lambda: _ensure_transport_selected_impl(
+                current_transport=self._transport,
+                connection_type=self.config.connection_type,
+                connection_mode=self.config.connection_mode,
+                host=self.config.host,
+                port=self.config.port,
+                serial_port=self.config.serial_port,
+                baudrate=self.config.baud_rate,
+                parity=parity,
+                stopbits=stop_bits,
+                retry=self.retry,
+                backoff=self.backoff,
+                max_backoff=DEFAULT_MAX_BACKOFF,
+                timeout=self.timeout,
+                offline_state=self.offline_state,
+                connection_type_rtu=CONNECTION_TYPE_RTU,
+                connection_mode_auto=CONNECTION_MODE_AUTO,
+                connection_mode_tcp=CONNECTION_MODE_TCP,
+                build_rtu_transport_fn=_build_rtu_transport_impl,
+                build_tcp_transport_fn=self._build_tcp_transport,
+                select_auto_transport_fn=lambda: _select_auto_transport_impl(
+                    resolved_connection_mode=self._resolved_connection_mode,
+                    build_tcp_transport=self._build_tcp_transport,
+                    try_direct_client_connect=lambda allow_parameterless_ctor: self._try_direct_client_connect(
+                        allow_parameterless_ctor=allow_parameterless_ctor
                     ),
-                    connect_transport_or_client_fn=_connect_transport_or_client_impl,
-                    mark_connection_established_fn=lambda: _mark_connection_established_impl(
-                        offline_state_setter=lambda value: setattr(self, "offline_state", value)
-                    ),
-                    mark_connection_failure_fn=lambda: _mark_connection_failure_impl(
-                        statistics=self.statistics,
-                        offline_state_setter=lambda value: setattr(self, "offline_state", value),
-                    ),
+                    port=self.config.port,
+                    timeout=self.timeout,
+                    slave_id=self.config.slave_id,
+                    host=self.config.host,
                     logger=_LOGGER,
-                )
-                self._transport = transport
-                self.client = client
-                if selected_mode is not None:
-                    self._resolved_connection_mode = selected_mode
-            except (ModbusException, ConnectionException) as exc:
-                _LOGGER.exception("Failed to establish connection: %s", exc)
-                raise
-            except TimeoutError as exc:
-                _LOGGER.warning("Connection attempt timed out: %s", exc)
-                raise
-            except OSError as exc:
-                _LOGGER.exception("Unexpected error establishing connection: %s", exc)
-                raise
+                ),
+            )
+
+        await _ensure_connected_lifecycle_impl(
+            self,
+            ensure_connected_runtime_fn=_ensure_connected_runtime_impl,
+            reconnect_client_if_needed_fn=_reconnect_client_if_needed_impl,
+            ensure_transport_selected_fn_factory=_ensure_transport_selected,
+            connect_transport_or_client_fn=_connect_transport_or_client_impl,
+            mark_connection_established_fn=lambda: _mark_connection_established_impl(
+                offline_state_setter=lambda value: setattr(self, "offline_state", value)
+            ),
+            mark_connection_failure_fn=lambda: _mark_connection_failure_impl(
+                statistics=self.statistics,
+                offline_state_setter=lambda value: setattr(self, "offline_state", value),
+            ),
+            logger=_LOGGER,
+        )
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the device with optimized batch reading.

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -10,6 +10,7 @@ from ..const import MAX_REGS_PER_REQUEST
 from ..modbus_exceptions import ConnectionException, ModbusException
 from ..modbus_helpers import chunk_register_values
 from ..registers import REG_TEMPORARY_FLOW_START, REG_TEMPORARY_TEMP_START
+from .write_path import SingleWritePlan, run_single_write_attempts
 
 if TYPE_CHECKING:
     from ..modbus_transport import BaseModbusTransport
@@ -380,7 +381,6 @@ class _CoordinatorScheduleMixin:
         refresh_after_write = False
         async with self._write_lock:
             try:
-                original_value = value
                 definition = self._resolve_write_definition(register_name)
                 if definition is None:
                     return False
@@ -394,49 +394,18 @@ class _CoordinatorScheduleMixin:
                 if encoded_values is None and scalar_value is None:
                     return False
 
-                address = definition.address + offset
-
-                for attempt in range(1, self.retry + 1):
-                    try:
-                        response, success = await self._execute_single_register_write_attempt(
-                            definition=definition,
-                            register_name=register_name,
-                            address=address,
-                            encoded_values=encoded_values,
-                            scalar_value=scalar_value,
-                            attempt=attempt,
-                        )
-                        if not success:
-                            should_retry = self._handle_write_response_failure(
-                                is_final_attempt=attempt == self.retry,
-                                final_error_message="Error writing to register %s: %s",
-                                retry_message=f"Retrying write to register {register_name}",
-                                error_args=(register_name, response),
-                            )
-                            if not should_retry:
-                                return False
-                            continue
-
-                        refresh_after_write = self._handle_successful_single_register_write(
-                            register_name=register_name,
-                            original_value=original_value,
-                            refresh=refresh,
-                        )
-                        break
-                    except (ModbusException, ConnectionException, TimeoutError, OSError) as exc:
-                        should_retry = await self._handle_write_attempt_exception(
-                            register_name=register_name,
-                            attempt=attempt,
-                            exc=exc,
-                            timed_out_message="Writing register %s timed out (attempt %d/%d)",
-                            persistent_timeout_message="Persistent timeout writing register %s",
-                            failed_message="Failed to write register %s",
-                            retry_message="Retrying write to register %s after error: %s",
-                            unexpected_message="Unexpected error writing register %s",
-                        )
-                        if not should_retry:
-                            return False
-                        continue
+                plan = SingleWritePlan(
+                    register_name=register_name,
+                    address=definition.address + offset,
+                    encoded_values=encoded_values,
+                    scalar_value=scalar_value,
+                    original_value=value,
+                )
+                success, refresh_after_write = await run_single_write_attempts(
+                    self, definition, plan, refresh
+                )
+                if not success:
+                    return False
 
             except (ModbusException, ConnectionException):  # pragma: no cover - safety
                 _LOGGER.exception("Failed to write register %s", register_name)

--- a/custom_components/thessla_green_modbus/coordinator/write_path.py
+++ b/custom_components/thessla_green_modbus/coordinator/write_path.py
@@ -1,0 +1,64 @@
+"""Write-path orchestration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..modbus_exceptions import ConnectionException, ModbusException
+
+
+@dataclass(slots=True)
+class SingleWritePlan:
+    register_name: str
+    address: int
+    encoded_values: list[int] | None
+    scalar_value: Any
+    original_value: float | str | list[int] | tuple[int, ...]
+
+
+async def run_single_write_attempts(coordinator: Any, definition: Any, plan: SingleWritePlan, refresh: bool) -> tuple[bool, bool]:
+    """Execute retry loop for single-register write."""
+    refresh_after_write = False
+    for attempt in range(1, coordinator.retry + 1):
+        try:
+            response, success = await coordinator._execute_single_register_write_attempt(
+                definition=definition,
+                register_name=plan.register_name,
+                address=plan.address,
+                encoded_values=plan.encoded_values,
+                scalar_value=plan.scalar_value,
+                attempt=attempt,
+            )
+            if not success:
+                should_retry = coordinator._handle_write_response_failure(
+                    is_final_attempt=attempt == coordinator.retry,
+                    final_error_message="Error writing to register %s: %s",
+                    retry_message=f"Retrying write to register {plan.register_name}",
+                    error_args=(plan.register_name, response),
+                )
+                if not should_retry:
+                    return False, False
+                continue
+
+            refresh_after_write = coordinator._handle_successful_single_register_write(
+                register_name=plan.register_name,
+                original_value=plan.original_value,
+                refresh=refresh,
+            )
+            break
+        except (ModbusException, ConnectionException, TimeoutError, OSError) as exc:
+            should_retry = await coordinator._handle_write_attempt_exception(
+                register_name=plan.register_name,
+                attempt=attempt,
+                exc=exc,
+                timed_out_message="Writing register %s timed out (attempt %d/%d)",
+                persistent_timeout_message="Persistent timeout writing register %s",
+                failed_message="Failed to write register %s",
+                retry_message="Retrying write to register %s after error: %s",
+                unexpected_message="Unexpected error writing register %s",
+            )
+            if not should_retry:
+                return False, False
+            continue
+    return True, refresh_after_write


### PR DESCRIPTION
### Motivation
- Reduce the size and cognitive load of the main coordinator implementation by moving cohesive responsibilities into dedicated modules.  
- Improve maintainability of connection lifecycle and write retry logic without changing runtime semantics or the public coordinator API.  
- Prepare the codebase for further phased refactors (schedule, capabilities, retry/update) by isolating distinct concerns.  

### Description
- Extracted connection lifecycle orchestration from `ThesslaGreenModbusCoordinator._ensure_connected` into a new implementation module `custom_components/thessla_green_modbus/coordinator/connection_lifecycle.py`, preserving locking, state updates, and exception handling.  
- Moved single-register write retry orchestration into a new `custom_components/thessla_green_modbus/coordinator/write_path.py` module, introducing a `SingleWritePlan` dataclass and `run_single_write_attempts` helper to own retry loops and error handling.  
- Simplified `async_write_register` in `custom_components/thessla_green_modbus/coordinator/schedule.py` to prepare a `SingleWritePlan` and delegate execution to the new helper while preserving `_write_lock`, refresh-after-write semantics, and all logging/exception behavior.  
- Updated `custom_components/thessla_green_modbus/coordinator/coordinator.py` to use the extracted lifecycle helper and kept the package-root API unchanged (`CoordinatorConfig`, `ThesslaGreenModbusCoordinator`).  

### Testing
- Ran dependency import check and installed dev requirements when needed; imports succeeded.  
- Ran targeted and full automated validation: `ruff check`, `python -m compileall`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, targeted coordinator tests (`pytest -q tests/test_coordinator*.py tests/test_api_contracts.py tests/test_error_contract.py tests/unit/test_errors.py`) and the full test suite (`pytest tests/ -q`), and `python tools/validate_entity_mappings.py`, all of which completed successfully (test suite passed with the existing expected skips).  
- Verified coordinator package API invariant script (`__all__` contains only `CoordinatorConfig` and `ThesslaGreenModbusCoordinator`) and ran the requested AST/metrics checks; results indicate reduced sizes for the edited modules and no regressions in automated gates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8980d99648326ac5b96c3ff7134eb)