### PR TITLE
docs: refresh final maintainability audit

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -7,17 +7,17 @@ Date: 2026-05-04
 Executed:
 
 - `python -m pip install -q -r requirements-dev.txt` *(passed; pip warning about root user and pip upgrade notice)*
-- `ruff check custom_components tests tools` *(passed)*
-- `ruff check --select I custom_components tests tools` *(passed)*
-- `ruff format --check custom_components tests tools || true` *(informational; failed with `108 files would be reformatted`)*
+- `ruff check custom_components tests tools` *(failed; `F811` duplicate `register_maintenance_services` + `F821` undefined `_build_reset_filters_handler` in `services_handlers_maintenance.py`)*
+- `ruff check --select I custom_components tests tools` *(not executed because the required `ruff check` gate already failed in this run)*
+- `ruff format --check custom_components tests tools || true` *(not executed in this run due to earlier lint failure; latest documented drift from previous audit remains `108 files would be reformatted`)*
 - `python -m compileall -q custom_components/thessla_green_modbus tests tools` *(passed)*
 - `python tools/compare_registers_with_reference.py` *(passed; informational output: 62 extras and 242 name mismatches)*
 - `python tools/check_maintainability.py` *(passed; `Maintainability gate passed.`)*
-- `pytest tests/ -q` *(passed; 4 skipped)*
+- `pytest tests/ -q` *(failed; 69 failures, 1801 passed, 4 skipped; dominant failure: `NameError: _build_reset_filters_handler`)*
 - `python tools/validate_entity_mappings.py` *(passed; `OK: 366 entities validated`)*
 - `find custom_components/thessla_green_modbus -maxdepth 2 -name "coordinator.py" -print` *(informational; found only `coordinator/coordinator.py`, i.e. package implementation module)*
 - `rg "from homeassistant|import homeassistant" custom_components/thessla_green_modbus/core custom_components/thessla_green_modbus/transport custom_components/thessla_green_modbus/registers custom_components/thessla_green_modbus/scanner || true` *(passed; no matches)*
-- `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs || true` *(informational; matches include policy/docs/tests text plus known legacy-compat references outside the forbidden invariants)*
+- `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs || true` *(informational; matches include policy/docs/tests text plus known compatibility references and shim usage in production code paths)*
 
 ## 1) Current CI gates
 
@@ -27,101 +27,106 @@ Current required CI workflow gates remain:
 2. **Test gate**: `pytest --cov --cov-report=xml --cov-report=term -q` (+ coverage upload).
 3. **Entity mappings gate**: `python tools/validate_entity_mappings.py`.
 
+Current status from this audit run:
+
+- Required lint gate: **failing** (ruff check failure).
+- Required test gate: **failing** (pytest failures).
+- Required entity-mappings gate: **passing**.
+- Maintainability script: **passing**.
+
 Non-required tools status in this audit window:
 
 - `black`: not configured as a required gate.
 - `isort`: not configured as a required gate.
 - `mypy`: not configured as a required gate.
 - `hassfest`: not configured as a required gate.
-- HACS validation: not configured as a required gate.
+- HACS validation: not configured as a required gate and not executed in this run.
 
 ## 2) Fresh metrics snapshot
 
 ### Largest files (non-empty lines)
 
-1. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (711)
-2. `custom_components/thessla_green_modbus/scanner/io_read.py` (684)
-3. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` (514)
-4. `custom_components/thessla_green_modbus/coordinator/schedule.py` (503)
-5. `tests/test_coordinator.py` (502)
-6. `custom_components/thessla_green_modbus/modbus_helpers.py` (498)
-7. `custom_components/thessla_green_modbus/scanner/core.py` (470)
-8. `custom_components/thessla_green_modbus/mappings/_static_discrete.py` (438)
-9. `custom_components/thessla_green_modbus/config_flow.py` (432)
-10. `tests/test_register_loader.py` (402)
+1. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (697)
+2. `custom_components/thessla_green_modbus/scanner/io_read.py` (691)
+3. `tests/test_coordinator.py` (502)
+4. `custom_components/thessla_green_modbus/modbus_helpers.py` (498)
+5. `custom_components/thessla_green_modbus/coordinator/schedule.py` (474)
+6. `custom_components/thessla_green_modbus/scanner/core.py` (470)
+7. `custom_components/thessla_green_modbus/mappings/_static_discrete.py` (438)
+8. `custom_components/thessla_green_modbus/config_flow.py` (435)
+9. `tests/test_register_loader.py` (402)
+10. `tools/translate_register_descriptions.py` (397)
 
 ### Largest classes (AST span)
 
-1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (625)
-2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (528)
+1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (612)
+2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (496)
 3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (441)
 4. `RawRtuOverTcpTransport` in `modbus_transport_raw.py` (334)
 5. `RegisterDef` in `registers/register_def.py` (268)
 6. `ThesslaGreenFan` in `fan.py` (249)
-7. `_CoordinatorCapabilitiesMixin` in `coordinator/capabilities.py` (223)
-8. `ConfigFlow` in `config_flow.py` (221)
+7. `ConfigFlow` in `config_flow.py` (225)
+8. `_CoordinatorCapabilitiesMixin` in `coordinator/capabilities.py` (223)
 9. `BaseModbusTransport` in `modbus_transport_base.py` (210)
 10. `ThesslaGreenBinarySensor` in `binary_sensor.py` (175)
 
 ### Largest functions (AST span)
 
-1. `register_maintenance_services` in `services_handlers_maintenance.py` (128)
-2. `validate_input_impl` in `config_flow_device_validation.py` (111)
-3. `_call_modbus` in `modbus_helpers.py` (106)
-4. `read_input_registers_optimized` in `_coordinator_read_batches.py` (100)
-5. `async_setup_entry` in `sensor.py` (98)
-6. `read_bit_registers` in `scanner/io_read.py` (94)
-7. `run_full_scan` in `scanner/orchestration.py` (91)
-8. `scan` in `scanner/orchestration.py` (83)
-9. `_extend_entity_mappings_from_registers` in `mappings/_mapping_builders.py` (83)
-10. `async_write_register` in `coordinator/schedule.py` (81)
+1. `test_force_full_register_list_integration` in `tests/test_force_full_register_list_integration.py` (110)
+2. `test_migrate_entity_unique_ids` in `tests/test_entity_unique_id.py` (107)
+3. `migrate_unique_id` in `custom_components/thessla_green_modbus/unique_id_migration.py` (107)
+4. `_call_modbus` in `custom_components/thessla_green_modbus/modbus_helpers.py` (106)
+5. `test_reauth_flow_success` in `tests/test_config_flow_reauth.py` (105)
+6. `validate_optimization_metrics` in `tests/run_optimization_tests.py` (104)
+7. `run` in `tests/test_force_full_register_list_integration.py` (103)
+8. `test_entity_counts_per_platform` in `tests/test_all_entity_creation.py` (100)
+9. `read_input_registers_optimized` in `custom_components/thessla_green_modbus/_coordinator_read_batches.py` (100)
+10. `register_maintenance_services` in `custom_components/thessla_green_modbus/services_handlers_maintenance.py` (98)
 
-## 3) Completed refactor batch status
+## 3) Completed refactor/cleanup batch status
 
-The latest cleanup batch is reflected in current structure and checks (maintainability + full tests + entity mapping validation all pass). The previously tracked cleanup items (#1492-#1501 in project history) remain consistent with current codebase shape, and no rollback indicators were found in this audit run.
+No additional cleanup batch was completed in this audit run. Repository state currently shows regressions in service-handler wiring (`register_maintenance_services`) that block required lint/test gates, so this is not a “post-cleanup-green” snapshot.
 
 ## 4) Remaining production hotspots
 
 1. `coordinator/coordinator.py` and `_CoordinatorScheduleMixin` remain the largest coordinator hotspots.
 2. Scanner path still concentrates complexity in `scanner/io_read.py` and `scanner/core.py`.
-3. Mapping composition remains concentrated in `mappings/_mapping_builders.py`.
-4. `config_flow.py` + `config_flow_device_validation.py` still carry large flow/validation paths.
-5. Service registration remains top-heavy in `register_maintenance_services`.
+3. Service handling currently has a correctness regression in `services_handlers_maintenance.py` (duplicate function definition + missing handler symbol).
+4. Mapping composition remains concentrated in `mappings/_mapping_builders.py` and static mapping modules.
+5. `config_flow.py` + `config_flow_device_validation.py` still carry large flow/validation paths.
 
 ## 5) Remaining test hotspots
 
-Largest tests by file size still include `tests/test_coordinator.py`, `tests/test_register_loader.py`, and other large scanner/config-flow suites. Next cleanup should continue splitting broad integration-heavy files into narrower behavior-focused suites.
+1. `tests/test_coordinator.py` and `tests/test_register_loader.py` remain large files.
+2. Service-handler suites currently expose the dominant breakage surface (69 failures in this run) and should be stabilized before any further structural test splitting.
 
 ## 6) Next recommended PRs
 
-1. Split coordinator update-cycle and lifecycle orchestration out of `coordinator/coordinator.py`.
-2. Extract grouped-read planning/error normalization helpers from `scanner/io_read.py`.
-3. Decompose `_mapping_builders.py` by domain/entity family.
-4. Isolate config-flow runtime validation branches from `validate_input_impl`.
-5. Split `register_maintenance_services` into schema wiring, handler factories, and registration loops.
-6. Break large coordinator/scanner tests into focused sub-suites mirroring production-module boundaries.
+1. **Fix-forward PR (highest priority):** restore single authoritative `register_maintenance_services` implementation and missing handler symbol wiring so ruff + pytest return green.
+2. After gate recovery, continue decomposition PRs for coordinator/scanner/mapping-builder/config-flow hotspots.
+3. Keep optional formatting-only PR (`ruff format`) isolated from functional cleanup.
 
 ## 7) CI hardening status
 
-- `ruff check`: **pass**.
-- `ruff import-order signal` (`ruff check --select I`): **pass**.
-- `ruff format drift count`: **108 files would be reformatted**.
+- `ruff check`: **fail**.
+- `ruff import-order signal` (`ruff check --select I`): **not executed in this run**.
+- `ruff format drift count`: **not refreshed in this run** (last known: 108 files would be reformatted).
 - `black`: **not a current required gate**.
 - `isort`: **not a current required gate**.
 - `mypy`: **not a current required gate**.
 - `hassfest`: **not a current required gate**.
-- `HACS`: **not a current required gate**.
+- `HACS`: **not a current required gate / not validated here**.
 
 ## 8) Preserved invariants (audit status)
 
 - No top-level `custom_components/thessla_green_modbus/coordinator.py` file.
 - No Home Assistant imports under `core/`, `transport/`, `registers/`, `scanner/`.
 - Entity mappings validation passes (`OK: 366 entities validated`).
-- Architectural policy still requires no compatibility shims/proxy modules/re-export-only modules; however, informational grep still reports compatibility-related references and shim code paths that should be addressed in follow-up cleanup PRs.
+- No new compatibility/proxy/re-export-only module was introduced in this audit task; informational grep still reports compatibility terms and existing shim references that should be handled in dedicated cleanup.
 
 ## 9) Readiness summary
 
-1. **Maintainability/refactor readiness**: good incremental progress; maintainability gate passes, but large hotspots remain.
-2. **CI readiness**: required gates are passing.
-3. **Release/HACS readiness**: not fully evidenced in this audit because hassfest/HACS checks are not active gates.
-4. **Real device validation status**: not proven by this document; compare script signals vendor-name mismatches/extras as informational and requires device/vendor confirmation.
+1. **Maintainability/refactor readiness**: maintainability script passes, but required lint/test gates are currently red due to service-handler regression.
+2. **CI readiness**: not ready (required gates not all green).
+3. **Release/HACS readiness**: not demonstrated by this run; HACS validation was not executed.
+4. **Real device validation status**: not demonstrated in this run; register-compare extras/name mismatches remain informational and require vendor/device confirmation.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -34,27 +34,29 @@ The following constraints remain active and must be preserved:
 - HA imports in `core/transport/registers/scanner`: **none detected**.
 - Entity mapping validation: **passes** (`OK: 366 entities validated`).
 - Maintainability gate: **passes**.
-- Full test suite (`pytest tests/ -q`): **passes** (4 skipped).
+- Full test suite (`pytest tests/ -q`): **fails** (69 failed, 1801 passed, 4 skipped).
+- Lint gate (`ruff check custom_components tests tools`): **fails** (`F811` + `F821` in `services_handlers_maintenance.py`).
 
 ## Latest cleanup-batch outcome
 
-- Maintained CI required gates currently pass (lint + tests + entity mappings).
-- Fresh metrics still identify coordinator/scanner/mapping-builder concentration as remaining hotspots.
-- Import-order lint signal is clean.
-- Formatting drift remains significant (`ruff format --check`: 108 files would be reformatted).
+- This audit run did **not** confirm a fully green post-cleanup state.
+- Regressions are currently concentrated in maintenance service registration (`register_maintenance_services` duplication / missing symbol), causing both lint and test failures.
+- Maintainability and entity-mapping checks remain green.
 
 ## Remaining hotspots (next PR queue)
 
-1. Coordinator decomposition (`coordinator/coordinator.py`, `coordinator/schedule.py`).
-2. Scanner read-path decomposition (`scanner/io_read.py`, `scanner/core.py`).
-3. Mapping builder decomposition (`mappings/_mapping_builders.py`).
-4. Config-flow validation branch extraction (`config_flow_device_validation.py`).
-5. Large test module splits (`tests/test_coordinator.py`, scanner/config-flow mega suites).
+1. **Gate-recovery first:** fix maintenance service registration regression so required CI gates are green again.
+2. Coordinator decomposition (`coordinator/coordinator.py`, `coordinator/schedule.py`).
+3. Scanner read-path decomposition (`scanner/io_read.py`, `scanner/core.py`).
+4. Mapping builder decomposition (`mappings/_mapping_builders.py`).
+5. Config-flow validation branch extraction (`config_flow_device_validation.py`).
+6. Large test module splits after gate recovery (`tests/test_coordinator.py`, scanner/config-flow suites).
 
 ## CI hardening status
 
 - Required now: `ruff check`, compileall, register-reference compare, maintainability check, pytest+coverage, entity mappings validation.
-- Informational/non-required now: `ruff check --select I` (clean), `ruff format --check` (drift present).
+- Current state in this audit: `compileall`, register compare, maintainability, entity mappings are green; `ruff check` and `pytest` are red.
+- Informational/non-required now: `ruff check --select I` (not re-run after lint failure), `ruff format --check` (drift not refreshed in this run; last known 108 files).
 - Not currently required: `black`, `isort`, `mypy`, `hassfest`, HACS validation.
 
 ## Documentation policy for refactor work


### PR DESCRIPTION
### Motivation

- Bring `docs/maintainability_audit.md` and `docs/refactor_status.md` up-to-date with the actual validation run performed on 2026-05-04 and record real gate status and metrics. 
- Record factual outcomes (lint/test regressions) so follow-up work can target the current highest-priority recovery items without changing production code.

### Description

- Updated `docs/maintainability_audit.md` to reflect the 2026-05-04 run results, including failing `ruff check` (`F811` duplicate `register_maintenance_services` and `F821` undefined `_build_reset_filters_handler`), failing `pytest` (69 failures), and preserved invariants such as coordinator package location and lack of HA imports in core/transport/registers/scanner. 
- Updated `docs/refactor_status.md` to align refactor/readiness status with the same run and to prioritise a gate-recovery PR to fix the maintenance service registration regression before further decomposition PRs. 
- This change is documentation-only; no production code, tests, or CI workflow files were modified. 
- Commit created: `3201427d` and an internal PR was created with title `docs: refresh final maintainability audit` containing this summary.

### Testing

- Executed `python -m pip install -q -r requirements-dev.txt`, which completed (with a pip root-user notice). 
- Executed `ruff check custom_components tests tools`, which failed due to `F811` (duplicate `register_maintenance_services`) and `F821` (undefined `_build_reset_filters_handler`) in `custom_components/thessla_green_modbus/services_handlers_maintenance.py`. 
- Executed `python -m compileall -q custom_components/thessla_green_modbus tests tools`, which passed. 
- Executed `python tools/compare_registers_with_reference.py`, which passed but reported `62` extra integration entries and `242` name mismatches (documented as informational). 
- Executed `python tools/check_maintainability.py`, which passed (`Maintainability gate passed.`). 
- Executed `pytest tests/ -q`, which failed with `69` failing tests, `1801` passed and `4` skipped, with the dominant failure originating from the maintenance services wiring (`NameError: _build_reset_filters_handler`). 
- Executed `python tools/validate_entity_mappings.py`, which passed (`OK: 366 entities validated`). 
- Invariant checks run: `find custom_components/thessla_green_modbus -maxdepth 2 -name "coordinator.py" -print` (no top-level `coordinator.py`), and `rg "from homeassistant|import homeassistant" ...` in `core/transport/registers/scanner` showed no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89b56aaac8326a3c19105e5a32641)