### PR TITLE
docs: refresh maintainability audit and refactor status (2026-05-04)

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -8,16 +8,16 @@ Executed:
 
 - `python -m pip install -q -r requirements-dev.txt` *(passed; pip warning about root user and pip upgrade notice)*
 - `ruff check custom_components tests tools` *(failed; `F811` duplicate `register_maintenance_services` + `F821` undefined `_build_reset_filters_handler` in `services_handlers_maintenance.py`)*
-- `ruff check --select I custom_components tests tools` *(not executed because the required `ruff check` gate already failed in this run)*
-- `ruff format --check custom_components tests tools || true` *(not executed in this run due to earlier lint failure; latest documented drift from previous audit remains `108 files would be reformatted`)*
+- `ruff check --select I custom_components tests tools` *(passed)*
+- `ruff format --check custom_components tests tools` *(failed informationally; **5 files would be reformatted**)*
 - `python -m compileall -q custom_components/thessla_green_modbus tests tools` *(passed)*
 - `python tools/compare_registers_with_reference.py` *(passed; informational output: 62 extras and 242 name mismatches)*
 - `python tools/check_maintainability.py` *(passed; `Maintainability gate passed.`)*
-- `pytest tests/ -q` *(failed; 69 failures, 1801 passed, 4 skipped; dominant failure: `NameError: _build_reset_filters_handler`)*
+- `pytest tests/ -q` *(failed; 69 failed, 1801 passed, 4 skipped, 3 errors; dominant issue: `NameError: _build_reset_filters_handler`)*
 - `python tools/validate_entity_mappings.py` *(passed; `OK: 366 entities validated`)*
 - `find custom_components/thessla_green_modbus -maxdepth 2 -name "coordinator.py" -print` *(informational; found only `coordinator/coordinator.py`, i.e. package implementation module)*
 - `rg "from homeassistant|import homeassistant" custom_components/thessla_green_modbus/core custom_components/thessla_green_modbus/transport custom_components/thessla_green_modbus/registers custom_components/thessla_green_modbus/scanner || true` *(passed; no matches)*
-- `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs || true` *(informational; matches include policy/docs/tests text plus known compatibility references and shim usage in production code paths)*
+- `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs || true` *(informational; matches include docs/policy/test text and existing known compatibility references in code)*
 
 ## 1) Current CI gates
 
@@ -29,8 +29,8 @@ Current required CI workflow gates remain:
 
 Current status from this audit run:
 
-- Required lint gate: **failing** (ruff check failure).
-- Required test gate: **failing** (pytest failures).
+- Required lint gate: **failing** (`ruff check` red).
+- Required test gate: **failing** (`pytest` red).
 - Required entity-mappings gate: **passing**.
 - Maintainability script: **passing**.
 
@@ -46,87 +46,95 @@ Non-required tools status in this audit window:
 
 ### Largest files (non-empty lines)
 
-1. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (697)
-2. `custom_components/thessla_green_modbus/scanner/io_read.py` (691)
+1. `custom_components/thessla_green_modbus/scanner/io_read.py` (713)
+2. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (697)
 3. `tests/test_coordinator.py` (502)
 4. `custom_components/thessla_green_modbus/modbus_helpers.py` (498)
-5. `custom_components/thessla_green_modbus/coordinator/schedule.py` (474)
+5. `custom_components/thessla_green_modbus/coordinator/schedule.py` (472)
 6. `custom_components/thessla_green_modbus/scanner/core.py` (470)
-7. `custom_components/thessla_green_modbus/mappings/_static_discrete.py` (438)
-8. `custom_components/thessla_green_modbus/config_flow.py` (435)
-9. `tests/test_register_loader.py` (402)
+7. `custom_components/thessla_green_modbus/mappings/_static_discrete.py` (444)
+8. `custom_components/thessla_green_modbus/config_flow.py` (437)
+9. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` (414)
 10. `tools/translate_register_descriptions.py` (397)
 
 ### Largest classes (AST span)
 
 1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (612)
-2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (496)
+2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (492)
 3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (441)
 4. `RawRtuOverTcpTransport` in `modbus_transport_raw.py` (334)
 5. `RegisterDef` in `registers/register_def.py` (268)
-6. `ThesslaGreenFan` in `fan.py` (249)
-7. `ConfigFlow` in `config_flow.py` (225)
-8. `_CoordinatorCapabilitiesMixin` in `coordinator/capabilities.py` (223)
+6. `ThesslaGreenFan` in `fan.py` (251)
+7. `_CoordinatorCapabilitiesMixin` in `coordinator/capabilities.py` (230)
+8. `ConfigFlow` in `config_flow.py` (227)
 9. `BaseModbusTransport` in `modbus_transport_base.py` (210)
-10. `ThesslaGreenBinarySensor` in `binary_sensor.py` (175)
+10. `ThesslaGreenClimate` in `climate.py` (183)
 
 ### Largest functions (AST span)
 
-1. `test_force_full_register_list_integration` in `tests/test_force_full_register_list_integration.py` (110)
-2. `test_migrate_entity_unique_ids` in `tests/test_entity_unique_id.py` (107)
-3. `migrate_unique_id` in `custom_components/thessla_green_modbus/unique_id_migration.py` (107)
-4. `_call_modbus` in `custom_components/thessla_green_modbus/modbus_helpers.py` (106)
-5. `test_reauth_flow_success` in `tests/test_config_flow_reauth.py` (105)
-6. `validate_optimization_metrics` in `tests/run_optimization_tests.py` (104)
-7. `run` in `tests/test_force_full_register_list_integration.py` (103)
-8. `test_entity_counts_per_platform` in `tests/test_all_entity_creation.py` (100)
-9. `read_input_registers_optimized` in `custom_components/thessla_green_modbus/_coordinator_read_batches.py` (100)
-10. `register_maintenance_services` in `custom_components/thessla_green_modbus/services_handlers_maintenance.py` (98)
+1. `register_maintenance_services` in `custom_components/thessla_green_modbus/services_handlers_maintenance.py` (111)
+2. `test_force_full_register_list_integration` in `tests/test_force_full_register_list_integration.py` (110)
+3. `test_migrate_entity_unique_ids` in `tests/test_entity_unique_id.py` (107)
+4. `migrate_unique_id` in `custom_components/thessla_green_modbus/unique_id_migration.py` (107)
+5. `_call_modbus` in `custom_components/thessla_green_modbus/modbus_helpers.py` (106)
+6. `test_reauth_flow_success` in `tests/test_config_flow_reauth.py` (105)
+7. `validate_optimization_metrics` in `tests/run_optimization_tests.py` (104)
+8. `run` in `tests/test_force_full_register_list_integration.py` (103)
+9. `test_entity_counts_per_platform` in `tests/test_all_entity_creation.py` (100)
+10. `read_input_registers_optimized` in `custom_components/thessla_green_modbus/_coordinator_read_batches.py` (100)
 
-## 3) Completed refactor/cleanup batch status
+## 3) Completed cleanup PRs from latest batch
 
-No additional cleanup batch was completed in this audit run. Repository state currently shows regressions in service-handler wiring (`register_maintenance_services`) that block required lint/test gates, so this is not a “post-cleanup-green” snapshot.
+Based on `CHANGELOG.md`, the latest explicitly documented cleanup batch entries are:
+
+- **2.7.0 — Dead fallback & pragma cleanup**
+- **2.6.0 — Dead fallback cleanup**
+- **2.5.1 — Config flow cleanup**
+
+This audit run does **not** add a new cleanup completion; it documents current post-batch state only.
 
 ## 4) Remaining production hotspots
 
-1. `coordinator/coordinator.py` and `_CoordinatorScheduleMixin` remain the largest coordinator hotspots.
-2. Scanner path still concentrates complexity in `scanner/io_read.py` and `scanner/core.py`.
-3. Service handling currently has a correctness regression in `services_handlers_maintenance.py` (duplicate function definition + missing handler symbol).
-4. Mapping composition remains concentrated in `mappings/_mapping_builders.py` and static mapping modules.
-5. `config_flow.py` + `config_flow_device_validation.py` still carry large flow/validation paths.
+1. `services_handlers_maintenance.py` is currently the primary correctness hotspot (duplicate function definition + missing symbol).
+2. `coordinator/coordinator.py` and `coordinator/schedule.py` remain the largest coordinator hotspots.
+3. Scanner complexity remains concentrated in `scanner/io_read.py` and `scanner/core.py`.
+4. Mapping assembly remains dense in `mappings/_mapping_builders.py`.
+5. Flow validation remains dense in `config_flow.py` and `config_flow_device_validation.py`.
 
 ## 5) Remaining test hotspots
 
-1. `tests/test_coordinator.py` and `tests/test_register_loader.py` remain large files.
-2. Service-handler suites currently expose the dominant breakage surface (69 failures in this run) and should be stabilized before any further structural test splitting.
+1. `tests/test_coordinator.py` remains a large integration-heavy test module.
+2. Service-handler test suites are the dominant current failure surface due to maintenance-handler regression.
+3. Register-loader error tests currently show 3 fixture errors (`registers` / `register` / `reg`).
 
 ## 6) Next recommended PRs
 
-1. **Fix-forward PR (highest priority):** restore single authoritative `register_maintenance_services` implementation and missing handler symbol wiring so ruff + pytest return green.
-2. After gate recovery, continue decomposition PRs for coordinator/scanner/mapping-builder/config-flow hotspots.
-3. Keep optional formatting-only PR (`ruff format`) isolated from functional cleanup.
+1. **Gate recovery PR (required first):** fix `services_handlers_maintenance.py` duplication/missing handler symbol, then re-run lint + tests.
+2. **Follow-up gate recovery PR:** resolve register-loader fixture wiring errors if still present after maintenance-handler fix.
+3. After green gates, continue targeted decomposition of coordinator/scanner/mappings/config-flow hotspots.
+4. Keep optional formatting-only PR (`ruff format`) isolated.
 
 ## 7) CI hardening status
 
 - `ruff check`: **fail**.
-- `ruff import-order signal` (`ruff check --select I`): **not executed in this run**.
-- `ruff format drift count`: **not refreshed in this run** (last known: 108 files would be reformatted).
-- `black`: **not a current required gate**.
-- `isort`: **not a current required gate**.
-- `mypy`: **not a current required gate**.
-- `hassfest`: **not a current required gate**.
-- `HACS`: **not a current required gate / not validated here**.
+- `ruff import-order` (`ruff check --select I`): **pass**.
+- `ruff format drift count`: **5 files** would be reformatted.
+- `black`: **not a required gate**.
+- `isort`: **not a required gate**.
+- `mypy`: **not a required gate**.
+- `hassfest`: **not a required gate**.
+- `HACS`: **not a required gate / not validated in this run**.
 
 ## 8) Preserved invariants (audit status)
 
 - No top-level `custom_components/thessla_green_modbus/coordinator.py` file.
 - No Home Assistant imports under `core/`, `transport/`, `registers/`, `scanner/`.
 - Entity mappings validation passes (`OK: 366 entities validated`).
-- No new compatibility/proxy/re-export-only module was introduced in this audit task; informational grep still reports compatibility terms and existing shim references that should be handled in dedicated cleanup.
+- No new compatibility/proxy/re-export-only module was introduced in this task (informational grep still returns existing references).
 
 ## 9) Readiness summary
 
-1. **Maintainability/refactor readiness**: maintainability script passes, but required lint/test gates are currently red due to service-handler regression.
-2. **CI readiness**: not ready (required gates not all green).
-3. **Release/HACS readiness**: not demonstrated by this run; HACS validation was not executed.
-4. **Real device validation status**: not demonstrated in this run; register-compare extras/name mismatches remain informational and require vendor/device confirmation.
+1. **Maintainability/refactor readiness**: maintainability script passes, but required lint/test gates are red.
+2. **CI readiness**: not ready (not all required gates are green).
+3. **Release/HACS readiness**: not demonstrated in this run; HACS validation not executed.
+4. **Real device validation status**: not demonstrated in this run; register compare extras/name mismatches are informational and still require vendor/device confirmation.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -34,29 +34,33 @@ The following constraints remain active and must be preserved:
 - HA imports in `core/transport/registers/scanner`: **none detected**.
 - Entity mapping validation: **passes** (`OK: 366 entities validated`).
 - Maintainability gate: **passes**.
-- Full test suite (`pytest tests/ -q`): **fails** (69 failed, 1801 passed, 4 skipped).
+- Full test suite (`pytest tests/ -q`): **fails** (69 failed, 1801 passed, 4 skipped, 3 errors).
 - Lint gate (`ruff check custom_components tests tools`): **fails** (`F811` + `F821` in `services_handlers_maintenance.py`).
 
 ## Latest cleanup-batch outcome
 
-- This audit run did **not** confirm a fully green post-cleanup state.
-- Regressions are currently concentrated in maintenance service registration (`register_maintenance_services` duplication / missing symbol), causing both lint and test failures.
-- Maintainability and entity-mapping checks remain green.
+Documented latest cleanup-oriented releases in `CHANGELOG.md`:
+
+- 2.7.0 — Dead fallback & pragma cleanup
+- 2.6.0 — Dead fallback cleanup
+- 2.5.1 — Config flow cleanup
+
+Current audit state is **not** fully green post-cleanup because required lint/test gates are red.
 
 ## Remaining hotspots (next PR queue)
 
-1. **Gate-recovery first:** fix maintenance service registration regression so required CI gates are green again.
-2. Coordinator decomposition (`coordinator/coordinator.py`, `coordinator/schedule.py`).
-3. Scanner read-path decomposition (`scanner/io_read.py`, `scanner/core.py`).
-4. Mapping builder decomposition (`mappings/_mapping_builders.py`).
-5. Config-flow validation branch extraction (`config_flow_device_validation.py`).
-6. Large test module splits after gate recovery (`tests/test_coordinator.py`, scanner/config-flow suites).
+1. **Gate-recovery first:** fix maintenance service registration regression (`register_maintenance_services` duplication and missing handler symbol).
+2. Resolve register-loader fixture errors in `tests/test_register_loader_errors.py` if still failing after step 1.
+3. Coordinator decomposition (`coordinator/coordinator.py`, `coordinator/schedule.py`).
+4. Scanner read-path decomposition (`scanner/io_read.py`, `scanner/core.py`).
+5. Mapping builder decomposition (`mappings/_mapping_builders.py`).
+6. Config-flow validation branch extraction (`config_flow_device_validation.py`).
 
 ## CI hardening status
 
 - Required now: `ruff check`, compileall, register-reference compare, maintainability check, pytest+coverage, entity mappings validation.
-- Current state in this audit: `compileall`, register compare, maintainability, entity mappings are green; `ruff check` and `pytest` are red.
-- Informational/non-required now: `ruff check --select I` (not re-run after lint failure), `ruff format --check` (drift not refreshed in this run; last known 108 files).
+- Current state in this audit: compileall, register compare, maintainability, entity mappings are green; `ruff check` and `pytest` are red.
+- Informational/non-required now: `ruff check --select I` is green; `ruff format --check` reports 5-file drift.
 - Not currently required: `black`, `isort`, `mypy`, `hassfest`, HACS validation.
 
 ## Documentation policy for refactor work


### PR DESCRIPTION
### Motivation
- Refresh the project's maintainability audit to reflect current validation outputs and metrics as of `2026-05-04` so stakeholders and contributors have an accurate snapshot of CI/test health. 
- Align `docs/refactor_status.md` with the refreshed audit and call out immediate gate-recovery work and next PR priorities.

### Description
- Updated `docs/maintainability_audit.md` to include the exact validation commands executed, their outcomes, up-to-date largest files/classes/functions metrics, preserved-invariants checks, CI gate statuses, and recommended next PRs. 
- Updated `docs/refactor_status.md` to mirror the audit results, list hard constraints and invariant verification, and enumerate the prioritized hotspot/PR queue (gate recovery first). 
- Documented factual, non-speculative items only (lint/test outcomes, format drift count, register-compare informational mismatches, maintainability script status, and entity mapping validation). 
- Changes are limited to documentation files and do not modify production code, tests, or CI workflows.

### Testing
- `python -m pip install -q -r requirements-dev.txt` executed successfully (with a root-user pip warning). 
- `ruff check custom_components tests tools` failed due to `F811` (duplicate `register_maintenance_services`) and `F821` (undefined `_build_reset_filters_handler`) in `services_handlers_maintenance.py`. 
- `ruff check --select I custom_components tests tools` passed (import-order checks succeeded). 
- `ruff format --check custom_components tests tools` reported a format drift of `5 files would be reformatted`. 
- `python -m compileall -q custom_components/thessla_green_modbus tests tools` passed. 
- `python tools/compare_registers_with_reference.py` passed but reported informational output (62 extras and 242 name mismatches). 
- `python tools/check_maintainability.py` passed (`Maintainability gate passed.`). 
- `pytest tests/ -q` failed (summary: 69 failed, 1801 passed, 4 skipped, 3 errors), with the dominant failure rooted in the maintenance service-handler regression. 
- `python tools/validate_entity_mappings.py` passed (`OK: 366 entities validated`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b5ae26748326820fc3a46b1c359d)