### PR TITLE
fix: restore maintenance service handler registration

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -144,9 +144,8 @@ async def _write_then_refresh(
     return await _run_with_success_log(coordinator, deps, success_message, *success_args)
 
 
-def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
-    """Register maintenance services."""
 
+def _build_reset_filters_handler(hass: HomeAssistant, deps: ServiceHandlerDeps):
     async def reset_filters(call: ServiceCall) -> None:
         filter_value = filter_reset_value(deps.normalize_option, call.data["filter_type"])
 
@@ -202,17 +201,6 @@ def _build_reset_settings_handler(hass: HomeAssistant, deps: ServiceHandlerDeps)
         await _run_for_targets(hass, call, deps, _reset_settings_for_target)
 
     return reset_settings
-
-
-async def _run_for_targets(
-    hass: HomeAssistant,
-    call: ServiceCall,
-    deps: ServiceHandlerDeps,
-    action: Callable[[str, object], Awaitable[bool]],
-) -> None:
-    """Run a maintenance action for each targeted coordinator."""
-    for entity_id, coordinator in _iter_targets(hass, call, deps):
-        await action(entity_id, coordinator)
 
 
 def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:


### PR DESCRIPTION
### Motivation

- A refactor left two `register_maintenance_services` definitions and removed the `_build_reset_filters_handler` factory, causing lint (`F811`/`F821`) and runtime `NameError` failures for maintenance service registration. This change restores the expected wiring with minimal surface area.

### Description

- Remove the stale duplicate `register_maintenance_services` implementation so only a single canonical implementation remains.
- Restore the `_build_reset_filters_handler(hass, deps)` factory and wire it into `register_maintenance_services` so the `reset_filters` binding resolves correctly.
- Remove the duplicate `_run_for_targets` definition and keep the single shared helper used by all handlers.
- Preserve the existing registration ordering and schema usage driven by `_maintenance_registrations()` and `_register_maintenance_bindings()`.

### Testing

- Ran `ruff check custom_components/thessla_green_modbus/services_handlers_maintenance.py tests/test_services_handlers_maintenance.py --fix` and `ruff check custom_components tests tools`; all checks passed.
- Ran `python -m compileall -q custom_components/thessla_green_modbus/services_handlers_maintenance.py tests/test_services_handlers_maintenance.py`; compilation passed.
- Attempted targeted `pytest -q tests/test_services*.py tests/test_services_handlers_*.py` but pytest was deferred locally due to missing `pydantic` (import error); no tests were modified in this PR.
- Ran the source invariant check asserting a single `def register_maintenance_services` and presence of `_build_reset_filters_handler`; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ea0566708326ab290b99987bf478)