### PR TITLE
test: restore register loader fixture wiring

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+pytest_plugins = ("tests.helpers_register_loader",)
+
+
 
 def _ensure_current_event_loop() -> asyncio.AbstractEventLoop:
     """Ensure a main-thread event loop exists for PHCC/pytest-asyncio startup.

--- a/tests/helpers_register_loader.py
+++ b/tests/helpers_register_loader.py
@@ -1,0 +1,92 @@
+"""Shared fixtures for split register-loader tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(
+    params=[
+        [
+            {"function": "01", "address_dec": 1, "name": "dup1", "access": "R"},
+            {"function": "01", "address_dec": 1, "name": "dup2", "access": "R"},
+        ],
+        [
+            {"function": "01", "address_dec": 1, "name": "dup", "access": "R"},
+            {"function": "02", "address_dec": 2, "name": "dup", "access": "R"},
+        ],
+    ]
+)
+def registers(request: pytest.FixtureRequest) -> list[dict]:
+    """Parameterized invalid register sets with duplicate addresses or names."""
+
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bad_len",
+            "access": "R",
+            "length": 1,
+            "extra": {"type": "u32"},
+        },
+        {
+            "function": "01",
+            "address_dec": 0,
+            "name": "bad_access",
+            "access": "RW",
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bad_bits",
+            "access": "R",
+            "bits": [{"name": "a"}],
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bad_string_len",
+            "access": "R",
+            "length": 0,
+            "extra": {"type": "string"},
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bad_bit_name",
+            "access": "R",
+            "extra": {"bitmask": 0b1},
+            "bits": [{"name": "BadName", "index": 0}],
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bit_index_out_of_range",
+            "access": "R",
+            "extra": {"bitmask": 65535},
+            "bits": [{"name": f"b{i}", "index": i} for i in range(17)],
+        },
+    ]
+)
+def register(request: pytest.FixtureRequest) -> dict:
+    """Parameterized invalid single-register definitions."""
+
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        {"description_en": "en"},
+        {"description": "pl"},
+        {"description": "", "description_en": "en"},
+        {"description": "pl", "description_en": ""},
+    ]
+)
+def reg(request: pytest.FixtureRequest) -> dict:
+    """Parameterized malformed description combinations."""
+
+    return request.param


### PR DESCRIPTION
### Motivation
- Splitting `tests/test_register_loader.py` removed the parameterized inputs that other split modules relied on, leaving fixtures `registers`, `register`, and `reg` unresolved during pytest discovery.
- Restore the original parameterized inputs as shared fixtures so the split tests can run without changing production behavior or test assertions.

### Description
- Added `tests/helpers_register_loader.py` containing the parameterized fixtures `registers`, `register`, and `reg` with the original test data.
- Exposed the helper fixtures to the test suite by registering `tests.helpers_register_loader` in `tests/conftest.py` via `pytest_plugins` so pytest discovers the fixtures across modules.
- Kept scope strictly to tests and preserved original parametrization and assertions; no production code, CI config, or docs were modified.
- Files changed: `tests/helpers_register_loader.py`, `tests/conftest.py`.

### Testing
- Ran `ruff check tests/test_register_loader*.py tests/helpers_register_loader.py tests/conftest.py --fix` and `ruff check ...` which completed and reported all checks passed.
- Ran `python -m compileall -q tests/test_register_loader*.py tests/helpers_register_loader.py tests/conftest.py` which succeeded with no syntax errors.
- Performed the dependency gate check using a small Python script that attempted to import `pydantic`, `pytest`, and `homeassistant`; pytest execution was deferred due to missing dependency: `No module named 'pydantic'`.
- Targeted pytest runs were therefore deferred in this environment; no production behavior was changed and the test-only invariant (changes limited to `tests/`) was satisfied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f99f10288326bd41ceff05de21c7)