### PR TITLE
style: clear remaining ruff format drift

### DIFF
--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -144,7 +144,6 @@ async def _write_then_refresh(
     return await _run_with_success_log(coordinator, deps, success_message, *success_args)
 
 
-
 def _build_reset_filters_handler(hass: HomeAssistant, deps: ServiceHandlerDeps):
     async def reset_filters(call: ServiceCall) -> None:
         filter_value = filter_reset_value(deps.normalize_option, call.data["filter_type"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import pytest
 pytest_plugins = ("tests.helpers_register_loader",)
 
 
-
 def _ensure_current_event_loop() -> asyncio.AbstractEventLoop:
     """Ensure a main-thread event loop exists for PHCC/pytest-asyncio startup.
 

--- a/tests/test_register_loader_basic.py
+++ b/tests/test_register_loader_basic.py
@@ -11,11 +11,16 @@ from custom_components.thessla_green_modbus.registers.register_def import Regist
 
 
 def _add_desc(reg: dict) -> dict:
-    return {**reg, "description": reg.get("description", "desc"), "description_en": reg.get("description_en", "desc")}
+    return {
+        **reg,
+        "description": reg.get("description", "desc"),
+        "description_en": reg.get("description_en", "desc"),
+    }
 
 
 def _write(path: Path, regs: list[dict]) -> None:
     path.write_text(json.dumps({"registers": [_add_desc(r) for r in regs]}))
+
 
 def test_example_register_mapping() -> None:
     """Verify example registers map to expected addresses."""
@@ -30,6 +35,7 @@ def test_example_register_mapping() -> None:
     assert addr("03", "mode") == 4208
     assert addr("04", "outside_temperature") == 16
 
+
 def test_enum_multiplier_resolution_handling() -> None:
     """Ensure optional register metadata is preserved."""
 
@@ -42,6 +48,7 @@ def test_enum_multiplier_resolution_handling() -> None:
     assert required.multiplier == 0.5
     assert required.resolution == 0.5
     assert required.decode(45) == 22.5
+
 
 def test_default_multiplier_resolution(tmp_path) -> None:
     """Omitted multiplier/resolution fields default to 1."""
@@ -59,6 +66,7 @@ def test_default_multiplier_resolution(tmp_path) -> None:
     loaded = load_registers_from_file(path)[0]
     assert loaded.multiplier == 1
     assert loaded.resolution == 1
+
 
 def test_multi_register_metadata() -> None:
     """Registers spanning multiple words expose length and type info."""
@@ -78,6 +86,7 @@ def test_multi_register_metadata() -> None:
     assert serial.length == 6
     assert serial.extra["encoding"] == "ascii"
 
+
 def test_decode_multi_register_string() -> None:
     """Multi-register strings decode without applying scaling."""
     reg = RegisterDef(
@@ -93,6 +102,7 @@ def test_decode_multi_register_string() -> None:
     raw = [16706, 17220, 17664]  # "ABCDE"
     assert reg.decode(raw) == "ABCDE"
 
+
 def test_decode_multi_register_string_with_non_ascii_bytes() -> None:
     """String decode should tolerate non-ASCII bytes without raising."""
     reg = RegisterDef(
@@ -105,6 +115,7 @@ def test_decode_multi_register_string_with_non_ascii_bytes() -> None:
     )
     raw = [0x5445, 0xDF00]  # "TE" + 0xDF + NUL
     assert reg.decode(raw) == "TE�"
+
 
 def test_decode_multi_register_number_scaled_once() -> None:
     """Numeric multi-register values apply multiplier/resolution exactly once."""
@@ -121,6 +132,7 @@ def test_decode_multi_register_number_scaled_once() -> None:
     raw = [0, 1]
     assert reg.decode(raw) == 10
 
+
 def test_decode_bitmask_ignores_scaling() -> None:
     """Bitmask registers return labels without scaling the raw value."""
     reg = RegisterDef(
@@ -134,6 +146,7 @@ def test_decode_bitmask_ignores_scaling() -> None:
         resolution=1,
     )
     assert reg.decode(5) == ["A", "C"]
+
 
 def test_function_aliases() -> None:
     """Aliases with spaces/underscores should resolve to correct functions."""

--- a/tests/test_register_loader_cache.py
+++ b/tests/test_register_loader_cache.py
@@ -12,11 +12,16 @@ from custom_components.thessla_green_modbus.registers.loader import (
 
 
 def _add_desc(reg: dict) -> dict:
-    return {**reg, "description": reg.get("description", "desc"), "description_en": reg.get("description_en", "desc")}
+    return {
+        **reg,
+        "description": reg.get("description", "desc"),
+        "description_en": reg.get("description_en", "desc"),
+    }
 
 
 def _write(path: Path, regs: list[dict]) -> None:
     path.write_text(json.dumps({"registers": [_add_desc(r) for r in regs]}))
+
 
 def test_register_cache_invalidation(tmp_path, monkeypatch) -> None:
     """Ensure register file caching and invalidation behave correctly."""
@@ -63,6 +68,7 @@ def test_register_cache_invalidation(tmp_path, monkeypatch) -> None:
     assert hash_calls == 2
     assert hash_before != hash_after
 
+
 def test_registers_sha256_uses_cache(tmp_path, monkeypatch) -> None:
     """registers_sha256 should avoid re-reading unchanged files."""
 
@@ -94,6 +100,7 @@ def test_registers_sha256_uses_cache(tmp_path, monkeypatch) -> None:
 
     assert read_calls == 2
 
+
 def test_registers_reload_on_file_change(tmp_path) -> None:
     """Changing the register JSON file triggers a reload."""
 
@@ -111,6 +118,7 @@ def test_registers_reload_on_file_change(tmp_path) -> None:
 
     updated = load_registers(path)
     assert any(r.name == "cache_test_marker" for r in updated)
+
 
 def test_clear_cache_resets_file_hash(tmp_path, monkeypatch) -> None:
     """clear_cache should reset the cached file hash."""

--- a/tests/test_register_loader_errors.py
+++ b/tests/test_register_loader_errors.py
@@ -8,11 +8,16 @@ from custom_components.thessla_green_modbus.registers.parser import load_registe
 
 
 def _add_desc(reg: dict) -> dict:
-    return {**reg, "description": reg.get("description", "desc"), "description_en": reg.get("description_en", "desc")}
+    return {
+        **reg,
+        "description": reg.get("description", "desc"),
+        "description_en": reg.get("description_en", "desc"),
+    }
 
 
 def _write(path: Path, regs: list[dict]) -> None:
     path.write_text(json.dumps({"registers": [_add_desc(r) for r in regs]}))
+
 
 def test_duplicate_registers_raise_error(tmp_path, registers) -> None:
     """Duplicate names or addresses should raise an error."""
@@ -23,6 +28,7 @@ def test_duplicate_registers_raise_error(tmp_path, registers) -> None:
     with pytest.raises(ValueError):
         load_registers_from_file(path)
 
+
 def test_invalid_registers_rejected(tmp_path, register) -> None:
     """Registers violating schema constraints should raise an error."""
 
@@ -31,6 +37,7 @@ def test_invalid_registers_rejected(tmp_path, register) -> None:
 
     with pytest.raises(ValueError):
         load_registers_from_file(path)
+
 
 def test_bits_within_bitmask_width(tmp_path) -> None:
     """Registers with bits not exceeding bitmask width should load."""
@@ -48,6 +55,7 @@ def test_bits_within_bitmask_width(tmp_path) -> None:
 
     load_registers_from_file(path)
 
+
 def test_missing_descriptions_rejected(tmp_path, reg) -> None:
     base = {
         "function": "03",
@@ -62,6 +70,7 @@ def test_missing_descriptions_rejected(tmp_path, reg) -> None:
     with pytest.raises(ValueError):
         load_registers_from_file(path)
 
+
 def test_missing_register_file_raises_runtime_error(tmp_path) -> None:
     """Missing register definition file should raise RuntimeError."""
 
@@ -69,6 +78,7 @@ def test_missing_register_file_raises_runtime_error(tmp_path) -> None:
     with pytest.raises(RuntimeError) as exc:
         load_registers_from_file(path)
     assert str(path) in str(exc.value)
+
 
 def test_invalid_register_file_raises_runtime_error(tmp_path) -> None:
     """Invalid register definition file should raise RuntimeError."""
@@ -78,6 +88,7 @@ def test_invalid_register_file_raises_runtime_error(tmp_path) -> None:
     with pytest.raises(RuntimeError) as exc:
         load_registers_from_file(path)
     assert str(path) in str(exc.value)
+
 
 def test_special_modes_invalid_json(monkeypatch) -> None:
     """Parser falls back to empty special mode enum on invalid file."""

--- a/tests/test_register_loader_filters.py
+++ b/tests/test_register_loader_filters.py
@@ -5,10 +5,12 @@ from pathlib import Path
 
 
 def _add_desc(reg: dict) -> dict:
-    return {**reg, "description": reg.get("description", "desc"), "description_en": reg.get("description_en", "desc")}
+    return {
+        **reg,
+        "description": reg.get("description", "desc"),
+        "description_en": reg.get("description_en", "desc"),
+    }
 
 
 def _write(path: Path, regs: list[dict]) -> None:
     path.write_text(json.dumps({"registers": [_add_desc(r) for r in regs]}))
-
-

--- a/tests/test_register_loader_public_api.py
+++ b/tests/test_register_loader_public_api.py
@@ -11,11 +11,16 @@ from custom_components.thessla_green_modbus.registers.loader import (
 
 
 def _add_desc(reg: dict) -> dict:
-    return {**reg, "description": reg.get("description", "desc"), "description_en": reg.get("description_en", "desc")}
+    return {
+        **reg,
+        "description": reg.get("description", "desc"),
+        "description_en": reg.get("description_en", "desc"),
+    }
 
 
 def _write(path: Path, regs: list[dict]) -> None:
     path.write_text(json.dumps({"registers": [_add_desc(r) for r in regs]}))
+
 
 def test_register_file_sorted() -> None:
     """Ensure register JSON is sorted and loader preserves ordering."""
@@ -24,6 +29,7 @@ def test_register_file_sorted() -> None:
     regs = data["registers"]
     keys = [(str(r["function"]), int(r["address_dec"])) for r in regs]
     assert keys == sorted(keys)
+
 
 def test_get_all_registers_sorted(tmp_path) -> None:
     """get_all_registers should order registers by function then address."""
@@ -56,6 +62,7 @@ def test_get_all_registers_sorted(tmp_path) -> None:
     ordered = get_all_registers(path)
     keys = [(r.function, r.address) for r in ordered]
     assert keys == sorted(keys)
+
 
 def test_loader_all_has_no_private_cache_names() -> None:
     """loader.__all__ should only expose public API names."""


### PR DESCRIPTION
### Motivation
- Remove remaining formatting drift reported by `ruff` in the repository scopes targeted for formatting to keep code style consistent and avoid CI churn.
- This change is strictly formatting-only and preserves all runtime and test logic.

### Description
- Applied `ruff format` to resolve style drift in 7 Python files under `custom_components/thessla_green_modbus` and `tests`, with no functional refactors.
- Files modified: `custom_components/thessla_green_modbus/services_handlers_maintenance.py`, `tests/conftest.py`, `tests/test_register_loader_basic.py`, `tests/test_register_loader_cache.py`, `tests/test_register_loader_errors.py`, `tests/test_register_loader_filters.py`, and `tests/test_register_loader_public_api.py`.
- Changes are limited to whitespace/formatting (reflowed dicts, removed/added blank lines) and do not alter assertions, logic, imports, or public APIs.

### Testing
- Ran `ruff format --check custom_components tests tools` before and after formatting; initial check reported files already formatted for most files and `ruff format` reformatted 7 files, and the post-run check reports all files formatted.
- Ran `ruff check custom_components tests tools` which returned `All checks passed!`.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which completed with no compile errors.
- Ran `git diff --check` which produced no spacing/patch errors and inspected the diff summary showing `7 files changed, 48 insertions(+), 9 deletions(-)`.
- Attempted the pytest dependency gate and deferred full `pytest` because `pydantic` is not installed (`pytest deferred because dependency is missing: No module named 'pydantic'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fbde8d988326b21a11b835253397)