### PR TITLE
docs: refresh maintainability and refactor status with verification snapshot

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -2,139 +2,107 @@
 
 Date: 2026-05-04
 
-## Inputs and checks
+## Commands executed (exact)
 
-Executed:
+- `python -m pip install -q -r requirements-dev.txt`
+- `ruff check custom_components tests tools`
+- `ruff check --select I custom_components tests tools`
+- `ruff format --check custom_components tests tools`
+- `python -m compileall -q custom_components/thessla_green_modbus tests tools`
+- `python tools/compare_registers_with_reference.py`
+- `python tools/check_maintainability.py`
+- `pytest tests/ -q`
+- `python tools/validate_entity_mappings.py`
+- `find custom_components/thessla_green_modbus -maxdepth 2 -name "coordinator.py" -print`
+- `rg "from homeassistant|import homeassistant" custom_components/thessla_green_modbus/core custom_components/thessla_green_modbus/transport custom_components/thessla_green_modbus/registers custom_components/thessla_green_modbus/scanner || true`
+- `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs || true`
+- AST metrics script (largest files/classes/functions snapshot)
 
-- `python -m pip install -q -r requirements-dev.txt` *(passed; pip warning about root user and pip upgrade notice)*
-- `ruff check custom_components tests tools` *(failed; `F811` duplicate `register_maintenance_services` + `F821` undefined `_build_reset_filters_handler` in `services_handlers_maintenance.py`)*
-- `ruff check --select I custom_components tests tools` *(passed)*
-- `ruff format --check custom_components tests tools` *(failed informationally; **5 files would be reformatted**)*
-- `python -m compileall -q custom_components/thessla_green_modbus tests tools` *(passed)*
-- `python tools/compare_registers_with_reference.py` *(passed; informational output: 62 extras and 242 name mismatches)*
-- `python tools/check_maintainability.py` *(passed; `Maintainability gate passed.`)*
-- `pytest tests/ -q` *(failed; 69 failed, 1801 passed, 4 skipped, 3 errors; dominant issue: `NameError: _build_reset_filters_handler`)*
-- `python tools/validate_entity_mappings.py` *(passed; `OK: 366 entities validated`)*
-- `find custom_components/thessla_green_modbus -maxdepth 2 -name "coordinator.py" -print` *(informational; found only `coordinator/coordinator.py`, i.e. package implementation module)*
-- `rg "from homeassistant|import homeassistant" custom_components/thessla_green_modbus/core custom_components/thessla_green_modbus/transport custom_components/thessla_green_modbus/registers custom_components/thessla_green_modbus/scanner || true` *(passed; no matches)*
-- `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs || true` *(informational; matches include docs/policy/test text and existing known compatibility references in code)*
+## Exact status by gate
 
-## 1) Current CI gates
+### Required maintained gates
 
-Current required CI workflow gates remain:
+- **ruff check**: ✅ pass (`All checks passed!`).
+- **compileall**: ✅ pass.
+- **register compare** (`compare_registers_with_reference.py`): ✅ pass (informational output remains: 62 extras; 242 name mismatches on common addresses).
+- **maintainability** (`check_maintainability.py`): ✅ pass (`Maintainability gate passed.`).
+- **pytest** (`pytest tests/ -q`): ❌ fail (`ModuleNotFoundError: pytest_homeassistant_custom_component`).
+- **entity mappings** (`validate_entity_mappings.py`): ❌ fail (`ModuleNotFoundError: pydantic`).
 
-1. **Lint gate**: `ruff check`, `compileall`, register-reference compare, maintainability check.
-2. **Test gate**: `pytest --cov --cov-report=xml --cov-report=term -q` (+ coverage upload).
-3. **Entity mappings gate**: `python tools/validate_entity_mappings.py`.
+### Non-required tools
 
-Current status from this audit run:
+- **black**: not executed in this run; not a required gate.
+- **isort**: not executed in this run; not a required gate.
+- **mypy**: not executed in this run; not a required gate.
+- **hassfest**: not executed in this run; not a required gate.
+- **HACS**: not executed in this run; readiness not claimable from this audit.
 
-- Required lint gate: **failing** (`ruff check` red).
-- Required test gate: **failing** (`pytest` red).
-- Required entity-mappings gate: **passing**.
-- Maintainability script: **passing**.
+## Ruff format drift
 
-Non-required tools status in this audit window:
+- `ruff format --check custom_components tests tools`: reports **7 files would be reformatted**.
 
-- `black`: not configured as a required gate.
-- `isort`: not configured as a required gate.
-- `mypy`: not configured as a required gate.
-- `hassfest`: not configured as a required gate.
-- HACS validation: not configured as a required gate and not executed in this run.
+## Architecture invariants snapshot
 
-## 2) Fresh metrics snapshot
+- `find ... coordinator.py`: only `custom_components/thessla_green_modbus/coordinator/coordinator.py` found.
+- No `homeassistant` imports detected under `core/`, `transport/`, `registers/`, `scanner/`.
+- `compat|shim|proxy|re-export|legacy` grep returns informational matches (docs/tests/comments + known compatibility references); no new invariant claim beyond grep evidence.
+
+## Largest files/classes/functions (current)
 
 ### Largest files (non-empty lines)
 
-1. `custom_components/thessla_green_modbus/scanner/io_read.py` (713)
-2. `custom_components/thessla_green_modbus/coordinator/coordinator.py` (697)
-3. `tests/test_coordinator.py` (502)
-4. `custom_components/thessla_green_modbus/modbus_helpers.py` (498)
-5. `custom_components/thessla_green_modbus/coordinator/schedule.py` (472)
-6. `custom_components/thessla_green_modbus/scanner/core.py` (470)
-7. `custom_components/thessla_green_modbus/mappings/_static_discrete.py` (444)
-8. `custom_components/thessla_green_modbus/config_flow.py` (437)
-9. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` (414)
-10. `tools/translate_register_descriptions.py` (397)
+1. `custom_components/thessla_green_modbus/scanner/io_read.py` — 713
+2. `custom_components/thessla_green_modbus/coordinator/coordinator.py` — 697
+3. `tests/test_coordinator.py` — 502
+4. `custom_components/thessla_green_modbus/modbus_helpers.py` — 498
+5. `custom_components/thessla_green_modbus/coordinator/schedule.py` — 472
+6. `custom_components/thessla_green_modbus/scanner/core.py` — 470
+7. `custom_components/thessla_green_modbus/mappings/_static_discrete.py` — 444
+8. `custom_components/thessla_green_modbus/config_flow.py` — 437
+9. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` — 414
+10. `tools/translate_register_descriptions.py` — 397
 
 ### Largest classes (AST span)
 
-1. `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` (612)
-2. `_CoordinatorScheduleMixin` in `coordinator/schedule.py` (492)
-3. `ThesslaGreenDeviceScanner` in `scanner/core.py` (441)
-4. `RawRtuOverTcpTransport` in `modbus_transport_raw.py` (334)
-5. `RegisterDef` in `registers/register_def.py` (268)
-6. `ThesslaGreenFan` in `fan.py` (251)
-7. `_CoordinatorCapabilitiesMixin` in `coordinator/capabilities.py` (230)
-8. `ConfigFlow` in `config_flow.py` (227)
-9. `BaseModbusTransport` in `modbus_transport_base.py` (210)
-10. `ThesslaGreenClimate` in `climate.py` (183)
+1. `ThesslaGreenModbusCoordinator` (`coordinator/coordinator.py`) — 612
+2. `_CoordinatorScheduleMixin` (`coordinator/schedule.py`) — 492
+3. `ThesslaGreenDeviceScanner` (`scanner/core.py`) — 441
+4. `RawRtuOverTcpTransport` (`modbus_transport_raw.py`) — 334
+5. `RegisterDef` (`registers/register_def.py`) — 268
+6. `ThesslaGreenFan` (`fan.py`) — 251
+7. `_CoordinatorCapabilitiesMixin` (`coordinator/capabilities.py`) — 230
+8. `ConfigFlow` (`config_flow.py`) — 227
+9. `BaseModbusTransport` (`modbus_transport_base.py`) — 210
+10. `ThesslaGreenClimate` (`climate.py`) — 183
 
 ### Largest functions (AST span)
 
-1. `register_maintenance_services` in `custom_components/thessla_green_modbus/services_handlers_maintenance.py` (111)
-2. `test_force_full_register_list_integration` in `tests/test_force_full_register_list_integration.py` (110)
-3. `test_migrate_entity_unique_ids` in `tests/test_entity_unique_id.py` (107)
-4. `migrate_unique_id` in `custom_components/thessla_green_modbus/unique_id_migration.py` (107)
-5. `_call_modbus` in `custom_components/thessla_green_modbus/modbus_helpers.py` (106)
-6. `test_reauth_flow_success` in `tests/test_config_flow_reauth.py` (105)
-7. `validate_optimization_metrics` in `tests/run_optimization_tests.py` (104)
-8. `run` in `tests/test_force_full_register_list_integration.py` (103)
-9. `test_entity_counts_per_platform` in `tests/test_all_entity_creation.py` (100)
-10. `read_input_registers_optimized` in `custom_components/thessla_green_modbus/_coordinator_read_batches.py` (100)
+1. `register_maintenance_services` (`services_handlers_maintenance.py`) — 111
+2. `test_force_full_register_list_integration` (`tests/test_force_full_register_list_integration.py`) — 110
+3. `test_migrate_entity_unique_ids` (`tests/test_entity_unique_id.py`) — 107
+4. `migrate_unique_id` (`unique_id_migration.py`) — 107
+5. `_call_modbus` (`modbus_helpers.py`) — 106
+6. `test_reauth_flow_success` (`tests/test_config_flow_reauth.py`) — 105
+7. `validate_optimization_metrics` (`tests/run_optimization_tests.py`) — 104
+8. `run` (`tests/test_force_full_register_list_integration.py`) — 103
+9. `test_entity_counts_per_platform` (`tests/test_all_entity_creation.py`) — 100
+10. `read_input_registers_optimized` (`_coordinator_read_batches.py`) — 100
 
-## 3) Completed cleanup PRs from latest batch
+## Current remaining hotspots
 
-Based on `CHANGELOG.md`, the latest explicitly documented cleanup batch entries are:
+- Coordinator concentration: `coordinator/coordinator.py`, `coordinator/schedule.py`.
+- Scanner complexity: `scanner/io_read.py`, `scanner/core.py`.
+- Mapping assembly density: `mappings/_mapping_builders.py`.
+- Config-flow branching density: `config_flow.py`, `config_flow_device_validation.py`.
 
-- **2.7.0 — Dead fallback & pragma cleanup**
-- **2.6.0 — Dead fallback cleanup**
-- **2.5.1 — Config flow cleanup**
+## Readiness caveats
 
-This audit run does **not** add a new cleanup completion; it documents current post-batch state only.
+- **Required gates are not fully green** in this environment because `pytest` and `validate_entity_mappings.py` fail due to missing Python packages.
+- **Release/HACS readiness** cannot be claimed because HACS validation was not executed.
+- **Real-device validation** cannot be claimed from this run; no new device-evidence artifacts were produced.
 
-## 4) Remaining production hotspots
+## Next recommended PRs
 
-1. `services_handlers_maintenance.py` is currently the primary correctness hotspot (duplicate function definition + missing symbol).
-2. `coordinator/coordinator.py` and `coordinator/schedule.py` remain the largest coordinator hotspots.
-3. Scanner complexity remains concentrated in `scanner/io_read.py` and `scanner/core.py`.
-4. Mapping assembly remains dense in `mappings/_mapping_builders.py`.
-5. Flow validation remains dense in `config_flow.py` and `config_flow_device_validation.py`.
-
-## 5) Remaining test hotspots
-
-1. `tests/test_coordinator.py` remains a large integration-heavy test module.
-2. Service-handler test suites are the dominant current failure surface due to maintenance-handler regression.
-3. Register-loader error tests currently show 3 fixture errors (`registers` / `register` / `reg`).
-
-## 6) Next recommended PRs
-
-1. **Gate recovery PR (required first):** fix `services_handlers_maintenance.py` duplication/missing handler symbol, then re-run lint + tests.
-2. **Follow-up gate recovery PR:** resolve register-loader fixture wiring errors if still present after maintenance-handler fix.
-3. After green gates, continue targeted decomposition of coordinator/scanner/mappings/config-flow hotspots.
-4. Keep optional formatting-only PR (`ruff format`) isolated.
-
-## 7) CI hardening status
-
-- `ruff check`: **fail**.
-- `ruff import-order` (`ruff check --select I`): **pass**.
-- `ruff format drift count`: **5 files** would be reformatted.
-- `black`: **not a required gate**.
-- `isort`: **not a required gate**.
-- `mypy`: **not a required gate**.
-- `hassfest`: **not a required gate**.
-- `HACS`: **not a required gate / not validated in this run**.
-
-## 8) Preserved invariants (audit status)
-
-- No top-level `custom_components/thessla_green_modbus/coordinator.py` file.
-- No Home Assistant imports under `core/`, `transport/`, `registers/`, `scanner/`.
-- Entity mappings validation passes (`OK: 366 entities validated`).
-- No new compatibility/proxy/re-export-only module was introduced in this task (informational grep still returns existing references).
-
-## 9) Readiness summary
-
-1. **Maintainability/refactor readiness**: maintainability script passes, but required lint/test gates are red.
-2. **CI readiness**: not ready (not all required gates are green).
-3. **Release/HACS readiness**: not demonstrated in this run; HACS validation not executed.
-4. **Real device validation status**: not demonstrated in this run; register compare extras/name mismatches are informational and still require vendor/device confirmation.
+1. **Gate-recovery PR:** ensure dev requirements include/import `pytest_homeassistant_custom_component` and `pydantic` in the verification environment, then rerun full maintained gates.
+2. Optional formatting-only PR: apply `ruff format` drift cleanup (7 files) only after required gates are green.
+3. Continue decomposition PRs for coordinator/scanner/mapping/config-flow hotspots once gates are green.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -31,44 +31,43 @@ The following constraints remain active and must be preserved:
 
 - Top-level `custom_components/thessla_green_modbus/coordinator.py`: **absent**.
 - Canonical coordinator module: `custom_components/thessla_green_modbus/coordinator/coordinator.py`.
-- HA imports in `core/transport/registers/scanner`: **none detected**.
-- Entity mapping validation: **passes** (`OK: 366 entities validated`).
-- Maintainability gate: **passes**.
-- Full test suite (`pytest tests/ -q`): **fails** (69 failed, 1801 passed, 4 skipped, 3 errors).
-- Lint gate (`ruff check custom_components tests tools`): **fails** (`F811` + `F821` in `services_handlers_maintenance.py`).
+- HA imports in `core/transport/registers/scanner`: **none detected** by grep.
+- Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches present in docs/tests/comments/known compatibility code references.
 
-## Latest cleanup-batch outcome
+## Required gate status snapshot (2026-05-04)
 
-Documented latest cleanup-oriented releases in `CHANGELOG.md`:
+- `ruff check custom_components tests tools`: **pass**.
+- `python -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
+- `python tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
+- `python tools/check_maintainability.py`: **pass**.
+- `pytest tests/ -q`: **fail** (`ModuleNotFoundError: pytest_homeassistant_custom_component`).
+- `python tools/validate_entity_mappings.py`: **fail** (`ModuleNotFoundError: pydantic`).
 
-- 2.7.0 — Dead fallback & pragma cleanup
-- 2.6.0 — Dead fallback cleanup
-- 2.5.1 — Config flow cleanup
+Because two required gates fail in this environment, the repo cannot be declared fully green under maintained gates from this run.
 
-Current audit state is **not** fully green post-cleanup because required lint/test gates are red.
+## Non-required tool status
 
-## Remaining hotspots (next PR queue)
+- `black`: not executed.
+- `isort`: not executed.
+- `mypy`: not executed.
+- `hassfest`: not executed.
+- `HACS`: not executed.
+- `ruff format --check`: **7 files drift**.
 
-1. **Gate-recovery first:** fix maintenance service registration regression (`register_maintenance_services` duplication and missing handler symbol).
-2. Resolve register-loader fixture errors in `tests/test_register_loader_errors.py` if still failing after step 1.
-3. Coordinator decomposition (`coordinator/coordinator.py`, `coordinator/schedule.py`).
-4. Scanner read-path decomposition (`scanner/io_read.py`, `scanner/core.py`).
-5. Mapping builder decomposition (`mappings/_mapping_builders.py`).
-6. Config-flow validation branch extraction (`config_flow_device_validation.py`).
+## Remaining hotspots (current queue)
 
-## CI hardening status
+1. Coordinator size/branching (`coordinator/coordinator.py`, `coordinator/schedule.py`).
+2. Scanner read/orchestration complexity (`scanner/io_read.py`, `scanner/core.py`).
+3. Mapping build complexity (`mappings/_mapping_builders.py`).
+4. Config-flow/device validation complexity (`config_flow.py`, `config_flow_device_validation.py`).
 
-- Required now: `ruff check`, compileall, register-reference compare, maintainability check, pytest+coverage, entity mappings validation.
-- Current state in this audit: compileall, register compare, maintainability, entity mappings are green; `ruff check` and `pytest` are red.
-- Informational/non-required now: `ruff check --select I` is green; `ruff format --check` reports 5-file drift.
-- Not currently required: `black`, `isort`, `mypy`, `hassfest`, HACS validation.
+## Readiness caveats
 
-## Documentation policy for refactor work
+- **Release/HACS readiness:** not claimable (HACS validation not executed).
+- **Real-device readiness:** not claimable from this verification run; no new on-device evidence captured.
 
-- Keep architecture docs aligned with current repository state.
-- Do not document speculative capabilities as completed.
-- Keep readiness claims split across:
-  1. maintainability/refactor readiness,
-  2. CI readiness,
-  3. release/HACS readiness,
-  4. real device validation evidence.
+## Next recommended PRs
+
+1. Gate recovery: make the verification environment reliably install `pytest_homeassistant_custom_component` and `pydantic`, then rerun required maintained gates.
+2. Optional formatting-only PR for `ruff format` drift (7 files) after required gates pass.
+3. Continue focused decomposition PRs for the largest coordinator/scanner/mapping/config-flow hotspots.


### PR DESCRIPTION
### Motivation

- Record an exact verification snapshot of repo health after a local gate run so maintainers have an auditable, up-to-date state without touching production code.
- Surface failing gates, formatting drift, large hotspots, preserved invariants, and the next recommended recovery steps to guide follow-up PRs.

### Description

- Updated `docs/maintainability_audit.md` to include the exact commands executed, gate-by-gate pass/fail results, `ruff format` drift count, AST metrics (largest files/classes/functions), preserved invariants, current hotspots, and next recommended PRs.
- Updated `docs/refactor_status.md` to align with the same verification snapshot and to enumerate required-gate statuses and readiness caveats.
- No production source, tests, CI configuration, or register JSON files were changed in this update.

### Testing

- `python -m pip install -q -r requirements-dev.txt` — succeeded (installation completed in the verification environment). 
- `ruff check custom_components tests tools` — succeeded (`All checks passed!`).
- `ruff check --select I custom_components tests tools` — succeeded. 
- `ruff format --check custom_components tests tools` — reported formatting drift (`7 files would be reformatted`).
- `python -m compileall -q custom_components/thessla_green_modbus tests tools` — succeeded (bytecode compile passed). 
- `python tools/compare_registers_with_reference.py` — succeeded (informational output: Reference entries 294, Integration entries 356, Common 294, Extra in integration 62, Name mismatches on common addresses 242). 
- `python tools/check_maintainability.py` — succeeded (`Maintainability gate passed.`). 
- `pytest tests/ -q` — failed with import error (`ModuleNotFoundError: pytest_homeassistant_custom_component`).
- `python tools/validate_entity_mappings.py` — failed with import error (`ModuleNotFoundError: pydantic`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fbe4d0488326990b074087349175)