### PR TITLE
test: restore register loader fixture wiring

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,8 @@ except ImportError:
 
 from custom_components.thessla_green_modbus.const import DOMAIN
 
+pytest_plugins = ["tests.helpers_register_loader"]
+
 try:
     asyncio.get_event_loop()
 except RuntimeError:

--- a/tests/helpers_register_loader.py
+++ b/tests/helpers_register_loader.py
@@ -1,0 +1,78 @@
+"""Shared fixtures for register-loader tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def registers() -> list[list[dict[str, object]]]:
+    """Duplicate register scenarios used by validation tests."""
+    return [
+        [
+            {"function": "01", "address_dec": 1, "name": "dup1", "access": "R"},
+            {"function": "01", "address_dec": 1, "name": "dup2", "access": "R"},
+        ],
+        [
+            {"function": "01", "address_dec": 1, "name": "dup", "access": "R"},
+            {"function": "02", "address_dec": 2, "name": "dup", "access": "R"},
+        ],
+    ]
+
+
+@pytest.fixture
+def register() -> list[dict[str, object]]:
+    """Invalid register schema scenarios used by validation tests."""
+    return [
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bad_len",
+            "access": "R",
+            "length": 1,
+            "extra": {"type": "u32"},
+        },
+        {"function": "01", "address_dec": 0, "name": "bad_access", "access": "RW"},
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bad_bits",
+            "access": "R",
+            "bits": [{"name": "a"}],
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bad_string_len",
+            "access": "R",
+            "length": 0,
+            "extra": {"type": "string"},
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bad_bit_name",
+            "access": "R",
+            "extra": {"bitmask": 0b1},
+            "bits": [{"name": "BadName", "index": 0}],
+        },
+        {
+            "function": "03",
+            "address_dec": 0,
+            "name": "bit_index_out_of_range",
+            "access": "R",
+            "extra": {"bitmask": 65535},
+            "bits": [{"name": f"b{i}", "index": i} for i in range(17)],
+        },
+    ]
+
+
+@pytest.fixture
+def reg() -> list[dict[str, str]]:
+    """Missing-description scenarios used by validation tests."""
+    return [
+        {"description_en": "en"},
+        {"description": "pl"},
+        {"description": "", "description_en": "en"},
+        {"description": "pl", "description_en": ""},
+    ]


### PR DESCRIPTION
### Motivation
- After splitting register-loader tests the shared fixtures `registers`, `register`, and `reg` were no longer discoverable which caused pytest fixture resolution errors.
- Restore shared fixtures in a minimal, test-only way so multiple register-loader test modules can reuse them without changing production behavior.

### Description
- Add `tests/helpers_register_loader.py` defining `@pytest.fixture` fixtures `registers`, `register`, and `reg` containing the scenario payloads consumed by validation tests.
- Wire the helper into pytest test discovery by adding `pytest_plugins = ["tests.helpers_register_loader"]` to `tests/conftest.py` so fixtures are available across test modules.
- Keep changes limited to tests only and avoid touching production code or CI configuration; changed files are `tests/helpers_register_loader.py` (new) and `tests/conftest.py` (modified).
- Commit created with message `test: restore register loader fixture wiring` (commit `f2ec5bb5`).

### Testing
- Ran `ruff check tests/test_register_loader*.py tests/helpers_register_loader.py tests/conftest.py --fix` and `ruff check ...` and both returned all checks passed. (success)
- Ran `python -m compileall -q tests/test_register_loader*.py tests/helpers_register_loader.py tests/conftest.py` and compilation succeeded. (success)
- Dependency gate script attempted to import `pydantic`, `pytest`, and `homeassistant` and aborted pytest runs because `pydantic` is missing in this environment, so targeted `pytest` runs were deferred. (deferred)
- Verified `git` state and committed the test-only changes; no production files were modified. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9aae837008326916b0f6c31cbdafd)