### PR TITLE
refactor: restore lint/import health to allow targeted maintainability work

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -8,6 +8,8 @@ from functools import cache, lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from .registers.loader import get_registers_by_function
+
 try:
     from homeassistant.const import Platform as _HAPlatform
 except ModuleNotFoundError:  # pragma: no cover - test/runtime fallback without HA
@@ -26,9 +28,6 @@ except ModuleNotFoundError:  # pragma: no cover - test/runtime fallback without 
     _HAPlatform = _FallbackPlatform
 
 Platform = _HAPlatform
-
-
-from .registers.loader import get_registers_by_function
 
 if TYPE_CHECKING:  # pragma: no cover
     from homeassistant.core import HomeAssistant

--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -10,7 +10,6 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.helpers.entity import EntityCategory
 
 from ..const import (
-    SPECIAL_FUNCTION_MAP,
     coil_registers,
     discrete_input_registers,
     holding_registers,

--- a/custom_components/thessla_green_modbus/modbus_transport.py
+++ b/custom_components/thessla_green_modbus/modbus_transport.py
@@ -19,12 +19,12 @@ from .modbus_transport_client import (
 from .modbus_transport_raw import RawRtuOverTcpTransport
 
 __all__ = [
+    "SERIAL_IMPORT_ERROR",
     "BaseModbusTransport",
     "RawModbusResponse",
     "RawModbusWriteResponse",
     "RawRtuOverTcpTransport",
     "RtuModbusTransport",
-    "SERIAL_IMPORT_ERROR",
     "TcpModbusTransport",
     "_AsyncModbusSerialClient",
     "_ClientBackedTransport",

--- a/custom_components/thessla_green_modbus/modbus_transport_base.py
+++ b/custom_components/thessla_green_modbus/modbus_transport_base.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 from abc import ABC, abstractmethod
 from typing import Any
-
-from pymodbus.client import AsyncModbusTcpClient
 
 try:  # pragma: no cover
     from pymodbus.client import AsyncModbusSerialClient as _AsyncModbusSerialClient
@@ -19,14 +16,11 @@ else:  # pragma: no cover
     SERIAL_IMPORT_ERROR = None
 
 from ._transport_retry import apply_transport_backoff, log_transport_retry
-from .const import CONNECTION_TYPE_TCP, CONNECTION_TYPE_TCP_RTU
 from .error_contract import classify_error
 from .error_policy import to_log_message
 from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
 from .modbus_helpers import (
     _call_modbus,
-    async_maybe_await_close,
-    get_rtu_framer,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -293,13 +287,13 @@ class BaseModbusTransport(ABC):
 
 
 __all__ = [
-    "BaseModbusTransport",
-    "RawModbusResponse",
-    "RawModbusWriteResponse",
     "_MAX_READ_REGISTERS",
     "_MAX_SLAVE_ID",
     "_MAX_WRITE_REGISTERS",
     "_MIN_SLAVE_ID",
+    "BaseModbusTransport",
+    "RawModbusResponse",
+    "RawModbusWriteResponse",
     "_append_crc",
     "_crc16",
     "classify_transport_error",

--- a/custom_components/thessla_green_modbus/modbus_transport_client.py
+++ b/custom_components/thessla_green_modbus/modbus_transport_client.py
@@ -293,8 +293,8 @@ class RtuModbusTransport(_ClientBackedTransport):
 
 
 __all__ = [
-    "RtuModbusTransport",
     "SERIAL_IMPORT_ERROR",
+    "RtuModbusTransport",
     "TcpModbusTransport",
     "_AsyncModbusSerialClient",
     "_ClientBackedTransport",

--- a/custom_components/thessla_green_modbus/modbus_transport_raw.py
+++ b/custom_components/thessla_green_modbus/modbus_transport_raw.py
@@ -7,13 +7,13 @@ from typing import Any
 
 from .modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
 from .modbus_transport_base import (
-    BaseModbusTransport,
-    RawModbusResponse,
-    RawModbusWriteResponse,
     _MAX_READ_REGISTERS,
     _MAX_SLAVE_ID,
     _MAX_WRITE_REGISTERS,
     _MIN_SLAVE_ID,
+    BaseModbusTransport,
+    RawModbusResponse,
+    RawModbusWriteResponse,
     _append_crc,
     _crc16,
 )

--- a/custom_components/thessla_green_modbus/scanner/capabilities.py
+++ b/custom_components/thessla_green_modbus/scanner/capabilities.py
@@ -12,7 +12,6 @@ from ..utils import BCD_TIME_PREFIXES, decode_bcd_time
 
 if TYPE_CHECKING:
     from ..scanner_device_info import DeviceCapabilities
-    from .core import ThesslaGreenDeviceScanner
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/scanner/firmware.py
+++ b/custom_components/thessla_green_modbus/scanner/firmware.py
@@ -9,7 +9,6 @@ from ..scanner_register_maps import HOLDING_REGISTERS, INPUT_REGISTERS, REGISTER
 
 if TYPE_CHECKING:
     from ..scanner_device_info import ScannerDeviceInfo
-    from .core import ThesslaGreenDeviceScanner
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thessla_green_modbus/scanner/io_core.py
+++ b/custom_components/thessla_green_modbus/scanner/io_core.py
@@ -12,14 +12,13 @@ from typing import TYPE_CHECKING, Any, cast
 from pymodbus.client import AsyncModbusTcpClient
 
 from .. import modbus_helpers as _mh
-from ..error_contract import classify_error, log_retry_attempt
-from ..modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
-from ..modbus_helpers import _call_modbus, chunk_register_range
+from ..error_contract import log_retry_attempt
+from ..modbus_exceptions import ConnectionException
+from ..modbus_helpers import _call_modbus
 
 if TYPE_CHECKING:
     from pymodbus.client import AsyncModbusSerialClient as AsyncModbusSerialClientType
 
-    from .core import ThesslaGreenDeviceScanner
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -262,13 +261,13 @@ def _expand_cached_failed_range(
 
 
 __all__ = [
+    "_call_modbus_with_fallback",
+    "_expand_cached_failed_range",
+    "_sleep_retry_backoff",
     "ensure_pymodbus_client_module",
     "is_request_cancelled_error",
     "resolve_transport_and_client",
     "track_holding_failure",
     "track_input_failure",
     "unpack_read_args",
-    "_call_modbus_with_fallback",
-    "_expand_cached_failed_range",
-    "_sleep_retry_backoff",
 ]

--- a/custom_components/thessla_green_modbus/scanner/registers.py
+++ b/custom_components/thessla_green_modbus/scanner/registers.py
@@ -11,7 +11,7 @@ from ..scanner_helpers import UART_OPTIONAL_REGS
 from ..scanner_register_maps import MULTI_REGISTER_SIZES
 
 if TYPE_CHECKING:
-    from .core import ThesslaGreenDeviceScanner
+    pass
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Motivation
- The repo's maintainability gates (`ruff` / compile) were failing and blocked any targeted refactor, so a minimal, safe cleanup was required to restore gate health before further changes.
- Changes are strictly behavior-preserving static cleanups to imports, export lists and unused symbols so downstream behavior is unchanged.

### Description
- Moved the `get_registers_by_function` import to the top-level imports in `custom_components/thessla_green_modbus/const.py` to resolve a module-level import ordering error (`E402`).
- Removed unused imports and forward TYPE_CHECKING-only references and reorganized import blocks in several modules to satisfy linter rules without changing runtime behavior.
- Sorted and normalized `__all__` lists and adjusted small ordering-only edits across transport and scanner modules to satisfy `ruff` import/export checks.
- Files changed: `const.py`, `mappings/_mapping_builders.py`, `modbus_transport.py`, `modbus_transport_base.py`, `modbus_transport_client.py`, `modbus_transport_raw.py`, `scanner/capabilities.py`, `scanner/firmware.py`, `scanner/io_core.py`, `scanner/registers.py`.

### Testing
- Ran `ruff check custom_components tests tools` and fixed issues with `ruff --fix`, after which `ruff` passed successfully.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which completed without errors.
- Ran `python tools/check_maintainability.py` which reported the maintainability gate passed.
- Dependency probe for running targeted `pytest` was deferred because `pydantic` (and therefore test dependencies) are missing in the local environment, so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b0e896cc8326b9e3d5947f922ed1)