### PR TITLE
refactor(modbus): extract helpers to simplify _call_modbus

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -365,25 +365,14 @@ async def _call_modbus(
     func_name = getattr(func, "__name__", repr(func))
     batch_size = kwargs.get("count") or len(kwargs.get("values", [])) or 1
 
-    delay = 0.0
-    if apply_backoff:
-        delay = _calculate_backoff_delay(
-            base=backoff,
-            attempt=attempt,
-            jitter=backoff_jitter,
-        )
-
-    if delay > 0:
-        _LOGGER.debug(
-            "Delaying %.3fs before attempt %s/%s of %s", delay, attempt, max_attempts, func_name
-        )
-        try:
-            await asyncio.sleep(delay)
-        except asyncio.CancelledError:
-            _LOGGER.debug(
-                "Sleep cancelled before calling %s attempt %s/%s", func_name, attempt, max_attempts
-            )
-            raise
+    await _sleep_with_backoff(
+        func_name=func_name,
+        attempt=attempt,
+        max_attempts=max_attempts,
+        backoff=backoff,
+        backoff_jitter=backoff_jitter,
+        apply_backoff=apply_backoff,
+    )
 
     _LOGGER.debug(
         "Calling %s on slave %s (batch=%s attempt %s/%s)",
@@ -401,14 +390,73 @@ async def _call_modbus(
         kwargs=kwargs,
     )
 
+    response = await _execute_modbus_call(
+        func=func,
+        positional=positional,
+        kwargs=kwargs,
+        kwarg=kwarg,
+        slave_id=slave_id,
+        timeout=timeout,
+        func_name=func_name,
+        attempt=attempt,
+        max_attempts=max_attempts,
+    )
+
+    _log_modbus_response(func_name, response)
+    return response
+
+
+async def _sleep_with_backoff(
+    *,
+    func_name: str,
+    attempt: int,
+    max_attempts: int,
+    backoff: float,
+    backoff_jitter: float | tuple[float, float] | None,
+    apply_backoff: bool,
+) -> None:
+    """Apply optional exponential backoff delay before a Modbus call."""
+
+    delay = 0.0
+    if apply_backoff:
+        delay = _calculate_backoff_delay(
+            base=backoff,
+            attempt=attempt,
+            jitter=backoff_jitter,
+        )
+
+    if delay <= 0:
+        return
+
+    _LOGGER.debug("Delaying %.3fs before attempt %s/%s of %s", delay, attempt, max_attempts, func_name)
+    try:
+        await asyncio.sleep(delay)
+    except asyncio.CancelledError:
+        _LOGGER.debug("Sleep cancelled before calling %s attempt %s/%s", func_name, attempt, max_attempts)
+        raise
+
+
+async def _execute_modbus_call(
+    *,
+    func: Callable[..., Awaitable[Any]],
+    positional: list[Any],
+    kwargs: dict[str, Any],
+    kwarg: str,
+    slave_id: int,
+    timeout: float | None,
+    func_name: str,
+    attempt: int,
+    max_attempts: int,
+) -> Any:
+    """Execute Modbus call with timeout/cancellation/error normalization."""
+
     async def _invoke() -> Any:
         return await _invoke_with_slave_kwarg(func, positional, kwargs, kwarg, slave_id)
 
     try:
         if timeout is not None and _should_apply_external_timeout(func):
-            response = await asyncio.wait_for(_invoke(), timeout=timeout)
-        else:
-            response = await _invoke()
+            return await asyncio.wait_for(_invoke(), timeout=timeout)
+        return await _invoke()
     except TimeoutError as err:
         _LOGGER.debug("Call to %s timed out on attempt %s/%s", func_name, attempt, max_attempts)
         raise TimeoutError("Modbus request timed out") from err
@@ -428,9 +476,6 @@ async def _call_modbus(
         else:
             _LOGGER.debug("Call to %s failed on attempt %s/%s", func_name, attempt, max_attempts)
         raise
-
-    _log_modbus_response(func_name, response)
-    return response
 
 
 def group_reads(


### PR DESCRIPTION
### Motivation
- `modbus_helpers.py` contained a large `_call_modbus` function that was a maintainability hotspot and a safe target for focused extraction.
- The intent is to reduce cyclomatic complexity and improve readability without changing public behavior or interfaces.

### Description
- Extracted backoff/sleep logic into a new helper `async def _sleep_with_backoff(...)` and replaced the inline delay code in `_call_modbus` with a call to it.
- Extracted timeout/await/cancellation/error normalization into a new helper `async def _execute_modbus_call(...)` and delegated the invocation logic from `_call_modbus` to it.
- Preserved existing logging, timeout semantics (conditional use of `asyncio.wait_for` via `_should_apply_external_timeout`), backoff calculation (`_calculate_backoff_delay`), and exception paths.
- Only `custom_components/thessla_green_modbus/modbus_helpers.py` was modified and no public APIs or module exports were changed.

### Testing
- Ran `ruff check custom_components tests tools` which passed and `ruff --fix` was applied where applicable with no remaining issues.
- Ran `python -m compileall -q custom_components/thessla_green_modbus tests tools` which passed and `python tools/check_maintainability.py` which passed.
- Dependency probe for running pytest was performed and pytest was deferred because `pydantic` was missing in the environment, so targeted pytest was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b20c3f108326bc98f3b2b4ef14d3)