### PR TITLE
Refresh maintainability audit and refactor status (update gates, import gate, ruff drift)

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,51 +1,63 @@
 # Maintainability audit
 
-Date: 2026-05-04
+Date: 2026-05-05
 
 ## Commands executed (exact)
 
-- `python -m pip install -q -r requirements-dev.txt`
+- `git branch --show-current`
+- `git status --short`
+- `python -m pip install --upgrade pip setuptools wheel`
+- `python -m pip install -r requirements-dev.txt`
+- Import gate script:
+  - `python - <<'PY' ... __import__(...) ... PY`
 - `ruff check custom_components tests tools`
 - `ruff check --select I custom_components tests tools`
-- `ruff format --check custom_components tests tools`
+- `ruff format --check custom_components tests tools || true`
 - `python -m compileall -q custom_components/thessla_green_modbus tests tools`
 - `python tools/compare_registers_with_reference.py`
 - `python tools/check_maintainability.py`
-- `pytest tests/ -q`
 - `python tools/validate_entity_mappings.py`
+- `pytest tests/ -q`
+- AST metrics script (largest files/classes/functions snapshot)
 - `find custom_components/thessla_green_modbus -maxdepth 2 -name "coordinator.py" -print`
 - `rg "from homeassistant|import homeassistant" custom_components/thessla_green_modbus/core custom_components/thessla_green_modbus/transport custom_components/thessla_green_modbus/registers custom_components/thessla_green_modbus/scanner || true`
 - `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs || true`
-- AST metrics script (largest files/classes/functions snapshot)
 
-## Exact status by gate
+## Import gate result
+
+- `pydantic`: ✅ `OK pydantic`
+- `pytest`: ✅ `OK pytest`
+- `pytest_asyncio`: ✅ `OK pytest_asyncio`
+- `pytest_homeassistant_custom_component`: ✅ `OK pytest_homeassistant_custom_component`
+- `homeassistant`: ✅ `OK homeassistant`
+
+## Exact status by validation gate
 
 ### Required maintained gates
 
 - **ruff check**: ✅ pass (`All checks passed!`).
+- **ruff import order check**: ✅ pass (`All checks passed!`).
 - **compileall**: ✅ pass.
 - **register compare** (`compare_registers_with_reference.py`): ✅ pass (informational output remains: 62 extras; 242 name mismatches on common addresses).
 - **maintainability** (`check_maintainability.py`): ✅ pass (`Maintainability gate passed.`).
-- **pytest** (`pytest tests/ -q`): ❌ fail (`ModuleNotFoundError: pytest_homeassistant_custom_component`).
-- **entity mappings** (`validate_entity_mappings.py`): ❌ fail (`ModuleNotFoundError: pydantic`).
+- **entity mappings** (`validate_entity_mappings.py`): ✅ pass (`OK: 366 entities validated`).
+- **pytest** (`pytest tests/ -q`): ✅ pass with skips (`4 skipped`, no failures).
 
-### Non-required tools
+### Required CI gate status note
 
-- **black**: not executed in this run; not a required gate.
-- **isort**: not executed in this run; not a required gate.
-- **mypy**: not executed in this run; not a required gate.
-- **hassfest**: not executed in this run; not a required gate.
-- **HACS**: not executed in this run; readiness not claimable from this audit.
+- This local audit run indicates maintained quality gates are green in this environment.
+- CI/HACS/hassfest gates were **not** executed in this run and are not claimed as proven.
 
 ## Ruff format drift
 
-- `ruff format --check custom_components tests tools`: reports **7 files would be reformatted**.
+- `ruff format --check custom_components tests tools`: reports **1 file would be reformatted**:
+  - `custom_components/thessla_green_modbus/mappings/_mapping_builders.py`
 
 ## Architecture invariants snapshot
 
 - `find ... coordinator.py`: only `custom_components/thessla_green_modbus/coordinator/coordinator.py` found.
-- No `homeassistant` imports detected under `core/`, `transport/`, `registers/`, `scanner/`.
-- `compat|shim|proxy|re-export|legacy` grep returns informational matches (docs/tests/comments + known compatibility references); no new invariant claim beyond grep evidence.
+- No `homeassistant` imports detected under `core/`, `transport/`, `registers/`, `scanner/` by the specified grep command.
+- `compat|shim|proxy|re-export|legacy` grep returns informational matches in docs/tests/comments and known compatibility references.
 
 ## Largest files/classes/functions (current)
 
@@ -59,7 +71,7 @@ Date: 2026-05-04
 6. `custom_components/thessla_green_modbus/scanner/core.py` — 470
 7. `custom_components/thessla_green_modbus/mappings/_static_discrete.py` — 444
 8. `custom_components/thessla_green_modbus/config_flow.py` — 437
-9. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` — 414
+9. `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` — 433
 10. `tools/translate_register_descriptions.py` — 397
 
 ### Largest classes (AST span)
@@ -88,21 +100,20 @@ Date: 2026-05-04
 9. `test_entity_counts_per_platform` (`tests/test_all_entity_creation.py`) — 100
 10. `read_input_registers_optimized` (`_coordinator_read_batches.py`) — 100
 
-## Current remaining hotspots
+## Remaining hotspots
 
-- Coordinator concentration: `coordinator/coordinator.py`, `coordinator/schedule.py`.
-- Scanner complexity: `scanner/io_read.py`, `scanner/core.py`.
-- Mapping assembly density: `mappings/_mapping_builders.py`.
-- Config-flow branching density: `config_flow.py`, `config_flow_device_validation.py`.
+1. Coordinator concentration (`coordinator/coordinator.py`, `coordinator/schedule.py`).
+2. Scanner read/orchestration complexity (`scanner/io_read.py`, `scanner/core.py`).
+3. Mapping builder density (`mappings/_mapping_builders.py`).
+4. Config-flow branching (`config_flow.py`, `config_flow_device_validation.py`).
 
-## Readiness caveats
+## Branch note (authoritative target)
 
-- **Required gates are not fully green** in this environment because `pytest` and `validate_entity_mappings.py` fail due to missing Python packages.
-- **Release/HACS readiness** cannot be claimed because HACS validation was not executed.
-- **Real-device validation** cannot be claimed from this run; no new device-evidence artifacts were produced.
+- The working target branch is **dev**.
+- **main** is not authoritative for this refactor/audit track.
+- No `main -> dev` merge is recommended as part of this audit.
 
-## Next recommended PRs
+## Release readiness caveats
 
-1. **Gate-recovery PR:** ensure dev requirements include/import `pytest_homeassistant_custom_component` and `pydantic` in the verification environment, then rerun full maintained gates.
-2. Optional formatting-only PR: apply `ruff format` drift cleanup (7 files) only after required gates are green.
-3. Continue decomposition PRs for coordinator/scanner/mapping/config-flow hotspots once gates are green.
+- **HACS/hassfest readiness is not proven** in this audit because those validations were not run.
+- **Real-device validation is not proven** in this audit unless explicitly documented with device evidence.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-04.
+Last reviewed: 2026-05-05.
 
 Related document:
 
@@ -27,23 +27,24 @@ The following constraints remain active and must be preserved:
 4. No proxy modules.
 5. `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant.
 
-## Current invariant verification snapshot (2026-05-04)
+## Current invariant verification snapshot (2026-05-05)
 
 - Top-level `custom_components/thessla_green_modbus/coordinator.py`: **absent**.
 - Canonical coordinator module: `custom_components/thessla_green_modbus/coordinator/coordinator.py`.
 - HA imports in `core/transport/registers/scanner`: **none detected** by grep.
 - Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches present in docs/tests/comments/known compatibility code references.
 
-## Required gate status snapshot (2026-05-04)
+## Required gate status snapshot (2026-05-05)
 
 - `ruff check custom_components tests tools`: **pass**.
+- `ruff check --select I custom_components tests tools`: **pass**.
+- `ruff format --check custom_components tests tools`: **1 file drift**.
 - `python -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
 - `python tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
 - `python tools/check_maintainability.py`: **pass**.
-- `pytest tests/ -q`: **fail** (`ModuleNotFoundError: pytest_homeassistant_custom_component`).
-- `python tools/validate_entity_mappings.py`: **fail** (`ModuleNotFoundError: pydantic`).
-
-Because two required gates fail in this environment, the repo cannot be declared fully green under maintained gates from this run.
+- `python tools/validate_entity_mappings.py`: **pass**.
+- `pytest tests/ -q`: **pass** (with 4 skips).
+- Import gate (`pydantic`, `pytest`, `pytest_asyncio`, `pytest_homeassistant_custom_component`, `homeassistant`): **pass**.
 
 ## Non-required tool status
 
@@ -52,7 +53,6 @@ Because two required gates fail in this environment, the repo cannot be declared
 - `mypy`: not executed.
 - `hassfest`: not executed.
 - `HACS`: not executed.
-- `ruff format --check`: **7 files drift**.
 
 ## Remaining hotspots (current queue)
 
@@ -61,13 +61,13 @@ Because two required gates fail in this environment, the repo cannot be declared
 3. Mapping build complexity (`mappings/_mapping_builders.py`).
 4. Config-flow/device validation complexity (`config_flow.py`, `config_flow_device_validation.py`).
 
+## Branch note
+
+- Target branch for ongoing work and PR base is **dev**.
+- `main` is not authoritative for this stream.
+- No `main -> dev` merge is recommended by this audit.
+
 ## Readiness caveats
 
-- **Release/HACS readiness:** not claimable (HACS validation not executed).
+- **HACS/hassfest readiness:** not claimable (not executed in this run).
 - **Real-device readiness:** not claimable from this verification run; no new on-device evidence captured.
-
-## Next recommended PRs
-
-1. Gate recovery: make the verification environment reliably install `pytest_homeassistant_custom_component` and `pydantic`, then rerun required maintained gates.
-2. Optional formatting-only PR for `ruff format` drift (7 files) after required gates pass.
-3. Continue focused decomposition PRs for the largest coordinator/scanner/mapping/config-flow hotspots.


### PR DESCRIPTION
### Motivation

- Refresh the maintainability audit and refactor status documentation after a local verification run to reflect current gate results and meta-information. 
- Capture the successful import gate and resolve prior false negatives caused by missing local package installs in the audit output. 
- Narrow formatting drift reporting and update AST/size snapshots to reflect current code changes.

### Description

- Updated `docs/maintainability_audit.md` and `docs/refactor_status.md` dates and command list to include explicit import-gate checks and an upgraded `pip` install step. 
- Added an import gate summary showing `pydantic`, `pytest`, `pytest_asyncio`, `pytest_homeassistant_custom_component`, and `homeassistant` as OK, and moved `pytest` and entity-mapping statuses to pass. 
- Reduced reported `ruff format` drift to a single file (`custom_components/thessla_green_modbus/mappings/_mapping_builders.py`) and updated AST metrics (size of `_mapping_builders.py` increased). 
- Clarified branch targeting and readiness caveats by marking `dev` as the working target and noting CI/HACS/hassfest validations were not executed.

### Testing

- `ruff check custom_components tests tools` passed as reported in the audit. 
- `ruff format --check custom_components tests tools` reports one file would be reformatted (`_mapping_builders.py`). 
- `python -m compileall -q custom_components/thessla_green_modbus tests tools`, `python tools/compare_registers_with_reference.py`, and `python tools/check_maintainability.py` all passed (with informational output documented). 
- `python tools/validate_entity_mappings.py` passed and `pytest tests/ -q` passed with `4 skipped` and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c646ae0c8326ab0d39525e1a886e)