### PR TITLE
refactor(config_flow): extract resolve_reauth_form_state helper

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -50,12 +50,10 @@ from .config_flow_runtime import (
 )
 from .config_flow_runtime import run_with_retry as _run_with_retry_impl
 from .config_flow_schema import build_connection_schema as _build_connection_schema_impl
-from .config_flow_steps import build_reauth_form_defaults as _build_reauth_form_defaults_impl
 from .config_flow_steps import extract_discovered_state as _extract_discovered_state_impl
-from .config_flow_steps import initialize_reauth_state as _initialize_reauth_state_impl
 from .config_flow_steps import merge_options_payload as _merge_options_payload_impl
-from .config_flow_steps import resolve_reauth_defaults as _resolve_reauth_defaults_impl
 from .config_flow_steps import resolve_reauth_entry as _resolve_reauth_entry_impl
+from .config_flow_steps import resolve_reauth_form_state as _resolve_reauth_form_state_impl
 from .config_flow_steps import validate_options_submission as _validate_options_submission_impl
 from .config_flow_user_submit import process_user_submission as _process_user_submission_impl
 from .config_flow_validation import process_scan_capabilities as _process_scan_capabilities_impl
@@ -398,22 +396,17 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
         errors: dict[str, str] = {}
         entry = _resolve_reauth_entry_impl(self.hass, self.context)
 
-        defaults: dict[str, Any] = {}
-        if entry is not None:
-            defaults = _resolve_reauth_defaults_impl(entry.data, entry.options)
-
-        should_initialize, reauth_entry_id, reauth_defaults = _initialize_reauth_state_impl(
+        should_initialize, reauth_entry_id, defaults = _resolve_reauth_form_state_impl(
             active_entry_id=self._tg_flow_reauth_entry_id,
             entry=entry,
-            defaults=defaults,
+            user_input=user_input,
+            existing_data=self._tg_flow_reauth_existing_data,
         )
 
         if should_initialize:
             self._tg_flow_reauth_entry_id = reauth_entry_id
-            self._tg_flow_reauth_existing_data = reauth_defaults
-            return self._show_connection_form(
-                step_id="reauth", defaults=reauth_defaults, errors=errors
-            )
+            self._tg_flow_reauth_existing_data = defaults
+            return self._show_connection_form(step_id="reauth", defaults=defaults, errors=errors)
 
         if user_input is not None:
             info, submit_errors = await _process_reauth_submission_impl(
@@ -430,10 +423,7 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
 
         return self._show_connection_form(
             step_id="reauth",
-            defaults=_build_reauth_form_defaults_impl(
-                user_input=user_input,
-                existing_data=self._tg_flow_reauth_existing_data,
-            ),
+            defaults=defaults,
             errors=errors,
         )
 

--- a/custom_components/thessla_green_modbus/config_flow_steps.py
+++ b/custom_components/thessla_green_modbus/config_flow_steps.py
@@ -65,6 +65,34 @@ def initialize_reauth_state(
     return False, active_entry_id, dict(defaults)
 
 
+def resolve_reauth_form_state(
+    *,
+    active_entry_id: str | None,
+    entry: Any | None,
+    user_input: dict[str, Any] | None,
+    existing_data: dict[str, Any] | None,
+) -> tuple[bool, str | None, dict[str, Any]]:
+    """Resolve reauth flow state transition and form defaults."""
+    entry_defaults = resolve_reauth_defaults(
+        getattr(entry, "data", None),
+        getattr(entry, "options", None),
+    )
+    should_initialize, reauth_entry_id, reauth_defaults = initialize_reauth_state(
+        active_entry_id=active_entry_id,
+        entry=entry,
+        defaults=entry_defaults,
+    )
+    form_defaults = (
+        reauth_defaults
+        if should_initialize
+        else build_reauth_form_defaults(
+            user_input=user_input,
+            existing_data=existing_data,
+        )
+    )
+    return should_initialize, reauth_entry_id, form_defaults
+
+
 def build_reauth_form_defaults(
     *,
     user_input: dict[str, Any] | None,

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -23,6 +23,7 @@ from custom_components.thessla_green_modbus.config_flow_steps import (
     initialize_reauth_state,
     resolve_reauth_defaults,
     resolve_reauth_entry,
+    resolve_reauth_form_state,
 )
 from custom_components.thessla_green_modbus.errors import CannotConnect
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
@@ -335,6 +336,40 @@ def test_initialize_reauth_state_initializes_from_entry():
     assert defaults == {"host": "10.0.0.10"}
 
 
+
+
+def test_resolve_reauth_form_state_initializes_from_entry():
+    from types import SimpleNamespace
+
+    entry = SimpleNamespace(
+        entry_id="entry-9",
+        data={"host": "10.0.0.1"},
+        options={"deep_scan": True},
+    )
+
+    should_init, entry_id, defaults = resolve_reauth_form_state(
+        active_entry_id=None,
+        entry=entry,
+        user_input=None,
+        existing_data=None,
+    )
+
+    assert should_init is True
+    assert entry_id == "entry-9"
+    assert defaults == {"host": "10.0.0.1", "deep_scan": True}
+
+
+def test_resolve_reauth_form_state_uses_form_defaults_after_init():
+    should_init, entry_id, defaults = resolve_reauth_form_state(
+        active_entry_id="entry-9",
+        entry=None,
+        user_input={"host": "from_user"},
+        existing_data={"host": "from_existing"},
+    )
+
+    assert should_init is False
+    assert entry_id == "entry-9"
+    assert defaults == {"host": "from_user"}
 def test_build_reauth_form_defaults_prefers_user_input():
     defaults = build_reauth_form_defaults(
         user_input={"host": "from_user"},


### PR DESCRIPTION
### Motivation
- Reduce branching and inline form/state logic in `config_flow.py` by centralizing reauth state/default resolution in a focused helper to improve maintainability without changing user-visible behavior.
- Preserve existing config flow steps, reauth/reconfigure semantics, options flow behavior, error keys, and abort reasons while making the reauth orchestration easier to reason about and test.

### Description
- Added `resolve_reauth_form_state(...)` to `custom_components/thessla_green_modbus/config_flow_steps.py` to encapsulate entry-default extraction, initialization decision, and selection of form defaults.
- Updated `custom_components/thessla_green_modbus/config_flow.py` to import and delegate to `resolve_reauth_form_state` from `async_step_reauth`, removing the previous inline branching and defaults assembly.
- Added focused unit tests in `tests/test_config_flow_helpers.py` covering initialization-from-entry and post-initialization (form-default) paths for the new helper.
- Files changed: `custom_components/thessla_green_modbus/config_flow.py`, `custom_components/thessla_green_modbus/config_flow_steps.py`, and `tests/test_config_flow_helpers.py` and no user-facing behavior or schemas were altered.

### Testing
- Ran `ruff check custom_components/thessla_green_modbus/config_flow*.py tests/test_config_flow*.py --fix` and `ruff check ...` successfully with no remaining lint errors.
- Ran `python -m compileall -q custom_components/thessla_green_modbus/config_flow*.py tests/test_config_flow*.py` successfully with no syntax errors.
- `pytest -q tests/test_config_flow*.py` could not complete in this environment due to a missing external dependency (`pydantic`) during test import, preventing full test execution here.
- `python tools/check_maintainability.py` passed, `python tools/validate_entity_mappings.py` failed to run here due to the same missing dependency, and `python tools/compare_registers_with_reference.py` executed and reported its reference output.

Commit hash: `cbaba1d3`.
PR base branch: `dev`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce57143848326a25a71e324933251)