### PR TITLE
refactor(mappings): split static discrete mapping group

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_static_discrete.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_discrete.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
+from ._static_discrete_diagnostics import DIAGNOSTIC_BINARY_SENSOR_ENTITY_MAPPINGS
+
 
 def _select_payload(icon: str, translation_key: str, states: dict[str, int]) -> dict[str, Any]:
     """Build a standard select entity mapping payload."""
@@ -178,7 +180,7 @@ SELECT_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     },
 }
 
-BINARY_SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
+BINARY_SENSOR_BASE_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
     # System status (from coil registers)
     "duct_water_heater_pump": {
         "translation_key": "duct_water_heater_pump",
@@ -348,38 +350,11 @@ BINARY_SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
         "device_class": BinarySensorDeviceClass.RUNNING,
         "register_type": "holding_registers",
     },
-    # Filter alarm flags (f_ prefix → diagnostic binary sensors)
-    "f_142": {
-        "translation_key": "f_142",
-        "icon": "mdi:filter-remove",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "holding_registers",
-    },
-    "f_143": {
-        "translation_key": "f_143",
-        "icon": "mdi:filter-remove",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "holding_registers",
-    },
-    "f_146": {
-        "translation_key": "f_146",
-        "icon": "mdi:filter-alert",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "holding_registers",
-    },
-    "f_147": {
-        "translation_key": "f_147",
-        "icon": "mdi:filter-alert",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "register_type": "holding_registers",
-    },
-    # Secondary heater (ERV) status
-    "post_heater_on": {
-        "translation_key": "post_heater_on",
-        "icon": "mdi:radiator",
-        "device_class": BinarySensorDeviceClass.HEAT,
-        "register_type": "holding_registers",
-    },
+}
+
+BINARY_SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
+    **BINARY_SENSOR_BASE_ENTITY_MAPPINGS,
+    **DIAGNOSTIC_BINARY_SENSOR_ENTITY_MAPPINGS,
 }
 
 SWITCH_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {

--- a/custom_components/thessla_green_modbus/mappings/_static_discrete_diagnostics.py
+++ b/custom_components/thessla_green_modbus/mappings/_static_discrete_diagnostics.py
@@ -1,0 +1,44 @@
+"""Extracted diagnostic binary-sensor mappings from static discrete mappings."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+DIAGNOSTIC_BINARY_SENSOR_ENTITY_MAPPINGS: dict[str, dict[str, Any]] = {
+    # Filter alarm flags (f_ prefix → diagnostic binary sensors)
+    "f_142": {
+        "translation_key": "f_142",
+        "icon": "mdi:filter-remove",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "register_type": "holding_registers",
+    },
+    "f_143": {
+        "translation_key": "f_143",
+        "icon": "mdi:filter-remove",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "register_type": "holding_registers",
+    },
+    "f_146": {
+        "translation_key": "f_146",
+        "icon": "mdi:filter-alert",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "register_type": "holding_registers",
+    },
+    "f_147": {
+        "translation_key": "f_147",
+        "icon": "mdi:filter-alert",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "register_type": "holding_registers",
+    },
+    # Secondary heater (ERV) status
+    "post_heater_on": {
+        "translation_key": "post_heater_on",
+        "icon": "mdi:radiator",
+        "device_class": BinarySensorDeviceClass.HEAT,
+        "register_type": "holding_registers",
+    },
+}
+
+__all__ = ["DIAGNOSTIC_BINARY_SENSOR_ENTITY_MAPPINGS"]

--- a/tests/test_entity_mappings_static_groups.py
+++ b/tests/test_entity_mappings_static_groups.py
@@ -1,5 +1,11 @@
 """Focused tests for extracted static mapping groups."""
 
+from custom_components.thessla_green_modbus.mappings._static_discrete import (
+    BINARY_SENSOR_ENTITY_MAPPINGS,
+)
+from custom_components.thessla_green_modbus.mappings._static_discrete_diagnostics import (
+    DIAGNOSTIC_BINARY_SENSOR_ENTITY_MAPPINGS,
+)
 from custom_components.thessla_green_modbus.mappings._static_sensor_temperatures import (
     HOLDING_TEMPERATURE_SENSOR_MAPPINGS,
     INPUT_TEMPERATURE_SENSOR_MAPPINGS,
@@ -36,3 +42,8 @@ def test_extracted_group_payloads_match_exported_sensor_mappings() -> None:
         **HOLDING_TEMPERATURE_SENSOR_MAPPINGS,
     }.items():
         assert SENSOR_ENTITY_MAPPINGS[key] == payload
+
+
+def test_extracted_diagnostic_binary_group_payloads_match_exported_mappings() -> None:
+    for key, payload in DIAGNOSTIC_BINARY_SENSOR_ENTITY_MAPPINGS.items():
+        assert BINARY_SENSOR_ENTITY_MAPPINGS[key] == payload


### PR DESCRIPTION
### Motivation
- Reduce the size and complexity of `custom_components/thessla_green_modbus/mappings/_static_discrete.py` by extracting a cohesive diagnostic binary-sensor mapping group into its own module while preserving all exported mapping payloads and identifiers.
- Keep all mapping payloads, entity unique IDs, names, register addresses and platforms unchanged so downstream validation and consumers see identical outputs.

### Description
- Added a new module `custom_components/thessla_green_modbus/mappings/_static_discrete_diagnostics.py` that defines `DIAGNOSTIC_BINARY_SENSOR_ENTITY_MAPPINGS` for the diagnostic sensors (`f_142`, `f_143`, `f_146`, `f_147`, `post_heater_on`).
- Kept the original entries in the main file under `BINARY_SENSOR_BASE_ENTITY_MAPPINGS` and re-exported the final `BINARY_SENSOR_ENTITY_MAPPINGS` by composing `**BINARY_SENSOR_BASE_ENTITY_MAPPINGS` with `**DIAGNOSTIC_BINARY_SENSOR_ENTITY_MAPPINGS` to preserve final payloads.
- Added `test_extracted_diagnostic_binary_group_payloads_match_exported_mappings` in `tests/test_entity_mappings_static_groups.py` to assert the extracted diagnostic payloads exactly match the exported `BINARY_SENSOR_ENTITY_MAPPINGS`.
- Export and public API shape unchanged (`BINARY_SENSOR_ENTITY_MAPPINGS`, `SELECT_ENTITY_MAPPINGS`, `SWITCH_ENTITY_MAPPINGS`) and target branch is `dev`.

### Testing
- Ran `ruff` with `--fix` and `ruff` checks successfully and applied fixes where needed.
- Ran `python -m compileall` successfully and static import-level checks passed in this environment.
- Could not run full mapping validation or `pytest` in this environment because `python tools/validate_entity_mappings.py` and `pytest` failed due to a missing optional dependency (`pydantic`), so total entity count validation was not produced here.
- Ran `python tools/check_maintainability.py` (passed) and `python tools/compare_registers_with_reference.py` which executed and reported existing reference/integration differences (no changes introduced by this refactor aside from file splitting).
- File metrics: `custom_components/thessla_green_modbus/mappings/_static_discrete.py` non-empty lines reduced from 444 to 417 (net -27 lines) and payloads for extracted keys remain present via composed export.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce576ae5c8326b8a52b77e93510be)