### PR TITLE
refactor(scanner): extract connection-configuration resolution into scanner.state

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/core.py
+++ b/custom_components/thessla_green_modbus/scanner/core.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, cast
 
 from .. import scanner_register_maps as _register_maps
 from ..const import (
-    CONNECTION_MODE_AUTO,
     DEFAULT_BAUD_RATE,
     DEFAULT_CONNECTION_TYPE,
     DEFAULT_PARITY,
@@ -38,9 +37,6 @@ from ..scanner_helpers import (
 )
 from ..scanner_helpers import (
     SAFE_REGISTERS as _SAFE_REGISTERS,
-)
-from ..utils import (
-    resolve_connection_settings,
 )
 from . import capabilities_facade as scanner_capabilities_facade
 from . import firmware as scanner_firmware
@@ -164,7 +160,7 @@ class ThesslaGreenDeviceScanner(
             resolved_type,
             resolved_mode,
             resolved_fixed_mode,
-        ) = self._resolve_connection_configuration(
+        ) = scanner_state.resolve_connection_configuration(
             connection_type,
             connection_mode,
             port,
@@ -195,19 +191,6 @@ class ThesslaGreenDeviceScanner(
         """Pre-compute addresses of known missing registers for batch grouping."""
         scanner_setup.populate_known_missing_addresses(self)
         self._update_known_missing_addresses()
-
-    @staticmethod
-    def _resolve_connection_configuration(
-        connection_type: str,
-        connection_mode: str | None,
-        port: int,
-    ) -> tuple[str, str, str | None]:
-        """Resolve transport selection and cached fixed mode."""
-        resolved_type, resolved_mode = resolve_connection_settings(
-            connection_type, connection_mode, port
-        )
-        resolved_fixed_mode = resolved_mode if resolved_mode != CONNECTION_MODE_AUTO else None
-        return resolved_type, resolved_mode, resolved_fixed_mode
 
     def _update_known_missing_addresses(self) -> None:
         """Populate cached missing register addresses from known missing list."""

--- a/custom_components/thessla_green_modbus/scanner/state.py
+++ b/custom_components/thessla_green_modbus/scanner/state.py
@@ -21,6 +21,7 @@ from ..scanner_register_maps import (
     INPUT_REGISTERS,
     MULTI_REGISTER_SIZES,
 )
+from ..utils import resolve_connection_settings
 
 
 @dataclass(frozen=True)
@@ -76,6 +77,19 @@ def build_connection_state(
         parity=normalized_parity,
         stop_bits=normalized_stop_bits,
     )
+
+
+def resolve_connection_configuration(
+    connection_type: str,
+    connection_mode: str | None,
+    port: int,
+) -> tuple[str, str, str | None]:
+    """Resolve transport selection and cached fixed mode."""
+    resolved_type, resolved_mode = resolve_connection_settings(
+        connection_type, connection_mode, port
+    )
+    resolved_fixed_mode = resolved_mode if resolved_mode != CONNECTION_MODE_AUTO else None
+    return resolved_type, resolved_mode, resolved_fixed_mode
 
 
 def apply_connection_state(scanner: Any, state: ScannerConnectionState) -> None:

--- a/tests/test_device_scanner_setup.py
+++ b/tests/test_device_scanner_setup.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from custom_components.thessla_green_modbus.const import CONNECTION_MODE_AUTO
 from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
+from custom_components.thessla_green_modbus.scanner import state as scanner_state
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 
 pytestmark = pytest.mark.asyncio
@@ -73,7 +74,7 @@ async def test_scanner_has_read_coil_method():
 def test_resolve_connection_configuration_fixed_mode():
     """Resolved non-auto mode should be cached as fixed mode."""
     resolved_type, resolved_mode, resolved_fixed_mode = (
-        ThesslaGreenDeviceScanner._resolve_connection_configuration(
+        scanner_state.resolve_connection_configuration(
             "tcp",
             "tcp",
             502,
@@ -87,7 +88,7 @@ def test_resolve_connection_configuration_fixed_mode():
 def test_resolve_connection_configuration_auto_mode():
     """Resolved auto mode should not pre-cache fixed mode."""
     resolved_type, resolved_mode, resolved_fixed_mode = (
-        ThesslaGreenDeviceScanner._resolve_connection_configuration(
+        scanner_state.resolve_connection_configuration(
             "tcp",
             CONNECTION_MODE_AUTO,
             502,


### PR DESCRIPTION
### Motivation
- Reduce size and surface area of `ThesslaGreenDeviceScanner` by extracting the cohesive responsibility of connection parameter normalization and transport-mode resolution to a dedicated helper.

### Description
- Added `resolve_connection_configuration(...)` to `custom_components/thessla_green_modbus/scanner/state.py` which encapsulates resolution of transport type/mode and the cached fixed-mode semantics.
- Removed the `_resolve_connection_configuration` staticmethod from `custom_components/thessla_green_modbus/scanner/core.py` and updated the scanner initialization to call `scanner_state.resolve_connection_configuration(...)` instead.
- Updated `tests/test_device_scanner_setup.py` to call `scanner_state.resolve_connection_configuration(...)` in the focused setup tests so behavior is validated via the new helper.

### Testing
- Ran `ruff check ... --fix` and `ruff check ...` on the scanner and related tests and the checks passed.
- Ran `python -m compileall -q` on the modified scanner and tests and compilation succeeded.
- Ran `pytest -q tests/test_scanner*.py tests/test_device_scanner*.py` but test execution was aborted by a missing environment dependency (`ModuleNotFoundError: No module named 'pydantic'`).
- Ran `python tools/check_maintainability.py` which passed, and `python tools/compare_registers_with_reference.py` which executed; `python tools/validate_entity_mappings.py` was unable to complete due to the same missing `pydantic` dependency.
- Verified there are no Home Assistant imports in the scanner package via the required grep check, and `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce57c253883268ad13761b5c7f6ce)