### PR TITLE
refactor(coordinator): extract finalize_write_result helper into write_path

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -10,7 +10,7 @@ from ..const import MAX_REGS_PER_REQUEST
 from ..modbus_exceptions import ConnectionException, ModbusException
 from ..modbus_helpers import chunk_register_values
 from ..registers import REG_TEMPORARY_FLOW_START, REG_TEMPORARY_TEMP_START
-from .write_path import SingleWritePlan, run_single_write_attempts
+from .write_path import SingleWritePlan, finalize_write_result, run_single_write_attempts
 
 if TYPE_CHECKING:
     from ..modbus_transport import BaseModbusTransport
@@ -49,6 +49,9 @@ class _CoordinatorScheduleMixin:
     async def _ensure_connection(self) -> None: ...
     async def _disconnect(self) -> None: ...
     def _clear_register_failure(self, name: str) -> None: ...
+    async def _safe_request_refresh(self) -> None:
+        """Request refresh and ignore mock-context TypeError in tests."""
+        await _safe_request_refresh(self)
     def _assert_write_connection_ready(self) -> None:
         """Ensure transport/client is present and connected for writes."""
         transport = self._transport
@@ -287,12 +290,6 @@ class _CoordinatorScheduleMixin:
 
         raise exc
 
-    async def _finalize_write_result(self, refresh_after_write: bool) -> bool:
-        """Finish write operation with optional refresh."""
-        if refresh_after_write:
-            await _safe_request_refresh(self)
-        return True
-
     def _handle_successful_single_register_write(
         self,
         *,
@@ -407,7 +404,7 @@ class _CoordinatorScheduleMixin:
                 _LOGGER.exception("Failed to write register %s", register_name)
                 return False
 
-        return await self._finalize_write_result(refresh_after_write)
+        return await finalize_write_result(self, refresh_after_write)
 
     async def async_write_registers(
         self,
@@ -475,9 +472,7 @@ class _CoordinatorScheduleMixin:
                 _LOGGER.exception("Failed to write registers at %s", start_address)
                 return False
 
-        if refresh_after_write:
-            await _safe_request_refresh(self)
-        return True
+        return await finalize_write_result(self, refresh_after_write)
 
     async def async_write_temporary_airflow(self, airflow: float, refresh: bool = True) -> bool:
         """Write temporary airflow settings using the 3-register block."""

--- a/custom_components/thessla_green_modbus/coordinator/write_path.py
+++ b/custom_components/thessla_green_modbus/coordinator/write_path.py
@@ -64,3 +64,10 @@ async def run_single_write_attempts(
                 return False, False
             continue
     return True, refresh_after_write
+
+
+async def finalize_write_result(coordinator: Any, refresh_after_write: bool) -> bool:
+    """Finish write operation with optional refresh."""
+    if refresh_after_write:
+        await coordinator._safe_request_refresh()
+    return True

--- a/tests/test_coordinator_register_writes.py
+++ b/tests/test_coordinator_register_writes.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
+from custom_components.thessla_green_modbus.coordinator.write_path import finalize_write_result
 from custom_components.thessla_green_modbus.registers.loader import RegisterDef
 
 
@@ -222,3 +223,25 @@ def test_handle_successful_single_register_write_without_refresh(coordinator):
 
     assert refresh_after_write is False
     coordinator._clear_register_failure.assert_called_once_with("mode")
+
+
+@pytest.mark.asyncio
+async def test_finalize_write_result_refreshes_when_enabled(coordinator):
+    """Finalize helper should refresh when flag is set."""
+    coordinator._safe_request_refresh = AsyncMock()
+
+    result = await finalize_write_result(coordinator, True)
+
+    assert result is True
+    coordinator._safe_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_finalize_write_result_skips_refresh_when_disabled(coordinator):
+    """Finalize helper should skip refresh when flag is unset."""
+    coordinator._safe_request_refresh = AsyncMock()
+
+    result = await finalize_write_result(coordinator, False)
+
+    assert result is True
+    coordinator._safe_request_refresh.assert_not_called()


### PR DESCRIPTION
### Motivation
- Reduce size and complexity of `_CoordinatorScheduleMixin` by extracting the write-finalization step (refresh-after-write) into a focused helper to centralize post-write behavior and simplify write-path orchestration.

### Description
- Extracted `finalize_write_result(coordinator, refresh_after_write)` into `custom_components/thessla_green_modbus/coordinator/write_path.py` and delegated both `async_write_register` and `async_write_registers` to it for post-lock finalization; introduced a small `_safe_request_refresh` delegator on the mixin to keep internal orchestration unchanged.
- Added two unit tests in `tests/test_coordinator_register_writes.py` to verify the finalization helper refreshes when enabled and skips refresh when disabled.
- Files changed: `custom_components/thessla_green_modbus/coordinator/schedule.py`, `custom_components/thessla_green_modbus/coordinator/write_path.py`, and `tests/test_coordinator_register_writes.py`.
- No changes were made to public coordinator API or to retry/chunking/disconnect/refresh semantics and logging/exception behavior.

### Testing
- Ran `ruff` (with `--fix`) and `ruff` checks successfully and ran `python -m compileall` successfully for the modified modules.
- Ran repository tooling: maintainability check passed and register reference comparison executed (project-level report produced); entity-mapping validation produced an execution error due to a missing environment dependency.
- Attempted `pytest` run for coordinator tests but execution was blocked by a missing `pydantic` dependency in this environment, so full test execution could not be completed here; the newly added tests are small and focused on the extracted helper.
- The change is limited to internal refactoring and preserves the prior observed write-lock and write-path behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce581933c83269ef286487dc6d321)