### PR TITLE
refactor(modbus): continue helper call-path cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -401,6 +401,56 @@ async def _dispatch_modbus_call(
     return await _invoke()
 
 
+async def _apply_attempt_delay(
+    *,
+    delay: float,
+    func_name: str,
+    attempt: int,
+    max_attempts: int,
+) -> None:
+    """Apply pre-attempt delay while preserving cancellation diagnostics."""
+    if delay <= 0:
+        return
+
+    _LOGGER.debug(
+        "Delaying %.3fs before attempt %s/%s of %s",
+        delay,
+        attempt,
+        max_attempts,
+        func_name,
+    )
+    try:
+        await asyncio.sleep(delay)
+    except asyncio.CancelledError:
+        _LOGGER.debug(
+            "Sleep cancelled before calling %s attempt %s/%s",
+            func_name,
+            attempt,
+            max_attempts,
+        )
+        raise
+
+
+def _raise_mapped_call_exception(
+    err: Exception,
+    *,
+    func_name: str,
+    attempt: int,
+    max_attempts: int,
+) -> None:
+    """Log call classification and re-raise preserving existing behavior."""
+    if isinstance(err, TimeoutError):
+        _LOGGER.debug("Call to %s timed out on attempt %s/%s", func_name, attempt, max_attempts)
+        raise TimeoutError("Modbus request timed out") from err
+
+    classification = _classify_modbus_exception(err)
+    if classification == "cancelled":
+        _LOGGER.debug("Call to %s cancelled on attempt %s/%s", func_name, attempt, max_attempts)
+    else:
+        _LOGGER.debug("Call to %s failed on attempt %s/%s", func_name, attempt, max_attempts)
+    raise
+
+
 async def _call_modbus(
     func: Callable[..., Awaitable[Any]],
     slave_id: int,
@@ -432,24 +482,12 @@ async def _call_modbus(
     )
 
     prepared = _PreparedCall(positional, kwarg, func_name, batch_size, delay)
-    if prepared.delay > 0:
-        _LOGGER.debug(
-            "Delaying %.3fs before attempt %s/%s of %s",
-            prepared.delay,
-            attempt,
-            max_attempts,
-            prepared.func_name,
-        )
-        try:
-            await asyncio.sleep(prepared.delay)
-        except asyncio.CancelledError:
-            _LOGGER.debug(
-                "Sleep cancelled before calling %s attempt %s/%s",
-                prepared.func_name,
-                attempt,
-                max_attempts,
-            )
-            raise
+    await _apply_attempt_delay(
+        delay=prepared.delay,
+        func_name=prepared.func_name,
+        attempt=attempt,
+        max_attempts=max_attempts,
+    )
 
     _LOGGER.debug(
         "Calling %s on slave %s (batch=%s attempt %s/%s)",
@@ -477,10 +515,9 @@ async def _call_modbus(
             timeout=timeout,
         )
     except TimeoutError as err:
-        _LOGGER.debug(
-            "Call to %s timed out on attempt %s/%s", prepared.func_name, attempt, max_attempts
+        _raise_mapped_call_exception(
+            err, func_name=prepared.func_name, attempt=attempt, max_attempts=max_attempts
         )
-        raise TimeoutError("Modbus request timed out") from err
     except asyncio.CancelledError:
         _LOGGER.debug(
             "Call to %s cancelled on attempt %s/%s", prepared.func_name, attempt, max_attempts
@@ -494,16 +531,9 @@ async def _call_modbus(
         TypeError,
         ValueError,
     ) as err:
-        classification = _classify_modbus_exception(err)
-        if classification == "cancelled":
-            _LOGGER.debug(
-                "Call to %s cancelled on attempt %s/%s", prepared.func_name, attempt, max_attempts
-            )
-        else:
-            _LOGGER.debug(
-                "Call to %s failed on attempt %s/%s", prepared.func_name, attempt, max_attempts
-            )
-        raise
+        _raise_mapped_call_exception(
+            err, func_name=prepared.func_name, attempt=attempt, max_attempts=max_attempts
+        )
 
     _log_modbus_response(prepared.func_name, response)
     return response

--- a/tests/test_modbus_helpers_call_flow.py
+++ b/tests/test_modbus_helpers_call_flow.py
@@ -29,10 +29,12 @@ from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOExc
 from custom_components.thessla_green_modbus.modbus_helpers import (
     _KWARG_CACHE,
     _SIG_CACHE,
+    _apply_attempt_delay,
     _calculate_batch_size,
     _call_modbus,
     _classify_modbus_exception,
     _prepare_modbus_call,
+    _raise_mapped_call_exception,
     async_close_client,
     group_reads,
 )
@@ -217,6 +219,34 @@ def test_calculate_batch_size_uses_values_length():
 def test_calculate_batch_size_defaults_to_one():
     """Empty kwargs defaults to one request item."""
     assert _calculate_batch_size({}) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_attempt_delay_zero_does_not_sleep(monkeypatch):
+    """Zero delay exits early without calling asyncio.sleep."""
+    called = False
+
+    async def fake_sleep(_delay):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await _apply_attempt_delay(delay=0.0, func_name="read_holding_registers", attempt=1, max_attempts=2)
+    assert called is False  # nosec B101
+
+
+def test_raise_mapped_call_exception_timeout():
+    """Timeout errors are wrapped with the helper message."""
+    with pytest.raises(TimeoutError, match="Modbus request timed out"):
+        try:
+            raise TimeoutError("inner timeout")
+        except TimeoutError as err:
+            _raise_mapped_call_exception(
+                err,
+                func_name="read_input_registers",
+                attempt=1,
+                max_attempts=3,
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Reduce complexity inside `_call_modbus` by extracting cohesive, behavior-preserving helpers for pre-attempt delay and mapped exception handling.
- Make the call flow easier to reason about and unit-test without changing observable Modbus behavior.

### Description
- Extracted `_apply_attempt_delay(...)` to encapsulate pre-attempt backoff sleep and cancellation diagnostics, and replaced the inline sleep logic in `_call_modbus` with a call to this helper; files changed: `custom_components/thessla_green_modbus/modbus_helpers.py` and `tests/test_modbus_helpers_call_flow.py`.
- Extracted `_raise_mapped_call_exception(...)` to centralize timeout wrapping and failure/cancelled classification logging and replaced duplicate exception-logging branches in `_call_modbus` with this helper.
- Added direct unit tests for the new helpers: `test_apply_attempt_delay_zero_does_not_sleep` and `test_raise_mapped_call_exception_timeout` in `tests/test_modbus_helpers_call_flow.py`.
- Preserved external behavior: timeout mapping (`TimeoutError("Modbus request timed out")`), cancellation propagation, retry/backoff math and application, exception classification for `ModbusIOException("request cancelled")`, slave/unit/device_id detection, logging semantics, and all public function signatures.
- `_call_modbus` length reduced from 106 to 86 lines (AST-based measurement) after delegating delay and exception paths to helpers.

### Testing
- Ran lint/format checks: `ruff check ... --fix` and `ruff check ...` — all checks passed.
- Verified syntax: `python -m compileall -q ...` — success.
- Ran targeted `pytest -q tests/test_modbus_helpers*.py tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py` but the run aborted due to a missing dependency (`ModuleNotFoundError: No module named 'pydantic'`) arising during test import, so the suite could not complete in this environment.
- Maintainers/tools: `python tools/check_maintainability.py` passed, `python tools/compare_registers_with_reference.py` executed (reported integration/reference diffs as informational), and `python tools/validate_entity_mappings.py` failed to run in this environment due to the same missing `pydantic` dependency.

Commit/branch notes: base branch for the PR must be `dev`, head branch used was `work`, and the change is recorded in commit `2fb4a96f`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce588254883269b9d5a3671626ad6)