### PR TITLE
refactor(coordinator): extract scan-cache entry retrieval from coordinator

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -144,6 +144,9 @@ from .scan import (
     firmware_lacks_known_missing as _firmware_lacks_known_missing_impl,
 )
 from .scan import (
+    get_scan_cache_from_entry as _get_scan_cache_from_entry_impl,
+)
+from .scan import (
     load_full_register_list as _load_full_register_list_impl,
 )
 from .scan import (
@@ -528,10 +531,7 @@ class ThesslaGreenModbusCoordinator(
 
     def _get_scan_cache_from_entry(self) -> dict[str, Any]:
         """Return cached scan payload from config entry options."""
-        if self.entry is None:
-            return {}
-        raw_cache = self.entry.options.get("device_scan_cache", {})
-        return raw_cache if isinstance(raw_cache, dict) else {}
+        return _get_scan_cache_from_entry_impl(self.entry)
 
     def _load_full_register_list(self) -> None:
         """Load full register list when forced."""

--- a/custom_components/thessla_green_modbus/coordinator/scan.py
+++ b/custom_components/thessla_green_modbus/coordinator/scan.py
@@ -12,6 +12,14 @@ from ..scanner_device_info import DeviceCapabilities
 _LOGGER = logging.getLogger(__name__)
 
 
+
+def get_scan_cache_from_entry(entry: Any) -> dict[str, Any]:
+    """Return cached scan payload from config entry options."""
+    if entry is None:
+        return {}
+    raw_cache = entry.options.get("device_scan_cache", {})
+    return raw_cache if isinstance(raw_cache, dict) else {}
+
 def load_full_register_list(coordinator: Any) -> None:
     """Load full register list when forced."""
     coordinator.available_registers = {

--- a/tests/test_coordinator_scan_cache.py
+++ b/tests/test_coordinator_scan_cache.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from custom_components.thessla_green_modbus.coordinator.scan import get_scan_cache_from_entry
+
+
+class _Entry:
+    def __init__(self, options):
+        self.options = options
+
+
+def test_get_scan_cache_from_entry_none_returns_empty_dict() -> None:
+    assert get_scan_cache_from_entry(None) == {}
+
+
+def test_get_scan_cache_from_entry_invalid_payload_returns_empty_dict() -> None:
+    entry = _Entry({"device_scan_cache": "bad"})
+    assert get_scan_cache_from_entry(entry) == {}
+
+
+def test_get_scan_cache_from_entry_valid_payload_returns_dict() -> None:
+    cache = {"available_registers": {"input_registers": ["mode"]}}
+    entry = _Entry({"device_scan_cache": cache})
+    assert get_scan_cache_from_entry(entry) == cache


### PR DESCRIPTION
### Motivation
- Reduce responsibilities inside `ThesslaGreenModbusCoordinator` by moving scan-cache retrieval/validation out of the main coordinator file into a focused helper.

### Description
- Add `get_scan_cache_from_entry(entry)` to `custom_components/thessla_green_modbus/coordinator/scan.py` to encapsulate retrieval and payload validation of the `device_scan_cache` entry option.
- Update `ThesslaGreenModbusCoordinator._get_scan_cache_from_entry()` to delegate to the new helper (`get_scan_cache_from_entry`) so the coordinator surface API remains unchanged.
- Add unit tests in `tests/test_coordinator_scan_cache.py` covering `None`, invalid payload, and valid payload scenarios.
- No package-root exports (`CoordinatorConfig`, `ThesslaGreenModbusCoordinator`) or Home Assistant-facing behavior were changed.

### Testing
- Ran `ruff` against the coordinator package and tests with `--fix` and then without errors, and `python -m compileall` for the changed modules; both succeeded.
- Added focused unit tests in `tests/test_coordinator_scan_cache.py` but running `pytest` for the full test selection was blocked in this environment due to missing Home Assistant test dependencies (`pytest_homeassistant_custom_component` / `homeassistant`).
- `tools/check_maintainability.py` passed and `tools/compare_registers_with_reference.py` executed (reported dataset differences as part of its output), while `tools/validate_entity_mappings.py` could not complete due to missing Home Assistant packages.
- Path invariant `test ! -f custom_components/thessla_green_modbus/coordinator.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce58da86c832685f9c8ed39f02c8c)