### PR TITLE
refactor(scanner): extract skip-range classification and terminal-logging helpers

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -26,8 +26,10 @@ from .io_read_helpers import (
     append_read_block,
     build_read_attempt_meta,
     build_success_result,
+    classify_skip_range,
     iter_grouped_read_chunks,
     normalize_bit_read_result,
+    should_log_terminal_failure,
 )
 
 try:
@@ -41,11 +43,6 @@ _LOGGER = logging.getLogger(__name__)
 def _mark_failed_addresses(scanner: Any, register_type: str, start: int, end: int) -> None:
     """Track read failures for a contiguous address range."""
     scanner.failed_addresses["modbus_exceptions"][register_type].update(range(start, end + 1))
-
-
-def _is_unsupported_range(ranges: Any, start: int, end: int) -> bool:
-    """Return True when start-end is fully covered by any unsupported range."""
-    return any(skip_start <= start and end <= skip_end for skip_start, skip_end in ranges)
 
 
 def _log_read_abort(kind: str, start: int, end: int, attempt: int, retry: int) -> None:
@@ -223,7 +220,7 @@ def _finalize_register_read_failure(
     kind = "input" if register_type == "input_registers" else "holding"
     if aborted_transiently:
         _log_read_abort(kind, start, end, attempted_reads, retry)
-        if register_type == "holding_registers":
+        if should_log_terminal_failure(register_type, aborted_transiently):
             _log_read_failure(kind, start, end, retry)
         return
 
@@ -235,36 +232,28 @@ def _should_skip_input_range(
     scanner: Any, start: int, end: int, skip_cache: bool
 ) -> tuple[bool, int, int]:
     """Return (skip, mark_start, mark_end) for unsupported/cached input ranges."""
-    if skip_cache:
-        return False, start, end
-    if _is_unsupported_range(scanner._unsupported_input_ranges, start, end):
-        return True, start, end
-    cached_failed_range = _expand_cached_failed_range(
+    return classify_skip_range(
         start=start,
         end=end,
+        skip_cache=skip_cache,
+        unsupported_ranges=scanner._unsupported_input_ranges,
         failed_registers=scanner._failed_input,
+        expand_cached_failed_range=_expand_cached_failed_range,
     )
-    if cached_failed_range is None:
-        return False, start, end
-    return True, cached_failed_range[0], cached_failed_range[1]
 
 
 def _should_skip_holding_range(
     scanner: Any, start: int, end: int, skip_cache: bool
 ) -> tuple[bool, int, int]:
     """Return (skip, mark_start, mark_end) for unsupported/cached holding ranges."""
-    if skip_cache:
-        return False, start, end
-    if _is_unsupported_range(scanner._unsupported_holding_ranges, start, end):
-        return True, start, end
-    cached_failed_range = _expand_cached_failed_range(
+    return classify_skip_range(
         start=start,
         end=end,
+        skip_cache=skip_cache,
+        unsupported_ranges=scanner._unsupported_holding_ranges,
         failed_registers=scanner._failed_holding,
+        expand_cached_failed_range=_expand_cached_failed_range,
     )
-    if cached_failed_range is None:
-        return False, start, end
-    return True, cached_failed_range[0], cached_failed_range[1]
 
 
 def _prepare_input_read(scanner: Any, start: int, end: int, skip_cache: bool) -> bool:

--- a/custom_components/thessla_green_modbus/scanner/io_read_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read_helpers.py
@@ -44,3 +44,34 @@ def normalize_bit_read_result(response: Any, count: int) -> list[bool] | None:
     if response is None or response.isError():
         return None
     return cast(list[bool], response.bits[:count])
+
+
+def classify_skip_range(
+    *,
+    start: int,
+    end: int,
+    skip_cache: bool,
+    unsupported_ranges: set[tuple[int, int]],
+    failed_registers: set[int],
+    expand_cached_failed_range: Any,
+) -> tuple[bool, int, int]:
+    """Classify whether a read range should be skipped as unsupported/cached-failed."""
+    if skip_cache:
+        return False, start, end
+    if any(skip_start <= start and end <= skip_end for skip_start, skip_end in unsupported_ranges):
+        return True, start, end
+    cached_failed_range = expand_cached_failed_range(
+        start=start,
+        end=end,
+        failed_registers=failed_registers,
+    )
+    if cached_failed_range is None:
+        return False, start, end
+    return True, cached_failed_range[0], cached_failed_range[1]
+
+
+def should_log_terminal_failure(register_type: str, aborted_transiently: bool) -> bool:
+    """Return True when terminal failure should be logged for the read type."""
+    if not aborted_transiently:
+        return True
+    return register_type == "holding_registers"

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -14,7 +14,9 @@ from custom_components.thessla_green_modbus.scanner.io_read import (
 )
 from custom_components.thessla_green_modbus.scanner.io_read_helpers import (
     build_read_attempt_meta,
+    classify_skip_range,
     normalize_bit_read_result,
+    should_log_terminal_failure,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -310,3 +312,52 @@ def test_normalize_bit_read_result_handles_error_and_success():
     ok_response.isError.return_value = False
     ok_response.bits = [True, False, True]
     assert normalize_bit_read_result(ok_response, 2) == [True, False]
+
+
+def test_classify_skip_range_covers_skip_cache_unsupported_and_failed():
+    """Skip classifier should preserve unsupported and cached-failed semantics."""
+    expand = MagicMock(return_value=(22, 24))
+    assert classify_skip_range(
+        start=20,
+        end=21,
+        skip_cache=True,
+        unsupported_ranges={(20, 30)},
+        failed_registers={20, 21},
+        expand_cached_failed_range=expand,
+    ) == (False, 20, 21)
+
+    assert classify_skip_range(
+        start=20,
+        end=21,
+        skip_cache=False,
+        unsupported_ranges={(20, 30)},
+        failed_registers=set(),
+        expand_cached_failed_range=expand,
+    ) == (True, 20, 21)
+
+    expand.return_value = None
+    assert classify_skip_range(
+        start=20,
+        end=21,
+        skip_cache=False,
+        unsupported_ranges=set(),
+        failed_registers={20, 21},
+        expand_cached_failed_range=expand,
+    ) == (False, 20, 21)
+
+    expand.return_value = (18, 25)
+    assert classify_skip_range(
+        start=20,
+        end=21,
+        skip_cache=False,
+        unsupported_ranges=set(),
+        failed_registers={20, 21},
+        expand_cached_failed_range=expand,
+    ) == (True, 18, 25)
+
+
+def test_should_log_terminal_failure_tracks_holding_vs_input_aborts():
+    """Terminal failure logging policy should match prior behavior."""
+    assert should_log_terminal_failure("input_registers", True) is False
+    assert should_log_terminal_failure("holding_registers", True) is True
+    assert should_log_terminal_failure("input_registers", False) is True


### PR DESCRIPTION
### Motivation
- Reduce size and duplication in `scanner/io_read.py` by extracting repeated skip/failure/finalization decision logic into small, focused helpers.
- Preserve existing retry/backoff, unsupported-range, skip-cache, and failed-register tracking semantics while making the code easier to reason about and test.

### Description
- Extracted `classify_skip_range(...)` and `should_log_terminal_failure(...)` into `custom_components/thessla_green_modbus/scanner/io_read_helpers.py` and imported them into `io_read.py` to centralize unsupported/cached-failed range classification and terminal-failure logging policy.
- Rewired `_should_skip_input_range(...)` and `_should_skip_holding_range(...)` to call `classify_skip_range(...)`, and updated `_finalize_register_read_failure(...)` to consult `should_log_terminal_failure(...)`, with no change to public function signatures.
- Added focused unit tests for both helpers in `tests/test_scanner_io.py` and left the existing retry/read loops and failure-tracking behavior intact.
- Reduced `io_read.py` non-empty line count from 713 to 704 while preserving runtime behavior.

### Testing
- Ran `ruff check` across the scanner and test files and the checks passed successfully.
- Ran `python -m compileall` over the modified modules and compilation succeeded.
- Ran `python tools/check_maintainability.py` and the maintainability gate passed.
- Executed `pytest` in this environment but it could not complete due to missing external dependency `pydantic` (environment limitation), while the new helper unit tests were added and are expected to pass in CI where dependencies are available; other repository validation scripts `compare_registers_with_reference.py` ran and returned (informational) results, and `validate_entity_mappings.py` was blocked by the same `pydantic` absence.
- Verified there are no `homeassistant` imports added to the `scanner` package and `git diff`/style checks produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce592b444832688a8e2f3472ba67b)