### PR TITLE
style: format mapping builders

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -134,7 +134,11 @@ def _should_skip_number_mapping(
 
 def _build_number_mapping_payload(info: dict[str, Any]) -> dict[str, Any]:
     """Build number mapping payload from register info metadata."""
-    cfg: dict[str, Any] = {"unit": info.get("unit"), "step": info.get("step", 1), "scale": info.get("scale", 1)}
+    cfg: dict[str, Any] = {
+        "unit": info.get("unit"),
+        "step": info.get("step", 1),
+        "scale": info.get("scale", 1),
+    }
     if info.get("min") is not None:
         cfg["min"] = info["min"]
     if info.get("max") is not None:


### PR DESCRIPTION
### Motivation
- Clear Ruff formatting drift by reformatting `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` while preserving all logic and behavior.

### Description
- Applied `ruff format` to `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` with only whitespace/formatting changes, committed as `style: format mapping builders` (commit `70a54dab`) and prepared as a PR against base branch `dev`.

### Testing
- Executed `ruff format --check`, `ruff format`, and `ruff check` (passed after formatting), `python -m compileall` (passed), `python tools/validate_entity_mappings.py` (failed in this environment due to missing `pydantic`), and `python tools/check_maintainability.py` (passed); `git diff --name-only` contains only `custom_components/thessla_green_modbus/mappings/_mapping_builders.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce597b7f08326b9adad37b7c6b967)