### PR TITLE
Split coordinator error-path tests into separate file and remove unused import

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,6 @@
 """Tests for ThesslaGreenModbusCoordinator - HA 2025.7.1+ & pymodbus 3.5+ Compatible."""
 
 import asyncio
-import logging
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -101,45 +100,6 @@ def test_coordinator_clamps_effective_batch():
     )
     assert coord.effective_batch == MAX_BATCH_REGISTERS
     assert coord.max_registers_per_request == MAX_BATCH_REGISTERS
-
-
-@pytest.mark.asyncio
-async def test_read_holding_registers_none_client(coordinator, caplog):
-    """Return empty data when no Modbus client is present."""
-    coordinator.client = None
-    coordinator._register_groups = {"holding_registers": [(0, 1)]}
-
-    with caplog.at_level(logging.DEBUG):
-        result = await coordinator._read_holding_registers_optimized()
-
-    assert result == {}
-    assert "Modbus client is not connected" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_read_holding_registers_cancelled_error(coordinator, caplog):
-    """Propagate cancellation without logging noise."""
-    coordinator.client = MagicMock()
-    coordinator._register_groups = {"holding_registers": [(0, 1)]}
-    coordinator._call_modbus = AsyncMock(side_effect=asyncio.CancelledError)
-
-    with caplog.at_level(logging.ERROR), pytest.raises(asyncio.CancelledError):
-        await coordinator._read_holding_registers_optimized()
-    assert caplog.text == ""
-
-
-@pytest.mark.asyncio
-async def test_read_input_registers_reconnect_on_error(coordinator):
-    """Ensure disconnect is triggered after Modbus errors."""
-    coordinator.client = MagicMock()
-    coordinator.client.connected = True
-    coordinator._register_groups = {"input_registers": [(0, 1)]}
-    coordinator._call_modbus = AsyncMock(side_effect=ConnectionException("boom"))
-    coordinator._disconnect = AsyncMock()
-
-    await coordinator._read_input_registers_optimized()
-
-    coordinator._disconnect.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_error_paths_split.py
+++ b/tests/test_coordinator_error_paths_split.py
@@ -1,0 +1,47 @@
+"""Focused coordinator error-path tests split from test_coordinator.py."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus.modbus_exceptions import ConnectionException
+
+
+@pytest.mark.asyncio
+async def test_read_holding_registers_none_client(coordinator, caplog):
+    """Return empty data when no Modbus client is present."""
+    coordinator.client = None
+    coordinator._register_groups = {"holding_registers": [(0, 1)]}
+
+    with caplog.at_level(logging.DEBUG):
+        result = await coordinator._read_holding_registers_optimized()
+
+    assert result == {}
+    assert "Modbus client is not connected" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_read_holding_registers_cancelled_error(coordinator, caplog):
+    """Propagate cancellation without logging noise."""
+    coordinator.client = MagicMock()
+    coordinator._register_groups = {"holding_registers": [(0, 1)]}
+    coordinator._call_modbus = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(asyncio.CancelledError):
+        await coordinator._read_holding_registers_optimized()
+    assert caplog.text == ""
+
+
+@pytest.mark.asyncio
+async def test_read_input_registers_reconnect_on_error(coordinator):
+    """Ensure disconnect is triggered after Modbus errors."""
+    coordinator.client = MagicMock()
+    coordinator.client.connected = True
+    coordinator._register_groups = {"input_registers": [(0, 1)]}
+    coordinator._call_modbus = AsyncMock(side_effect=ConnectionException("boom"))
+    coordinator._disconnect = AsyncMock()
+
+    await coordinator._read_input_registers_optimized()
+
+    coordinator._disconnect.assert_called()


### PR DESCRIPTION
### Motivation
- Separate focused error-path tests from the larger `test_coordinator.py` to improve test organization and readability.
- Reduce noise in the main coordinator test module by isolating tests that exercise reconnection and error handling.
- Remove an unused `logging` import from `tests/test_coordinator.py` to keep imports clean.

### Description
- Removed three error-path tests from `tests/test_coordinator.py` and added them into a new file `tests/test_coordinator_error_paths_split.py`.
- The moved tests are `test_read_holding_registers_none_client`, `test_read_holding_registers_cancelled_error`, and `test_read_input_registers_reconnect_on_error`, preserved with their original logic and fixtures.
- Deleted the now-unused `import logging` from `tests/test_coordinator.py` to clean up imports.

### Testing
- Ran the affected tests with `pytest tests/test_coordinator_error_paths_split.py` and `pytest tests/test_coordinator.py`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce560cee083268709653e7e2e3b03)