### PR TITLE
tests: add shared coordinator fixtures and refactor coordinator tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-pytest_plugins = ("tests.helpers_register_loader",)
+pytest_plugins = ("tests.helpers_register_loader", "tests.helpers_coordinator")
 
 
 def _ensure_current_event_loop() -> asyncio.AbstractEventLoop:

--- a/tests/helpers_coordinator.py
+++ b/tests/helpers_coordinator.py
@@ -1,0 +1,46 @@
+"""Shared coordinator fixtures/helpers for split coordinator tests."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+)
+from custom_components.thessla_green_modbus.registers.loader import get_registers_by_function
+
+
+def _make_config_entry(data: dict, options: dict | None = None) -> MagicMock:
+    """Create a minimal config entry mock."""
+    entry = MagicMock()
+    entry.data = data
+    entry.entry_id = "test"
+    entry.options = options or {}
+    return entry
+
+
+INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function("04")}
+HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
+
+
+@pytest.fixture
+def coordinator():
+    """Create a test coordinator."""
+    hass = MagicMock()
+    available_registers = {
+        "holding_registers": {"mode", "air_flow_rate_manual", "special_mode"},
+        "input_registers": {"outside_temperature", "supply_temperature"},
+        "coil_registers": {"system_on_off"},
+        "discrete_inputs": set(),
+    }
+    coordinator = ThesslaGreenModbusCoordinator.from_params(
+        hass=hass,
+        host="localhost",
+        port=502,
+        slave_id=1,
+        name="test",
+        scan_interval=30,
+        timeout=10,
+        retry=3,
+    )
+    coordinator.available_registers = available_registers
+    return coordinator

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -15,10 +15,9 @@ from custom_components.thessla_green_modbus.modbus_exceptions import (
     ConnectionException,
     ModbusException,
 )
-from custom_components.thessla_green_modbus.registers.loader import (
-    RegisterDef,
-    get_registers_by_function,
-)
+from custom_components.thessla_green_modbus.registers.loader import RegisterDef
+
+from tests.helpers_coordinator import HOLDING_REGISTERS, INPUT_REGISTERS, _make_config_entry
 
 try:
     from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
@@ -31,18 +30,6 @@ except ImportError:
     class UpdateFailed(Exception):  # type: ignore[no-redef]
         pass
 
-
-def _make_config_entry(data: dict, options: dict | None = None) -> MagicMock:
-    """Create a minimal config entry mock."""
-    entry = MagicMock()
-    entry.data = data
-    entry.entry_id = "test"
-    entry.options = options or {}
-    return entry
-
-
-INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function("04")}
-HOLDING_REGISTERS = {r.name: r.address for r in get_registers_by_function("03")}
 
 # ✅ FIXED: Import correct coordinator class name
 from custom_components.thessla_green_modbus.coordinator import (
@@ -57,30 +44,6 @@ def test_dt_util_timezone_awareness():
     """Ensure coordinator dt util keeps expected callables available."""
     assert callable(coordinator_dt_util.now)
     assert callable(coordinator_dt_util.utcnow)
-
-
-@pytest.fixture
-def coordinator():
-    """Create a test coordinator."""
-    hass = MagicMock()
-    available_registers = {
-        "holding_registers": {"mode", "air_flow_rate_manual", "special_mode"},
-        "input_registers": {"outside_temperature", "supply_temperature"},
-        "coil_registers": {"system_on_off"},
-        "discrete_inputs": set(),
-    }
-    coordinator = ThesslaGreenModbusCoordinator.from_params(
-        hass=hass,
-        host="localhost",
-        port=502,
-        slave_id=1,
-        name="test",
-        scan_interval=30,
-        timeout=10,
-        retry=3,
-    )
-    coordinator.available_registers = available_registers
-    return coordinator
 
 
 def test_coordinator_clamps_effective_batch():


### PR DESCRIPTION
### Motivation
- Provide a shared coordinator fixture and helpers to reduce duplication across coordinator tests and support split/coordinator test layouts.
- Make tests compatible with the new helper module and simplify imports in `tests/test_coordinator.py`.

### Description
- Added `tests/helpers_coordinator.py` which provides `_make_config_entry`, `INPUT_REGISTERS`, `HOLDING_REGISTERS`, and a `coordinator` fixture that constructs a `ThesslaGreenModbusCoordinator` test instance.
- Updated `tests/conftest.py` to load the new plugin by appending `"tests.helpers_coordinator"` to `pytest_plugins`.
- Refactored `tests/test_coordinator.py` to import `HOLDING_REGISTERS`, `INPUT_REGISTERS`, and `_make_config_entry` from `tests.helpers_coordinator` and removed the duplicated local definitions and fixture, while cleaning up related imports.

### Testing
- Ran the test suite for coordinator tests with `pytest` targeting `tests/test_coordinator.py` and the related fixtures, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7a503074832693ac142400f132c8)