### PR TITLE
style: apply ruff formatting

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -648,8 +648,8 @@ class ThesslaGreenModbusCoordinator(
         transport, mode = await _select_auto_transport_impl(
             resolved_connection_mode=self._resolved_connection_mode,
             build_tcp_transport=self._build_tcp_transport,
-            try_direct_client_connect=lambda allow_parameterless_ctor: self._try_direct_client_connect(
-                allow_parameterless_ctor=allow_parameterless_ctor
+            try_direct_client_connect=lambda allow_parameterless_ctor: (
+                self._try_direct_client_connect(allow_parameterless_ctor=allow_parameterless_ctor)
             ),
             port=self.config.port,
             timeout=self.timeout,
@@ -694,8 +694,10 @@ class ThesslaGreenModbusCoordinator(
                 select_auto_transport_fn=lambda: _select_auto_transport_impl(
                     resolved_connection_mode=self._resolved_connection_mode,
                     build_tcp_transport=self._build_tcp_transport,
-                    try_direct_client_connect=lambda allow_parameterless_ctor: self._try_direct_client_connect(
-                        allow_parameterless_ctor=allow_parameterless_ctor
+                    try_direct_client_connect=lambda allow_parameterless_ctor: (
+                        self._try_direct_client_connect(
+                            allow_parameterless_ctor=allow_parameterless_ctor
+                        )
                     ),
                     port=self.config.port,
                     timeout=self.timeout,

--- a/custom_components/thessla_green_modbus/coordinator/scan.py
+++ b/custom_components/thessla_green_modbus/coordinator/scan.py
@@ -12,13 +12,13 @@ from ..scanner_device_info import DeviceCapabilities
 _LOGGER = logging.getLogger(__name__)
 
 
-
 def get_scan_cache_from_entry(entry: Any) -> dict[str, Any]:
     """Return cached scan payload from config entry options."""
     if entry is None:
         return {}
     raw_cache = entry.options.get("device_scan_cache", {})
     return raw_cache if isinstance(raw_cache, dict) else {}
+
 
 def load_full_register_list(coordinator: Any) -> None:
     """Load full register list when forced."""

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -52,6 +52,7 @@ class _CoordinatorScheduleMixin:
     async def _safe_request_refresh(self) -> None:
         """Request refresh and ignore mock-context TypeError in tests."""
         await _safe_request_refresh(self)
+
     def _assert_write_connection_ready(self) -> None:
         """Ensure transport/client is present and connected for writes."""
         transport = self._transport

--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -213,17 +213,21 @@ async def run_full_scan(
         coil_max,
         "coil_registers",
         1,
-        lambda start, count: scanner._read_coil(scanner._client, start, count)
-        if scanner._client is not None
-        else scanner._read_coil(start, count),
+        lambda start, count: (
+            scanner._read_coil(scanner._client, start, count)
+            if scanner._client is not None
+            else scanner._read_coil(start, count)
+        ),
     )
     await _run_bit_phase(
         discrete_max,
         "discrete_inputs",
         2,
-        lambda start, count: scanner._read_discrete(scanner._client, start, count)
-        if scanner._client is not None
-        else scanner._read_discrete(start, count),
+        lambda start, count: (
+            scanner._read_discrete(scanner._client, start, count)
+            if scanner._client is not None
+            else scanner._read_discrete(start, count)
+        ),
     )
 
 

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -336,8 +336,6 @@ def test_initialize_reauth_state_initializes_from_entry():
     assert defaults == {"host": "10.0.0.10"}
 
 
-
-
 def test_resolve_reauth_form_state_initializes_from_entry():
     from types import SimpleNamespace
 
@@ -370,6 +368,8 @@ def test_resolve_reauth_form_state_uses_form_defaults_after_init():
     assert should_init is False
     assert entry_id == "entry-9"
     assert defaults == {"host": "from_user"}
+
+
 def test_build_reauth_form_defaults_prefers_user_input():
     defaults = build_reauth_form_defaults(
         user_input={"host": "from_user"},

--- a/tests/test_modbus_helpers_call_flow.py
+++ b/tests/test_modbus_helpers_call_flow.py
@@ -231,7 +231,9 @@ async def test_apply_attempt_delay_zero_does_not_sleep(monkeypatch):
         called = True
 
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
-    await _apply_attempt_delay(delay=0.0, func_name="read_holding_registers", attempt=1, max_attempts=2)
+    await _apply_attempt_delay(
+        delay=0.0, func_name="read_holding_registers", attempt=1, max_attempts=2
+    )
     assert called is False  # nosec B101
 
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -52,9 +52,7 @@ def _make_coordinator(data: dict | None = None) -> MagicMock:
     coord.available_registers = {"holding_registers": set()}
     coord.async_write_register = AsyncMock(return_value=True)
     coord.async_request_refresh = AsyncMock()
-    coord.get_register_map = lambda rtype: (
-        HOLDING_REGISTERS if rtype == "holding_registers" else {}
-    )
+    coord.get_register_map = lambda rtype: HOLDING_REGISTERS if rtype == "holding_registers" else {}
     coord.get_device_info = lambda: {}
     return coord
 


### PR DESCRIPTION
Base branch: dev

## Summary

Formatting-only diff — no logic changes, no refactoring, no doc changes.

**Files reformatted (7):**
- `custom_components/thessla_green_modbus/coordinator/coordinator.py`
- `custom_components/thessla_green_modbus/coordinator/scan.py`
- `custom_components/thessla_green_modbus/coordinator/schedule.py`
- `custom_components/thessla_green_modbus/scanner/orchestration.py`
- `tests/test_config_flow_helpers.py`
- `tests/test_modbus_helpers_call_flow.py`
- `tests/test_text.py`

## Verification results

| Check | Result |
|---|---|
| `ruff format --check` before | 7 files would reformat |
| `ruff format --check` after | 413 files already formatted ✅ |
| `ruff check` | All checks passed ✅ |
| `ruff check --select I` | All checks passed ✅ |
| `python -m compileall` | No errors ✅ |
| `check_maintainability.py` | Maintainability gate passed ✅ |
| `validate_entity_mappings.py` | Deferred — missing `pydantic` dependency |
| `compare_registers_with_reference.py` | Ran (pre-existing output, no formatting impact) |
| `pytest` | Deferred — missing `pydantic` dependency |

`git diff --check` clean. No whitespace errors.

https://claude.ai/code/session_01MErgFVqPRNdS5v4BCbAmn3

---
_Generated by [Claude Code](https://claude.ai/code/session_01MErgFVqPRNdS5v4BCbAmn3)_