### PR TITLE
refactor(scanner): extract focused io read helper

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -9,7 +9,6 @@ from typing import Any
 from pymodbus.client import AsyncModbusTcpClient
 
 from ..modbus_exceptions import ConnectionException, ModbusException, ModbusIOException
-from ..modbus_helpers import chunk_register_range
 from ..transport.retry import ErrorKind, classify_transport_error
 from .io_core import (
     _call_modbus_with_fallback,
@@ -25,9 +24,9 @@ from .io_core import (
 from .io_read_helpers import (
     append_read_block,
     build_read_attempt_meta,
+    build_register_chunks,
     build_success_result,
     classify_skip_range,
-    iter_grouped_read_chunks,
     normalize_bit_read_result,
     should_log_terminal_failure,
 )
@@ -91,17 +90,6 @@ def _should_abort_input_exception(exc: Exception) -> bool:
 def _log_read_failure(kind: str, start: int, end: int, retry: int) -> None:
     """Log terminal read failure after retry budget is exhausted."""
     _LOGGER.error("Failed to read %s registers %d-%d after %d retries", kind, start, end, retry)
-
-
-def _build_register_chunks(scanner: Any, start: int, count: int) -> list[tuple[int, int]]:
-    """Build contiguous chunk plan for a register range."""
-    return iter_grouped_read_chunks(
-        start,
-        count,
-        lambda chunk_start, chunk_count: chunk_register_range(
-            chunk_start, chunk_count, scanner.effective_batch
-        ),
-    )
 
 
 def _normalize_bit_read_request(
@@ -489,7 +477,7 @@ async def read_register_block(
 
     results: list[int] = []
     active_client = client or scanner._client
-    for chunk_start, chunk_count in _build_register_chunks(scanner, start, count):
+    for chunk_start, chunk_count in build_register_chunks(start, count, scanner.effective_batch):
         block = await (
             read_fn(chunk_start, chunk_count)
             if active_client is None

--- a/custom_components/thessla_green_modbus/scanner/io_read_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read_helpers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
+from ..modbus_helpers import chunk_register_range
+
 
 @dataclass(frozen=True)
 class ReadAttemptMeta:
@@ -24,6 +26,17 @@ def build_read_attempt_meta(address: int, count: int) -> ReadAttemptMeta:
 def iter_grouped_read_chunks(start: int, count: int, chunk_builder: Any) -> list[tuple[int, int]]:
     """Create grouped chunk plan for optimized/batched reads."""
     return list(chunk_builder(start, count))
+
+
+def build_register_chunks(start: int, count: int, batch_size: int) -> list[tuple[int, int]]:
+    """Build a batched chunk plan for a contiguous register range."""
+    return iter_grouped_read_chunks(
+        start,
+        count,
+        lambda chunk_start, chunk_count: chunk_register_range(
+            chunk_start, chunk_count, batch_size
+        ),
+    )
 
 
 def append_read_block(results: list[int], block: list[int] | None) -> bool:

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -7,13 +7,13 @@ import pytest
 from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.scanner.io_read import (
-    _build_register_chunks,
     _extend_or_abort_register_results,
     _finalize_register_read_failure,
     _handle_input_attempt_exception,
 )
 from custom_components.thessla_green_modbus.scanner.io_read_helpers import (
     build_read_attempt_meta,
+    build_register_chunks,
     classify_skip_range,
     normalize_bit_read_result,
     should_log_terminal_failure,
@@ -279,9 +279,17 @@ def test_finalize_register_read_failure_holding_non_aborted_marks_and_logs(caplo
 
 def test_build_register_chunks_uses_effective_batch():
     """Chunk construction should respect effective batch size boundaries."""
-    scanner = MagicMock()
-    scanner.effective_batch = 2
-    assert _build_register_chunks(scanner, 10, 5) == [(10, 2), (12, 2), (14, 1)]
+    assert build_register_chunks(10, 5, 2) == [(10, 2), (12, 2), (14, 1)]
+
+
+def test_build_register_chunks_single_chunk_when_count_fits():
+    """Single chunk produced when count does not exceed batch size."""
+    assert build_register_chunks(0, 3, 10) == [(0, 3)]
+
+
+def test_build_register_chunks_exact_multiple():
+    """Produces even chunks when count is an exact multiple of batch size."""
+    assert build_register_chunks(5, 6, 3) == [(5, 3), (8, 3)]
 
 
 def test_extend_or_abort_register_results_handles_none_and_appends():


### PR DESCRIPTION
## Summary

- Extracts `_build_register_chunks` from `scanner/io_read.py` into a new public `build_register_chunks(start, count, batch_size)` helper in `scanner/io_read_helpers.py`
- Removes the `scanner` dependency by accepting `batch_size: int` directly, making the function a pure, scanner-independent, testable utility
- Drops the now-unused `chunk_register_range` and `iter_grouped_read_chunks` imports from `io_read.py`; call site in `read_register_block` updated to pass `scanner.effective_batch` explicitly
- Adds two focused unit tests (`test_build_register_chunks_single_chunk_when_count_fits`, `test_build_register_chunks_exact_multiple`) and rewrites the existing test to call the helper directly without a scanner mock

## Test plan

- [ ] `ruff check` passes with no violations
- [ ] `python -m compileall` passes cleanly
- [ ] All targeted pytest suites pass: `tests/test_scanner_io*.py tests/test_device_scanner*.py tests/test_scanner*.py`
- [ ] `python tools/check_maintainability.py` → `Maintainability gate passed.`
- [ ] `rg "from homeassistant|import homeassistant" scanner/` → no matches (HA-independence preserved)

https://claude.ai/code/session_01QRjWKSiCJvGdU4bECHWdC3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRjWKSiCJvGdU4bECHWdC3)_