### PR TITLE
refactor(modbus): extract focused call helper

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -383,6 +383,31 @@ def _classify_modbus_exception(err: Exception) -> str:
     return "failed"
 
 
+def _log_call_attempt(
+    prepared: _PreparedCall,
+    *,
+    slave_id: int,
+    attempt: int,
+    max_attempts: int,
+    kwargs: dict[str, Any],
+) -> None:
+    """Emit pre-dispatch attempt diagnostics at debug level."""
+    _LOGGER.debug(
+        "Calling %s on slave %s (batch=%s attempt %s/%s)",
+        prepared.func_name,
+        slave_id,
+        prepared.batch_size,
+        attempt,
+        max_attempts,
+    )
+    _log_modbus_request(
+        func_name=prepared.func_name,
+        slave_id=slave_id,
+        positional=prepared.positional,
+        kwargs=kwargs,
+    )
+
+
 async def _dispatch_modbus_call(
     func: Callable[..., Awaitable[Any]],
     positional: list[Any],
@@ -489,19 +514,11 @@ async def _call_modbus(
         max_attempts=max_attempts,
     )
 
-    _LOGGER.debug(
-        "Calling %s on slave %s (batch=%s attempt %s/%s)",
-        prepared.func_name,
-        slave_id,
-        prepared.batch_size,
-        attempt,
-        max_attempts,
-    )
-
-    _log_modbus_request(
-        func_name=prepared.func_name,
+    _log_call_attempt(
+        prepared,
         slave_id=slave_id,
-        positional=prepared.positional,
+        attempt=attempt,
+        max_attempts=max_attempts,
         kwargs=kwargs,
     )
 

--- a/tests/test_modbus_helpers_call_flow.py
+++ b/tests/test_modbus_helpers_call_flow.py
@@ -33,7 +33,9 @@ from custom_components.thessla_green_modbus.modbus_helpers import (
     _calculate_batch_size,
     _call_modbus,
     _classify_modbus_exception,
+    _log_call_attempt,
     _prepare_modbus_call,
+    _PreparedCall,
     _raise_mapped_call_exception,
     async_close_client,
     group_reads,
@@ -541,3 +543,53 @@ async def test_call_modbus_response_encode_error_logged(caplog):
         result = await _call_modbus(bad_func, 1)
     assert isinstance(result, BadResponse)
     assert any("Failed to encode" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _log_call_attempt — direct tests
+# ---------------------------------------------------------------------------
+
+
+def _make_prepared(
+    func_name: str = "read_registers",
+    batch_size: int = 4,
+    positional: list | None = None,
+    kwarg: str = "slave",
+    delay: float = 0.0,
+) -> _PreparedCall:
+    return _PreparedCall(
+        positional=positional if positional is not None else [10],
+        kwarg=kwarg,
+        func_name=func_name,
+        batch_size=batch_size,
+        delay=delay,
+    )
+
+
+def test_log_call_attempt_emits_calling_message(caplog):
+    """_log_call_attempt logs the 'Calling ... on slave ...' summary."""
+    prepared = _make_prepared(func_name="read_holding_registers", batch_size=3)
+    with caplog.at_level(_logging.DEBUG, logger=_mh._LOGGER.name):
+        _log_call_attempt(prepared, slave_id=5, attempt=1, max_attempts=3, kwargs={})
+    messages = [r.message for r in caplog.records]
+    assert any("read_holding_registers" in m and "slave 5" in m for m in messages)
+
+
+def test_log_call_attempt_emits_request_frame_when_known(caplog):
+    """_log_call_attempt logs a masked request frame for known function names."""
+    prepared = _make_prepared(func_name="read_input_registers", positional=[20], batch_size=2)
+    with caplog.at_level(_logging.DEBUG, logger=_mh._LOGGER.name):
+        _log_call_attempt(
+            prepared, slave_id=1, attempt=1, max_attempts=1, kwargs={"count": 2}
+        )
+    messages = [r.message for r in caplog.records]
+    assert any("Modbus request" in m for m in messages)
+
+
+def test_log_call_attempt_includes_attempt_context(caplog):
+    """_log_call_attempt includes attempt/max_attempts in the summary message."""
+    prepared = _make_prepared(func_name="write_register", batch_size=1)
+    with caplog.at_level(_logging.DEBUG, logger=_mh._LOGGER.name):
+        _log_call_attempt(prepared, slave_id=2, attempt=2, max_attempts=4, kwargs={})
+    messages = [r.message for r in caplog.records]
+    assert any("2/4" in m for m in messages)


### PR DESCRIPTION
## Summary

- Extracts `_log_call_attempt` from `_call_modbus` to consolidate the two inline pre-dispatch diagnostic calls (call-attempt summary log + `_log_modbus_request`) into one cohesive helper
- Reduces `_call_modbus` from **86 → 78 lines** with no behaviour change
- Adds **3 direct unit tests** for `_log_call_attempt` (calling-message, request-frame, attempt-context)

## Behaviour preserved

- Timeout behaviour: unchanged (`_dispatch_modbus_call` + `_raise_mapped_call_exception`)
- Cancellation propagation: unchanged (`asyncio.CancelledError` path untouched)
- Retry/backoff behaviour: unchanged (`_apply_attempt_delay` call untouched)
- Exception wrapping: unchanged (`_raise_mapped_call_exception` untouched)
- Logging semantics: identical — same two log calls, same arguments, same order
- Public function signatures: unchanged
- slave/unit/device_id handling: unchanged

## Validation

- `ruff check` — all clean
- `python -m compileall` — no errors
- `pytest tests/test_modbus_helpers*.py tests/test_modbus_transport*.py tests/unit/test_transport_retry.py tests/unit/test_errors.py` — **162 passed**
- `python tools/check_maintainability.py` — **Maintainability gate passed**

## Test plan

- [x] All 162 existing targeted tests pass
- [x] 3 new direct tests for `_log_call_attempt` pass
- [x] No tests skipped or xfailed

https://claude.ai/code/session_01HYAJHM7oBEBarVB3rQw5MC

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYAJHM7oBEBarVB3rQw5MC)_