### PR TITLE
docs: refresh dev audit after test recovery

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,6 +1,6 @@
 # Maintainability audit
 
-Date: 2026-05-08
+Date: 2026-05-08 (refresh after test recovery)
 
 ## Commands executed (exact)
 
@@ -18,8 +18,11 @@ Date: 2026-05-08
 - `python tools/check_maintainability.py`
 - `python tools/validate_entity_mappings.py`
 - `pytest tests/ -q`
-- `pytest -q tests/test_coordinator_error_paths_split.py tests/test_coordinator.py tests/test_coordinator_*.py`
 - AST metrics script (largest files/classes/functions snapshot)
+- `find custom_components/thessla_green_modbus -maxdepth 2 -name "coordinator.py" -print`
+- `rg "from homeassistant|import homeassistant" core/ transport/ registers/ scanner/`
+- `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs`
+- Release tool availability: `pip show homeassistant hassfest hacs`, `hassfest --help`, `hacs --help`
 
 ## Import gate result
 
@@ -28,7 +31,7 @@ Python >=3.12 for versions >=0.13.110; `homeassistant` also requires Python
 >=3.12. Both fail to install/import on this Python 3.11 host. This is an
 **environment constraint**, not a code defect. All other imports pass.
 
-- `pydantic`: ✅ `OK pydantic: 2.13.4`
+- `pydantic`: ✅ `OK pydantic: 2.12.2`
 - `pytest`: ✅ `OK pytest: 9.0.3`
 - `pytest_asyncio`: ✅ `OK pytest_asyncio: 1.3.0`
 - `pytest_homeassistant_custom_component`: ❌ `FAIL — requires Python >=3.12 (env is 3.11)`
@@ -40,7 +43,7 @@ Python >=3.12 for versions >=0.13.110; `homeassistant` also requires Python
 
 - **ruff check**: ✅ pass (`All checks passed!`).
 - **ruff import order check**: ✅ pass (`All checks passed!`).
-- **ruff format --check**: ⚠️ **7 files would be reformatted** (see drift section below).
+- **ruff format --check**: ⚠️ **3 files would be reformatted** (see drift section below).
 - **compileall**: ✅ pass.
 - **register compare** (`compare_registers_with_reference.py`): ✅ pass
   (informational: 62 extras; 242 name mismatches on common addresses — unchanged from prior audit).
@@ -52,29 +55,32 @@ Python >=3.12 for versions >=0.13.110; `homeassistant` also requires Python
   `pytest_homeassistant_custom_component` which is not available on Python 3.11.
   Not a code failure; suite passes on Python 3.12 CI.
 
-### Targeted coordinator split test result
+### Notable changes since previous audit (2026-05-08 pre-refresh)
 
-```
-pytest -q tests/test_coordinator_error_paths_split.py tests/test_coordinator.py tests/test_coordinator_*.py
-```
+- `coordinator/scan.py` — present (124 non-empty lines), focused scan sub-module.
+- `scanner/io_read_helpers.py` — new scanner helper module; has ruff format drift.
+- `coordinator/coordinator.py` — slight growth (697 → 699 non-empty lines).
+- `coordinator/schedule.py` — stable at 468 non-empty lines.
+- `scanner/io_read.py` — reduced (704 → 694 non-empty lines).
+- `modbus_helpers.py` — grown (522 → 538 non-empty lines).
+- `config_flow.py` — reduced (428 → 414 non-empty lines).
+- `tests/test_config_flow_helpers.py` — ruff format drift remains (431 non-empty lines).
+- `tests/test_text.py` — ruff format drift resolved (no longer in drift list).
 
-❌ BLOCKED — same reason as above: `pytest_homeassistant_custom_component` not
-available on Python 3.11. The shared coordinator fixture (`tests/helpers_coordinator.py`,
-loaded as plugin via `conftest.py`) and split test file
-(`tests/test_coordinator_error_paths_split.py`) are present and syntactically
-correct (compileall passes).
+### Ruff format drift improvement
 
-### Notable changes since previous audit (2026-05-05)
+Format drift reduced from **7 files** (previous audit) to **3 files** (this run):
 
-- `custom_components/thessla_green_modbus/coordinator/scan.py` — new focused
-  sub-module extracted from coordinator.
-- `tests/helpers_coordinator.py` — new shared coordinator fixture module
-  (46 lines). Provides `coordinator` fixture reused across split test files.
-- `tests/conftest.py` — updated `pytest_plugins` to load `tests.helpers_coordinator`.
-- `tests/test_coordinator.py` — simplified; fixture moved to shared helper
-  (file shrank from 502 → 440 non-empty lines).
-- `tests/test_coordinator_error_paths_split.py` — new split test file using
-  shared fixture.
+| Status | File |
+|--------|------|
+| ✅ resolved | `coordinator/coordinator.py` |
+| ✅ resolved | `coordinator/scan.py` |
+| ✅ resolved | `coordinator/schedule.py` |
+| ✅ resolved | `scanner/orchestration.py` |
+| ✅ resolved | `tests/test_text.py` |
+| ⚠️ still drifted | `scanner/io_read_helpers.py` |
+| ⚠️ still drifted | `tests/test_config_flow_helpers.py` |
+| ⚠️ still drifted | `tests/test_modbus_helpers_call_flow.py` |
 
 ### Required CI gate status note
 
@@ -83,18 +89,12 @@ correct (compileall passes).
 
 ## Ruff format drift
 
-`ruff format --check custom_components tests tools` reports **7 files would be reformatted**:
+`ruff format --check custom_components tests tools` reports **3 files would be reformatted**
+(down from 7 in the previous audit):
 
-1. `custom_components/thessla_green_modbus/coordinator/coordinator.py`
-2. `custom_components/thessla_green_modbus/coordinator/scan.py`
-3. `custom_components/thessla_green_modbus/coordinator/schedule.py`
-4. `custom_components/thessla_green_modbus/scanner/orchestration.py`
-5. `tests/test_config_flow_helpers.py`
-6. `tests/test_modbus_helpers_call_flow.py`
-7. `tests/test_text.py`
-
-(Up from 1 file in the 2026-05-05 audit. The newly added `coordinator/scan.py`
-and related refactor commits introduced format drift; no style-only pass was run.)
+1. `custom_components/thessla_green_modbus/scanner/io_read_helpers.py`
+2. `tests/test_config_flow_helpers.py`
+3. `tests/test_modbus_helpers_call_flow.py`
 
 ## Architecture invariants snapshot
 
@@ -104,36 +104,36 @@ and related refactor commits introduced format drift; no style-only pass was run
 - `compat|shim|proxy|re-export|legacy` grep returns only informational matches
   in docs/tests/comments and known compatibility-reference strings.
 
-## Largest files/classes/functions (current — 2026-05-08)
+## Largest files/classes/functions (current — 2026-05-08 refresh)
 
 ### Largest files (non-empty lines, top 10)
 
 | Lines | Path |
 |------:|------|
-| 704 | `custom_components/thessla_green_modbus/scanner/io_read.py` |
-| 697 | `custom_components/thessla_green_modbus/coordinator/coordinator.py` |
-| 522 | `custom_components/thessla_green_modbus/modbus_helpers.py` |
+| 699 | `custom_components/thessla_green_modbus/coordinator/coordinator.py` |
+| 694 | `custom_components/thessla_green_modbus/scanner/io_read.py` |
+| 538 | `custom_components/thessla_green_modbus/modbus_helpers.py` |
 | 468 | `custom_components/thessla_green_modbus/coordinator/schedule.py` |
 | 454 | `custom_components/thessla_green_modbus/scanner/core.py` |
 | 440 | `tests/test_coordinator.py` |
 | 437 | `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` |
-| 428 | `custom_components/thessla_green_modbus/config_flow.py` |
+| 431 | `tests/test_config_flow_helpers.py` |
+| 422 | `tests/test_modbus_helpers_call_flow.py` |
 | 417 | `custom_components/thessla_green_modbus/mappings/_static_discrete.py` |
-| 397 | `tools/translate_register_descriptions.py` |
 
 ### Largest classes (AST span, top 10)
 
 | Lines | Class | File |
 |------:|-------|------|
-| 609 | `ThesslaGreenModbusCoordinator` | `coordinator/coordinator.py` |
-| 487 | `_CoordinatorScheduleMixin` | `coordinator/schedule.py` |
+| 611 | `ThesslaGreenModbusCoordinator` | `coordinator/coordinator.py` |
+| 488 | `_CoordinatorScheduleMixin` | `coordinator/schedule.py` |
 | 428 | `ThesslaGreenDeviceScanner` | `scanner/core.py` |
 | 334 | `RawRtuOverTcpTransport` | `modbus_transport_raw.py` |
 | 268 | `RegisterDef` | `registers/register_def.py` |
 | 251 | `ThesslaGreenFan` | `fan.py` |
 | 230 | `_CoordinatorCapabilitiesMixin` | `coordinator/capabilities.py` |
-| 219 | `ConfigFlow` | `config_flow.py` |
 | 210 | `BaseModbusTransport` | `modbus_transport_base.py` |
+| 204 | `ConfigFlow` | `config_flow.py` |
 | 183 | `ThesslaGreenClimate` | `climate.py` |
 
 ### Largest functions (AST span, top 10)
@@ -153,19 +153,24 @@ and related refactor commits introduced format drift; no style-only pass was run
 
 ## Remaining hotspots
 
-1. Coordinator concentration (`coordinator/coordinator.py` 697 lines, `ThesslaGreenModbusCoordinator` class 609 lines; `coordinator/schedule.py` 468 lines, `_CoordinatorScheduleMixin` 487 lines).
-2. Scanner read/orchestration complexity (`scanner/io_read.py` 704 lines, `scanner/core.py` 454 lines).
+1. Coordinator concentration (`coordinator/coordinator.py` 699 lines, `ThesslaGreenModbusCoordinator` class 611 lines; `coordinator/schedule.py` 468 lines, `_CoordinatorScheduleMixin` 488 lines).
+2. Scanner read/orchestration complexity (`scanner/io_read.py` 694 lines, `scanner/core.py` 454 lines).
 3. Mapping builder density (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow branching (`config_flow.py` 428 lines, `config_flow_device_validation.py`).
+4. Config-flow branching (`config_flow.py` 414 lines, `config_flow_device_validation.py`).
+5. Three files with ruff format drift: `scanner/io_read_helpers.py`, `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`.
 
 ## Branch note (authoritative target)
 
 - The working target branch is **dev**.
 - **main** is **not** authoritative for this refactor/audit track.
 - No `main -> dev` merge is recommended as part of this audit.
-- This branch (`claude/refresh-dev-audit-cM0Bm`) targets **dev** as PR base.
+- This branch (`claude/refresh-dev-audit-uw36O`) targets **dev** as PR base.
 
 ## Release readiness caveats
 
-- **HACS/hassfest readiness is not proven** in this audit because those validations were not run.
-- **Real-device validation is not proven** in this audit unless explicitly documented with device evidence.
+- **HACS/hassfest readiness is not proven** in this audit. `hassfest` and `hacs` are
+  not installable PyPI packages; they run exclusively as GitHub Actions in CI.
+  Release readiness via those gates must be verified through the CI pipeline.
+- **Real-device validation is not proven** in this audit unless explicitly documented
+  with device evidence. No on-device test evidence was captured in this run.
+- `root manifest.json` is not flagged as a blocker unless tooling specifically requires it.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08.
+Last reviewed: 2026-05-08 (refresh after test recovery).
 
 Related document:
 
@@ -27,35 +27,36 @@ The following constraints remain active and must be preserved:
 4. No proxy modules.
 5. `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant.
 
-## Current invariant verification snapshot (2026-05-08)
+## Current invariant verification snapshot (2026-05-08 refresh)
 
 - Top-level `custom_components/thessla_green_modbus/coordinator.py`: **absent**.
 - Canonical coordinator module: `custom_components/thessla_green_modbus/coordinator/coordinator.py`.
 - HA imports in `core/transport/registers/scanner`: **none detected** by grep.
 - Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches present in docs/tests/comments/known compatibility code references.
 
-## Notable since previous snapshot (2026-05-05)
+## Notable since previous snapshot (2026-05-08 pre-refresh)
 
-- `coordinator/scan.py` added — focused scan sub-module extracted from coordinator.
-- `tests/helpers_coordinator.py` added — shared coordinator fixture (46 lines);
-  loaded as plugin via `tests/conftest.py` (`pytest_plugins`).
-- `tests/test_coordinator_error_paths_split.py` added — split test file using shared fixture.
-- `tests/test_coordinator.py` simplified — fixture moved to `helpers_coordinator.py`
-  (shrank from 502 → 440 non-empty lines).
+- `scanner/io_read_helpers.py` — new scanner helper module added; has ruff format drift.
+- `coordinator/coordinator.py` — slight growth (697 → 699 non-empty lines).
+- `scanner/io_read.py` — reduced (704 → 694 non-empty lines).
+- `modbus_helpers.py` — grown (522 → 538 non-empty lines).
+- `config_flow.py` — reduced (428 → 414 non-empty lines).
+- `tests/test_text.py` — ruff format drift resolved (removed from drift list).
+- Ruff format drift reduced from **7 files** to **3 files**:
+  - `scanner/io_read_helpers.py`, `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`.
 
-## Required gate status snapshot (2026-05-08)
+## Required gate status snapshot (2026-05-08 refresh)
 
 - `ruff check custom_components tests tools`: **pass**.
 - `ruff check --select I custom_components tests tools`: **pass**.
-- `ruff format --check custom_components tests tools`: **7 files drift**
-  (coordinator.py, scan.py, schedule.py, scanner/orchestration.py,
-  test_config_flow_helpers.py, test_modbus_helpers_call_flow.py, test_text.py).
+- `ruff format --check custom_components tests tools`: **3 files drift**
+  (scanner/io_read_helpers.py, tests/test_config_flow_helpers.py,
+  tests/test_modbus_helpers_call_flow.py). Improved from 7 files in prior audit.
 - `python -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
 - `python tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
 - `python tools/check_maintainability.py`: **pass**.
 - `python tools/validate_entity_mappings.py`: **BLOCKED** — requires `homeassistant` (Python >=3.12); code is syntactically valid.
 - `pytest tests/ -q`: **BLOCKED** — `pytest-homeassistant-custom-component` requires Python >=3.12; not available in Python 3.11 audit environment.
-- `pytest -q tests/test_coordinator_error_paths_split.py tests/test_coordinator.py tests/test_coordinator_*.py`: **BLOCKED** — same reason; shared fixture and split test files are present and syntactically correct.
 - Import gate (`pydantic`, `pytest`, `pytest_asyncio`): **pass** (3.11 env).
 - Import gate (`pytest_homeassistant_custom_component`, `homeassistant`): **BLOCKED** — Python 3.11 env only; passes on Python 3.12 CI.
 
@@ -64,15 +65,16 @@ The following constraints remain active and must be preserved:
 - `black`: not executed.
 - `isort`: not executed.
 - `mypy`: not executed.
-- `hassfest`: not executed.
-- `HACS`: not executed.
+- `hassfest`: not executed (runs as GitHub Action only; not a PyPI package).
+- `HACS`: not executed (runs as GitHub Action only; not a PyPI package).
 
 ## Remaining hotspots (current queue)
 
-1. Coordinator size/branching (`coordinator/coordinator.py` 697 lines, `coordinator/schedule.py` 468 lines).
-2. Scanner read/orchestration complexity (`scanner/io_read.py` 704 lines, `scanner/core.py` 454 lines).
+1. Coordinator size/branching (`coordinator/coordinator.py` 699 lines, `coordinator/schedule.py` 468 lines).
+2. Scanner read/orchestration complexity (`scanner/io_read.py` 694 lines, `scanner/core.py` 454 lines).
 3. Mapping build complexity (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow/device validation complexity (`config_flow.py` 428 lines, `config_flow_device_validation.py`).
+4. Config-flow/device validation complexity (`config_flow.py` 414 lines, `config_flow_device_validation.py`).
+5. Ruff format drift: 3 files (`scanner/io_read_helpers.py`, `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`).
 
 ## Branch note
 
@@ -82,5 +84,5 @@ The following constraints remain active and must be preserved:
 
 ## Readiness caveats
 
-- **HACS/hassfest readiness:** not claimable (not executed in this run).
+- **HACS/hassfest readiness:** not claimable (not executed in this run; these run as GitHub Actions only).
 - **Real-device readiness:** not claimable from this verification run; no new on-device evidence captured.


### PR DESCRIPTION
## Summary

- Refreshed `docs/maintainability_audit.md` and `docs/refactor_status.md` with current gate results.
- Ruff format drift reduced from **7 → 3 files** since previous audit (5 files resolved).
- Updated largest files/classes/functions metrics snapshot.
- Corrected branch note to this branch (`claude/refresh-dev-audit-uw36O`) targeting `dev`.

Base branch: dev

## Gate results

| Gate | Result |
|------|--------|
| `ruff check` | ✅ pass |
| `ruff check --select I` | ✅ pass |
| `ruff format --check` | ⚠️ 3 files drift (down from 7) |
| `compileall` | ✅ pass |
| `compare_registers_with_reference.py` | ✅ pass (informational: 62 extras, 242 name mismatches) |
| `check_maintainability.py` | ✅ pass |
| `validate_entity_mappings.py` | ❌ BLOCKED — requires Python ≥3.12 (env is 3.11) |
| `pytest tests/ -q` | ❌ BLOCKED — `pytest-homeassistant-custom-component` requires Python ≥3.12 |
| Import gate (pydantic, pytest, pytest_asyncio) | ✅ pass |
| Import gate (pytest_homeassistant_custom_component, homeassistant) | ❌ BLOCKED — Python 3.11 env; passes on Python 3.12 CI |

## Files changed

- `docs/maintainability_audit.md`
- `docs/refactor_status.md`

No production code, tests, or CI files were modified.

https://claude.ai/code/session_01K4tYY5wZ49UMkB2ja7cyE2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4tYY5wZ49UMkB2ja7cyE2)_