### PR TITLE
refactor(scanner/io_read): extract _run_holding_read_retry_loop; fix format drift

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -556,47 +556,32 @@ def _handle_holding_read_exception(
     raise exc
 
 
-async def read_holding(
+async def _run_holding_read_retry_loop(
     scanner: Any,
-    client_or_address: AsyncModbusTcpClient | AsyncModbusSerialClientType | int,
-    address_or_count: int,
-    count: int | None = None,
     *,
-    skip_cache: bool = False,
+    transport: Any,
+    client: Any,
+    address: int,
+    count: int,
+    start: int,
+    end: int,
+    skip_cache: bool,
 ) -> list[int] | None:
-    """Read holding registers with retry, backoff and failure tracking."""
-    client, address, count = unpack_read_args(scanner, client_or_address, address_or_count, count)
-    meta = build_read_attempt_meta(address, count)
-    start = meta.start
-    end = meta.end
-
-    if _prepare_holding_read(scanner, start, end, address, skip_cache):
-        return None
-
-    transport, client = resolve_transport_and_client(scanner, client)
-
+    """Run holding read retry loop and finalize failure state when needed."""
     aborted_transiently = False
     attempted_reads = 0
     for attempt in range(1, scanner.retry + 1):
         attempted_reads = attempt
         try:
-            if transport is not None:
-                response = await transport.read_holding_registers(
-                    scanner.slave_id, address, count=count
-                )
-            else:
-                response = await _call_modbus_with_fallback(
-                    scanner,
-                    client.read_holding_registers,
-                    scanner.slave_id,
-                    address,
-                    count=count,
-                    attempt=attempt,
-                    retry=scanner.retry,
-                    timeout=scanner.timeout,
-                    backoff=scanner.backoff,
-                    backoff_jitter=scanner.backoff_jitter,
-                )
+            response = await _execute_word_read_attempt(
+                scanner,
+                transport=transport,
+                client=client,
+                method_name="read_holding_registers",
+                address=address,
+                count=count,
+                attempt=attempt,
+            )
             done, payload = _process_register_response(
                 scanner,
                 response=response,
@@ -648,6 +633,37 @@ async def read_holding(
         aborted_transiently=aborted_transiently,
     )
     return None
+
+
+async def read_holding(
+    scanner: Any,
+    client_or_address: AsyncModbusTcpClient | AsyncModbusSerialClientType | int,
+    address_or_count: int,
+    count: int | None = None,
+    *,
+    skip_cache: bool = False,
+) -> list[int] | None:
+    """Read holding registers with retry, backoff and failure tracking."""
+    client, address, count = unpack_read_args(scanner, client_or_address, address_or_count, count)
+    meta = build_read_attempt_meta(address, count)
+    start = meta.start
+    end = meta.end
+
+    if _prepare_holding_read(scanner, start, end, address, skip_cache):
+        return None
+
+    transport, client = resolve_transport_and_client(scanner, client)
+
+    return await _run_holding_read_retry_loop(
+        scanner,
+        transport=transport,
+        client=client,
+        address=address,
+        count=count,
+        start=start,
+        end=end,
+        skip_cache=skip_cache,
+    )
 
 
 async def read_bit_registers(

--- a/custom_components/thessla_green_modbus/scanner/io_read_helpers.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read_helpers.py
@@ -33,9 +33,7 @@ def build_register_chunks(start: int, count: int, batch_size: int) -> list[tuple
     return iter_grouped_read_chunks(
         start,
         count,
-        lambda chunk_start, chunk_count: chunk_register_range(
-            chunk_start, chunk_count, batch_size
-        ),
+        lambda chunk_start, chunk_count: chunk_register_range(chunk_start, chunk_count, batch_size),
     )
 
 

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,6 +1,6 @@
 # Maintainability audit
 
-Date: 2026-05-08 (refresh after test recovery)
+Date: 2026-05-08 (Python 3.13 full-pass + scanner/io_read refactor)
 
 ## Commands executed (exact)
 
@@ -26,75 +26,58 @@ Date: 2026-05-08 (refresh after test recovery)
 
 ## Import gate result
 
-Environment: Python 3.11.15. `pytest-homeassistant-custom-component` requires
-Python >=3.12 for versions >=0.13.110; `homeassistant` also requires Python
->=3.12. Both fail to install/import on this Python 3.11 host. This is an
-**environment constraint**, not a code defect. All other imports pass.
+Environment: **Python 3.13.12**. All five required modules import successfully.
 
 - `pydantic`: ✅ `OK pydantic: 2.12.2`
-- `pytest`: ✅ `OK pytest: 9.0.3`
+- `pytest`: ✅ `OK pytest: 9.0.0`
 - `pytest_asyncio`: ✅ `OK pytest_asyncio: 1.3.0`
-- `pytest_homeassistant_custom_component`: ❌ `FAIL — requires Python >=3.12 (env is 3.11)`
-- `homeassistant`: ❌ `FAIL — requires Python >=3.12 (env is 3.11)`
+- `pytest_homeassistant_custom_component`: ✅ pass
+- `homeassistant`: ✅ pass
 
 ## Exact status by validation gate
 
-### Required maintained gates
+### Required maintained gates (Python 3.13.12)
 
 - **ruff check**: ✅ pass (`All checks passed!`).
 - **ruff import order check**: ✅ pass (`All checks passed!`).
-- **ruff format --check**: ⚠️ **3 files would be reformatted** (see drift section below).
+- **ruff format --check**: ⚠️ **2 files would be reformatted** (see drift section below; down from 3).
 - **compileall**: ✅ pass.
 - **register compare** (`compare_registers_with_reference.py`): ✅ pass
-  (informational: 62 extras; 242 name mismatches on common addresses — unchanged from prior audit).
+  (informational: 62 extras; 242 name mismatches on common addresses — unchanged).
 - **maintainability** (`check_maintainability.py`): ✅ pass (`Maintainability gate passed.`).
-- **entity mappings** (`validate_entity_mappings.py`): ❌ BLOCKED — requires
-  `homeassistant` package, not installable on Python 3.11. Code is syntactically
-  valid (compileall passes). Tool passed on Python 3.12 CI.
-- **pytest** (`pytest tests/ -q`): ❌ BLOCKED — `conftest.py` imports
-  `pytest_homeassistant_custom_component` which is not available on Python 3.11.
-  Not a code failure; suite passes on Python 3.12 CI.
+- **entity mappings** (`validate_entity_mappings.py`): ✅ pass (`OK: 366 entities validated`).
+- **pytest** (`pytest tests/ -q`): ✅ **1892 passed, 4 skipped**, 84 warnings in 14.30s.
+- **coordinator split check**: ✅ pass (277 passed, 1 warning in 2.59s).
 
-### Notable changes since previous audit (2026-05-08 pre-refresh)
+### Notable changes since previous audit (2026-05-08 3.11 run)
 
-- `coordinator/scan.py` — present (124 non-empty lines), focused scan sub-module.
-- `scanner/io_read_helpers.py` — new scanner helper module; has ruff format drift.
-- `coordinator/coordinator.py` — slight growth (697 → 699 non-empty lines).
-- `coordinator/schedule.py` — stable at 468 non-empty lines.
-- `scanner/io_read.py` — reduced (704 → 694 non-empty lines).
-- `modbus_helpers.py` — grown (522 → 538 non-empty lines).
-- `config_flow.py` — reduced (428 → 414 non-empty lines).
-- `tests/test_config_flow_helpers.py` — ruff format drift remains (431 non-empty lines).
-- `tests/test_text.py` — ruff format drift resolved (no longer in drift list).
+- Full test suite now runs on Python 3.13 — all gates green.
+- `scanner/io_read_helpers.py` — ruff format drift **resolved** (lambda inline).
+- `scanner/io_read.py` — `_run_holding_read_retry_loop` extracted; `read_holding` reduced from 92 → 29 lines; now mirrors `read_input` pattern.
+- `scanner/io_read.py` non-empty lines: 694 → 708 (net +14 from added function scaffolding/docstring).
 
 ### Ruff format drift improvement
 
-Format drift reduced from **7 files** (previous audit) to **3 files** (this run):
+Format drift reduced from **3 files** (previous audit) to **2 files** (this run):
 
 | Status | File |
 |--------|------|
-| ✅ resolved | `coordinator/coordinator.py` |
-| ✅ resolved | `coordinator/scan.py` |
-| ✅ resolved | `coordinator/schedule.py` |
-| ✅ resolved | `scanner/orchestration.py` |
-| ✅ resolved | `tests/test_text.py` |
-| ⚠️ still drifted | `scanner/io_read_helpers.py` |
+| ✅ resolved | `scanner/io_read_helpers.py` |
 | ⚠️ still drifted | `tests/test_config_flow_helpers.py` |
 | ⚠️ still drifted | `tests/test_modbus_helpers_call_flow.py` |
 
 ### Required CI gate status note
 
-- This local audit run indicates maintained quality gates are green in this environment.
+- All local maintained quality gates are green on Python 3.13.
 - CI/HACS/hassfest gates were **not** executed in this run and are not claimed as proven.
 
 ## Ruff format drift
 
-`ruff format --check custom_components tests tools` reports **3 files would be reformatted**
-(down from 7 in the previous audit):
+`ruff format --check custom_components tests tools` reports **2 files would be reformatted**
+(down from 3 in the previous audit):
 
-1. `custom_components/thessla_green_modbus/scanner/io_read_helpers.py`
-2. `tests/test_config_flow_helpers.py`
-3. `tests/test_modbus_helpers_call_flow.py`
+1. `tests/test_config_flow_helpers.py`
+2. `tests/test_modbus_helpers_call_flow.py`
 
 ## Architecture invariants snapshot
 
@@ -111,7 +94,7 @@ Format drift reduced from **7 files** (previous audit) to **3 files** (this run)
 | Lines | Path |
 |------:|------|
 | 699 | `custom_components/thessla_green_modbus/coordinator/coordinator.py` |
-| 694 | `custom_components/thessla_green_modbus/scanner/io_read.py` |
+| 708 | `custom_components/thessla_green_modbus/scanner/io_read.py` |
 | 538 | `custom_components/thessla_green_modbus/modbus_helpers.py` |
 | 468 | `custom_components/thessla_green_modbus/coordinator/schedule.py` |
 | 454 | `custom_components/thessla_green_modbus/scanner/core.py` |
@@ -149,22 +132,23 @@ Format drift reduced from **7 files** (previous audit) to **3 files** (this run)
 | 103 | `run` | `tests/test_force_full_register_list_integration.py` |
 | 100 | `test_entity_counts_per_platform` | `tests/test_all_entity_creation.py` |
 | 100 | `read_input_registers_optimized` | `_coordinator_read_batches.py` |
-| 92 | `read_holding` | `scanner/io_read.py` |
+| 79 | `read_bit_registers` | `scanner/io_read.py` |
+| 77 | `_run_holding_read_retry_loop` | `scanner/io_read.py` (extracted) |
 
 ## Remaining hotspots
 
 1. Coordinator concentration (`coordinator/coordinator.py` 699 lines, `ThesslaGreenModbusCoordinator` class 611 lines; `coordinator/schedule.py` 468 lines, `_CoordinatorScheduleMixin` 488 lines).
-2. Scanner read/orchestration complexity (`scanner/io_read.py` 694 lines, `scanner/core.py` 454 lines).
+2. Scanner read/orchestration complexity (`scanner/io_read.py` 708 lines, `scanner/core.py` 454 lines). `read_holding` reduced to 29 lines (was 92); `read_bit_registers` (79 lines) is next candidate.
 3. Mapping builder density (`mappings/_mapping_builders.py` 437 lines).
 4. Config-flow branching (`config_flow.py` 414 lines, `config_flow_device_validation.py`).
-5. Three files with ruff format drift: `scanner/io_read_helpers.py`, `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`.
+5. Two files with ruff format drift: `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`.
 
 ## Branch note (authoritative target)
 
 - The working target branch is **dev**.
 - **main** is **not** authoritative for this refactor/audit track.
 - No `main -> dev` merge is recommended as part of this audit.
-- This branch (`claude/refresh-dev-audit-uw36O`) targets **dev** as PR base.
+- This branch (`claude/dev-audit-refactor-SNaO3`) targets **dev** as PR base.
 
 ## Release readiness caveats
 

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08 (refresh after test recovery).
+Last reviewed: 2026-05-08 (Python 3.13 full-pass + scanner/io_read refactor).
 
 Related document:
 
@@ -34,31 +34,28 @@ The following constraints remain active and must be preserved:
 - HA imports in `core/transport/registers/scanner`: **none detected** by grep.
 - Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches present in docs/tests/comments/known compatibility code references.
 
-## Notable since previous snapshot (2026-05-08 pre-refresh)
+## Notable since previous snapshot (2026-05-08 3.11 run)
 
-- `scanner/io_read_helpers.py` — new scanner helper module added; has ruff format drift.
-- `coordinator/coordinator.py` — slight growth (697 → 699 non-empty lines).
-- `scanner/io_read.py` — reduced (704 → 694 non-empty lines).
-- `modbus_helpers.py` — grown (522 → 538 non-empty lines).
-- `config_flow.py` — reduced (428 → 414 non-empty lines).
-- `tests/test_text.py` — ruff format drift resolved (removed from drift list).
-- Ruff format drift reduced from **7 files** to **3 files**:
-  - `scanner/io_read_helpers.py`, `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`.
+- Full test suite now validated on Python 3.13 — **1892 passed, 4 skipped**.
+- `scanner/io_read_helpers.py` — ruff format drift **resolved** (lambda inline fix).
+- `scanner/io_read.py` — `_run_holding_read_retry_loop` extracted; `read_holding` reduced from 92 → 29 lines; now mirrors `read_input` pattern symmetrically.
+- `scanner/io_read.py` non-empty lines: 694 → 708 (net +14 from function scaffolding).
+- Ruff format drift reduced from **3 files** to **2 files**:
+  - `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`.
 
-## Required gate status snapshot (2026-05-08 refresh)
+## Required gate status snapshot (2026-05-08 Python 3.13 run)
 
 - `ruff check custom_components tests tools`: **pass**.
 - `ruff check --select I custom_components tests tools`: **pass**.
-- `ruff format --check custom_components tests tools`: **3 files drift**
-  (scanner/io_read_helpers.py, tests/test_config_flow_helpers.py,
-  tests/test_modbus_helpers_call_flow.py). Improved from 7 files in prior audit.
-- `python -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
-- `python tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
-- `python tools/check_maintainability.py`: **pass**.
-- `python tools/validate_entity_mappings.py`: **BLOCKED** — requires `homeassistant` (Python >=3.12); code is syntactically valid.
-- `pytest tests/ -q`: **BLOCKED** — `pytest-homeassistant-custom-component` requires Python >=3.12; not available in Python 3.11 audit environment.
-- Import gate (`pydantic`, `pytest`, `pytest_asyncio`): **pass** (3.11 env).
-- Import gate (`pytest_homeassistant_custom_component`, `homeassistant`): **BLOCKED** — Python 3.11 env only; passes on Python 3.12 CI.
+- `ruff format --check custom_components tests tools`: **2 files drift**
+  (tests/test_config_flow_helpers.py, tests/test_modbus_helpers_call_flow.py).
+  Improved from 3 files in prior audit.
+- `python3.13 -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
+- `python3.13 tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
+- `python3.13 tools/check_maintainability.py`: **pass** (`Maintainability gate passed.`).
+- `python3.13 tools/validate_entity_mappings.py`: **pass** (`OK: 366 entities validated`).
+- `python3.13 -m pytest tests/ -q`: **pass** — 1892 passed, 4 skipped, 84 warnings.
+- Import gate (all 5 modules): **pass** on Python 3.13.
 
 ## Non-required tool status
 
@@ -71,10 +68,10 @@ The following constraints remain active and must be preserved:
 ## Remaining hotspots (current queue)
 
 1. Coordinator size/branching (`coordinator/coordinator.py` 699 lines, `coordinator/schedule.py` 468 lines).
-2. Scanner read/orchestration complexity (`scanner/io_read.py` 694 lines, `scanner/core.py` 454 lines).
+2. Scanner read/orchestration complexity (`scanner/io_read.py` 708 lines, `scanner/core.py` 454 lines). `read_bit_registers` (79 lines) is the next candidate in this file.
 3. Mapping build complexity (`mappings/_mapping_builders.py` 437 lines).
 4. Config-flow/device validation complexity (`config_flow.py` 414 lines, `config_flow_device_validation.py`).
-5. Ruff format drift: 3 files (`scanner/io_read_helpers.py`, `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`).
+5. Ruff format drift: 2 files (`tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`).
 
 ## Branch note
 


### PR DESCRIPTION
## Base branch: dev

## Summary

**PHASE A — Python 3.13.12 full audit (green)**
- All import gates pass: pydantic 2.12.2, pytest 9.0.0, pytest_asyncio 1.3.0, pytest_homeassistant_custom_component, homeassistant
- ruff check: pass; ruff import sort: pass
- compileall: pass; check_maintainability: pass; validate_entity_mappings: 366 entities OK
- **pytest: 1892 passed, 4 skipped, 84 warnings** (coordinator split check: 277 passed)
- ruff format drift: 3 files before refactor

**PHASE B — Area 1: scanner/io_read (targeted refactor)**

Extract `_run_holding_read_retry_loop` from `read_holding`, creating symmetry with the existing `_run_input_read_retry_loop` pattern. Uses the already-present `_execute_word_read_attempt` helper (parameterised with `method_name="read_holding_registers"`).

- `read_holding`: **92 lines → 29 lines** (mirrors `read_input` structure exactly)
- `_run_holding_read_retry_loop`: new 77-line function
- `io_read_helpers.py`: ruff format drift fixed (lambda inline)
- All preserved: retry/backoff, `asyncio.CancelledError` re-raise, failure tracking, unsupported-range behaviour, skip-cache behaviour, public APIs
- No HA imports introduced into scanner/

## Files changed

- `custom_components/thessla_green_modbus/scanner/io_read.py`
- `custom_components/thessla_green_modbus/scanner/io_read_helpers.py`
- `docs/maintainability_audit.md`
- `docs/refactor_status.md`

## Before/after metrics (io_read.py)

| Metric | Before | After |
|--------|--------|-------|
| `read_holding` size | 92 lines | 29 lines |
| `_run_holding_read_retry_loop` | absent | 77 lines |
| non-empty lines total | 694 | 708 |
| Format drift files | 3 | 2 |

## Test plan

- [x] 177 scanner tests pass (`test_scanner_io*.py`, `test_device_scanner*.py`, `test_scanner*.py`)
- [x] Full suite: 1892 passed, 4 skipped
- [x] ruff check + import sort: all checks passed
- [x] compileall: clean
- [x] validate_entity_mappings: 366 entities OK
- [x] No HA imports in scanner/ (`rg` grep returns nothing)
- [x] PR base branch: **dev** (not main)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkiXUFhdfmF2VTWc3ZM2dx)_