### PR TITLE
refactor(scanner/io_read): dev health audit + extract _attempt_bit_reconnect

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -117,6 +117,28 @@ def _resolve_bit_read_client(scanner: Any, client: Any) -> Any:
     return client
 
 
+async def _attempt_bit_reconnect(scanner: Any, client: Any) -> Any:
+    """Try to reconnect via transport after a connection error; return updated client."""
+    if scanner._transport is None:
+        return client
+    try:
+        await scanner._transport.ensure_connected()
+        transport_client = getattr(scanner._transport, "client", None)
+        if transport_client is not None:
+            scanner._client = transport_client
+            return transport_client
+    except (
+        ModbusException,
+        ConnectionException,
+        ModbusIOException,
+        TimeoutError,
+        OSError,
+        AttributeError,
+    ):
+        pass
+    return client
+
+
 def _extend_or_abort_register_results(
     results: list[int], block: list[int] | None
 ) -> tuple[bool, list[int] | None]:
@@ -705,22 +727,7 @@ async def read_bit_registers(
                 attempt,
             )
         except (ModbusException, ConnectionException):
-            if scanner._transport is not None:
-                try:
-                    await scanner._transport.ensure_connected()
-                    transport_client = getattr(scanner._transport, "client", None)
-                    if transport_client is not None:
-                        client = transport_client
-                        scanner._client = transport_client
-                except (
-                    ModbusException,
-                    ConnectionException,
-                    ModbusIOException,
-                    TimeoutError,
-                    OSError,
-                    AttributeError,
-                ):
-                    pass
+            client = await _attempt_bit_reconnect(scanner, client)
         except asyncio.CancelledError:
             raise
         except OSError as exc:
@@ -784,6 +791,7 @@ async def read_discrete(
 
 
 __all__ = [
+    "_attempt_bit_reconnect",
     "read_bit_registers",
     "read_coil",
     "read_discrete",

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -568,7 +568,9 @@ def test_build_reconfigure_schema_empty_entry_data_uses_defaults():
     schema = build_reconfigure_schema({})
     assert isinstance(schema, vol.Schema)
 
-    result = schema({CONF_HOST: "192.168.1.1", CONF_PORT: DEFAULT_PORT, CONF_SLAVE_ID: DEFAULT_SLAVE_ID})
+    result = schema(
+        {CONF_HOST: "192.168.1.1", CONF_PORT: DEFAULT_PORT, CONF_SLAVE_ID: DEFAULT_SLAVE_ID}
+    )
     assert result[CONF_PORT] == DEFAULT_PORT
     assert result[CONF_SLAVE_ID] == DEFAULT_SLAVE_ID
 

--- a/tests/test_modbus_helpers_call_flow.py
+++ b/tests/test_modbus_helpers_call_flow.py
@@ -581,9 +581,7 @@ def test_log_call_attempt_emits_request_frame_when_known(caplog):
     """_log_call_attempt logs a masked request frame for known function names."""
     prepared = _make_prepared(func_name="read_input_registers", positional=[20], batch_size=2)
     with caplog.at_level(_logging.DEBUG, logger=_mh._LOGGER.name):
-        _log_call_attempt(
-            prepared, slave_id=1, attempt=1, max_attempts=1, kwargs={"count": 2}
-        )
+        _log_call_attempt(prepared, slave_id=1, attempt=1, max_attempts=1, kwargs={"count": 2})
     messages = [r.message for r in caplog.records]
     assert any("Modbus request" in m for m in messages)
 

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -4,9 +4,14 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from custom_components.thessla_green_modbus.modbus_exceptions import ModbusIOException
+from custom_components.thessla_green_modbus.modbus_exceptions import (
+    ConnectionException,
+    ModbusException,
+    ModbusIOException,
+)
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.scanner.io_read import (
+    _attempt_bit_reconnect,
     _extend_or_abort_register_results,
     _finalize_register_read_failure,
     _handle_input_attempt_exception,
@@ -369,3 +374,69 @@ def test_should_log_terminal_failure_tracks_holding_vs_input_aborts():
     assert should_log_terminal_failure("input_registers", True) is False
     assert should_log_terminal_failure("holding_registers", True) is True
     assert should_log_terminal_failure("input_registers", False) is True
+
+
+async def test_attempt_bit_reconnect_no_transport_returns_original_client():
+    """Returns original client unchanged when scanner has no transport."""
+    scanner = MagicMock()
+    scanner._transport = None
+    original = AsyncMock()
+    result = await _attempt_bit_reconnect(scanner, original)
+    assert result is original
+
+
+async def test_attempt_bit_reconnect_with_transport_returns_transport_client():
+    """Returns transport client and updates scanner._client when reconnect succeeds."""
+    scanner = MagicMock()
+    transport_client = AsyncMock()
+    mock_transport = MagicMock()
+    mock_transport.ensure_connected = AsyncMock()
+    mock_transport.client = transport_client
+    scanner._transport = mock_transport
+
+    original = AsyncMock()
+    result = await _attempt_bit_reconnect(scanner, original)
+
+    assert result is transport_client
+    assert scanner._client is transport_client
+    mock_transport.ensure_connected.assert_called_once()
+
+
+async def test_attempt_bit_reconnect_transport_no_client_attr_returns_original():
+    """Returns original client when transport has no .client attribute."""
+    scanner = MagicMock()
+    mock_transport = MagicMock()
+    mock_transport.ensure_connected = AsyncMock()
+    mock_transport.client = None
+    scanner._transport = mock_transport
+
+    original = AsyncMock()
+    result = await _attempt_bit_reconnect(scanner, original)
+
+    assert result is original
+
+
+async def test_attempt_bit_reconnect_ensure_connected_raises_returns_original():
+    """Returns original client when ensure_connected raises any connection error."""
+    scanner = MagicMock()
+    mock_transport = MagicMock()
+    mock_transport.ensure_connected = AsyncMock(side_effect=ModbusException("lost"))
+    scanner._transport = mock_transport
+
+    original = AsyncMock()
+    result = await _attempt_bit_reconnect(scanner, original)
+
+    assert result is original
+
+
+async def test_attempt_bit_reconnect_connection_exception_returns_original():
+    """Returns original client when ensure_connected raises ConnectionException."""
+    scanner = MagicMock()
+    mock_transport = MagicMock()
+    mock_transport.ensure_connected = AsyncMock(side_effect=ConnectionException("down"))
+    scanner._transport = mock_transport
+
+    original = AsyncMock()
+    result = await _attempt_bit_reconnect(scanner, original)
+
+    assert result is original


### PR DESCRIPTION
Base branch: dev

## Summary

- **PHASE A** — Full Python 3.13 health audit: 1892 passed, 4 skipped, 0 failed. All maintained gates green (ruff check, ruff import sort, compileall, compare_registers, check_maintainability, validate_entity_mappings, pytest).
- **PHASE B** — Cleared ruff format drift in `tests/test_config_flow_helpers.py` and `tests/test_modbus_helpers_call_flow.py`. Zero drift remains across all 413 files.
- **PHASE C** — Extracted `_attempt_bit_reconnect` from `read_bit_registers` in `scanner/io_read.py`. The 14-line transport-reconnect block inside the `ModbusException/ConnectionException` handler was a cohesive responsibility with no prior testable surface. Moving it to a named async helper reduces `read_bit_registers` from **79 → 64 lines** and adds 5 focused unit tests. Runtime behavior and all public APIs are preserved.

## Files changed

| File | Reason |
|---|---|
| `custom_components/thessla_green_modbus/scanner/io_read.py` | PHASE C: extract `_attempt_bit_reconnect` |
| `tests/test_scanner_io.py` | PHASE C: 5 new unit tests for `_attempt_bit_reconnect` |
| `tests/test_config_flow_helpers.py` | PHASE B: ruff format only |
| `tests/test_modbus_helpers_call_flow.py` | PHASE B: ruff format only |

## Metrics — `scanner/io_read.py`

| Metric | Before | After |
|---|---|---|
| `read_bit_registers` lines | 79 | 64 |
| `_attempt_bit_reconnect` lines | — | 20 |
| Total non-empty lines | 708 | 714 |

## Test plan

- [x] `python3.13 -m pytest tests/ → 1897 passed, 4 skipped, 0 failed`
- [x] `python3.13 -m pytest tests/test_scanner_io*.py tests/test_device_scanner*.py → 79 passed`
- [x] `ruff check custom_components tests tools → All checks passed`
- [x] `ruff format --check custom_components tests tools → 413 files already formatted`
- [x] `python3.13 tools/validate_entity_mappings.py → OK: 366 entities validated`
- [x] `python3.13 tools/check_maintainability.py → Maintainability gate passed`
- [x] `rg "from homeassistant|import homeassistant" custom_components/thessla_green_modbus/scanner` → empty (HA independence preserved)
- [x] pydantic version not changed
- [x] main not touched

https://claude.ai/code/session_01Kucqe49LJtLdcMRJ3JbcGe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kucqe49LJtLdcMRJ3JbcGe)_