### PR TITLE
refactor(modbus_helpers): extract _encode_read_frame + dev audit refresh

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -142,28 +142,31 @@ def _mask_frame(frame: bytes) -> str:
     return hex_str
 
 
+_READ_FC: dict[str, int] = {
+    "read_input_registers": 4,
+    "read_holding_registers": 3,
+    "read_coils": 1,
+    "read_discrete_inputs": 2,
+}
+
+
+def _encode_read_frame(
+    slave_id: int, fc: int, positional: list[Any], kwargs: dict[str, Any]
+) -> bytes:
+    """Encode a standard Modbus read request frame (addr + count)."""
+    addr = int(positional[0])
+    count = int(kwargs.get("count", positional[1] if len(positional) > 1 else 1))
+    return bytes([slave_id, fc, addr >> 8, addr & 255, count >> 8, count & 255])
+
+
 def _build_request_frame(
     func_name: str, slave_id: int, positional: list[Any], kwargs: dict[str, Any]
 ) -> bytes:
     """Best-effort Modbus request frame builder for logging."""
 
     try:
-        if func_name == "read_input_registers":
-            addr = int(positional[0])
-            count = int(kwargs.get("count", positional[1] if len(positional) > 1 else 1))
-            return bytes([slave_id, 4, addr >> 8, addr & 255, count >> 8, count & 255])
-        if func_name == "read_holding_registers":
-            addr = int(positional[0])
-            count = int(kwargs.get("count", positional[1] if len(positional) > 1 else 1))
-            return bytes([slave_id, 3, addr >> 8, addr & 255, count >> 8, count & 255])
-        if func_name == "read_coils":
-            addr = int(positional[0])
-            count = int(kwargs.get("count", positional[1] if len(positional) > 1 else 1))
-            return bytes([slave_id, 1, addr >> 8, addr & 255, count >> 8, count & 255])
-        if func_name == "read_discrete_inputs":
-            addr = int(positional[0])
-            count = int(kwargs.get("count", positional[1] if len(positional) > 1 else 1))
-            return bytes([slave_id, 2, addr >> 8, addr & 255, count >> 8, count & 255])
+        if func_name in _READ_FC:
+            return _encode_read_frame(slave_id, _READ_FC[func_name], positional, kwargs)
         if func_name == "write_register":
             addr = int(kwargs.get("address", positional[0]))
             value = int(kwargs.get("value", positional[1] if len(positional) > 1 else 0))

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,13 +1,12 @@
 # Maintainability audit
 
-Date: 2026-05-08 (Python 3.13 full-pass + scanner/io_read refactor)
+Date: 2026-05-08 (Python 3.13 full-pass + modbus_helpers._encode_read_frame refactor)
 
 ## Commands executed (exact)
 
 - `git branch --show-current`
 - `git status --short`
-- `python -m pip install --upgrade pip setuptools wheel`
-- `python -m pip install -r requirements-dev.txt`
+- `uv pip install -r requirements-dev.txt` (Python 3.13 venv)
 - Import gate script:
   - `python - <<'PY' ... __import__(...) ... PY`
 - `ruff check custom_components tests tools`
@@ -22,11 +21,10 @@ Date: 2026-05-08 (Python 3.13 full-pass + scanner/io_read refactor)
 - `find custom_components/thessla_green_modbus -maxdepth 2 -name "coordinator.py" -print`
 - `rg "from homeassistant|import homeassistant" core/ transport/ registers/ scanner/`
 - `rg "compat|shim|proxy|re-export|legacy" custom_components tests docs`
-- Release tool availability: `pip show homeassistant hassfest hacs`, `hassfest --help`, `hacs --help`
 
 ## Import gate result
 
-Environment: **Python 3.13.12**. All five required modules import successfully.
+Environment: **Python 3.13.12** (`.venv-py313`). All five required modules import successfully.
 
 - `pydantic`: ✅ `OK pydantic: 2.12.2`
 - `pytest`: ✅ `OK pytest: 9.0.0`
@@ -40,44 +38,32 @@ Environment: **Python 3.13.12**. All five required modules import successfully.
 
 - **ruff check**: ✅ pass (`All checks passed!`).
 - **ruff import order check**: ✅ pass (`All checks passed!`).
-- **ruff format --check**: ⚠️ **2 files would be reformatted** (see drift section below; down from 3).
+- **ruff format --check**: ✅ **0 files drift** (413 files already formatted — improved from 2 files in prior audit).
 - **compileall**: ✅ pass.
 - **register compare** (`compare_registers_with_reference.py`): ✅ pass
   (informational: 62 extras; 242 name mismatches on common addresses — unchanged).
 - **maintainability** (`check_maintainability.py`): ✅ pass (`Maintainability gate passed.`).
 - **entity mappings** (`validate_entity_mappings.py`): ✅ pass (`OK: 366 entities validated`).
-- **pytest** (`pytest tests/ -q`): ✅ **1892 passed, 4 skipped**, 84 warnings in 14.30s.
-- **coordinator split check**: ✅ pass (277 passed, 1 warning in 2.59s).
+- **pytest** (`pytest tests/ -q`): ✅ **1900 passed, 4 skipped**, 84 warnings in 12.13s.
+- **coordinator split check**: ✅ pass (277 passed, 1 warning in 2.01s).
 
-### Notable changes since previous audit (2026-05-08 3.11 run)
+### Notable changes since previous audit (2026-05-08 scanner/io_read refactor run)
 
-- Full test suite now runs on Python 3.13 — all gates green.
-- `scanner/io_read_helpers.py` — ruff format drift **resolved** (lambda inline).
-- `scanner/io_read.py` — `_run_holding_read_retry_loop` extracted; `read_holding` reduced from 92 → 29 lines; now mirrors `read_input` pattern.
-- `scanner/io_read.py` non-empty lines: 694 → 708 (net +14 from added function scaffolding/docstring).
+- Full test suite runs on Python 3.13 — all gates green.
+- `modbus_helpers.py` — `_encode_read_frame` extracted from `_build_request_frame`; function reduced from 56 → 42 AST lines; `_READ_FC` dict added.
+- Ruff format drift: **0 files** (down from 2 in previous audit; prior drift in `test_config_flow_helpers.py` and `test_modbus_helpers_call_flow.py` was resolved upstream).
+- pytest count: **1900 passed** (up from 1892; 3 new tests for `_encode_read_frame`, `read_input_registers`, `read_holding_registers` paths).
 
-### Ruff format drift improvement
+### Ruff format drift
 
-Format drift reduced from **3 files** (previous audit) to **2 files** (this run):
+`ruff format --check custom_components tests tools` reports **0 files would be reformatted**.
 
-| Status | File |
-|--------|------|
-| ✅ resolved | `scanner/io_read_helpers.py` |
-| ⚠️ still drifted | `tests/test_config_flow_helpers.py` |
-| ⚠️ still drifted | `tests/test_modbus_helpers_call_flow.py` |
+All 413 files are already formatted. ✅
 
 ### Required CI gate status note
 
 - All local maintained quality gates are green on Python 3.13.
 - CI/HACS/hassfest gates were **not** executed in this run and are not claimed as proven.
-
-## Ruff format drift
-
-`ruff format --check custom_components tests tools` reports **2 files would be reformatted**
-(down from 3 in the previous audit):
-
-1. `tests/test_config_flow_helpers.py`
-2. `tests/test_modbus_helpers_call_flow.py`
 
 ## Architecture invariants snapshot
 
@@ -93,15 +79,15 @@ Format drift reduced from **3 files** (previous audit) to **2 files** (this run)
 
 | Lines | Path |
 |------:|------|
+| 714 | `custom_components/thessla_green_modbus/scanner/io_read.py` |
 | 699 | `custom_components/thessla_green_modbus/coordinator/coordinator.py` |
-| 708 | `custom_components/thessla_green_modbus/scanner/io_read.py` |
-| 538 | `custom_components/thessla_green_modbus/modbus_helpers.py` |
+| 537 | `custom_components/thessla_green_modbus/modbus_helpers.py` |
 | 468 | `custom_components/thessla_green_modbus/coordinator/schedule.py` |
 | 454 | `custom_components/thessla_green_modbus/scanner/core.py` |
 | 440 | `tests/test_coordinator.py` |
 | 437 | `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` |
-| 431 | `tests/test_config_flow_helpers.py` |
-| 422 | `tests/test_modbus_helpers_call_flow.py` |
+| 433 | `tests/test_config_flow_helpers.py` |
+| 420 | `tests/test_modbus_helpers_call_flow.py` |
 | 417 | `custom_components/thessla_green_modbus/mappings/_static_discrete.py` |
 
 ### Largest classes (AST span, top 10)
@@ -132,23 +118,22 @@ Format drift reduced from **3 files** (previous audit) to **2 files** (this run)
 | 103 | `run` | `tests/test_force_full_register_list_integration.py` |
 | 100 | `test_entity_counts_per_platform` | `tests/test_all_entity_creation.py` |
 | 100 | `read_input_registers_optimized` | `_coordinator_read_batches.py` |
-| 79 | `read_bit_registers` | `scanner/io_read.py` |
-| 77 | `_run_holding_read_retry_loop` | `scanner/io_read.py` (extracted) |
+| 78 | `_call_modbus` | `modbus_helpers.py` |
+| 42 | `_build_request_frame` | `modbus_helpers.py` (was 56) |
 
 ## Remaining hotspots
 
-1. Coordinator concentration (`coordinator/coordinator.py` 699 lines, `ThesslaGreenModbusCoordinator` class 611 lines; `coordinator/schedule.py` 468 lines, `_CoordinatorScheduleMixin` 488 lines).
-2. Scanner read/orchestration complexity (`scanner/io_read.py` 708 lines, `scanner/core.py` 454 lines). `read_holding` reduced to 29 lines (was 92); `read_bit_registers` (79 lines) is next candidate.
+1. Coordinator concentration (`coordinator/coordinator.py` 699 lines, `ThesslaGreenModbusCoordinator` 611 lines; `coordinator/schedule.py` 468 lines, `_CoordinatorScheduleMixin` 488 lines).
+2. Scanner read/orchestration complexity (`scanner/io_read.py` 714 lines, `scanner/core.py` 454 lines).
 3. Mapping builder density (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow branching (`config_flow.py` 414 lines, `config_flow_device_validation.py`).
-5. Two files with ruff format drift: `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`.
+4. Config-flow branching (`config_flow.py` 414 lines).
+5. Ruff format drift: 0 files. ✅
 
 ## Branch note (authoritative target)
 
 - The working target branch is **dev**.
 - **main** is **not** authoritative for this refactor/audit track.
 - No `main -> dev` merge is recommended as part of this audit.
-- This branch (`claude/dev-audit-refactor-SNaO3`) targets **dev** as PR base.
 
 ## Release readiness caveats
 
@@ -157,4 +142,8 @@ Format drift reduced from **3 files** (previous audit) to **2 files** (this run)
   Release readiness via those gates must be verified through the CI pipeline.
 - **Real-device validation is not proven** in this audit unless explicitly documented
   with device evidence. No on-device test evidence was captured in this run.
-- `root manifest.json` is not flagged as a blocker unless tooling specifically requires it.
+
+## Dependabot note
+
+- PR #1567 was **not touched** in this session.
+- Pydantic version was **not changed** (installed: 2.12.2).

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08 (Python 3.13 full-pass + scanner/io_read refactor).
+Last reviewed: 2026-05-08 (Python 3.13 full-pass + modbus_helpers._encode_read_frame refactor).
 
 Related document:
 
@@ -34,27 +34,23 @@ The following constraints remain active and must be preserved:
 - HA imports in `core/transport/registers/scanner`: **none detected** by grep.
 - Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches present in docs/tests/comments/known compatibility code references.
 
-## Notable since previous snapshot (2026-05-08 3.11 run)
+## Notable since previous snapshot (2026-05-08 scanner/io_read refactor run)
 
-- Full test suite now validated on Python 3.13 — **1892 passed, 4 skipped**.
-- `scanner/io_read_helpers.py` — ruff format drift **resolved** (lambda inline fix).
-- `scanner/io_read.py` — `_run_holding_read_retry_loop` extracted; `read_holding` reduced from 92 → 29 lines; now mirrors `read_input` pattern symmetrically.
-- `scanner/io_read.py` non-empty lines: 694 → 708 (net +14 from function scaffolding).
-- Ruff format drift reduced from **3 files** to **2 files**:
-  - `tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`.
+- Full test suite validated on Python 3.13 — **1900 passed, 4 skipped**.
+- Ruff format drift: **0 files** (down from 2 — prior drift in `test_config_flow_helpers.py` and `test_modbus_helpers_call_flow.py` was resolved upstream).
+- `modbus_helpers.py` — `_encode_read_frame` extracted; `_build_request_frame` reduced from 56 → 42 AST lines. `_READ_FC` dict maps read function names to Modbus function codes.
+- 3 new focused tests: `test_encode_read_frame_produces_correct_bytes`, `test_build_request_frame_read_input_registers`, `test_build_request_frame_read_holding_registers`.
 
 ## Required gate status snapshot (2026-05-08 Python 3.13 run)
 
 - `ruff check custom_components tests tools`: **pass**.
 - `ruff check --select I custom_components tests tools`: **pass**.
-- `ruff format --check custom_components tests tools`: **2 files drift**
-  (tests/test_config_flow_helpers.py, tests/test_modbus_helpers_call_flow.py).
-  Improved from 3 files in prior audit.
+- `ruff format --check custom_components tests tools`: **0 files drift** ✅.
 - `python3.13 -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
 - `python3.13 tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
 - `python3.13 tools/check_maintainability.py`: **pass** (`Maintainability gate passed.`).
 - `python3.13 tools/validate_entity_mappings.py`: **pass** (`OK: 366 entities validated`).
-- `python3.13 -m pytest tests/ -q`: **pass** — 1892 passed, 4 skipped, 84 warnings.
+- `python3.13 -m pytest tests/ -q`: **pass** — 1900 passed, 4 skipped, 84 warnings.
 - Import gate (all 5 modules): **pass** on Python 3.13.
 
 ## Non-required tool status
@@ -68,10 +64,10 @@ The following constraints remain active and must be preserved:
 ## Remaining hotspots (current queue)
 
 1. Coordinator size/branching (`coordinator/coordinator.py` 699 lines, `coordinator/schedule.py` 468 lines).
-2. Scanner read/orchestration complexity (`scanner/io_read.py` 708 lines, `scanner/core.py` 454 lines). `read_bit_registers` (79 lines) is the next candidate in this file.
+2. Scanner read/orchestration complexity (`scanner/io_read.py` 714 lines, `scanner/core.py` 454 lines).
 3. Mapping build complexity (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow/device validation complexity (`config_flow.py` 414 lines, `config_flow_device_validation.py`).
-5. Ruff format drift: 2 files (`tests/test_config_flow_helpers.py`, `tests/test_modbus_helpers_call_flow.py`).
+4. Config-flow branching (`config_flow.py` 414 lines).
+5. Ruff format drift: 0 files ✅.
 
 ## Branch note
 
@@ -83,3 +79,8 @@ The following constraints remain active and must be preserved:
 
 - **HACS/hassfest readiness:** not claimable (not executed in this run; these run as GitHub Actions only).
 - **Real-device readiness:** not claimable from this verification run; no new on-device evidence captured.
+
+## Dependabot note
+
+- PR #1567 was **not touched** in this session.
+- Pydantic version was **not changed** (installed: 2.12.2).

--- a/tests/test_modbus_helpers_frames_and_chunks.py
+++ b/tests/test_modbus_helpers_frames_and_chunks.py
@@ -68,6 +68,33 @@ def test_mask_frame_multi_bytes():
     assert "0064" in result
 
 
+def test_encode_read_frame_produces_correct_bytes():
+    from custom_components.thessla_green_modbus.modbus_helpers import _encode_read_frame
+
+    frame = _encode_read_frame(1, 4, [100], {"count": 3})
+    assert frame == bytes([1, 4, 0, 100, 0, 3])
+
+
+def test_build_request_frame_read_input_registers():
+    from custom_components.thessla_green_modbus.modbus_helpers import _build_request_frame
+
+    frame = _build_request_frame("read_input_registers", 1, [256], {"count": 10})
+    assert frame[0] == 1
+    assert frame[1] == 4
+    assert frame[2] == 1
+    assert frame[3] == 0
+    assert len(frame) == 6
+
+
+def test_build_request_frame_read_holding_registers():
+    from custom_components.thessla_green_modbus.modbus_helpers import _build_request_frame
+
+    frame = _build_request_frame("read_holding_registers", 2, [50], {"count": 5})
+    assert frame[0] == 2
+    assert frame[1] == 3
+    assert len(frame) == 6
+
+
 def test_build_request_frame_read_coils():
     from custom_components.thessla_green_modbus.modbus_helpers import _build_request_frame
 


### PR DESCRIPTION
Base branch: dev

## Summary

- **PHASE A** — Full Python 3.13.12 audit: all gates green.
- **PHASE B** — Ruff format drift: 0 files (resolved since last audit; no changes needed).
- **PHASE C** — Focused refactor: `modbus_helpers._encode_read_frame` extracted from `_build_request_frame`.

## PHASE A gate results (Python 3.13.12)

| Gate | Result |
|------|--------|
| import gate (pydantic, pytest, pytest_asyncio, phcc, homeassistant) | ✅ pass |
| ruff check | ✅ pass |
| ruff import order | ✅ pass |
| ruff format --check | ✅ 0 files drift |
| compileall | ✅ pass |
| compare_registers_with_reference | ✅ pass (62 extras, 242 name mismatches — informational, unchanged) |
| check_maintainability | ✅ pass |
| validate_entity_mappings | ✅ 366 entities |
| pytest | ✅ 1900 passed, 4 skipped |
| coordinator split check | ✅ 277 passed |

## PHASE C: modbus_helpers — `_encode_read_frame` extraction

**Before:** `_build_request_frame` 56 AST lines with four identical read branches (read_input_registers, read_holding_registers, read_coils, read_discrete_inputs).

**After:** `_encode_read_frame` helper + `_READ_FC` dict; `_build_request_frame` reduced to 42 AST lines. Behavior unchanged, public API unchanged.

**New tests:** `test_encode_read_frame_produces_correct_bytes`, `test_build_request_frame_read_input_registers`, `test_build_request_frame_read_holding_registers` (previously untested paths).

## Files changed

| File | Change |
|------|--------|
| `custom_components/thessla_green_modbus/modbus_helpers.py` | extract `_encode_read_frame` + `_READ_FC` |
| `tests/test_modbus_helpers_frames_and_chunks.py` | 3 focused tests |
| `docs/maintainability_audit.md` | refresh (0 drift, 1900 tests, Python 3.13) |
| `docs/refactor_status.md` | refresh |

## Constraints verified

- Pydantic version: **not changed** (2.12.2).
- PR #1567: **not touched**.
- main: **not used**.
- CI: **not modified**.
- Register JSON files: **not modified**.
- Runtime behavior: **unchanged**.

https://claude.ai/code/session_01Xnc4EXbAS1UC1vf2sgFjMP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xnc4EXbAS1UC1vf2sgFjMP)_