### PR TITLE
refactor: continue config flow and coordinator test cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -57,10 +57,12 @@ from .config_flow_steps import resolve_reauth_entry as _resolve_reauth_entry_imp
 from .config_flow_steps import resolve_reauth_form_state as _resolve_reauth_form_state_impl
 from .config_flow_steps import validate_options_submission as _validate_options_submission_impl
 from .config_flow_user_submit import process_user_submission as _process_user_submission_impl
-from .config_flow_validation import process_scan_capabilities as _process_scan_capabilities_impl
-from .config_flow_validation import validate_rtu_config as _validate_rtu_config_impl
+from .config_flow_validation import (
+    process_scan_capabilities_bound as _process_scan_capabilities_bound,
+)
+from .config_flow_validation import validate_rtu_config_bound as _validate_rtu_config_bound
 from .config_flow_validation import validate_slave_id as _validate_slave_id_impl
-from .config_flow_validation import validate_tcp_config as _validate_tcp_config_impl
+from .config_flow_validation import validate_tcp_config_bound as _validate_tcp_config_bound
 from .const import (
     CONF_SLAVE_ID,
     CONF_TIMEOUT,
@@ -185,34 +187,6 @@ def _validate_slave_id(data: dict[str, Any]) -> int:
     return _validate_slave_id_impl(data)
 
 
-def _validate_tcp_config(data: dict[str, Any]) -> tuple[str, int]:
-    """Validate and normalise TCP fields in data. Returns (host, port)."""
-    return _validate_tcp_config_impl(data, looks_like_hostname=_looks_like_hostname)
-
-
-def _validate_rtu_config(data: dict[str, Any]) -> None:
-    """Validate and normalise RTU serial fields in data."""
-    _validate_rtu_config_impl(
-        data,
-        normalize_baud_rate=_normalize_baud_rate,
-        normalize_parity=_normalize_parity,
-        normalize_stop_bits=_normalize_stop_bits,
-    )
-
-
-def _process_scan_capabilities(
-    scan_result: dict[str, Any],
-    capabilities_cls: type,
-) -> dict[str, Any]:
-    """Extract and validate capabilities from a scan result dict."""
-    return _process_scan_capabilities_impl(
-        scan_result,
-        capabilities_cls=capabilities_cls,
-        caps_to_dict=_caps_to_dict,
-        logger=_LOGGER,
-    )
-
-
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
     return await _validate_input_impl(
@@ -220,8 +194,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         data,
         normalize_connection_type=_normalize_connection_type,
         validate_slave_id=_validate_slave_id,
-        validate_tcp_config=_validate_tcp_config,
-        validate_rtu_config=_validate_rtu_config,
+        validate_tcp_config=_validate_tcp_config_bound,
+        validate_rtu_config=_validate_rtu_config_bound,
         load_scanner_module=_load_scanner_module,
         scanner_cls_override=ThesslaGreenDeviceScanner,
         capabilities_cls_override=DeviceCapabilities,
@@ -231,7 +205,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
             backoff=backoff,
         ),
         call_with_optional_timeout=_call_with_optional_timeout,
-        process_scan_capabilities=_process_scan_capabilities,
+        process_scan_capabilities=_process_scan_capabilities_bound,
         is_request_cancelled_error=_is_request_cancelled_error,
         classify_os_error=_classify_os_error_impl,
         should_log_timeout_traceback=_should_log_timeout_traceback_impl,
@@ -333,7 +307,7 @@ class ConfigFlow(_ConfigFlowBase, domain=DOMAIN):
             device_info=self._device_info,
             scan_result=self._scan_result,
             cap_cls=cap_cls,
-            caps_to_dict=_caps_to_dict,
+            caps_to_dict=_caps_to_dict_impl,
         )
 
         return self.async_show_form(

--- a/custom_components/thessla_green_modbus/config_flow_validation.py
+++ b/custom_components/thessla_green_modbus/config_flow_validation.py
@@ -12,6 +12,9 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.util.network import is_host_valid
 from voluptuous import Invalid as VOL_INVALID
 
+from .config_flow_network import looks_like_hostname as _looks_like_hostname
+from .config_flow_options import normalize_baud_rate, normalize_parity, normalize_stop_bits
+from .config_flow_payloads import caps_to_dict as _caps_to_dict
 from .const import (
     CONF_BAUD_RATE,
     CONF_PARITY,
@@ -25,6 +28,8 @@ from .const import (
     DEFAULT_STOP_BITS,
 )
 from .errors import CannotConnect
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def validate_slave_id(data: dict[str, Any]) -> int:
@@ -144,3 +149,35 @@ def process_scan_capabilities(
         raise CannotConnect("invalid_capabilities")
 
     return caps_dict
+
+
+# --- Production-wired bound adapters ---
+
+
+def validate_tcp_config_bound(data: dict[str, Any]) -> tuple[str, int]:
+    """validate_tcp_config pre-wired with the production hostname checker."""
+    return validate_tcp_config(data, looks_like_hostname=_looks_like_hostname)
+
+
+def validate_rtu_config_bound(data: dict[str, Any]) -> None:
+    """validate_rtu_config pre-wired with the production option normalizers."""
+    validate_rtu_config(
+        data,
+        normalize_baud_rate=normalize_baud_rate,
+        normalize_parity=normalize_parity,
+        normalize_stop_bits=normalize_stop_bits,
+    )
+
+
+def process_scan_capabilities_bound(
+    scan_result: dict[str, Any],
+    capabilities_cls: type,
+    logger: logging.Logger = _LOGGER,
+) -> dict[str, Any]:
+    """process_scan_capabilities pre-wired with the production caps serializer."""
+    return process_scan_capabilities(
+        scan_result,
+        capabilities_cls=capabilities_cls,
+        caps_to_dict=_caps_to_dict,
+        logger=logger,
+    )

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,6 +1,6 @@
 # Maintainability audit
 
-Date: 2026-05-08 (Python 3.13 full-pass + modbus_helpers._encode_read_frame refactor)
+Date: 2026-05-08 (Python 3.13 full-pass + config_flow bound-adapter extraction + coordinator test split)
 
 ## Commands executed (exact)
 
@@ -26,8 +26,8 @@ Date: 2026-05-08 (Python 3.13 full-pass + modbus_helpers._encode_read_frame refa
 
 Environment: **Python 3.13.12** (`.venv-py313`). All five required modules import successfully.
 
-- `pydantic`: ✅ `OK pydantic: 2.12.2`
-- `pytest`: ✅ `OK pytest: 9.0.0`
+- `pydantic`: ✅ `OK pydantic: 2.13.4` (pip-installed; see Dependabot note)
+- `pytest`: ✅ `OK pytest: 9.0.3`
 - `pytest_asyncio`: ✅ `OK pytest_asyncio: 1.3.0`
 - `pytest_homeassistant_custom_component`: ✅ pass
 - `homeassistant`: ✅ pass
@@ -38,27 +38,28 @@ Environment: **Python 3.13.12** (`.venv-py313`). All five required modules impor
 
 - **ruff check**: ✅ pass (`All checks passed!`).
 - **ruff import order check**: ✅ pass (`All checks passed!`).
-- **ruff format --check**: ✅ **0 files drift** (413 files already formatted — improved from 2 files in prior audit).
+- **ruff format --check**: ✅ **0 files drift** (415 files already formatted).
 - **compileall**: ✅ pass.
 - **register compare** (`compare_registers_with_reference.py`): ✅ pass
   (informational: 62 extras; 242 name mismatches on common addresses — unchanged).
 - **maintainability** (`check_maintainability.py`): ✅ pass (`Maintainability gate passed.`).
 - **entity mappings** (`validate_entity_mappings.py`): ✅ pass (`OK: 366 entities validated`).
-- **pytest** (`pytest tests/ -q`): ✅ **1900 passed, 4 skipped**, 84 warnings in 12.13s.
-- **coordinator split check**: ✅ pass (277 passed, 1 warning in 2.01s).
+- **pytest** (`pytest tests/ -q`): ✅ **1913 passed, 4 skipped**, 84 warnings in 14.74s.
+- **coordinator split check**: ✅ pass (277 total — unchanged).
 
-### Notable changes since previous audit (2026-05-08 scanner/io_read refactor run)
+### Notable changes since previous audit (2026-05-08 config_flow + coordinator test cleanup)
 
 - Full test suite runs on Python 3.13 — all gates green.
-- `modbus_helpers.py` — `_encode_read_frame` extracted from `_build_request_frame`; function reduced from 56 → 42 AST lines; `_READ_FC` dict added.
-- Ruff format drift: **0 files** (down from 2 in previous audit; prior drift in `test_config_flow_helpers.py` and `test_modbus_helpers_call_flow.py` was resolved upstream).
-- pytest count: **1900 passed** (up from 1892; 3 new tests for `_encode_read_frame`, `read_input_registers`, `read_holding_registers` paths).
+- **PHASE B — config_flow bound-adapter extraction**: Three adapter functions (`_validate_tcp_config`, `_validate_rtu_config`, `_process_scan_capabilities`) removed from `config_flow.py` and replaced with `validate_tcp_config_bound`, `validate_rtu_config_bound`, `process_scan_capabilities_bound` in `config_flow_validation.py`. 13 new focused tests added in `tests/test_config_flow_validation_bound.py`. `config_flow.py` non-empty lines: 414 → 394 (-20).
+- **PHASE C — coordinator test split**: `TestParseBackoffJitter` class (5 tests) moved from `test_coordinator.py` to `tests/test_coordinator_parse_backoff.py`. Total coordinator tests unchanged (277). `test_coordinator.py` non-empty lines: 440 → 412 (-28).
+- pytest count: **1913 passed** (up from 1900; +13 bound-adapter tests).
+- Ruff format drift: **0 files** (415 files).
 
 ### Ruff format drift
 
 `ruff format --check custom_components tests tools` reports **0 files would be reformatted**.
 
-All 413 files are already formatted. ✅
+All 415 files are already formatted. ✅
 
 ### Required CI gate status note
 
@@ -84,11 +85,11 @@ All 413 files are already formatted. ✅
 | 537 | `custom_components/thessla_green_modbus/modbus_helpers.py` |
 | 468 | `custom_components/thessla_green_modbus/coordinator/schedule.py` |
 | 454 | `custom_components/thessla_green_modbus/scanner/core.py` |
-| 440 | `tests/test_coordinator.py` |
 | 437 | `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` |
 | 433 | `tests/test_config_flow_helpers.py` |
 | 420 | `tests/test_modbus_helpers_call_flow.py` |
 | 417 | `custom_components/thessla_green_modbus/mappings/_static_discrete.py` |
+| 412 | `tests/test_coordinator.py` |
 
 ### Largest classes (AST span, top 10)
 
@@ -126,7 +127,7 @@ All 413 files are already formatted. ✅
 1. Coordinator concentration (`coordinator/coordinator.py` 699 lines, `ThesslaGreenModbusCoordinator` 611 lines; `coordinator/schedule.py` 468 lines, `_CoordinatorScheduleMixin` 488 lines).
 2. Scanner read/orchestration complexity (`scanner/io_read.py` 714 lines, `scanner/core.py` 454 lines).
 3. Mapping builder density (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow branching (`config_flow.py` 414 lines).
+4. Config-flow branching (`config_flow.py` 394 lines; reduced from 414 in previous audit).
 5. Ruff format drift: 0 files. ✅
 
 ## Branch note (authoritative target)
@@ -146,4 +147,4 @@ All 413 files are already formatted. ✅
 ## Dependabot note
 
 - PR #1567 was **not touched** in this session.
-- Pydantic version was **not changed** (installed: 2.12.2).
+- Pydantic version was **not changed**. `requirements-dev.txt` still pins `pydantic==2.12.2`; the pip-installed version in this environment is 2.13.4 due to an unrelated global install, but the project pin was not modified.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08 (Python 3.13 full-pass + modbus_helpers._encode_read_frame refactor).
+Last reviewed: 2026-05-08 (Python 3.13 full-pass + config_flow bound-adapter extraction + coordinator test split).
 
 Related document:
 
@@ -34,12 +34,12 @@ The following constraints remain active and must be preserved:
 - HA imports in `core/transport/registers/scanner`: **none detected** by grep.
 - Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches present in docs/tests/comments/known compatibility code references.
 
-## Notable since previous snapshot (2026-05-08 scanner/io_read refactor run)
+## Notable since previous snapshot (2026-05-08 config_flow + coordinator test cleanup)
 
-- Full test suite validated on Python 3.13 — **1900 passed, 4 skipped**.
-- Ruff format drift: **0 files** (down from 2 — prior drift in `test_config_flow_helpers.py` and `test_modbus_helpers_call_flow.py` was resolved upstream).
-- `modbus_helpers.py` — `_encode_read_frame` extracted; `_build_request_frame` reduced from 56 → 42 AST lines. `_READ_FC` dict maps read function names to Modbus function codes.
-- 3 new focused tests: `test_encode_read_frame_produces_correct_bytes`, `test_build_request_frame_read_input_registers`, `test_build_request_frame_read_holding_registers`.
+- Full test suite validated on Python 3.13 — **1913 passed, 4 skipped** (+13 vs previous run).
+- Ruff format drift: **0 files** (415 files).
+- **PHASE B**: Three adapter functions removed from `config_flow.py`; replaced by `validate_tcp_config_bound`, `validate_rtu_config_bound`, `process_scan_capabilities_bound` in `config_flow_validation.py`. `config_flow.py` 414 → 394 non-empty lines. 13 new focused tests in `tests/test_config_flow_validation_bound.py`.
+- **PHASE C**: `TestParseBackoffJitter` (5 test methods) moved from `test_coordinator.py` to `tests/test_coordinator_parse_backoff.py`. `test_coordinator.py` 440 → 412 non-empty lines; total coordinator test count unchanged at 277.
 
 ## Required gate status snapshot (2026-05-08 Python 3.13 run)
 
@@ -50,7 +50,7 @@ The following constraints remain active and must be preserved:
 - `python3.13 tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
 - `python3.13 tools/check_maintainability.py`: **pass** (`Maintainability gate passed.`).
 - `python3.13 tools/validate_entity_mappings.py`: **pass** (`OK: 366 entities validated`).
-- `python3.13 -m pytest tests/ -q`: **pass** — 1900 passed, 4 skipped, 84 warnings.
+- `python3.13 -m pytest tests/ -q`: **pass** — 1913 passed, 4 skipped, 84 warnings.
 - Import gate (all 5 modules): **pass** on Python 3.13.
 
 ## Non-required tool status
@@ -66,7 +66,7 @@ The following constraints remain active and must be preserved:
 1. Coordinator size/branching (`coordinator/coordinator.py` 699 lines, `coordinator/schedule.py` 468 lines).
 2. Scanner read/orchestration complexity (`scanner/io_read.py` 714 lines, `scanner/core.py` 454 lines).
 3. Mapping build complexity (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow branching (`config_flow.py` 414 lines).
+4. Config-flow branching (`config_flow.py` 394 lines; reduced from 414).
 5. Ruff format drift: 0 files ✅.
 
 ## Branch note
@@ -83,4 +83,4 @@ The following constraints remain active and must be preserved:
 ## Dependabot note
 
 - PR #1567 was **not touched** in this session.
-- Pydantic version was **not changed** (installed: 2.12.2).
+- Pydantic version was **not changed**. `requirements-dev.txt` still pins `pydantic==2.12.2`.

--- a/tests/test_config_flow_validation_bound.py
+++ b/tests/test_config_flow_validation_bound.py
@@ -1,0 +1,139 @@
+"""Focused tests for the production-wired bound adapter functions in config_flow_validation."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any
+
+import pytest
+import voluptuous as vol
+from custom_components.thessla_green_modbus.config_flow_validation import (
+    process_scan_capabilities_bound,
+    validate_rtu_config_bound,
+    validate_tcp_config_bound,
+)
+from custom_components.thessla_green_modbus.const import (
+    CONF_BAUD_RATE,
+    CONF_PARITY,
+    CONF_SERIAL_PORT,
+    CONF_SLAVE_ID,
+    CONF_STOP_BITS,
+)
+from custom_components.thessla_green_modbus.errors import CannotConnect
+
+# --- validate_tcp_config_bound ---
+
+
+def test_validate_tcp_config_bound_valid_ip():
+    data: dict[str, Any] = {"host": "192.168.1.1", "port": 502, CONF_SLAVE_ID: 1}
+    host, port = validate_tcp_config_bound(data)
+    assert host == "192.168.1.1"
+    assert port == 502
+
+
+def test_validate_tcp_config_bound_valid_hostname():
+    data: dict[str, Any] = {"host": "modbus.local", "port": 502, CONF_SLAVE_ID: 1}
+    host, port = validate_tcp_config_bound(data)
+    assert host == "modbus.local"
+    assert port == 502
+
+
+def test_validate_tcp_config_bound_missing_host_raises():
+    with pytest.raises(vol.Invalid):
+        validate_tcp_config_bound({"port": 502})
+
+
+def test_validate_tcp_config_bound_invalid_port_raises():
+    with pytest.raises(vol.Invalid):
+        validate_tcp_config_bound({"host": "192.168.1.1", "port": 99999})
+
+
+def test_validate_tcp_config_bound_no_dot_hostname_raises():
+    with pytest.raises(vol.Invalid):
+        validate_tcp_config_bound({"host": "nodothost", "port": 502})
+
+
+# --- validate_rtu_config_bound ---
+
+
+def test_validate_rtu_config_bound_valid():
+    data: dict[str, Any] = {
+        CONF_SERIAL_PORT: "/dev/ttyUSB0",
+        CONF_BAUD_RATE: 9600,
+        CONF_PARITY: "none",
+        CONF_STOP_BITS: 1,
+    }
+    validate_rtu_config_bound(data)
+    assert data[CONF_SERIAL_PORT] == "/dev/ttyUSB0"
+    assert data[CONF_BAUD_RATE] == 9600
+
+
+def test_validate_rtu_config_bound_missing_serial_port_raises():
+    with pytest.raises(vol.Invalid):
+        validate_rtu_config_bound({CONF_SERIAL_PORT: "", CONF_BAUD_RATE: 9600})
+
+
+def test_validate_rtu_config_bound_normalizes_parity_prefix():
+    data: dict[str, Any] = {
+        CONF_SERIAL_PORT: "/dev/ttyUSB0",
+        CONF_BAUD_RATE: 9600,
+        CONF_PARITY: "modbus_parity_even",
+        CONF_STOP_BITS: 1,
+    }
+    validate_rtu_config_bound(data)
+    assert data[CONF_PARITY] == "even"
+
+
+def test_validate_rtu_config_bound_normalizes_baud_rate_string():
+    data: dict[str, Any] = {
+        CONF_SERIAL_PORT: "/dev/ttyUSB0",
+        CONF_BAUD_RATE: "19200",
+        CONF_PARITY: "none",
+        CONF_STOP_BITS: 1,
+    }
+    validate_rtu_config_bound(data)
+    assert data[CONF_BAUD_RATE] == 19200
+
+
+# --- process_scan_capabilities_bound ---
+
+
+def test_process_scan_capabilities_bound_valid_dataclass():
+    @dataclasses.dataclass
+    class Caps:
+        supported: bool = True
+
+    scan_result: dict[str, Any] = {"capabilities": Caps(supported=True)}
+    result = process_scan_capabilities_bound(scan_result, Caps)
+    assert result == {"supported": True}
+
+
+def test_process_scan_capabilities_bound_valid_dict():
+    @dataclasses.dataclass
+    class Caps:
+        supported: bool = False
+
+    scan_result: dict[str, Any] = {"capabilities": {"supported": False}}
+    result = process_scan_capabilities_bound(scan_result, Caps)
+    assert result == {"supported": False}
+
+
+def test_process_scan_capabilities_bound_missing_caps_raises():
+    @dataclasses.dataclass
+    class Caps:
+        x: int = 0
+
+    with pytest.raises(CannotConnect):
+        process_scan_capabilities_bound({}, Caps)
+
+
+def test_process_scan_capabilities_bound_accepts_custom_logger():
+    @dataclasses.dataclass
+    class Caps:
+        y: str = "ok"
+
+    logger = logging.getLogger("test.bound")
+    scan_result: dict[str, Any] = {"capabilities": Caps(y="ok")}
+    result = process_scan_capabilities_bound(scan_result, Caps, logger=logger)
+    assert result["y"] == "ok"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from custom_components.thessla_green_modbus.const import (
     CONF_MAX_REGISTERS_PER_REQUEST,
-    DEFAULT_BACKOFF_JITTER,
     MAX_BATCH_REGISTERS,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import (
@@ -506,45 +505,6 @@ async def test_async_setup_invalid_capabilities(coordinator):
 
     assert str(err.value) == "invalid_capabilities"
     scanner_instance.close.assert_awaited_once()
-
-
-class TestParseBackoffJitter:
-    """Direct tests for the _parse_backoff_jitter parser."""
-
-    def test_numeric_inputs(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse(0) == 0.0
-        assert parse(0.0) == 0.0
-        assert parse(1) == 1.0
-        assert parse(1.5) == 1.5
-
-    def test_string_inputs(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse("1.5") == 1.5
-        assert parse("0") == 0.0
-        assert parse("not-a-number") is None
-        assert parse("") is None
-
-    def test_tuple_list_inputs(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse((1.0, 2.0)) == (1.0, 2.0)
-        assert parse([1, 2]) == (1.0, 2.0)
-        assert parse((1.0, 2.0, 3.0)) == (1.0, 2.0)
-
-    def test_invalid_sequence_returns_none(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse(["a", "b"]) is None
-        assert parse((None, None)) is None
-
-    def test_none_and_sentinel_defaults(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse(None) is None
-        assert parse({"key": "value"}) == DEFAULT_BACKOFF_JITTER  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_parse_backoff.py
+++ b/tests/test_coordinator_parse_backoff.py
@@ -1,0 +1,45 @@
+"""Tests for ThesslaGreenModbusCoordinator._parse_backoff_jitter."""
+
+from custom_components.thessla_green_modbus.const import DEFAULT_BACKOFF_JITTER
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+)
+
+
+class TestParseBackoffJitter:
+    """Direct tests for the _parse_backoff_jitter parser."""
+
+    def test_numeric_inputs(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse(0) == 0.0
+        assert parse(0.0) == 0.0
+        assert parse(1) == 1.0
+        assert parse(1.5) == 1.5
+
+    def test_string_inputs(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse("1.5") == 1.5
+        assert parse("0") == 0.0
+        assert parse("not-a-number") is None
+        assert parse("") is None
+
+    def test_tuple_list_inputs(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse((1.0, 2.0)) == (1.0, 2.0)
+        assert parse([1, 2]) == (1.0, 2.0)
+        assert parse((1.0, 2.0, 3.0)) == (1.0, 2.0)
+
+    def test_invalid_sequence_returns_none(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse(["a", "b"]) is None
+        assert parse((None, None)) is None
+
+    def test_none_and_sentinel_defaults(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse(None) is None
+        assert parse({"key": "value"}) == DEFAULT_BACKOFF_JITTER  # type: ignore[arg-type]


### PR DESCRIPTION
Base branch: dev

## Summary

- **PHASE A**: Full Python 3.13.12 health audit — all gates green (ruff, compileall, compare_registers, check_maintainability, validate_entity_mappings, pytest).
- **PHASE B**: Extracted three DI-adapter functions (`_validate_tcp_config`, `_validate_rtu_config`, `_process_scan_capabilities`) from `config_flow.py` into production-wired bound functions (`validate_tcp_config_bound`, `validate_rtu_config_bound`, `process_scan_capabilities_bound`) in `config_flow_validation.py`. `config_flow.py` reduced from 414 → 394 non-empty lines. 13 focused tests added in `tests/test_config_flow_validation_bound.py`.
- **PHASE C**: Moved `TestParseBackoffJitter` class (5 tests) from `tests/test_coordinator.py` to `tests/test_coordinator_parse_backoff.py`. `test_coordinator.py` reduced from 440 → 412 non-empty lines. Total coordinator test count unchanged at 277.
- **PHASE D**: Refreshed `docs/maintainability_audit.md` and `docs/refactor_status.md`.

## Test plan

- [ ] All 1913 tests pass, 4 skipped, 0 failed (`python3.13 -m pytest tests/ -q`)
- [ ] ruff check: 0 errors
- [ ] ruff format drift: 0 files (415 already formatted)
- [ ] compileall: pass
- [ ] compare_registers: pass (exit 0)
- [ ] check_maintainability: pass
- [ ] validate_entity_mappings: 366 entities validated
- [ ] Coordinator test collection unchanged: 277 before and after split
- [ ] No pydantic version change (`requirements-dev.txt` still pins `pydantic==2.12.2`)
- [ ] PR #1567 not touched
- [ ] main branch not used

https://claude.ai/code/session_018NpAQsRPLRsFgex7LCVoAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018NpAQsRPLRsFgex7LCVoAZ)_