### PR TITLE
Extract load_scanner_module to runtime + split backoff jitter tests

### DIFF
--- a/custom_components/thessla_green_modbus/config_flow.py
+++ b/custom_components/thessla_green_modbus/config_flow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -48,6 +47,7 @@ from .config_flow_runtime import (
 from .config_flow_runtime import (
     is_request_cancelled_error as _is_request_cancelled_error_impl,
 )
+from .config_flow_runtime import load_scanner_module as _load_scanner_module
 from .config_flow_runtime import run_with_retry as _run_with_retry_impl
 from .config_flow_schema import build_connection_schema as _build_connection_schema_impl
 from .config_flow_schema import build_reconfigure_schema as _build_reconfigure_schema_impl
@@ -105,16 +105,6 @@ def _is_request_cancelled_error(exc: ModbusIOException) -> bool:
 
 ThesslaGreenDeviceScanner: Any | None = None
 DeviceCapabilities: Any | None = None
-
-
-async def _load_scanner_module(hass: HomeAssistant) -> Any:
-    """Import scanner.core via the HA executor to avoid blocking the event loop."""
-    if hass is None or not hasattr(hass, "async_add_executor_job"):
-        return import_module("custom_components.thessla_green_modbus.scanner.core")
-    return await hass.async_add_executor_job(
-        import_module, "custom_components.thessla_green_modbus.scanner.core"
-    )
-
 
 # Delay between retries when establishing the connection during the config flow.
 # Uses exponential backoff: ``backoff * 2 ** (attempt-1)``.

--- a/custom_components/thessla_green_modbus/config_flow_runtime.py
+++ b/custom_components/thessla_green_modbus/config_flow_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
+from importlib import import_module
 from typing import Any
 
 from .error_policy import (
@@ -14,6 +15,19 @@ from .modbus_exceptions import ModbusIOException
 from .transport.retry import ErrorKind, calculate_backoff, classify_transport_error, should_retry
 
 TIMEOUT_EXCEPTIONS = (TimeoutError, asyncio.TimeoutError)
+
+_SCANNER_MODULE_PATH = "custom_components.thessla_green_modbus.scanner.core"
+
+
+async def load_scanner_module(hass: Any) -> Any:
+    """Import scanner.core via the HA executor to avoid blocking the event loop.
+
+    When *hass* is ``None`` or lacks ``async_add_executor_job`` the import is
+    performed synchronously (unit-test / offline environments).
+    """
+    if hass is None or not hasattr(hass, "async_add_executor_job"):
+        return import_module(_SCANNER_MODULE_PATH)
+    return await hass.async_add_executor_job(import_module, _SCANNER_MODULE_PATH)
 
 
 def is_request_cancelled_error(exc: ModbusIOException) -> bool:

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,6 +1,6 @@
 # Maintainability audit
 
-Date: 2026-05-08 (Python 3.13 full-pass + schedule encode_write_value + scanner normalize_effective_batch)
+Date: 2026-05-08 (Python 3.13 full-pass + config_flow_runtime load_scanner_module + coordinator backoff jitter test split)
 
 ## Commands executed (exact)
 
@@ -42,37 +42,35 @@ Environment: **Python 3.13.12** (`/tmp/venv313`). All five required modules impo
   (informational: 62 extras; 242 name mismatches on common addresses — unchanged).
 - **maintainability** (`check_maintainability.py`): ✅ pass (`Maintainability gate passed.`).
 - **entity mappings** (`validate_entity_mappings.py`): ✅ pass (`OK: 366 entities validated`).
-- **pytest** (`pytest tests/ -q`): ✅ **1915 passed, 4 skipped**, 90 warnings in 12.68s.
+- **pytest** (`pytest tests/ -q`): ✅ **1920 passed, 4 skipped**, 90 warnings in 14.87s.
 
 ### Notable changes since previous audit (2026-05-08 modbus_helpers._encode_read_frame run)
 
-**PHASE B — coordinator/schedule.py write-path cleanup:**
+**PHASE B — config_flow_runtime.py: extract load_scanner_module:**
 
-- `_encode_write_value` (55-line method) extracted from `_CoordinatorScheduleMixin` into
-  standalone `encode_write_value` function in `coordinator/write_path.py`.
-- `_CoordinatorScheduleMixin` class: **488 → 432 AST lines** (−56).
-- `coordinator/schedule.py` non-empty lines: **468 → 419** (−49).
-- `coordinator/write_path.py` non-empty lines: **63 → 118** (+55).
-- 9 focused unit tests added in `tests/test_coordinator_register_writes.py`.
-- coordinator package `__all__` invariant: `["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]` — unchanged.
-- No top-level `coordinator.py` file created.
+- `_load_scanner_module` (7-line async function) moved from inline in `config_flow.py` into
+  `load_scanner_module` function in `config_flow_runtime.py`.
+- `config_flow.py` now imports `load_scanner_module as _load_scanner_module` from runtime module.
+- `import_module` import removed from `config_flow.py`.
+- `_SCANNER_MODULE_PATH` constant added to `config_flow_runtime.py` for testability.
+- 5 focused unit tests added in `tests/test_config_flow_runtime_loader.py`.
 
-**PHASE C — scanner/core.py focused cleanup:**
+**PHASE C — test_coordinator.py: move TestParseBackoffJitter test group:**
 
-- Inline batch-clamping logic in `ThesslaGreenDeviceScanner.__init__` extracted into
-  `normalize_effective_batch(max_registers_per_request, *, max_batch)` in `scanner/setup.py`.
-- `ThesslaGreenDeviceScanner.__init__`: **91 → 88 AST lines** (−3 inline lines replaced by 2-line call).
-- `scanner/setup.py` gained 14-line `normalize_effective_batch` function (parallel to existing `normalize_backoff_jitter`).
-- 7 focused unit tests added in `tests/test_device_scanner_setup.py`.
-- Scanner HA-independence invariant: **no Home Assistant imports** detected.
+- `TestParseBackoffJitter` class (5 tests, 37 lines) moved from `tests/test_coordinator.py`
+  into new `tests/test_coordinator_backoff_jitter.py`.
+- `DEFAULT_BACKOFF_JITTER` import removed from `test_coordinator.py` (no longer needed).
+- `test_coordinator.py` non-empty lines: **440 → 412** (−28).
+- Test collection total: **286 → 286** (unchanged, redistribution only).
+- No production files changed in PHASE C.
 
-**Test count change:** 1900 → 1909 → 1915 (+15 total from PHASE B + PHASE C).
+**Test count change:** 1915 → 1920 (+5 from PHASE B new tests).
 
 ### Ruff format drift
 
 `ruff format --check custom_components tests tools` reports **0 files would be reformatted**.
 
-All 414 files are already formatted. ✅
+All 416 files are already formatted. ✅
 
 ### Required CI gate status note
 
@@ -89,42 +87,42 @@ All 414 files are already formatted. ✅
 
 ## PHASE B summary
 
-**Extraction: `_read_coils_transport` and `_read_discrete_inputs_transport` → `coordinator/io.py`**
+**Extraction: `_load_scanner_module` → `config_flow_runtime.load_scanner_module`**
 
 Before:
-- `coordinator/coordinator.py` non-empty: **699** lines
-- `ThesslaGreenModbusCoordinator` AST span: **611** lines
-- Methods were implemented in `coordinator.py`; `io.py` had abstract stubs
+- `config_flow.py` non-empty: **414** lines
+- `_load_scanner_module` inline in `config_flow.py` (7-line async function)
+- `config_flow_runtime.py` non-empty: **48** lines
+- No tests for scanner module loading isolation
 
 After:
-- `coordinator/coordinator.py` non-empty: **666** lines (−33)
-- `ThesslaGreenModbusCoordinator` AST span: **577** lines (−34)
-- Implementations moved to `_ModbusIOMixin` in `coordinator/io.py`; stubs replaced with code
-- `ConnectionException` import removed from `coordinator.py`; added to `io.py`
+- `config_flow.py` non-empty: **407** lines (−7)
+- `config_flow_runtime.py` non-empty: **62** lines (+14)
+- `load_scanner_module` function + `_SCANNER_MODULE_PATH` constant added to runtime module
+- 5 focused tests added in `tests/test_config_flow_runtime_loader.py`
 
-API invariant confirmed: `sorted(__all__) == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]` ✅
+Step names, form schemas, error keys, abort reasons, reauth/reconfigure/options behavior: all unchanged ✅
 
-Path invariant confirmed: no `coordinator.py` at package root ✅
-
-Targeted test result: **293 passed**, 1 warning ✅
+Targeted config flow test result: **142 passed**, 1 warning ✅
 
 ## PHASE C summary
 
-**Extraction: UART select mappings → `mappings/_static_discrete_uart.py`**
+**Test-only split: `TestParseBackoffJitter` → `tests/test_coordinator_backoff_jitter.py`**
 
 Before:
-- `_static_discrete.py` non-empty: **417** lines
-- 6 UART/serial-port entries inline in `SELECT_ENTITY_MAPPINGS`
+- `test_coordinator.py` non-empty: **440** lines
+- `TestParseBackoffJitter` class (5 tests) inline in `test_coordinator.py`
+- `DEFAULT_BACKOFF_JITTER` import present but only used by that class
 
 After:
-- `_static_discrete.py` non-empty: **~363** lines (−54)
-- New `_static_discrete_uart.py` created with `UART_SELECT_ENTITY_MAPPINGS`
-- `SELECT_ENTITY_MAPPINGS` composed via `{..., **UART_SELECT_ENTITY_MAPPINGS}`
-- Pattern mirrors existing `_static_discrete_diagnostics.py` extraction
+- `test_coordinator.py` non-empty: **412** lines (−28)
+- New `tests/test_coordinator_backoff_jitter.py` with `TestParseBackoffJitter` (5 tests)
+- `DEFAULT_BACKOFF_JITTER` import removed from `test_coordinator.py`
+- Coordinator test collection: **286 → 286** (unchanged) ✅
 
-Entity count unchanged: **366** ✅
+No production files changed in PHASE C ✅
 
-Targeted mapping test result: **284 passed**, 3 skipped ✅
+Coordinator targeted test result: **300 passed**, 1 warning ✅
 
 ## Largest files/classes/functions (current — 2026-05-08 Phase B+C refresh)
 
@@ -136,20 +134,20 @@ Targeted mapping test result: **284 passed**, 3 skipped ✅
 | 666 | `custom_components/thessla_green_modbus/coordinator/coordinator.py` |
 | 537 | `custom_components/thessla_green_modbus/modbus_helpers.py` |
 | 451 | `custom_components/thessla_green_modbus/scanner/core.py` |
-| 440 | `tests/test_coordinator.py` |
 | 437 | `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` |
 | 433 | `tests/test_config_flow_helpers.py` |
 | 420 | `tests/test_modbus_helpers_call_flow.py` |
 | 419 | `custom_components/thessla_green_modbus/coordinator/schedule.py` |
-| 417 | `custom_components/thessla_green_modbus/mappings/_static_discrete.py` |
+| 412 | `tests/test_coordinator.py` |
+| 407 | `custom_components/thessla_green_modbus/config_flow.py` |
 
 ### Largest classes (AST span, top 10)
 
 | Lines | Class | File |
 |------:|-------|------|
-| 611 | `ThesslaGreenModbusCoordinator` | `coordinator/coordinator.py` |
-| 432 | `_CoordinatorScheduleMixin` | `coordinator/schedule.py` (was 488) |
-| 425 | `ThesslaGreenDeviceScanner` | `scanner/core.py` (was 428) |
+| 577 | `ThesslaGreenModbusCoordinator` | `coordinator/coordinator.py` |
+| 432 | `_CoordinatorScheduleMixin` | `coordinator/schedule.py` |
+| 425 | `ThesslaGreenDeviceScanner` | `scanner/core.py` |
 | 334 | `RawRtuOverTcpTransport` | `modbus_transport_raw.py` |
 | 268 | `RegisterDef` | `registers/register_def.py` |
 | 251 | `ThesslaGreenFan` | `fan.py` |
@@ -177,28 +175,39 @@ Targeted mapping test result: **284 passed**, 3 skipped ✅
 
 | Metric | Before | After |
 |--------|--------|-------|
-| `_CoordinatorScheduleMixin` AST lines | 488 | 432 |
-| `coordinator/schedule.py` non-empty | 468 | 419 |
-| `coordinator/write_path.py` non-empty | 63 | 118 |
-| New test functions | — | +9 |
-| `_encode_write_value` in mixin | yes | **removed** |
-| `encode_write_value` standalone in write_path | no | **added** |
+| `config_flow.py` non-empty | 414 | 407 |
+| `config_flow_runtime.py` non-empty | 48 | 62 |
+| `_load_scanner_module` inline in config_flow.py | yes | **removed** |
+| `load_scanner_module` in config_flow_runtime.py | no | **added** |
+| `_SCANNER_MODULE_PATH` constant | no | **added** |
+| New test functions | — | +5 |
+| `import_module` import in config_flow.py | yes | **removed** |
 
 ## PHASE C before/after metrics
 
 | Metric | Before | After |
 |--------|--------|-------|
-| `ThesslaGreenDeviceScanner.__init__` AST lines | 91 | 88 |
-| Inline batch-clamp lines in `__init__` | 6 | 2 (delegation) |
-| `normalize_effective_batch` in setup.py | no | **added** (14 lines) |
-| New test functions | — | +7 |
+| `test_coordinator.py` non-empty | 440 | 412 |
+| `TestParseBackoffJitter` in test_coordinator.py | yes | **moved** |
+| `test_coordinator_backoff_jitter.py` | absent | **created** |
+| Coordinator test count total | 286 | 286 (unchanged) |
+| `DEFAULT_BACKOFF_JITTER` import in test_coordinator.py | yes | **removed** |
+
+## Coordinator collection comparison
+
+```
+before count: 286
+after count: 286
+missing: []
+added: []
+```
 
 ## Remaining hotspots
 
-1. Coordinator concentration (`coordinator/coordinator.py` 699 lines, `ThesslaGreenModbusCoordinator` 611 lines; `coordinator/schedule.py` 419 lines, `_CoordinatorScheduleMixin` 432 lines).
+1. Coordinator concentration (`coordinator/coordinator.py` 666 lines, `ThesslaGreenModbusCoordinator` 577 AST lines; `coordinator/schedule.py` 419 lines, `_CoordinatorScheduleMixin` 432 lines).
 2. Scanner read/orchestration complexity (`scanner/io_read.py` 714 lines, `scanner/core.py` 451 lines).
 3. Mapping builder density (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow branching (`config_flow.py` 414 lines).
+4. Config-flow branching (`config_flow.py` 407 lines).
 5. Ruff format drift: 0 files. ✅
 
 ## Branch note (authoritative target)

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08 (Python 3.13 full-pass + schedule encode_write_value + scanner normalize_effective_batch).
+Last reviewed: 2026-05-08 (Python 3.13 full-pass + config_flow_runtime load_scanner_module + coordinator backoff jitter test split).
 
 Related document:
 
@@ -27,36 +27,38 @@ The following constraints remain active and must be preserved:
 4. No proxy modules.
 5. `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant.
 
-## Current invariant verification snapshot (2026-05-08 Phase B+C refresh)
+## Current invariant verification snapshot (2026-05-08 load_scanner_module + backoff jitter split)
 
 - Top-level `custom_components/thessla_green_modbus/coordinator.py`: **absent**.
 - Canonical coordinator module: `custom_components/thessla_green_modbus/coordinator/coordinator.py`.
 - HA imports in `core/transport/registers/scanner`: **none detected** by grep.
 - Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches present in docs/tests/comments/known compatibility code references.
 
-## Notable since previous snapshot (2026-05-08 modbus_helpers._encode_read_frame run)
+## Notable since previous snapshot (2026-05-08 Phase B+C run)
 
-- Full test suite validated on Python 3.13 — **1915 passed, 4 skipped**.
+- Full test suite validated on Python 3.13 — **1920 passed, 4 skipped**.
 - Ruff format drift: **0 files** ✅.
-- **PHASE B** — `_encode_write_value` (55-line method) moved from `_CoordinatorScheduleMixin` into
-  standalone `encode_write_value` in `coordinator/write_path.py`. `_CoordinatorScheduleMixin` class:
-  488 → 432 AST lines. 9 focused unit tests added.
-- **PHASE C** — Inline batch-clamping logic extracted from `ThesslaGreenDeviceScanner.__init__` into
-  `normalize_effective_batch` in `scanner/setup.py` (parallel to existing `normalize_backoff_jitter`).
-  `__init__` AST lines: 91 → 88. 7 focused unit tests added.
+- **PHASE B** — `_load_scanner_module` (7-line async function) moved from inline in `config_flow.py`
+  into `load_scanner_module` in `config_flow_runtime.py`. `config_flow.py` non-empty: 414 → 407.
+  `import_module` import removed from `config_flow.py`. `_SCANNER_MODULE_PATH` constant added for
+  testability. 5 focused unit tests added in `tests/test_config_flow_runtime_loader.py`.
+- **PHASE C** (test-only) — `TestParseBackoffJitter` class (5 tests) moved from `test_coordinator.py`
+  into `test_coordinator_backoff_jitter.py`. `test_coordinator.py` non-empty: 440 → 412.
+  Coordinator test collection total: **286 → 286** (unchanged). No production files changed.
 
-## Required gate status snapshot (2026-05-08 Phase B+C run)
+## Required gate status snapshot (2026-05-08 load_scanner_module run)
 
 - `ruff check custom_components tests tools`: **pass**.
 - `ruff check --select I custom_components tests tools`: **pass**.
-- `ruff format --check custom_components tests tools`: **0 files drift** ✅.
+- `ruff format --check custom_components tests tools`: **0 files drift** (416 formatted) ✅.
 - `python3.13 -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
 - `python3.13 tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
 - `python3.13 tools/check_maintainability.py`: **pass** (`Maintainability gate passed.`).
 - `python3.13 tools/validate_entity_mappings.py`: **pass** (`OK: 366 entities validated`).
-- `python3.13 -m pytest tests/ -q`: **pass** — 1915 passed, 4 skipped, 90 warnings.
+- `python3.13 -m pytest tests/ -q`: **pass** — 1920 passed, 4 skipped, 90 warnings.
 - Import gate (all 5 modules): **pass** on Python 3.13.
-- Coordinator split check: **277 passed**, 1 warning.
+- Coordinator tests: **300 passed**, 1 warning.
+- Config flow tests: **142 passed**, 1 warning.
 
 ## Non-required tool status
 
@@ -68,10 +70,10 @@ The following constraints remain active and must be preserved:
 
 ## Remaining hotspots (current queue)
 
-1. Coordinator size/branching (`coordinator/coordinator.py` 699 lines, `coordinator/schedule.py` 419 lines).
+1. Coordinator size/branching (`coordinator/coordinator.py` 666 lines, `coordinator/schedule.py` 419 lines).
 2. Scanner read/orchestration complexity (`scanner/io_read.py` 714 lines, `scanner/core.py` 451 lines).
 3. Mapping build complexity (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow branching (`config_flow.py` 414 lines).
+4. Config-flow branching (`config_flow.py` 407 lines).
 5. Ruff format drift: 0 files ✅.
 
 ## Branch note

--- a/tests/test_config_flow_runtime_loader.py
+++ b/tests/test_config_flow_runtime_loader.py
@@ -1,0 +1,97 @@
+"""Focused tests for the load_scanner_module runtime helper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.config_flow_runtime import (
+    load_scanner_module,
+)
+
+# ---------------------------------------------------------------------------
+# load_scanner_module — synchronous fallback (hass is None)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_scanner_module_none_hass_imports_synchronously():
+    """When hass is None the import is performed synchronously."""
+    fake_module = MagicMock()
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow_runtime.import_module",
+        return_value=fake_module,
+    ) as mock_import:
+        result = await load_scanner_module(None)
+
+    assert result is fake_module
+    mock_import.assert_called_once_with("custom_components.thessla_green_modbus.scanner.core")
+
+
+@pytest.mark.asyncio
+async def test_load_scanner_module_hass_without_executor_imports_synchronously():
+    """hass without async_add_executor_job falls back to synchronous import."""
+    fake_module = MagicMock()
+    hass_stub = object()  # no async_add_executor_job attribute
+
+    with patch(
+        "custom_components.thessla_green_modbus.config_flow_runtime.import_module",
+        return_value=fake_module,
+    ) as mock_import:
+        result = await load_scanner_module(hass_stub)
+
+    assert result is fake_module
+    mock_import.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# load_scanner_module — executor path (hass has async_add_executor_job)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_scanner_module_uses_executor_when_hass_available():
+    """When hass provides async_add_executor_job the module is loaded via executor."""
+    fake_module = MagicMock()
+    hass_stub = MagicMock()
+    hass_stub.async_add_executor_job = AsyncMock(return_value=fake_module)
+
+    result = await load_scanner_module(hass_stub)
+
+    assert result is fake_module
+    hass_stub.async_add_executor_job.assert_called_once()
+    # Verify import_module was passed as the callable
+    call_args = hass_stub.async_add_executor_job.call_args
+    from importlib import import_module
+
+    assert call_args.args[0] is import_module
+    assert call_args.args[1] == "custom_components.thessla_green_modbus.scanner.core"
+
+
+@pytest.mark.asyncio
+async def test_load_scanner_module_executor_receives_correct_path():
+    """The exact module path is passed to the executor import."""
+    from custom_components.thessla_green_modbus.config_flow_runtime import (
+        _SCANNER_MODULE_PATH,
+    )
+
+    fake_module = MagicMock()
+    hass_stub = MagicMock()
+    hass_stub.async_add_executor_job = AsyncMock(return_value=fake_module)
+
+    await load_scanner_module(hass_stub)
+
+    _, path_arg = hass_stub.async_add_executor_job.call_args.args
+    assert path_arg == _SCANNER_MODULE_PATH
+
+
+# ---------------------------------------------------------------------------
+# load_scanner_module — real import (integration smoke test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_scanner_module_returns_real_module_without_hass():
+    """Without hass the real scanner.core module is importable."""
+    module = await load_scanner_module(None)
+    assert hasattr(module, "DeviceCapabilities"), "scanner.core must export DeviceCapabilities"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from custom_components.thessla_green_modbus.const import (
     CONF_MAX_REGISTERS_PER_REQUEST,
-    DEFAULT_BACKOFF_JITTER,
     MAX_BATCH_REGISTERS,
 )
 from custom_components.thessla_green_modbus.modbus_exceptions import (
@@ -506,45 +505,6 @@ async def test_async_setup_invalid_capabilities(coordinator):
 
     assert str(err.value) == "invalid_capabilities"
     scanner_instance.close.assert_awaited_once()
-
-
-class TestParseBackoffJitter:
-    """Direct tests for the _parse_backoff_jitter parser."""
-
-    def test_numeric_inputs(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse(0) == 0.0
-        assert parse(0.0) == 0.0
-        assert parse(1) == 1.0
-        assert parse(1.5) == 1.5
-
-    def test_string_inputs(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse("1.5") == 1.5
-        assert parse("0") == 0.0
-        assert parse("not-a-number") is None
-        assert parse("") is None
-
-    def test_tuple_list_inputs(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse((1.0, 2.0)) == (1.0, 2.0)
-        assert parse([1, 2]) == (1.0, 2.0)
-        assert parse((1.0, 2.0, 3.0)) == (1.0, 2.0)
-
-    def test_invalid_sequence_returns_none(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse(["a", "b"]) is None
-        assert parse((None, None)) is None
-
-    def test_none_and_sentinel_defaults(self) -> None:
-        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
-
-        assert parse(None) is None
-        assert parse({"key": "value"}) == DEFAULT_BACKOFF_JITTER  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_backoff_jitter.py
+++ b/tests/test_coordinator_backoff_jitter.py
@@ -1,0 +1,47 @@
+"""Focused tests for ThesslaGreenModbusCoordinator._parse_backoff_jitter."""
+
+from __future__ import annotations
+
+from custom_components.thessla_green_modbus.const import DEFAULT_BACKOFF_JITTER
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+)
+
+
+class TestParseBackoffJitter:
+    """Direct tests for the _parse_backoff_jitter parser."""
+
+    def test_numeric_inputs(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse(0) == 0.0
+        assert parse(0.0) == 0.0
+        assert parse(1) == 1.0
+        assert parse(1.5) == 1.5
+
+    def test_string_inputs(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse("1.5") == 1.5
+        assert parse("0") == 0.0
+        assert parse("not-a-number") is None
+        assert parse("") is None
+
+    def test_tuple_list_inputs(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse((1.0, 2.0)) == (1.0, 2.0)
+        assert parse([1, 2]) == (1.0, 2.0)
+        assert parse((1.0, 2.0, 3.0)) == (1.0, 2.0)
+
+    def test_invalid_sequence_returns_none(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse(["a", "b"]) is None
+        assert parse((None, None)) is None
+
+    def test_none_and_sentinel_defaults(self) -> None:
+        parse = ThesslaGreenModbusCoordinator._parse_backoff_jitter
+
+        assert parse(None) is None
+        assert parse({"key": "value"}) == DEFAULT_BACKOFF_JITTER  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

This PR performs two focused maintainability improvements:

1. **PHASE B — Extract `_load_scanner_module` to `config_flow_runtime.py`**
   - Moved the 7-line async `_load_scanner_module` function from inline in `config_flow.py` into a new public `load_scanner_module` function in `config_flow_runtime.py`
   - Added `_SCANNER_MODULE_PATH` constant to `config_flow_runtime.py` for testability
   - Removed `import_module` import from `config_flow.py` (no longer needed)
   - `config_flow.py` non-empty lines: 414 → 407 (−7)
   - `config_flow_runtime.py` non-empty lines: 48 → 62 (+14)
   - Added 5 focused unit tests in new `tests/test_config_flow_runtime_loader.py`

2. **PHASE C — Move `TestParseBackoffJitter` test class to dedicated module**
   - Moved `TestParseBackoffJitter` class (5 tests, 37 lines) from `tests/test_coordinator.py` into new `tests/test_coordinator_backoff_jitter.py`
   - Removed `DEFAULT_BACKOFF_JITTER` import from `test_coordinator.py` (no longer needed)
   - `test_coordinator.py` non-empty lines: 440 → 412 (−28)
   - Test collection total: 286 → 286 (unchanged, redistribution only)
   - No production files changed in PHASE C

**Test count change:** 1915 → 1920 (+5 from PHASE B new tests).

## Maintainability checklist

- [x] Changed methods/files remain within maintainability thresholds
  - `config_flow.py`: 407 lines (was 414) — well below threshold
  - `config_flow_runtime.py`: 62 lines (was 48) — minimal growth, focused module
  - New test modules are focused and under 100 lines each
- [x] Extraction rationale documented
  - `load_scanner_module` extracted to enable isolated testing of scanner module loading behavior
  - Test split improves test organization and reduces `test_coordinator.py` cognitive load
- [x] Behavior compatibility preserved
  - `config_flow.py` imports `load_scanner_module as _load_scanner_module` — no call-site changes
  - `_SCANNER_MODULE_PATH` constant added for test mocking without hardcoding paths
  - All 5 backoff jitter tests moved as-is; no logic changes
- [x] Test impact documented
  - 5 new unit tests in `test_config_flow_runtime_loader.py` covering sync/async paths and executor behavior
  - 5 existing tests moved to `test_coordinator_backoff_jitter.py` (no new tests, redistribution only)
  - All 1920 tests pass; no regressions
- [x] Rollback plan: Simple revert of file moves and imports; no breaking changes to public APIs

## Validation

- [x] `ruff check custom_components tests tools`: **pass**
- [x] `ruff format --check custom_components tests tools`: **0 files drift** (416 formatted)
- [x] `pytest tests/ -q`: **1920 passed, 4 skipped**, 90 warnings in 14.87s
- [x] `python tools/check_maintainability.py`: **pass** (`Maintainability gate passed.`)
- [x] `python tools/validate_entity_mappings.py`: **pass** (`OK: 366 entities validated`)

## Notes

- No breaking changes to public APIs; `config_flow.py` behavior is identical
- `_SCANNER_MODULE_PATH` constant enables cleaner test mocking without string duplication
- Test split improves discoverability: backoff jitter tests are now in a dedicated module rather than mixed with broader coordinator tests
- All invariants preserved: coordinator `__all__`, no proxy

https://claude.ai/code/session_01C8zfpq6e8WXsi7mVQVGqKN