### PR TITLE
docs: clean up maintainability audit snapshot

### DIFF
--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,35 +1,31 @@
 # Maintainability audit
 
-Date: 2026-05-08 (Python 3.13 full-pass + config_flow bound-adapter extraction + coordinator test split)
-Date: 2026-05-08 (Python 3.13 full-pass + config_flow_runtime load_scanner_module + coordinator backoff jitter test split)
+Date: 2026-05-08 (Python 3.13 cleanup run — stale/duplicate sections removed)
 
 ## Commands executed (exact)
 
-- `git branch --show-current`
-- `git status --short`
-- `python3.13 -m venv /tmp/venv313 && /tmp/venv313/bin/pip install ...` (Python 3.13 venv)
-- Import gate script:
-  - `python3.13 - <<'PY' ... __import__(...) ... PY`
+- `git branch --show-current` / `git status --short`
+- `python3.13 --version`
+- Import gate: `python3.13 - <<'PY' ... __import__(...) ... PY`
 - `ruff check custom_components tests tools`
 - `ruff check --select I custom_components tests tools`
 - `ruff format --check custom_components tests tools`
 - `python3.13 -m compileall -q custom_components/thessla_green_modbus tests tools`
 - `python3.13 tools/compare_registers_with_reference.py`
 - `python3.13 tools/check_maintainability.py`
-- `python3.13 tools/validate_entity_mappings.py`
-- `pytest tests/ -q`
-- AST metrics script (largest files/classes/functions snapshot)
-- `rg "from homeassistant|import homeassistant" custom_components/thessla_green_modbus/scanner`
+- `python3.13 tools/validate_entity_mappings.py` (not run this session; see below)
+- `python3.13 -m pytest tests/ -q` (not run this session; see below)
+- AST metrics script (largest files/classes/functions)
 
 ## Import gate result
 
-Environment: **Python 3.13.12** (`/tmp/venv313`). All five required modules import successfully.
+Environment: **Python 3.13.12**. Results this session:
 
-- `pydantic`: ✅ `OK pydantic: 2.13.4` (pip-installed; see Dependabot note)
+- `pydantic`: ✅ `OK pydantic: 2.12.2` (project pin confirmed)
 - `pytest`: ✅ `OK pytest: 9.0.3`
 - `pytest_asyncio`: ✅ `OK pytest_asyncio: 1.3.0`
-- `pytest_homeassistant_custom_component`: ✅ pass
-- `homeassistant`: ✅ pass
+- `pytest_homeassistant_custom_component`: ❌ not installed (`PyRIC` binary build fails in this environment)
+- `homeassistant`: ✅ 2026.2.3 installed (transitive deps incomplete)
 
 ## Exact status by validation gate
 
@@ -37,129 +33,82 @@ Environment: **Python 3.13.12** (`/tmp/venv313`). All five required modules impo
 
 - **ruff check**: ✅ pass (`All checks passed!`).
 - **ruff import order check**: ✅ pass (`All checks passed!`).
-- **ruff format --check**: ✅ **0 files drift** (415 files already formatted).
-- **ruff format --check**: ✅ **0 files drift** (413 files already formatted).
+- **ruff format --check**: ✅ **0 files drift** (418 files already formatted).
 - **compileall**: ✅ pass.
 - **register compare** (`compare_registers_with_reference.py`): ✅ pass
   (informational: 62 extras; 242 name mismatches on common addresses — unchanged).
 - **maintainability** (`check_maintainability.py`): ✅ pass (`Maintainability gate passed.`).
-- **entity mappings** (`validate_entity_mappings.py`): ✅ pass (`OK: 366 entities validated`).
-- **pytest** (`pytest tests/ -q`): ✅ **1913 passed, 4 skipped**, 84 warnings in 14.74s.
-- **coordinator split check**: ✅ pass (277 total — unchanged).
-
-### Notable changes since previous audit (2026-05-08 config_flow + coordinator test cleanup)
-
-- Full test suite runs on Python 3.13 — all gates green.
-- **PHASE B — config_flow bound-adapter extraction**: Three adapter functions (`_validate_tcp_config`, `_validate_rtu_config`, `_process_scan_capabilities`) removed from `config_flow.py` and replaced with `validate_tcp_config_bound`, `validate_rtu_config_bound`, `process_scan_capabilities_bound` in `config_flow_validation.py`. 13 new focused tests added in `tests/test_config_flow_validation_bound.py`. `config_flow.py` non-empty lines: 414 → 394 (-20).
-- **PHASE C — coordinator test split**: `TestParseBackoffJitter` class (5 tests) moved from `test_coordinator.py` to `tests/test_coordinator_parse_backoff.py`. Total coordinator tests unchanged (277). `test_coordinator.py` non-empty lines: 440 → 412 (-28).
-- pytest count: **1913 passed** (up from 1900; +13 bound-adapter tests).
-- Ruff format drift: **0 files** (415 files).
-- **pytest** (`pytest tests/ -q`): ✅ **1920 passed, 4 skipped**, 90 warnings in 14.87s.
-
-### Notable changes since previous audit (2026-05-08 modbus_helpers._encode_read_frame run)
-
-**PHASE B — config_flow_runtime.py: extract load_scanner_module:**
-
-- `_load_scanner_module` (7-line async function) moved from inline in `config_flow.py` into
-  `load_scanner_module` function in `config_flow_runtime.py`.
-- `config_flow.py` now imports `load_scanner_module as _load_scanner_module` from runtime module.
-- `import_module` import removed from `config_flow.py`.
-- `_SCANNER_MODULE_PATH` constant added to `config_flow_runtime.py` for testability.
-- 5 focused unit tests added in `tests/test_config_flow_runtime_loader.py`.
-
-**PHASE C — test_coordinator.py: move TestParseBackoffJitter test group:**
-
-- `TestParseBackoffJitter` class (5 tests, 37 lines) moved from `tests/test_coordinator.py`
-  into new `tests/test_coordinator_backoff_jitter.py`.
-- `DEFAULT_BACKOFF_JITTER` import removed from `test_coordinator.py` (no longer needed).
-- `test_coordinator.py` non-empty lines: **440 → 412** (−28).
-- Test collection total: **286 → 286** (unchanged, redistribution only).
-- No production files changed in PHASE C.
-
-**Test count change:** 1915 → 1920 (+5 from PHASE B new tests).
-
-### Ruff format drift
-
-`ruff format --check custom_components tests tools` reports **0 files would be reformatted**.
-
-All 415 files are already formatted. ✅
-All 416 files are already formatted. ✅
+- **entity mappings** (`validate_entity_mappings.py`): not run this session — `homeassistant`
+  transitive deps incomplete (`PyRIC`/`propcache`/`voluptuous` conflicts block install).
+  Last confirmed result (2026-05-08 Phase B+C run): **OK: 366 entities validated**.
+- **pytest** (`pytest tests/ -q`): not run this session — `pytest_homeassistant_custom_component`
+  not installable (`PyRIC` build failure). Last confirmed result (2026-05-08 Phase B+C run):
+  **1920 passed, 4 skipped, 90 warnings**.
+- **targeted config flow** (`pytest tests/test_config_flow*.py`): not run this session.
+  Last confirmed: **142 passed**, 1 warning.
+- **targeted coordinator** (`pytest tests/test_coordinator*.py`): not run this session.
+  Last confirmed: **300 passed**, 1 warning.
 
 ### Required CI gate status note
 
-- All local maintained quality gates are green on Python 3.13.
+- Locally maintained quality gates (ruff, compileall, compare_registers, check_maintainability) are green on Python 3.13.
+- pytest and entity-mapping validation could not run this session due to missing native dependencies.
 - CI/HACS/hassfest gates were **not** executed in this run and are not claimed as proven.
+
+## Notable merged changes (2026-05-08 series)
+
+All changes below are already merged into **dev** as of this audit.
+
+**PHASE B (load_scanner_module extraction):**
+- `_load_scanner_module` (7-line async function) moved from inline in `config_flow.py` into
+  `load_scanner_module` in `config_flow_runtime.py`.
+- `import_module` import removed from `config_flow.py`.
+- `_SCANNER_MODULE_PATH` constant added to `config_flow_runtime.py` for testability.
+- 5 focused unit tests added in `tests/test_config_flow_runtime_loader.py`.
+- `config_flow.py` non-empty: 414 → 407 (−7).
+
+**PHASE B (bound-adapter extraction):**
+- `_validate_tcp_config`, `_validate_rtu_config`, `_process_scan_capabilities` removed from
+  `config_flow.py` and replaced by `validate_tcp_config_bound`, `validate_rtu_config_bound`,
+  `process_scan_capabilities_bound` in `config_flow_validation.py`.
+- 13 focused tests added in `tests/test_config_flow_validation_bound.py`.
+- `config_flow.py` non-empty: 407 → 387 (−20). Current: **387 lines**.
+
+**PHASE C (coordinator test splits):**
+- `TestParseBackoffJitter` class (5 tests) split out of `test_coordinator.py` into
+  `tests/test_coordinator_parse_backoff.py` and `tests/test_coordinator_backoff_jitter.py`.
+- `test_coordinator.py` non-empty: 440 → 412 (−28). Current: **412 lines**.
+- Coordinator test collection total: **286** (no tests removed; redistribution only).
+- No production files changed in PHASE C.
 
 ## Architecture invariants snapshot
 
 - Canonical coordinator module: `custom_components/thessla_green_modbus/coordinator/coordinator.py` only.
 - Top-level `custom_components/thessla_green_modbus/coordinator.py`: **absent**.
 - `core/`, `transport/`, `registers/`, `scanner/` do not import Home Assistant.
-- `compat|shim|proxy|re-export|legacy` grep returns only informational matches
-  in docs/tests/comments and known compatibility-reference strings.
+- `compat|shim|proxy|re-export|legacy` grep: informational matches in docs/tests/comments only.
 
-## PHASE B summary
+## Largest files/classes/functions (AST snapshot — 2026-05-08 cleanup run)
 
-**Extraction: `_load_scanner_module` → `config_flow_runtime.load_scanner_module`**
-
-Before:
-- `config_flow.py` non-empty: **414** lines
-- `_load_scanner_module` inline in `config_flow.py` (7-line async function)
-- `config_flow_runtime.py` non-empty: **48** lines
-- No tests for scanner module loading isolation
-
-After:
-- `config_flow.py` non-empty: **407** lines (−7)
-- `config_flow_runtime.py` non-empty: **62** lines (+14)
-- `load_scanner_module` function + `_SCANNER_MODULE_PATH` constant added to runtime module
-- 5 focused tests added in `tests/test_config_flow_runtime_loader.py`
-
-Step names, form schemas, error keys, abort reasons, reauth/reconfigure/options behavior: all unchanged ✅
-
-Targeted config flow test result: **142 passed**, 1 warning ✅
-
-## PHASE C summary
-
-**Test-only split: `TestParseBackoffJitter` → `tests/test_coordinator_backoff_jitter.py`**
-
-Before:
-- `test_coordinator.py` non-empty: **440** lines
-- `TestParseBackoffJitter` class (5 tests) inline in `test_coordinator.py`
-- `DEFAULT_BACKOFF_JITTER` import present but only used by that class
-
-After:
-- `test_coordinator.py` non-empty: **412** lines (−28)
-- New `tests/test_coordinator_backoff_jitter.py` with `TestParseBackoffJitter` (5 tests)
-- `DEFAULT_BACKOFF_JITTER` import removed from `test_coordinator.py`
-- Coordinator test collection: **286 → 286** (unchanged) ✅
-
-No production files changed in PHASE C ✅
-
-Coordinator targeted test result: **300 passed**, 1 warning ✅
-
-## Largest files/classes/functions (current — 2026-05-08 Phase B+C refresh)
-
-### Largest files (non-empty lines, top 10)
+### Largest files (non-empty lines, top 15)
 
 | Lines | Path |
 |------:|------|
 | 714 | `custom_components/thessla_green_modbus/scanner/io_read.py` |
 | 666 | `custom_components/thessla_green_modbus/coordinator/coordinator.py` |
 | 537 | `custom_components/thessla_green_modbus/modbus_helpers.py` |
-| 468 | `custom_components/thessla_green_modbus/coordinator/schedule.py` |
-| 454 | `custom_components/thessla_green_modbus/scanner/core.py` |
-| 437 | `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` |
-| 433 | `tests/test_config_flow_helpers.py` |
-| 420 | `tests/test_modbus_helpers_call_flow.py` |
-| 417 | `custom_components/thessla_green_modbus/mappings/_static_discrete.py` |
-| 412 | `tests/test_coordinator.py` |
 | 451 | `custom_components/thessla_green_modbus/scanner/core.py` |
 | 437 | `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` |
 | 433 | `tests/test_config_flow_helpers.py` |
 | 420 | `tests/test_modbus_helpers_call_flow.py` |
 | 419 | `custom_components/thessla_green_modbus/coordinator/schedule.py` |
 | 412 | `tests/test_coordinator.py` |
-| 407 | `custom_components/thessla_green_modbus/config_flow.py` |
+| 406 | `custom_components/thessla_green_modbus/scanner/setup.py` |
+| 397 | `tools/translate_register_descriptions.py` |
+| 387 | `custom_components/thessla_green_modbus/config_flow.py` |
+| 380 | `custom_components/thessla_green_modbus/config_flow_device_validation.py` |
+| 376 | `custom_components/thessla_green_modbus/registers/schema.py` |
+| 373 | `tests/test_validate_registers.py` |
 
 ### Largest classes (AST span, top 10)
 
@@ -189,46 +138,19 @@ Coordinator targeted test result: **300 passed**, 1 warning ✅
 | 103 | `run` | `tests/test_force_full_register_list_integration.py` |
 | 100 | `test_entity_counts_per_platform` | `tests/test_all_entity_creation.py` |
 | 100 | `read_input_registers_optimized` | `_coordinator_read_batches.py` |
-| 91 | `verify_connection` | `scanner/setup.py` |
-
-## PHASE B before/after metrics
-
-| Metric | Before | After |
-|--------|--------|-------|
-| `config_flow.py` non-empty | 414 | 407 |
-| `config_flow_runtime.py` non-empty | 48 | 62 |
-| `_load_scanner_module` inline in config_flow.py | yes | **removed** |
-| `load_scanner_module` in config_flow_runtime.py | no | **added** |
-| `_SCANNER_MODULE_PATH` constant | no | **added** |
-| New test functions | — | +5 |
-| `import_module` import in config_flow.py | yes | **removed** |
-
-## PHASE C before/after metrics
-
-| Metric | Before | After |
-|--------|--------|-------|
-| `test_coordinator.py` non-empty | 440 | 412 |
-| `TestParseBackoffJitter` in test_coordinator.py | yes | **moved** |
-| `test_coordinator_backoff_jitter.py` | absent | **created** |
-| Coordinator test count total | 286 | 286 (unchanged) |
-| `DEFAULT_BACKOFF_JITTER` import in test_coordinator.py | yes | **removed** |
-
-## Coordinator collection comparison
-
-```
-before count: 286
-after count: 286
-missing: []
-added: []
-```
+|  98 | `async_setup_entry` | `sensor.py` |
+|  92 | `test_confirm_step_aborts_on_existing_entry` | `tests/test_config_flow_confirm.py` |
+|  91 | `run_full_scan` | `scanner/orchestration.py` |
+|  89 | `validate` | `tools/validate_registers.py` |
+|  88 | `__init__` | `scanner/core.py` |
+|  86 | `_install_homeassistant_stubs` | `tools/validate_dashboard_entities.py` |
 
 ## Remaining hotspots
 
-1. Coordinator concentration (`coordinator/coordinator.py` 666 lines, `ThesslaGreenModbusCoordinator` 577 AST lines; `coordinator/schedule.py` 419 lines, `_CoordinatorScheduleMixin` 432 lines).
-2. Scanner read/orchestration complexity (`scanner/io_read.py` 714 lines, `scanner/core.py` 451 lines).
-3. Mapping builder density (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow branching (`config_flow.py` 394 lines; reduced from 414 in previous audit).
-4. Config-flow branching (`config_flow.py` 407 lines).
+1. Coordinator concentration: `coordinator/coordinator.py` 666 lines (`ThesslaGreenModbusCoordinator` 577 AST lines); `coordinator/schedule.py` 419 lines (`_CoordinatorScheduleMixin` 432 AST lines).
+2. Scanner read/orchestration complexity: `scanner/io_read.py` 714 lines; `scanner/core.py` 451 lines.
+3. Mapping builder density: `mappings/_mapping_builders.py` 437 lines.
+4. Config-flow branching: `config_flow.py` 387 lines (reduced from 414 after two PHASE B extractions).
 5. Ruff format drift: 0 files. ✅
 
 ## Branch note (authoritative target)
@@ -239,13 +161,15 @@ added: []
 
 ## Release readiness caveats
 
-- **HACS/hassfest readiness is not proven** in this audit. `hassfest` and `hacs` are
-  not installable PyPI packages; they run exclusively as GitHub Actions in CI.
-  Release readiness via those gates must be verified through the CI pipeline.
-- **Real-device validation is not proven** in this audit unless explicitly documented
-  with device evidence. No on-device test evidence was captured in this run.
+- **HACS/hassfest readiness is not proven** in this audit. `hassfest` and `hacs` are not
+  installable PyPI packages; they run exclusively as GitHub Actions in CI. Release readiness via
+  those gates must be verified through the CI pipeline.
+- **Real-device validation is not proven** in this audit unless explicitly documented with device
+  evidence. No on-device test evidence was captured in this run.
 
 ## Dependabot note
 
 - PR #1567 was **not touched** in this session.
-- Pydantic version was **not changed**. `requirements-dev.txt` still pins `pydantic==2.12.2`; the pip-installed version in this environment is 2.13.4 due to an unrelated global install, but the project pin was not modified.
+- Pydantic version was **not changed**. `requirements-dev.txt` pins `pydantic==2.12.2`. The
+  project pin is unchanged. This environment has `pydantic 2.12.2` installed (project pin
+  confirmed; no global override active in this run).

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,11 +1,8 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08 (Python 3.13 full-pass + config_flow bound-adapter extraction + coordinator test split).
-Last reviewed: 2026-05-08 (Python 3.13 full-pass + config_flow_runtime load_scanner_module + coordinator backoff jitter test split).
+Last reviewed: 2026-05-08 (Python 3.13 cleanup run — stale/duplicate sections removed)
 
-Related document:
-
-- `docs/maintainability_audit.md`
+Related document: `docs/maintainability_audit.md`
 
 ## Scope and direction
 
@@ -28,45 +25,32 @@ The following constraints remain active and must be preserved:
 4. No proxy modules.
 5. `core/`, `transport/`, `registers/`, and `scanner/` must not import Home Assistant.
 
-## Current invariant verification snapshot (2026-05-08 load_scanner_module + backoff jitter split)
+## Current invariant verification snapshot (2026-05-08)
 
 - Top-level `custom_components/thessla_green_modbus/coordinator.py`: **absent**.
 - Canonical coordinator module: `custom_components/thessla_green_modbus/coordinator/coordinator.py`.
 - HA imports in `core/transport/registers/scanner`: **none detected** by grep.
-- Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches present in docs/tests/comments/known compatibility code references.
+- Compatibility grep (`compat|shim|proxy|re-export|legacy`): informational matches in docs/tests/comments/known compatibility code references only.
 
-## Notable since previous snapshot (2026-05-08 config_flow + coordinator test cleanup)
+## Notable merged changes (2026-05-08 series)
 
-- Full test suite validated on Python 3.13 — **1913 passed, 4 skipped** (+13 vs previous run).
-- Ruff format drift: **0 files** (415 files).
-- **PHASE B**: Three adapter functions removed from `config_flow.py`; replaced by `validate_tcp_config_bound`, `validate_rtu_config_bound`, `process_scan_capabilities_bound` in `config_flow_validation.py`. `config_flow.py` 414 → 394 non-empty lines. 13 new focused tests in `tests/test_config_flow_validation_bound.py`.
-- **PHASE C**: `TestParseBackoffJitter` (5 test methods) moved from `test_coordinator.py` to `tests/test_coordinator_parse_backoff.py`. `test_coordinator.py` 440 → 412 non-empty lines; total coordinator test count unchanged at 277.
-## Notable since previous snapshot (2026-05-08 Phase B+C run)
+- **PHASE B (load_scanner_module extraction):** `_load_scanner_module` moved from `config_flow.py` inline into `load_scanner_module` in `config_flow_runtime.py`. `import_module` import removed. `_SCANNER_MODULE_PATH` constant added. 5 focused tests added in `test_config_flow_runtime_loader.py`. `config_flow.py`: 414 → 407.
+- **PHASE B (bound-adapter extraction):** `_validate_tcp_config`, `_validate_rtu_config`, `_process_scan_capabilities` removed from `config_flow.py`; replaced by bound variants in `config_flow_validation.py`. 13 tests added in `test_config_flow_validation_bound.py`. `config_flow.py`: 407 → **387** (current).
+- **PHASE C (coordinator test splits):** `TestParseBackoffJitter` class redistributed into `test_coordinator_parse_backoff.py` and `test_coordinator_backoff_jitter.py`. `test_coordinator.py`: 440 → **412** (current). Coordinator test collection: **286** (unchanged; redistribution only). No production files changed.
 
-- Full test suite validated on Python 3.13 — **1920 passed, 4 skipped**.
-- Ruff format drift: **0 files** ✅.
-- **PHASE B** — `_load_scanner_module` (7-line async function) moved from inline in `config_flow.py`
-  into `load_scanner_module` in `config_flow_runtime.py`. `config_flow.py` non-empty: 414 → 407.
-  `import_module` import removed from `config_flow.py`. `_SCANNER_MODULE_PATH` constant added for
-  testability. 5 focused unit tests added in `tests/test_config_flow_runtime_loader.py`.
-- **PHASE C** (test-only) — `TestParseBackoffJitter` class (5 tests) moved from `test_coordinator.py`
-  into `test_coordinator_backoff_jitter.py`. `test_coordinator.py` non-empty: 440 → 412.
-  Coordinator test collection total: **286 → 286** (unchanged). No production files changed.
+## Required gate status snapshot (2026-05-08 cleanup run)
 
-## Required gate status snapshot (2026-05-08 load_scanner_module run)
-
-- `ruff check custom_components tests tools`: **pass**.
-- `ruff check --select I custom_components tests tools`: **pass**.
-- `ruff format --check custom_components tests tools`: **0 files drift** (416 formatted) ✅.
-- `python3.13 -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
-- `python3.13 tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches).
-- `python3.13 tools/check_maintainability.py`: **pass** (`Maintainability gate passed.`).
-- `python3.13 tools/validate_entity_mappings.py`: **pass** (`OK: 366 entities validated`).
-- `python3.13 -m pytest tests/ -q`: **pass** — 1913 passed, 4 skipped, 84 warnings.
-- `python3.13 -m pytest tests/ -q`: **pass** — 1920 passed, 4 skipped, 90 warnings.
-- Import gate (all 5 modules): **pass** on Python 3.13.
-- Coordinator tests: **300 passed**, 1 warning.
-- Config flow tests: **142 passed**, 1 warning.
+- `ruff check custom_components tests tools`: **pass** ✅.
+- `ruff check --select I custom_components tests tools`: **pass** ✅.
+- `ruff format --check custom_components tests tools`: **0 files drift** (418 files formatted) ✅.
+- `python3.13 -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass** ✅.
+- `python3.13 tools/compare_registers_with_reference.py`: **pass** (informational: 62 extras, 242 name mismatches) ✅.
+- `python3.13 tools/check_maintainability.py`: **pass** (`Maintainability gate passed.`) ✅.
+- `python3.13 tools/validate_entity_mappings.py`: not run this session (native dep build failure). Last confirmed: **OK: 366 entities validated** (2026-05-08 Phase B+C run).
+- `python3.13 -m pytest tests/ -q`: not run this session (native dep build failure). Last confirmed: **1920 passed, 4 skipped, 90 warnings** (2026-05-08 Phase B+C run).
+- Import gate (pydantic/pytest/pytest_asyncio): **pass** on Python 3.13.12. `pydantic 2.12.2` (project pin confirmed).
+- Coordinator tests (last confirmed): **300 passed**, 1 warning.
+- Config flow tests (last confirmed): **142 passed**, 1 warning.
 
 ## Non-required tool status
 
@@ -78,11 +62,10 @@ The following constraints remain active and must be preserved:
 
 ## Remaining hotspots (current queue)
 
-1. Coordinator size/branching (`coordinator/coordinator.py` 666 lines, `coordinator/schedule.py` 419 lines).
-2. Scanner read/orchestration complexity (`scanner/io_read.py` 714 lines, `scanner/core.py` 451 lines).
-3. Mapping build complexity (`mappings/_mapping_builders.py` 437 lines).
-4. Config-flow branching (`config_flow.py` 394 lines; reduced from 414).
-4. Config-flow branching (`config_flow.py` 407 lines).
+1. Coordinator size/branching: `coordinator/coordinator.py` 666 lines; `coordinator/schedule.py` 419 lines.
+2. Scanner read/orchestration complexity: `scanner/io_read.py` 714 lines; `scanner/core.py` 451 lines.
+3. Mapping build complexity: `mappings/_mapping_builders.py` 437 lines.
+4. Config-flow branching: `config_flow.py` 387 lines (reduced from 414 after two PHASE B extractions).
 5. Ruff format drift: 0 files ✅.
 
 ## Branch note
@@ -99,4 +82,4 @@ The following constraints remain active and must be preserved:
 ## Dependabot note
 
 - PR #1567 was **not touched** in this session.
-- Pydantic version was **not changed**. `requirements-dev.txt` still pins `pydantic==2.12.2`.
+- Pydantic version was **not changed**. `requirements-dev.txt` still pins `pydantic==2.12.2`. Project pin confirmed unchanged.


### PR DESCRIPTION
## Summary

Base branch: dev

- Removed all duplicated/stale sections from `docs/maintainability_audit.md` and `docs/refactor_status.md` accumulated after recent merged PRs
- Replaced contradictory file-count, pytest-total, and hotspot entries with one clean, internally consistent snapshot
- Corrected the pydantic note: project pin is `2.12.2` (confirmed in this environment); the old note about an unrelated global `2.13.4` install has been removed

## What was removed

| Stale content | Detail |
|---|---|
| Duplicate Date lines | Two `Date:` lines in audit, two `Last reviewed:` lines in status |
| Contradictory ruff file counts | 413 / 415 / 416 → single current value: **418** |
| Contradictory pytest totals | 1913 and 1920 both present → single last-confirmed value: **1920 passed** |
| Duplicate largest-files table rows | Rows appeared twice with differing line counts |
| Duplicate PHASE B/C summaries | Each phase described twice in different sections |
| Duplicate hotspot list entries | Item 4 appeared twice with conflicting `config_flow.py` line counts |
| Misleading pydantic 2.13.4 note | No global override present in this run; project pin 2.12.2 confirmed |

## Validation run (Python 3.13.12)

- `ruff check`: ✅ pass
- `ruff --select I`: ✅ pass
- `ruff format --check`: ✅ 0 drift (418 files)
- `compileall`: ✅ pass
- `compare_registers_with_reference.py`: ✅ pass
- `check_maintainability.py`: ✅ pass
- `validate_entity_mappings.py`: not run (PyRIC build failure blocks install)
- `pytest`: not run (pytest-homeassistant-custom-component not installable)
- Last confirmed pytest (2026-05-08 Phase B+C run): **1920 passed, 4 skipped, 90 warnings**

## Invariants

- Only `docs/` files changed — confirmed by `git diff --name-only`
- No production code, tests, CI, or dependency files touched
- PR #1567 not touched; pydantic project pin unchanged (`pydantic==2.12.2`)
- main not used as source of truth; no main → dev merge performed

https://claude.ai/code/session_019Y4wypcWTSyhqDT3mM8Pbr

---
_Generated by [Claude Code](https://claude.ai/code/session_019Y4wypcWTSyhqDT3mM8Pbr)_