### PR TITLE
refactor: reduce remaining hotspot complexity (phases B–F)

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -345,17 +345,12 @@ class ThesslaGreenModbusCoordinator(
 
     def _get_client_method(self, name: str) -> Callable[..., Any]:
         """Return a Modbus method from transport/client or a no-op placeholder."""
-
-        transport = self._transport
-        transport_method = getattr(transport, name, None) if transport is not None else None
-        if callable(transport_method):
-            return cast(Callable[..., Any], transport_method)
-        """Return a Modbus client method or a no-op async placeholder."""
-
-        client = self.client
-        method = getattr(client, name, None) if client is not None else None
-        if callable(method):
-            return cast(Callable[..., Any], method)
+        for obj in (self._transport, self.client):
+            if obj is None:
+                continue
+            method = getattr(obj, name, None)
+            if callable(method):
+                return cast(Callable[..., Any], method)
 
         async def _missing_method(*_args: Any, **_kwargs: Any) -> Any:
             return None
@@ -548,56 +543,59 @@ class ThesslaGreenModbusCoordinator(
         if mode is not None:
             self._resolved_connection_mode = mode
 
-    async def _ensure_connected(self) -> None:
-        """Ensure Modbus connection is established using the shared client."""
+    def _build_transport_selector_fn(self) -> Any:
+        """Return the transport selector callable for the connection lifecycle.
 
+        Computes parity and stop-bits from current config at call time so that
+        the returned callable always reflects the live coordinator settings.
+        """
         parity = SERIAL_PARITY_MAP.get(self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
         stop_bits = SERIAL_STOP_BITS_MAP.get(
             self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
         )
-
-        def _ensure_transport_selected() -> Any:
-            return lambda: _ensure_transport_selected_impl(
-                current_transport=self._transport,
-                connection_type=self.config.connection_type,
-                connection_mode=self.config.connection_mode,
-                host=self.config.host,
-                port=self.config.port,
-                serial_port=self.config.serial_port,
-                baudrate=self.config.baud_rate,
-                parity=parity,
-                stopbits=stop_bits,
-                retry=self.retry,
-                backoff=self.backoff,
-                max_backoff=DEFAULT_MAX_BACKOFF,
-                timeout=self.timeout,
-                offline_state=self.offline_state,
-                connection_type_rtu=CONNECTION_TYPE_RTU,
-                connection_mode_auto=CONNECTION_MODE_AUTO,
-                connection_mode_tcp=CONNECTION_MODE_TCP,
-                build_rtu_transport_fn=_build_rtu_transport_impl,
-                build_tcp_transport_fn=self._build_tcp_transport,
-                select_auto_transport_fn=lambda: _select_auto_transport_impl(
-                    resolved_connection_mode=self._resolved_connection_mode,
-                    build_tcp_transport=self._build_tcp_transport,
-                    try_direct_client_connect=lambda allow_parameterless_ctor: (
-                        self._try_direct_client_connect(
-                            allow_parameterless_ctor=allow_parameterless_ctor
-                        )
-                    ),
-                    port=self.config.port,
-                    timeout=self.timeout,
-                    slave_id=self.config.slave_id,
-                    host=self.config.host,
-                    logger=_LOGGER,
+        return lambda: _ensure_transport_selected_impl(
+            current_transport=self._transport,
+            connection_type=self.config.connection_type,
+            connection_mode=self.config.connection_mode,
+            host=self.config.host,
+            port=self.config.port,
+            serial_port=self.config.serial_port,
+            baudrate=self.config.baud_rate,
+            parity=parity,
+            stopbits=stop_bits,
+            retry=self.retry,
+            backoff=self.backoff,
+            max_backoff=DEFAULT_MAX_BACKOFF,
+            timeout=self.timeout,
+            offline_state=self.offline_state,
+            connection_type_rtu=CONNECTION_TYPE_RTU,
+            connection_mode_auto=CONNECTION_MODE_AUTO,
+            connection_mode_tcp=CONNECTION_MODE_TCP,
+            build_rtu_transport_fn=_build_rtu_transport_impl,
+            build_tcp_transport_fn=self._build_tcp_transport,
+            select_auto_transport_fn=lambda: _select_auto_transport_impl(
+                resolved_connection_mode=self._resolved_connection_mode,
+                build_tcp_transport=self._build_tcp_transport,
+                try_direct_client_connect=lambda allow_parameterless_ctor: (
+                    self._try_direct_client_connect(
+                        allow_parameterless_ctor=allow_parameterless_ctor
+                    )
                 ),
-            )
+                port=self.config.port,
+                timeout=self.timeout,
+                slave_id=self.config.slave_id,
+                host=self.config.host,
+                logger=_LOGGER,
+            ),
+        )
 
+    async def _ensure_connected(self) -> None:
+        """Ensure Modbus connection is established using the shared client."""
         await _ensure_connected_lifecycle_impl(
             self,
             ensure_connected_runtime_fn=_ensure_connected_runtime_impl,
             reconnect_client_if_needed_fn=_reconnect_client_if_needed_impl,
-            ensure_transport_selected_fn_factory=_ensure_transport_selected,
+            ensure_transport_selected_fn_factory=self._build_transport_selector_fn,
             connect_transport_or_client_fn=_connect_transport_or_client_impl,
             mark_connection_established_fn=lambda: _mark_connection_established_impl(
                 offline_state_setter=lambda value: setattr(self, "offline_state", value)

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -14,6 +14,7 @@ from .write_path import (
     SingleWritePlan,
     encode_write_value,
     finalize_write_result,
+    run_multi_register_write_attempts,
     run_single_write_attempts,
 )
 
@@ -358,47 +359,11 @@ class _CoordinatorScheduleMixin:
                 await self._ensure_connection()
                 self._assert_write_connection_ready()
 
-                for attempt in range(1, self.retry + 1):
-                    try:
-                        response, success = await self._execute_multi_register_chunks(
-                            self._plan_multi_register_chunks(
-                                start_address, values, require_single_request
-                            ),
-                            attempt,
-                        )
-                        if not success:
-                            should_retry = self._handle_write_response_failure(
-                                is_final_attempt=attempt == self.retry,
-                                final_error_message="Error writing registers at %s: %s",
-                                retry_message=f"Retrying multi-register write at {start_address}",
-                                error_args=(start_address, response),
-                            )
-                            if not should_retry:
-                                return False
-                            await self._disconnect()
-                            continue
-
-                        refresh_after_write = refresh
-                        _LOGGER.info(
-                            "Successfully wrote %s to registers starting at %s",
-                            values,
-                            start_address,
-                        )
-                        break
-                    except (ModbusException, ConnectionException, TimeoutError, OSError) as exc:
-                        should_retry = await self._handle_write_attempt_exception(
-                            register_name=str(start_address),
-                            attempt=attempt,
-                            exc=exc,
-                            timed_out_message="Writing registers at %s timed out (attempt %d/%d)",
-                            persistent_timeout_message="Persistent timeout writing registers at %s",
-                            failed_message="Failed to write registers at %s",
-                            retry_message="Retrying multi-register write at %s after error: %s",
-                            unexpected_message="Unexpected error writing registers at %s",
-                        )
-                        if not should_retry:
-                            return False
-                        continue
+                success, refresh_after_write = await run_multi_register_write_attempts(
+                    self, start_address, values, require_single_request, refresh
+                )
+                if not success:
+                    return False
 
             except (ModbusException, ConnectionException):  # pragma: no cover - safety
                 _LOGGER.exception("Failed to write registers at %s", start_address)

--- a/custom_components/thessla_green_modbus/coordinator/write_path.py
+++ b/custom_components/thessla_green_modbus/coordinator/write_path.py
@@ -125,6 +125,58 @@ async def run_single_write_attempts(
     return True, refresh_after_write
 
 
+async def run_multi_register_write_attempts(
+    coordinator: Any,
+    start_address: int,
+    values: list[int],
+    require_single_request: bool,
+    refresh: bool,
+) -> tuple[bool, bool]:
+    """Execute retry loop for multi-register write. Returns (success, refresh_after_write)."""
+    refresh_after_write = False
+    for attempt in range(1, coordinator.retry + 1):
+        try:
+            response, success = await coordinator._execute_multi_register_chunks(
+                coordinator._plan_multi_register_chunks(
+                    start_address, values, require_single_request
+                ),
+                attempt,
+            )
+            if not success:
+                should_retry = coordinator._handle_write_response_failure(
+                    is_final_attempt=attempt == coordinator.retry,
+                    final_error_message="Error writing registers at %s: %s",
+                    retry_message=f"Retrying multi-register write at {start_address}",
+                    error_args=(start_address, response),
+                )
+                if not should_retry:
+                    return False, False
+                await coordinator._disconnect()
+                continue
+            refresh_after_write = refresh
+            _LOGGER.info(
+                "Successfully wrote %s to registers starting at %s",
+                values,
+                start_address,
+            )
+            break
+        except (ModbusException, ConnectionException, TimeoutError, OSError) as exc:
+            should_retry = await coordinator._handle_write_attempt_exception(
+                register_name=str(start_address),
+                attempt=attempt,
+                exc=exc,
+                timed_out_message="Writing registers at %s timed out (attempt %d/%d)",
+                persistent_timeout_message="Persistent timeout writing registers at %s",
+                failed_message="Failed to write registers at %s",
+                retry_message="Retrying multi-register write at %s after error: %s",
+                unexpected_message="Unexpected error writing registers at %s",
+            )
+            if not should_retry:
+                return False, False
+            continue
+    return True, refresh_after_write
+
+
 async def finalize_write_result(coordinator: Any, refresh_after_write: bool) -> bool:
     """Finish write operation with optional refresh."""
     if refresh_after_write:

--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -283,12 +283,19 @@ def _resolve(attr: str, fallback: Any) -> Any:
     return fallback
 
 
+def _resolve_base_helpers() -> tuple[Any, Any, Any]:
+    """Return (get_all_registers, get_register_info, parse_states) for loaders."""
+    return (
+        _resolve("get_all_registers", get_all_registers),
+        _resolve("_get_register_info", _get_register_info),
+        _resolve("_parse_states", _parse_states),
+    )
+
+
 def _load_number_mappings() -> dict[str, dict[str, Any]]:
     """Build number entity configurations from register metadata."""
 
-    _get_all = _resolve("get_all_registers", get_all_registers)
-    _get_info = _resolve("_get_register_info", _get_register_info)
-    _parse = _resolve("_parse_states", _parse_states)
+    _get_all, _get_info, _parse = _resolve_base_helpers()
     _num_trans = _resolve("_number_translation_keys", _number_translation_keys)
 
     parent = _get_parent()
@@ -336,9 +343,7 @@ def _load_discrete_mappings() -> tuple[
 ]:
     """Generate mappings for binary_sensor, switch and select entities."""
 
-    _get_all = _resolve("get_all_registers", get_all_registers)
-    _get_info = _resolve("_get_register_info", _get_register_info)
-    _parse = _resolve("_parse_states", _parse_states)
+    _get_all, _get_info, _parse = _resolve_base_helpers()
     _tkeys = _resolve("_load_translation_keys", _load_translation_keys)
     _coil_regs = _resolve("coil_registers", coil_registers)
     _discrete_regs = _resolve("discrete_input_registers", discrete_input_registers)
@@ -508,6 +513,7 @@ __all__ = [
     "_parse_info_states",
     "_register_context",
     "_resolve",
+    "_resolve_base_helpers",
     "_resolve_parent_child_mappings",
     "_route_enum_mapping",
     "_route_enum_or_min_max_mapping",

--- a/custom_components/thessla_green_modbus/scanner/core.py
+++ b/custom_components/thessla_green_modbus/scanner/core.py
@@ -132,50 +132,30 @@ class ThesslaGreenDeviceScanner(
             )
         # Avoid sticky logger levels from previous tests/services.
         _LOGGER.setLevel(logging.DEBUG)
-        self.host = host
-        self.port = port
-        self.slave_id = slave_id
-        self.timeout = timeout
-        self.retry = retry
-        try:
-            self.backoff = float(backoff)
-        except (TypeError, ValueError):
-            self.backoff = 0.0
-        self.backoff_jitter = scanner_setup.normalize_backoff_jitter(backoff_jitter)
-        self.verbose_invalid_values = verbose_invalid_values
-        self.scan_uart_settings = scan_uart_settings
-        self.skip_known_missing = skip_known_missing
-        self.deep_scan = deep_scan
-        self.full_register_scan = full_register_scan
-        self.safe_scan = safe_scan
-        self.effective_batch = scanner_setup.normalize_effective_batch(
-            max_registers_per_request, max_batch=MAX_BATCH_REGISTERS
-        )
-        self.max_registers_per_request = self.effective_batch
-
-        (
-            resolved_type,
-            resolved_mode,
-            resolved_fixed_mode,
-        ) = scanner_state.resolve_connection_configuration(
-            connection_type,
-            connection_mode,
-            port,
-        )
-        scanner_state.apply_connection_state(
+        scanner_setup.apply_scanner_params(
             self,
-            scanner_state.build_connection_state(
-                connection_type=resolved_type,
-                connection_mode=resolved_mode,
-                resolved_connection_mode=resolved_fixed_mode,
-                serial_port=serial_port,
-                baud_rate=baud_rate,
-                parity=parity,
-                stop_bits=stop_bits,
-            ),
+            host=host,
+            port=port,
+            slave_id=slave_id,
+            timeout=timeout,
+            retry=retry,
+            backoff=backoff,
+            backoff_jitter=backoff_jitter,
+            verbose_invalid_values=verbose_invalid_values,
+            scan_uart_settings=scan_uart_settings,
+            skip_known_missing=skip_known_missing,
+            deep_scan=deep_scan,
+            full_register_scan=full_register_scan,
+            safe_scan=safe_scan,
+            max_registers_per_request=max_registers_per_request,
+            connection_type=connection_type,
+            connection_mode=connection_mode,
+            serial_port=serial_port,
+            baud_rate=baud_rate,
+            parity=parity,
+            stop_bits=stop_bits,
+            hass=hass,
         )
-        self._hass = hass
-
         scanner_setup.initialize_runtime_collections(self, DeviceCapabilities)
         scanner_state.apply_register_defaults(
             self,

--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -350,7 +350,7 @@ async def _execute_word_read_attempt(
     )
 
 
-async def _run_input_read_retry_loop(
+async def _run_word_read_retry_loop(
     scanner: Any,
     *,
     transport: Any,
@@ -360,8 +360,12 @@ async def _run_input_read_retry_loop(
     start: int,
     end: int,
     skip_cache: bool,
+    method_name: str,
+    register_type: str,
+    handle_attempt_exception: Any,
+    log_success: bool = False,
 ) -> list[int] | None:
-    """Run input read retry loop and finalize failure state when needed."""
+    """Shared retry loop for word-register (input/holding) reads."""
     attempted_reads = 0
     aborted_transiently = False
     for attempt in range(1, scanner.retry + 1):
@@ -371,7 +375,7 @@ async def _run_input_read_retry_loop(
                 scanner,
                 transport=transport,
                 client=client,
-                method_name="read_input_registers",
+                method_name=method_name,
                 address=address,
                 count=count,
                 attempt=attempt,
@@ -379,7 +383,7 @@ async def _run_input_read_retry_loop(
             done, payload = _process_register_response(
                 scanner,
                 response=response,
-                register_type="input_registers",
+                register_type=register_type,
                 start=start,
                 end=end,
                 address=address,
@@ -387,17 +391,25 @@ async def _run_input_read_retry_loop(
                 skip_cache=skip_cache,
             )
             if done:
-                if payload is not None:
-                    _LOGGER.debug("Read input registers %d-%d: %s", start, end, payload)
+                if log_success and payload is not None:
+                    _LOGGER.debug(
+                        "Read %s %d-%d: %s",
+                        register_type.replace("_", " "),
+                        start,
+                        end,
+                        payload,
+                    )
                 return payload
+        except asyncio.CancelledError:
+            raise
         except (
-            ModbusIOException,
             TimeoutError,
+            ModbusIOException,
             OSError,
             ModbusException,
             ConnectionException,
         ) as exc:
-            aborted, stop = _handle_input_attempt_exception(
+            aborted, stop = handle_attempt_exception(
                 scanner,
                 exc,
                 start=start,
@@ -417,7 +429,7 @@ async def _run_input_read_retry_loop(
         )
     _finalize_register_read_failure(
         scanner,
-        register_type="input_registers",
+        register_type=register_type,
         start=start,
         end=end,
         retry=scanner.retry,
@@ -425,6 +437,34 @@ async def _run_input_read_retry_loop(
         aborted_transiently=aborted_transiently,
     )
     return None
+
+
+async def _run_input_read_retry_loop(
+    scanner: Any,
+    *,
+    transport: Any,
+    client: Any,
+    address: int,
+    count: int,
+    start: int,
+    end: int,
+    skip_cache: bool,
+) -> list[int] | None:
+    """Run input read retry loop and finalize failure state when needed."""
+    return await _run_word_read_retry_loop(
+        scanner,
+        transport=transport,
+        client=client,
+        address=address,
+        count=count,
+        start=start,
+        end=end,
+        skip_cache=skip_cache,
+        method_name="read_input_registers",
+        register_type="input_registers",
+        handle_attempt_exception=_handle_input_attempt_exception,
+        log_success=True,
+    )
 
 
 async def read_input(
@@ -571,71 +611,20 @@ async def _run_holding_read_retry_loop(
     skip_cache: bool,
 ) -> list[int] | None:
     """Run holding read retry loop and finalize failure state when needed."""
-    aborted_transiently = False
-    attempted_reads = 0
-    for attempt in range(1, scanner.retry + 1):
-        attempted_reads = attempt
-        try:
-            response = await _execute_word_read_attempt(
-                scanner,
-                transport=transport,
-                client=client,
-                method_name="read_holding_registers",
-                address=address,
-                count=count,
-                attempt=attempt,
-            )
-            done, payload = _process_register_response(
-                scanner,
-                response=response,
-                register_type="holding_registers",
-                start=start,
-                end=end,
-                address=address,
-                count=count,
-                skip_cache=skip_cache,
-            )
-            if done:
-                return payload
-        except asyncio.CancelledError:
-            raise
-        except (
-            TimeoutError,
-            ModbusIOException,
-            ModbusException,
-            ConnectionException,
-            OSError,
-        ) as exc:
-            aborted, stop = _handle_holding_read_exception(
-                scanner,
-                exc,
-                start=start,
-                end=end,
-                address=address,
-                count=count,
-                attempt=attempt,
-            )
-            aborted_transiently = aborted_transiently or aborted
-            if stop:
-                break
-
-        await _sleep_retry_backoff(
-            backoff=scanner.backoff,
-            backoff_jitter=scanner.backoff_jitter,
-            attempt=attempt,
-            retry=scanner.retry,
-        )
-
-    _finalize_register_read_failure(
+    return await _run_word_read_retry_loop(
         scanner,
-        register_type="holding_registers",
+        transport=transport,
+        client=client,
+        address=address,
+        count=count,
         start=start,
         end=end,
-        retry=scanner.retry,
-        attempted_reads=attempted_reads,
-        aborted_transiently=aborted_transiently,
+        skip_cache=skip_cache,
+        method_name="read_holding_registers",
+        register_type="holding_registers",
+        handle_attempt_exception=_handle_holding_read_exception,
+        log_success=False,
     )
-    return None
 
 
 async def read_holding(

--- a/custom_components/thessla_green_modbus/scanner/setup.py
+++ b/custom_components/thessla_green_modbus/scanner/setup.py
@@ -29,9 +29,10 @@ from ..modbus_transport import (
     RtuModbusTransport,
     TcpModbusTransport,
 )
-from ..scanner_helpers import SAFE_REGISTERS
+from ..scanner_helpers import MAX_BATCH_REGISTERS, SAFE_REGISTERS
 from ..scanner_register_maps import REGISTER_DEFINITIONS
 from ..utils import default_connection_mode
+from . import state as _state
 from .io import is_request_cancelled_error
 from .io_runtime import attach_pymodbus_client_module
 from .register_map_runtime import async_ensure_register_maps, initial_register_hash
@@ -76,6 +77,71 @@ def normalize_backoff_jitter(
     if jitter in (0, 0.0):
         jitter = 0.0
     return jitter
+
+
+def apply_scanner_params(
+    scanner: Any,
+    *,
+    host: str,
+    port: int,
+    slave_id: int,
+    timeout: int,
+    retry: int,
+    backoff: float,
+    backoff_jitter: float | tuple[float, float] | None,
+    verbose_invalid_values: bool,
+    scan_uart_settings: bool,
+    skip_known_missing: bool,
+    deep_scan: bool,
+    full_register_scan: bool,
+    safe_scan: bool,
+    max_registers_per_request: int,
+    connection_type: str,
+    connection_mode: str | None,
+    serial_port: str,
+    baud_rate: int,
+    parity: str,
+    stop_bits: int,
+    hass: Any | None,
+) -> None:
+    """Assign all scalar parameters and connection state to a scanner instance."""
+    scanner.host = host
+    scanner.port = port
+    scanner.slave_id = slave_id
+    scanner.timeout = timeout
+    scanner.retry = retry
+    try:
+        scanner.backoff = float(backoff)
+    except (TypeError, ValueError):
+        scanner.backoff = 0.0
+    scanner.backoff_jitter = normalize_backoff_jitter(backoff_jitter)
+    scanner.verbose_invalid_values = verbose_invalid_values
+    scanner.scan_uart_settings = scan_uart_settings
+    scanner.skip_known_missing = skip_known_missing
+    scanner.deep_scan = deep_scan
+    scanner.full_register_scan = full_register_scan
+    scanner.safe_scan = safe_scan
+    scanner.effective_batch = normalize_effective_batch(
+        max_registers_per_request, max_batch=MAX_BATCH_REGISTERS
+    )
+    scanner.max_registers_per_request = scanner.effective_batch
+
+    resolved_type, resolved_mode, resolved_fixed_mode = _state.resolve_connection_configuration(
+        connection_type, connection_mode, port
+    )
+    _state.apply_connection_state(
+        scanner,
+        _state.build_connection_state(
+            connection_type=resolved_type,
+            connection_mode=resolved_mode,
+            resolved_connection_mode=resolved_fixed_mode,
+            serial_port=serial_port,
+            baud_rate=baud_rate,
+            parity=parity,
+            stop_bits=stop_bits,
+        ),
+    )
+    scanner._hass = hass
 
 
 def initialize_runtime_collections(scanner: Any, capabilities_cls: Any) -> None:

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,18 +1,19 @@
 # Maintainability audit
 
-Date: 2026-05-08 (post-PR #1595 documentation cleanup).
+Date: 2026-05-08 (post-hotspot cleanup PR — phases B–F).
 
 ## Commands covered by latest successful validation
 
-Latest complete validation evidence comes from PR #1595, using Python 3.12:
+Latest complete validation uses Python 3.13.12:
 
-- `ruff check custom_components tests tools`
-- `ruff check --select I custom_components tests tools`
-- `ruff format --check custom_components tests tools`
-- `python3.12 -m compileall -q custom_components/thessla_green_modbus tests tools`
-- `python3.12 tools/check_maintainability.py`
-- `python3.12 tools/validate_entity_mappings.py`
-- `python3.12 -m pytest tests/ -q`
+- `ruff check custom_components tests tools` — **pass**
+- `ruff check --select I custom_components tests tools` — **pass**
+- `ruff format --check custom_components tests tools` — **0 files drift** (419 already formatted)
+- `python3.13 -m compileall -q custom_components/thessla_green_modbus tests tools` — **pass**
+- `python3.13 tools/compare_registers_with_reference.py` — **pass**
+- `python3.13 tools/check_maintainability.py` — **Maintainability gate passed**
+- `python3.13 tools/validate_entity_mappings.py` — **OK: 366 entities validated**
+- `python3.13 -m pytest tests/ -q` — **1938 passed, 4 skipped**
 
 ## Exact status by validation gate
 
@@ -20,52 +21,72 @@ Latest complete validation evidence comes from PR #1595, using Python 3.12:
 - **ruff import order check**: pass.
 - **ruff format --check**: 0 files drift.
 - **compileall**: pass.
+- **compare_registers**: pass.
 - **maintainability** (`check_maintainability.py`): pass.
 - **entity mappings** (`validate_entity_mappings.py`): pass — **366 entities**.
 - **pytest** (`pytest tests/ -q`): **1938 passed, 4 skipped**.
-
-Earlier Python 3.13 validation from the 2026-05-08 config-flow cleanup series remains historical context, but the latest full post-#1595 validation evidence is the Python 3.12 pass above.
 
 ## Notable merged changes (2026-05-08 series)
 
 All changes below are already merged into **dev** as of this audit.
 
-### Config-flow runtime extraction
+### Config-flow runtime extraction (merged, earlier PR)
 
 - `_load_scanner_module` moved from inline in `config_flow.py` into `load_scanner_module` in `config_flow_runtime.py`.
-- `import_module` import removed from `config_flow.py`.
-- `_SCANNER_MODULE_PATH` constant added to `config_flow_runtime.py` for testability.
-- 5 focused unit tests added in `tests/test_config_flow_runtime_loader.py`.
 
-### Config-flow bound-adapter extraction
+### Config-flow bound-adapter extraction (merged, earlier PR)
 
 - `_validate_tcp_config`, `_validate_rtu_config`, `_process_scan_capabilities` removed from `config_flow.py`.
-- Replaced by `validate_tcp_config_bound`, `validate_rtu_config_bound`, and `process_scan_capabilities_bound` in `config_flow_validation.py`.
-- 13 focused tests added in `tests/test_config_flow_validation_bound.py`.
 
-### Coordinator test splits
+### Coordinator config property extraction (merged, earlier PR)
 
-- `TestParseBackoffJitter` split out of `test_coordinator.py` into focused coordinator backoff/jitter test modules.
-- No production behavior changed.
-
-### Coordinator config property extraction
-
-- 9 pairs of config-backed property getter/setter moved from `ThesslaGreenModbusCoordinator` into `_CoordinatorConfigPropertiesMixin` in `coordinator/config_properties.py`.
+- 9 pairs of config-backed property getter/setter moved into `_CoordinatorConfigPropertiesMixin`.
 - `coordinator.py` non-empty lines reduced from 666 to 605.
-- Coordinator package API invariant preserved.
 
-### Scanner failure logging helper promotion
+### Scanner failure logging helper promotion (merged, earlier PR)
 
-- `_mark_failed_addresses`, `_log_read_abort`, `_log_read_failure` moved from `scanner/io_read.py` to `scanner/io_read_helpers.py` as public helpers.
+- `_mark_failed_addresses`, `_log_read_abort`, `_log_read_failure` moved to `scanner/io_read_helpers.py`.
 - `scanner/io_read.py` non-empty lines reduced from 714 to 701.
-- HA-independence invariant preserved.
 
-### Schedule write-path deduplication
+### Schedule write-path deduplication (merged, earlier PR)
 
-- `_write_holding_multi` in `coordinator/schedule.py` now delegates to `_write_registers_payload` per chunk.
-- Duplicated transport/client/fallback branching removed from that method.
+- `_write_holding_multi` delegates to `_write_registers_payload` per chunk.
 - `coordinator/schedule.py` non-empty lines reduced from 419 to 401.
-- Write/chunking/retry behavior unchanged.
+
+### Hotspot cleanup — PHASE B: scanner/io_read.py (this PR)
+
+- Extracted `_run_word_read_retry_loop` as a shared core retry loop.
+- `_run_input_read_retry_loop` (75 lines) and `_run_holding_read_retry_loop` (77 lines) are now thin 26-line wrappers.
+- `scanner/io_read.py` non-empty lines: 701 → 690.
+- HA-independence invariant preserved. 188 scanner tests pass.
+
+### Hotspot cleanup — PHASE C: coordinator/coordinator.py (this PR)
+
+- Extracted `_build_transport_selector_fn` method from the 60-line `_ensure_connected`.
+- Removed dead duplicate docstring string from `_get_client_method`; simplified repeated getattr/callable pattern to a loop.
+- `_ensure_connected` reduced from 60 → 17 lines.
+- `coordinator.py` non-empty lines: 605 → 606 (same; inner function became named method).
+- Coordinator package API invariant preserved. 307 coordinator tests pass.
+
+### Hotspot cleanup — PHASE D: scanner/core.py (this PR)
+
+- Extracted `apply_scanner_params` into `scanner/setup.py`.
+- `ThesslaGreenDeviceScanner.__init__` reduced from 88 → 68 lines.
+- `scanner/core.py` non-empty lines: 451 → 433.
+- HA-independence invariant preserved. 188 scanner tests pass.
+
+### Hotspot cleanup — PHASE E: mappings/_mapping_builders.py (this PR)
+
+- Extracted `_resolve_base_helpers()` combining the identical 3-line resolver trio used in `_load_number_mappings` and `_load_discrete_mappings`.
+- `_mapping_builders.py` non-empty lines: 437 → 441 (net +4 from new helper; both loaders simplified).
+- 366 entities validated. 284 mapping tests pass.
+
+### Hotspot cleanup — PHASE F: coordinator/schedule.py (this PR)
+
+- Extracted `run_multi_register_write_attempts` into `coordinator/write_path.py`, mirroring existing `run_single_write_attempts`.
+- `async_write_registers` reduced from 67 → 31 lines.
+- `coordinator/schedule.py` non-empty lines: 401 → 367.
+- All write/retry/lock/refresh behaviors unchanged. 303 coordinator tests pass.
 
 ## Architecture invariants snapshot
 
@@ -77,27 +98,27 @@ All changes below are already merged into **dev** as of this audit.
 
 ## Current largest known production hotspots
 
-| Area | Current known size |
-|---|---:|
-| `custom_components/thessla_green_modbus/scanner/io_read.py` | 701 non-empty lines |
-| `custom_components/thessla_green_modbus/coordinator/coordinator.py` | 605 non-empty lines |
-| `custom_components/thessla_green_modbus/scanner/core.py` | 451 non-empty lines |
-| `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` | 437 non-empty lines |
-| `custom_components/thessla_green_modbus/coordinator/schedule.py` | 401 non-empty lines |
-| `custom_components/thessla_green_modbus/config_flow.py` | reduced by recent extractions; remeasure before next edit |
+| Area | Before | After this PR |
+|---|---:|---:|
+| `custom_components/thessla_green_modbus/scanner/io_read.py` | 701 | **690** |
+| `custom_components/thessla_green_modbus/coordinator/coordinator.py` | 605 | 606 |
+| `custom_components/thessla_green_modbus/scanner/core.py` | 451 | **433** |
+| `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` | 437 | 441 |
+| `custom_components/thessla_green_modbus/coordinator/schedule.py` | 401 | **367** |
+| `custom_components/thessla_green_modbus/coordinator/write_path.py` | 118 | 184 (gained `run_multi_register_write_attempts`) |
 
 ## Remaining hotspots
 
-1. Coordinator size/branching (`coordinator/coordinator.py`, `coordinator/schedule.py`).
-2. Scanner read/orchestration complexity (`scanner/io_read.py`, `scanner/core.py`).
-3. Mapping builder density (`mappings/_mapping_builders.py`).
-4. Config-flow branching (`config_flow.py`).
-5. Large test modules where focused splits remain possible.
+1. `coordinator/coordinator.py` — `from_params` (54 lines) and `__init__` (61 lines) still large.
+2. `scanner/io_read.py` — `_process_register_response` (60 lines) and `read_bit_registers` (64 lines) remain.
+3. `scanner/core.py` — `create` (52 lines) and `_group_registers_for_batch_read` (24 lines).
+4. `mappings/_mapping_builders.py` — `_extend_entity_mappings_from_registers` (83 lines) remains.
+5. Config-flow branching (`config_flow.py`) — not touched in this cycle.
 
 ## Recommended next work
 
-1. Continue with a focused extraction in `scanner/io_read.py` or `scanner/core.py`.
-2. Alternatively reduce `mappings/_mapping_builders.py` if a cohesive helper extraction is visible.
+1. `_process_register_response` and `read_bit_registers` in `scanner/io_read.py` are the next extraction candidates.
+2. `_extend_entity_mappings_from_registers` in `mappings/_mapping_builders.py` could be split by routing phase.
 3. Keep each PR narrow: one production extraction plus focused tests and refreshed docs.
 
 ## Branch note

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08 (post-PR #1595 documentation cleanup).
+Last reviewed: 2026-05-08 (post-hotspot cleanup PR — phases B–F, Python 3.13.12).
 
 Related document: `docs/maintainability_audit.md`
 


### PR DESCRIPTION
## Summary

Base branch: dev

Five sequential, independently behavior-preserving cleanup phases over the five largest hotspot files. Each phase has targeted validation and the full gate passes after every phase.

### PHASE B — scanner/io_read.py
- Extracted `_run_word_read_retry_loop` as a shared core retry loop
- `_run_input_read_retry_loop` (75 lines) and `_run_holding_read_retry_loop` (77 lines) are now thin 26-line wrappers over the shared helper
- `scanner/io_read.py` non-empty: 701 → 690
- HA-independence invariant preserved

### PHASE C — coordinator/coordinator.py
- Extracted `_build_transport_selector_fn` method from the 60-line `_ensure_connected`, eliminating the double-indirection inner-function closure
- Removed dead duplicate docstring string from `_get_client_method`; simplified repeated `getattr`/`callable` pattern to a loop
- `_ensure_connected`: 60 → 17 lines

### PHASE D — scanner/core.py
- Extracted `apply_scanner_params` into `scanner/setup.py`, consolidating all scalar parameter assignments and connection-state application from `__init__`
- `ThesslaGreenDeviceScanner.__init__`: 88 → 68 lines
- `scanner/core.py` non-empty: 451 → 433

### PHASE E — mappings/_mapping_builders.py
- Extracted `_resolve_base_helpers()` for the identical 3-line resolver trio duplicated in `_load_number_mappings` and `_load_discrete_mappings`
- 366 entities validated — no mapping payloads changed

### PHASE F — coordinator/schedule.py
- Extracted `run_multi_register_write_attempts` into `coordinator/write_path.py`, mirroring the existing `run_single_write_attempts` pattern
- `async_write_registers`: 67 → 31 lines
- `coordinator/schedule.py` non-empty: 401 → 367

## Validation

- **Python**: 3.13.12
- **pytest**: 1938 passed, 4 skipped (all gates green after every phase)
- **ruff check**: pass — 0 violations
- **ruff format drift**: 0 files
- **entity mappings**: 366 entities validated
- **maintainability gate**: pass
- **coordinator package API**: `["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]` — unchanged
- **scanner HA-independence**: no `homeassistant` imports in scanner package
- **top-level coordinator.py**: absent

## Invariants confirmed

- Pydantic version: not changed
- Dependabot PR #1567: not touched
- main branch: not used
- Register JSON files: not changed
- CI: not changed
- Runtime behavior: unchanged across all phases

---
_Generated by [Claude Code](https://claude.ai/code/session_018r9MCWHaNafLBHs1vqc6bt)_