### PR TITLE
refactor: finish remaining maintainability hotspots (phases B–E + docs)

### DIFF
--- a/custom_components/thessla_green_modbus/_coordinator_init.py
+++ b/custom_components/thessla_green_modbus/_coordinator_init.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import timedelta
+from typing import Any
 
 from .const import CONNECTION_MODE_AUTO
 from .coordinator.models import CoordinatorConfig
@@ -60,3 +61,36 @@ def normalize_runtime_config(
     )
     resolved_connection_mode = resolved_mode if resolved_mode != CONNECTION_MODE_AUTO else None
     return normalized_cfg, resolved_connection_mode, interval_seconds
+
+
+def apply_coordinator_config(
+    coordinator: Any,
+    normalized_cfg: CoordinatorConfig,
+    resolved_connection_mode: str | None,
+    entry: Any,
+    *,
+    normalize_backoff_fn: Callable[[float], float],
+    parse_backoff_jitter_fn: Callable[[Any], float | tuple[float, float] | None],
+    resolve_effective_batch_fn: Callable[[Any, int], int],
+) -> None:
+    """Assign normalized config attributes to a fresh coordinator instance."""
+    coordinator._device_name = normalized_cfg.name
+    coordinator.config = normalized_cfg
+    coordinator._resolved_connection_mode = resolved_connection_mode
+    coordinator.timeout = normalized_cfg.timeout
+    coordinator.retry = normalized_cfg.retry
+    coordinator.backoff = normalize_backoff_fn(normalized_cfg.backoff)
+    coordinator.backoff_jitter = parse_backoff_jitter_fn(normalized_cfg.backoff_jitter)
+    coordinator.force_full_register_list = normalized_cfg.force_full_register_list
+    coordinator.scan_uart_settings = normalized_cfg.scan_uart_settings
+    coordinator.deep_scan = normalized_cfg.deep_scan
+    coordinator.safe_scan = normalized_cfg.safe_scan
+    coordinator.entry = entry
+    coordinator.skip_missing_registers = normalized_cfg.skip_missing_registers
+
+    effective_batch = resolve_effective_batch_fn(entry, normalized_cfg.max_registers_per_request)
+    coordinator.effective_batch = effective_batch
+    coordinator.max_registers_per_request = effective_batch
+    coordinator.config.max_registers_per_request = effective_batch
+    coordinator.config.backoff = coordinator.backoff
+    coordinator.config.backoff_jitter = coordinator.backoff_jitter

--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -18,6 +18,7 @@ from .._coordinator_connection_test import run_connection_test as _run_connectio
 from .._coordinator_device_info import run_device_scan as _run_device_scan_impl
 from .._coordinator_device_info import warn_missing_device_info as _warn_missing_device_info_impl
 from .._coordinator_factory import build_config_from_params as _build_config_from_params_impl
+from .._coordinator_init import apply_coordinator_config as _apply_coordinator_config_impl
 from .._coordinator_init import normalize_runtime_config as _normalize_runtime_config_impl
 from .._coordinator_register_groups import (
     compute_register_groups as _compute_register_groups_impl,
@@ -240,29 +241,15 @@ class ThesslaGreenModbusCoordinator(
             )
         self.hass = hass
 
-        self._device_name = normalized_cfg.name
-        self.config = normalized_cfg
-        self._resolved_connection_mode = resolved_connection_mode
-        self.timeout = normalized_cfg.timeout
-        self.retry = normalized_cfg.retry
-        self.backoff = _normalize_backoff_impl(normalized_cfg.backoff)
-
-        self.backoff_jitter = self._parse_backoff_jitter(normalized_cfg.backoff_jitter)
-        self.force_full_register_list = normalized_cfg.force_full_register_list
-        self.scan_uart_settings = normalized_cfg.scan_uart_settings
-        self.deep_scan = normalized_cfg.deep_scan
-        self.safe_scan = normalized_cfg.safe_scan
-        self.entry = entry
-        self.skip_missing_registers = normalized_cfg.skip_missing_registers
-
-        self.effective_batch = _resolve_effective_batch_impl(
-            entry, normalized_cfg.max_registers_per_request
+        _apply_coordinator_config_impl(
+            self,
+            normalized_cfg,
+            resolved_connection_mode,
+            entry,
+            normalize_backoff_fn=_normalize_backoff_impl,
+            parse_backoff_jitter_fn=_parse_backoff_jitter_impl,
+            resolve_effective_batch_fn=_resolve_effective_batch_impl,
         )
-        self.max_registers_per_request = self.effective_batch
-
-        self.config.max_registers_per_request = self.max_registers_per_request
-        self.config.backoff = self.backoff
-        self.config.backoff_jitter = self.backoff_jitter
 
         _initialize_runtime_state_impl(self, entry=entry)
 

--- a/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
+++ b/custom_components/thessla_green_modbus/mappings/_mapping_builders.py
@@ -401,6 +401,57 @@ def _load_discrete_mappings() -> tuple[
     return binary_configs, switch_configs, select_configs
 
 
+def _route_holding_register_to_mapping(
+    reg: Any,
+    *,
+    number_mappings: dict[str, Any],
+    sensor_mappings: dict[str, Any],
+    binary_mappings: dict[str, Any],
+    switch_mappings: dict[str, Any],
+    select_mappings: dict[str, Any],
+    time_mappings: dict[str, Any],
+    binary_keys: Any,
+    switch_keys: Any,
+    select_keys: Any,
+    number_keys: Any,
+) -> None:
+    """Route one holding register to its appropriate mapping bucket."""
+    register, access, min_val, max_val, unit, info_text, scale, step = _register_context(reg)
+
+    if _is_problem_register(register):
+        _route_problem_mapping(register, binary_keys, binary_mappings)
+        return
+
+    if register.startswith("date_time"):
+        return
+
+    if _route_time_and_season_mappings(
+        register, access, sensor_mappings, time_mappings, select_mappings
+    ):
+        return
+
+    _route_enum_or_min_max_mapping(
+        reg=reg,
+        register=register,
+        access=access,
+        min_val=min_val,
+        max_val=max_val,
+        unit=unit,
+        info_text=info_text,
+        scale=scale,
+        step=step,
+        switch_keys=switch_keys,
+        binary_keys=binary_keys,
+        select_keys=select_keys,
+        number_keys=number_keys,
+        sensor_mappings=sensor_mappings,
+        number_mappings=number_mappings,
+        binary_mappings=binary_mappings,
+        switch_mappings=switch_mappings,
+        select_mappings=select_mappings,
+    )
+
+
 def _extend_entity_mappings_from_registers() -> None:
     """Populate entity mappings for registers not explicitly defined.
 
@@ -432,9 +483,8 @@ def _extend_entity_mappings_from_registers() -> None:
     for reg in _get_all():
         if reg.function != 3 or not reg.name:
             continue
-        register, access, min_val, max_val, unit, info_text, scale, step = _register_context(reg)
         if _is_unmappable_holding_register(
-            register,
+            reg.name,
             all_mappings=(
                 number_mappings,
                 sensor_mappings,
@@ -448,41 +498,18 @@ def _extend_entity_mappings_from_registers() -> None:
         ):
             continue
 
-        if _is_problem_register(register):
-            _route_problem_mapping(register, binary_keys, binary_mappings)
-            continue
-
-        if register.startswith("date_time"):
-            continue
-
-        if _route_time_and_season_mappings(
-            register,
-            access,
-            sensor_mappings,
-            time_mappings,
-            select_mappings,
-        ):
-            continue
-
-        _route_enum_or_min_max_mapping(
-            reg=reg,
-            register=register,
-            access=access,
-            min_val=min_val,
-            max_val=max_val,
-            unit=unit,
-            info_text=info_text,
-            scale=scale,
-            step=step,
-            switch_keys=switch_keys,
-            binary_keys=binary_keys,
-            select_keys=select_keys,
-            number_keys=number_keys,
-            sensor_mappings=sensor_mappings,
+        _route_holding_register_to_mapping(
+            reg,
             number_mappings=number_mappings,
+            sensor_mappings=sensor_mappings,
             binary_mappings=binary_mappings,
             switch_mappings=switch_mappings,
             select_mappings=select_mappings,
+            time_mappings=time_mappings,
+            binary_keys=binary_keys,
+            switch_keys=switch_keys,
+            select_keys=select_keys,
+            number_keys=number_keys,
         )
 
 
@@ -517,6 +544,7 @@ __all__ = [
     "_resolve_parent_child_mappings",
     "_route_enum_mapping",
     "_route_enum_or_min_max_mapping",
+    "_route_holding_register_to_mapping",
     "_route_min_max_mapping",
     "_route_problem_mapping",
     "_route_time_and_season_mappings",

--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -130,6 +130,50 @@ def _extend_or_abort_register_results(
     return True, results
 
 
+def _handle_register_error_response(
+    scanner: Any,
+    *,
+    register_type: str,
+    start: int,
+    end: int,
+    address: int,
+    count: int,
+    code: int | None,
+) -> tuple[bool, list[int] | None]:
+    """Classify and finalize a Modbus error response.
+
+    Returns (done, payload) — same contract as _process_register_response.
+    """
+    _LOGGER.warning(
+        "Exception code %s while reading %s %d-%d",
+        code,
+        register_type.replace("_", " "),
+        start,
+        end,
+    )
+    if register_type == "input_registers" or code == 2:
+        _handle_error_response(
+            scanner,
+            register_type=register_type,
+            start=start,
+            end=end,
+            code=code,
+        )
+        return True, None
+    if count == 1:
+        track_holding_failure(scanner, count, address)
+        if address in scanner._failed_holding:
+            _handle_error_response(
+                scanner,
+                register_type="holding_registers",
+                start=start,
+                end=end,
+                code=code or 0,
+            )
+            return True, None
+    return False, None
+
+
 def _process_register_response(
     scanner: Any,
     *,
@@ -152,34 +196,15 @@ def _process_register_response(
 
     is_error, code = _validate_register_response(response)
     if is_error:
-        _LOGGER.warning(
-            "Exception code %s while reading %s %d-%d",
-            code,
-            register_type.replace("_", " "),
-            start,
-            end,
+        return _handle_register_error_response(
+            scanner,
+            register_type=register_type,
+            start=start,
+            end=end,
+            address=address,
+            count=count,
+            code=code,
         )
-        if register_type == "input_registers" or code == 2:
-            _handle_error_response(
-                scanner,
-                register_type=register_type,
-                start=start,
-                end=end,
-                code=code,
-            )
-            return True, None
-        if count == 1:
-            track_holding_failure(scanner, count, address)
-            if address in scanner._failed_holding:
-                _handle_error_response(
-                    scanner,
-                    register_type="holding_registers",
-                    start=start,
-                    end=end,
-                    code=code or 0,
-                )
-                return True, None
-        return False, None
 
     if skip_cache and count == 1:
         if register_type == "input_registers":
@@ -762,6 +787,7 @@ async def read_discrete(
 
 __all__ = [
     "_attempt_bit_reconnect",
+    "_handle_register_error_response",
     "read_bit_registers",
     "read_coil",
     "read_discrete",

--- a/custom_components/thessla_green_modbus/scanner/selection.py
+++ b/custom_components/thessla_green_modbus/scanner/selection.py
@@ -21,6 +21,25 @@ def build_names_by_address(mapping: dict[str, int]) -> dict[int, set[str]]:
     return by_address
 
 
+def _split_groups_around_missing(
+    groups: list[tuple[int, int]],
+    known_missing_addresses: set[int],
+) -> list[tuple[int, int]]:
+    """Re-split batched groups so each known-missing address becomes its own group."""
+    result: list[tuple[int, int]] = []
+    for start, length in groups:
+        current = start
+        for addr in range(start, start + length):
+            if addr in known_missing_addresses:
+                if addr > current:
+                    result.append((current, addr - current))
+                result.append((addr, 1))
+                current = addr + 1
+        if current < start + length:
+            result.append((current, start + length - current))
+    return result
+
+
 def group_registers_for_batch_read(
     scanner: Any,
     addresses: list[int],
@@ -46,18 +65,7 @@ def group_registers_for_batch_read(
     if not scanner._known_missing_addresses:
         return groups
 
-    result: list[tuple[int, int]] = []
-    for start, length in groups:
-        current = start
-        for addr in range(start, start + length):
-            if addr in scanner._known_missing_addresses:
-                if addr > current:
-                    result.append((current, addr - current))
-                result.append((addr, 1))
-                current = addr + 1
-        if current < start + length:
-            result.append((current, start + length - current))
-    return result
+    return _split_groups_around_missing(groups, scanner._known_missing_addresses)
 
 
 def select_scan_registers(

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,6 +1,6 @@
 # Maintainability audit
 
-Date: 2026-05-08 (post-hotspot cleanup PR — phases B–F).
+Date: 2026-05-08 (final cleanup release PR — phases A–G).
 
 ## Commands covered by latest successful validation
 
@@ -13,7 +13,7 @@ Latest complete validation uses Python 3.13.12:
 - `python3.13 tools/compare_registers_with_reference.py` — **pass**
 - `python3.13 tools/check_maintainability.py` — **Maintainability gate passed**
 - `python3.13 tools/validate_entity_mappings.py` — **OK: 366 entities validated**
-- `python3.13 -m pytest tests/ -q` — **1938 passed, 4 skipped**
+- `python3.13 -m pytest tests/ -q` — **1948 passed, 4 skipped**
 
 ## Exact status by validation gate
 
@@ -24,102 +24,136 @@ Latest complete validation uses Python 3.13.12:
 - **compare_registers**: pass.
 - **maintainability** (`check_maintainability.py`): pass.
 - **entity mappings** (`validate_entity_mappings.py`): pass — **366 entities**.
-- **pytest** (`pytest tests/ -q`): **1938 passed, 4 skipped**.
+- **pytest** (`pytest tests/ -q`): **1948 passed, 4 skipped**.
 
-## Notable merged changes (2026-05-08 series)
+## Import gate (Python 3.13.12)
 
-All changes below are already merged into **dev** as of this audit.
+```
+OK pydantic: 2.12.2
+OK pytest: 9.0.0
+OK pytest_asyncio: 1.3.0
+OK pytest_homeassistant_custom_component: installed
+OK homeassistant: installed
+```
 
-### Config-flow runtime extraction (merged, earlier PR)
+## Final cleanup PR — phase log
 
-- `_load_scanner_module` moved from inline in `config_flow.py` into `load_scanner_module` in `config_flow_runtime.py`.
+### PHASE A — full Python >=3.12 health audit
 
-### Config-flow bound-adapter extraction (merged, earlier PR)
+- Python 3.13.12 interpreter used.
+- All gates passed at baseline.
+- Baseline pytest: 1938 passed, 4 skipped.
+- Result: **kept**.
 
-- `_validate_tcp_config`, `_validate_rtu_config`, `_process_scan_capabilities` removed from `config_flow.py`.
+### PHASE B — scanner/io_read.py final focused cleanup
 
-### Coordinator config property extraction (merged, earlier PR)
+Files touched: `scanner/io_read.py`, `tests/test_scanner_io.py`.
 
-- 9 pairs of config-backed property getter/setter moved into `_CoordinatorConfigPropertiesMixin`.
-- `coordinator.py` non-empty lines reduced from 666 to 605.
+Extraction: `_handle_register_error_response` pulled out of `_process_register_response`.
+- `_process_register_response` reduced: 60 → 41 lines.
+- New `_handle_register_error_response`: 42 lines (pure, testable error-branch classifier).
+- 4 new focused tests added in `test_scanner_io.py`.
+- HA-independence invariant preserved.
+- Targeted tests: 89 passed.
+- Full gates after phase: **1942 passed, 4 skipped**.
+- Result: **kept**.
 
-### Scanner failure logging helper promotion (merged, earlier PR)
+### PHASE C — coordinator/coordinator.py final focused cleanup
 
-- `_mark_failed_addresses`, `_log_read_abort`, `_log_read_failure` moved to `scanner/io_read_helpers.py`.
-- `scanner/io_read.py` non-empty lines reduced from 714 to 701.
+Files touched: `_coordinator_init.py`, `coordinator/coordinator.py`.
 
-### Schedule write-path deduplication (merged, earlier PR)
+Extraction: `apply_coordinator_config` added to `_coordinator_init.py`.
+- `ThesslaGreenModbusCoordinator.__init__` reduced: 61 → 47 lines.
+- New `apply_coordinator_config`: 31 lines (assigns normalized config attrs to fresh instance).
+- Coordinator package API invariant preserved: `__all__ == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]`.
+- Top-level `coordinator.py` remains absent.
+- Targeted tests: 307 passed.
+- Full gates after phase: **1942 passed, 4 skipped**.
+- Result: **kept**.
 
-- `_write_holding_multi` delegates to `_write_registers_payload` per chunk.
-- `coordinator/schedule.py` non-empty lines reduced from 419 to 401.
+### PHASE D — mappings/_mapping_builders.py final focused cleanup
 
-### Hotspot cleanup — PHASE B: scanner/io_read.py (this PR)
+Files touched: `mappings/_mapping_builders.py`.
 
-- Extracted `_run_word_read_retry_loop` as a shared core retry loop.
-- `_run_input_read_retry_loop` (75 lines) and `_run_holding_read_retry_loop` (77 lines) are now thin 26-line wrappers.
-- `scanner/io_read.py` non-empty lines: 701 → 690.
-- HA-independence invariant preserved. 188 scanner tests pass.
+Extraction: `_route_holding_register_to_mapping` pulled from the per-register dispatch loop in `_extend_entity_mappings_from_registers`.
+- `_extend_entity_mappings_from_registers` reduced: 83 → 59 lines.
+- New `_route_holding_register_to_mapping`: 49 lines (routes one holding register to its bucket).
+- Entity count stable: 366 entities validated.
+- Targeted tests: 284 passed, 3 skipped.
+- Full gates after phase: **1942 passed, 4 skipped**.
+- Result: **kept**.
 
-### Hotspot cleanup — PHASE C: coordinator/coordinator.py (this PR)
+### PHASE E — scanner/core.py final focused cleanup
 
-- Extracted `_build_transport_selector_fn` method from the 60-line `_ensure_connected`.
-- Removed dead duplicate docstring string from `_get_client_method`; simplified repeated getattr/callable pattern to a loop.
-- `_ensure_connected` reduced from 60 → 17 lines.
-- `coordinator.py` non-empty lines: 605 → 606 (same; inner function became named method).
-- Coordinator package API invariant preserved. 307 coordinator tests pass.
+Files touched: `scanner/selection.py`, `tests/test_scanner_safe_scan.py`.
 
-### Hotspot cleanup — PHASE D: scanner/core.py (this PR)
+Extraction: `_split_groups_around_missing` pulled from `group_registers_for_batch_read` in `scanner/selection.py`.
+- `group_registers_for_batch_read` reduced: 37 → 26 lines.
+- New `_split_groups_around_missing`: 17 lines (pure function, no scanner dependency).
+- 6 new focused unit tests added in `test_scanner_safe_scan.py`.
+- HA-independence invariant preserved.
+- Targeted tests: 198 passed.
+- Full gates after phase: **1948 passed, 4 skipped**.
+- Result: **kept**.
 
-- Extracted `apply_scanner_params` into `scanner/setup.py`.
-- `ThesslaGreenDeviceScanner.__init__` reduced from 88 → 68 lines.
-- `scanner/core.py` non-empty lines: 451 → 433.
-- HA-independence invariant preserved. 188 scanner tests pass.
+### PHASE F — release-readiness validation/audit
 
-### Hotspot cleanup — PHASE E: mappings/_mapping_builders.py (this PR)
+- manifest.json: domain `thessla_green_modbus`, version `2.8.0`, homeassistant `2026.1.0`, integration_type `hub`.
+- pyproject.toml: version `2.8.0`, requires-python `>=3.13`.
+- hacs.json: present — name "ThesslaGreen Modbus", content_in_root: false, render_readme: true.
+- **hassfest**: not available as installable CLI in this environment — **not proven locally**.
+- **HACS CLI**: not available as installable CLI in this environment — **not proven locally**.
+- CI (`ci.yaml`) installs `hacs` pip package during test runs; HACS/hassfest gates run via GitHub Actions.
+- Real-device validation: **not proven**.
+- Release notes/tag/changelog: **not finalized**.
+- Result: documented; no CI change made (hassfest/hacs not locally available).
 
-- Extracted `_resolve_base_helpers()` combining the identical 3-line resolver trio used in `_load_number_mappings` and `_load_discrete_mappings`.
-- `_mapping_builders.py` non-empty lines: 437 → 441 (net +4 from new helper; both loaders simplified).
-- 366 entities validated. 284 mapping tests pass.
+### PHASE G — docs/status refresh
 
-### Hotspot cleanup — PHASE F: coordinator/schedule.py (this PR)
-
-- Extracted `run_multi_register_write_attempts` into `coordinator/write_path.py`, mirroring existing `run_single_write_attempts`.
-- `async_write_registers` reduced from 67 → 31 lines.
-- `coordinator/schedule.py` non-empty lines: 401 → 367.
-- All write/retry/lock/refresh behaviors unchanged. 303 coordinator tests pass.
+- `docs/maintainability_audit.md`: refreshed with current state (this file).
+- `docs/refactor_status.md`: refreshed.
+- Result: **kept**.
 
 ## Architecture invariants snapshot
 
 - Canonical coordinator module: `custom_components/thessla_green_modbus/coordinator/coordinator.py`.
 - Top-level `custom_components/thessla_green_modbus/coordinator.py`: **absent**.
-- `core/`, `transport/`, `registers/`, and `scanner/` do not import Home Assistant in the last validation snapshot.
+- `core/`, `transport/`, `registers/`, and `scanner/` do not import Home Assistant.
 - Coordinator package API invariant: `__all__ == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]`.
 - Entity mapping invariant: **366 entities**.
 
-## Current largest known production hotspots
+## Before / after metrics
 
-| Area | Before | After this PR |
+| File | Before this PR | After this PR |
 |---|---:|---:|
-| `custom_components/thessla_green_modbus/scanner/io_read.py` | 701 | **690** |
-| `custom_components/thessla_green_modbus/coordinator/coordinator.py` | 605 | 606 |
-| `custom_components/thessla_green_modbus/scanner/core.py` | 451 | **433** |
-| `custom_components/thessla_green_modbus/mappings/_mapping_builders.py` | 437 | 441 |
-| `custom_components/thessla_green_modbus/coordinator/schedule.py` | 401 | **367** |
-| `custom_components/thessla_green_modbus/coordinator/write_path.py` | 118 | 184 (gained `run_multi_register_write_attempts`) |
+| `scanner/io_read.py` (non-empty lines) | 690 | **713** (+23 from new helper) |
+| `scanner/io_read.py::_process_register_response` | 60 lines | **41 lines** |
+| `coordinator/coordinator.py` (non-empty lines) | 606 | **596** |
+| `coordinator/coordinator.py::__init__` | 61 lines | **47 lines** |
+| `mappings/_mapping_builders.py` (non-empty lines) | 441 | **466** (+25 from new helper) |
+| `mappings/_mapping_builders.py::_extend_entity_mappings_from_registers` | 83 lines | **59 lines** |
+| `scanner/selection.py::group_registers_for_batch_read` | 37 lines | **26 lines** |
+| `_coordinator_init.py` | 63 non-empty lines | **86 non-empty lines** (+23 from helper) |
 
 ## Remaining hotspots
 
-1. `coordinator/coordinator.py` — `from_params` (54 lines) and `__init__` (61 lines) still large.
-2. `scanner/io_read.py` — `_process_register_response` (60 lines) and `read_bit_registers` (64 lines) remain.
-3. `scanner/core.py` — `create` (52 lines) and `_group_registers_for_batch_read` (24 lines).
-4. `mappings/_mapping_builders.py` — `_extend_entity_mappings_from_registers` (83 lines) remains.
+1. `scanner/io_read.py` — `_run_word_read_retry_loop` (87 lines) and `read_bit_registers` (64 lines) remain.
+2. `scanner/core.py` — `__init__` (68 lines) and `create` (52 lines) are parameter-list-heavy wrappers.
+3. `coordinator/coordinator.py` — `from_params` (54 lines) is a long-signature pass-through.
+4. `coordinator/schedule.py` — `async_write_register` (49 lines) and `_handle_write_attempt_exception` (45 lines).
 5. Config-flow branching (`config_flow.py`) — not touched in this cycle.
 
-## Recommended next work
+## Release-readiness status
 
-1. `_process_register_response` and `read_bit_registers` in `scanner/io_read.py` are the next extraction candidates.
-2. `_extend_entity_mappings_from_registers` in `mappings/_mapping_builders.py` could be split by routing phase.
-3. Keep each PR narrow: one production extraction plus focused tests and refreshed docs.
+| Item | Status |
+|---|---|
+| manifest.json | present, version 2.8.0 |
+| hacs.json | present |
+| HACS validation | **not proven** (CLI unavailable locally; CI runs it) |
+| hassfest validation | **not proven** (CLI unavailable locally; CI runs it) |
+| Real-device validation | **not proven** |
+| Release notes / tag | **not finalized** |
+| Dependabot #1567 | not touched; pydantic version unchanged |
 
 ## Branch note
 
@@ -127,12 +161,8 @@ All changes below are already merged into **dev** as of this audit.
 - **main** is **not** authoritative for this refactor/audit track.
 - No `main -> dev` merge is recommended as part of this audit.
 
-## Release readiness caveats
-
-- **HACS/hassfest readiness is not proven** unless CI explicitly runs those actions.
-- **Real-device validation is not proven** unless explicitly documented with device evidence.
-
 ## Dependabot note
 
 - PR #1567 remains separate from this refactor/audit stream.
 - This audit cleanup does not change dependency versions.
+- pydantic version unchanged at 2.12.2.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08 (post-hotspot cleanup PR — phases B–F, Python 3.13.12).
+Last reviewed: 2026-05-08 (final cleanup release PR — phases A–G, Python 3.13.12).
 
 Related document: `docs/maintainability_audit.md`
 
@@ -31,54 +31,55 @@ The following constraints remain active and must be preserved:
 - Top-level `custom_components/thessla_green_modbus/coordinator.py`: **absent**.
 - Canonical coordinator module: `custom_components/thessla_green_modbus/coordinator/coordinator.py`.
 - Coordinator package API invariant: `__all__ == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]`.
-- HA imports in `core/transport/registers/scanner`: **none detected** in the last validation pass.
-- Entity mapping invariant: **366 entities** in the last successful validation pass.
+- HA imports in `core/transport/registers/scanner`: **none detected**.
+- Entity mapping invariant: **366 entities**.
 
 ## Latest merged refactor snapshot
 
-Latest merged PR: **#1595 — Extract coordinator config properties & refactor schedule write logic**.
+Latest PR (this document): **final cleanup release — phases B–E + docs**.
 
-Merged changes:
+Changes in this PR:
 
-- `_CoordinatorConfigPropertiesMixin` extracted to `coordinator/config_properties.py`.
-- Nine config-backed property pairs moved out of `ThesslaGreenModbusCoordinator`.
-- Scanner failure logging helpers promoted to `scanner/io_read_helpers.py`.
-- `_write_holding_multi` in `coordinator/schedule.py` now delegates to `_write_registers_payload` per chunk.
+- **Phase B** (`scanner/io_read.py`): extracted `_handle_register_error_response` from `_process_register_response`; 4 new tests.
+- **Phase C** (`coordinator/coordinator.py` + `_coordinator_init.py`): extracted `apply_coordinator_config`; `__init__` reduced 61→47 lines.
+- **Phase D** (`mappings/_mapping_builders.py`): extracted `_route_holding_register_to_mapping` from `_extend_entity_mappings_from_registers`; latter reduced 83→59 lines.
+- **Phase E** (`scanner/selection.py`): extracted `_split_groups_around_missing` from `group_registers_for_batch_read`; 6 new tests.
 
-Current post-PR #1595 file-size snapshot from that PR:
+Current file-size snapshot:
 
-| Area | Current size |
+| Area | Size (non-empty lines) |
 |---|---:|
-| `coordinator/coordinator.py` | 605 non-empty lines |
-| `coordinator/schedule.py` | 401 non-empty lines |
-| `scanner/io_read.py` | 701 non-empty lines |
+| `coordinator/coordinator.py` | 596 |
+| `coordinator/schedule.py` | 367 |
+| `scanner/io_read.py` | 713 |
+| `scanner/selection.py` | 119 |
+| `mappings/_mapping_builders.py` | 466 |
+| `scanner/core.py` | 433 |
 
 ## Required gate status snapshot
 
-Last complete successful validation from PR #1595:
+Last complete successful validation (Python 3.13.12):
 
 - `ruff check custom_components tests tools`: **pass**.
 - `ruff check --select I custom_components tests tools`: **pass**.
 - `ruff format --check custom_components tests tools`: **0 files drift**.
-- `python3.12 -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
-- `python3.12 tools/check_maintainability.py`: **pass**.
-- `python3.12 tools/validate_entity_mappings.py`: **pass** — **366 entities**.
-- `python3.12 -m pytest tests/ -q`: **1938 passed, 4 skipped**.
-
-Earlier Python 3.13 validation from the 2026-05-08 cleanup/config-flow series remains useful historical context, but the latest full post-#1595 test evidence is the Python 3.12 pass above.
+- `python3.13 -m compileall -q custom_components/thessla_green_modbus tests tools`: **pass**.
+- `python3.13 tools/check_maintainability.py`: **Maintainability gate passed**.
+- `python3.13 tools/validate_entity_mappings.py`: **OK: 366 entities validated**.
+- `python3.13 -m pytest tests/ -q`: **1948 passed, 4 skipped**.
 
 ## Remaining hotspots
 
-1. Coordinator size/branching: `coordinator/coordinator.py` and `coordinator/schedule.py`.
-2. Scanner read/orchestration complexity: `scanner/io_read.py` and `scanner/core.py`.
-3. Mapping builder density: `mappings/_mapping_builders.py`.
-4. Config-flow branching: `config_flow.py`.
-5. Large test modules, where focused splits remain possible.
+1. `scanner/io_read.py` — `_run_word_read_retry_loop` (87 lines), `read_bit_registers` (64 lines).
+2. `scanner/core.py` — `__init__` (68 lines), `create` (52 lines) — mostly long parameter lists.
+3. `coordinator/coordinator.py` — `from_params` (54 lines) — long parameter list pass-through.
+4. `coordinator/schedule.py` — `async_write_register` (49 lines), `_handle_write_attempt_exception` (45 lines).
+5. Config-flow branching: `config_flow.py`.
 
 ## Recommended next work
 
-1. Continue with a focused extraction in `scanner/io_read.py` or `scanner/core.py`.
-2. Alternatively reduce `mappings/_mapping_builders.py` if a cohesive helper extraction is visible.
+1. Consider extracting `_handle_bit_attempt_exception` from `read_bit_registers` in `scanner/io_read.py`.
+2. `coordinator/schedule.py` write-path complexity still has extraction candidates.
 3. Keep each PR narrow: one production extraction plus focused tests and refreshed docs.
 
 ## Non-required tool status
@@ -86,8 +87,8 @@ Earlier Python 3.13 validation from the 2026-05-08 cleanup/config-flow series re
 - `black`: not executed.
 - `isort`: not executed.
 - `mypy`: not executed.
-- `hassfest`: not executed locally.
-- `HACS`: not executed locally.
+- `hassfest`: not available locally — CI runs it via GitHub Actions.
+- `HACS`: not available locally — CI runs it via GitHub Actions.
 
 ## Branch note
 
@@ -97,10 +98,11 @@ Earlier Python 3.13 validation from the 2026-05-08 cleanup/config-flow series re
 
 ## Readiness caveats
 
-- **HACS/hassfest readiness:** not claimable from local verification unless CI explicitly runs those actions.
+- **HACS/hassfest readiness:** not claimable from local verification; CI runs those gates.
 - **Real-device readiness:** not claimable from these refactor validations unless separate on-device evidence is captured.
+- **Release notes/tag:** not finalized.
 
 ## Dependabot note
 
 - PR #1567 is still separate from this refactor stream.
-- Pydantic remains pinned in the project; this document does not change dependency versions.
+- Pydantic remains pinned at 2.12.2; this document does not change dependency versions.

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -15,6 +15,7 @@ from custom_components.thessla_green_modbus.scanner.io_read import (
     _extend_or_abort_register_results,
     _finalize_register_read_failure,
     _handle_input_attempt_exception,
+    _handle_register_error_response,
 )
 from custom_components.thessla_green_modbus.scanner.io_read_helpers import (
     build_read_attempt_meta,
@@ -440,3 +441,84 @@ async def test_attempt_bit_reconnect_connection_exception_returns_original():
     result = await _attempt_bit_reconnect(scanner, original)
 
     assert result is original
+
+
+# ---------------------------------------------------------------------------
+# _handle_register_error_response
+# ---------------------------------------------------------------------------
+
+
+def _make_error_scanner():
+    scanner = MagicMock()
+    scanner._failed_input = set()
+    scanner._failed_holding = set()
+    scanner._holding_failures = {}
+    scanner.retry = 3
+    return scanner
+
+
+def test_handle_register_error_response_input_marks_failed_and_returns_done():
+    """Input register error marks range failed and signals done=True."""
+    scanner = _make_error_scanner()
+    done, payload = _handle_register_error_response(
+        scanner,
+        register_type="input_registers",
+        start=10,
+        end=10,
+        address=10,
+        count=1,
+        code=2,
+    )
+    assert done is True
+    assert payload is None
+    scanner._mark_input_unsupported.assert_called_once()
+
+
+def test_handle_register_error_response_code2_holding_marks_failed():
+    """Exception code 2 on holding registers marks range failed and signals done=True."""
+    scanner = _make_error_scanner()
+    done, payload = _handle_register_error_response(
+        scanner,
+        register_type="holding_registers",
+        start=20,
+        end=20,
+        address=20,
+        count=1,
+        code=2,
+    )
+    assert done is True
+    assert payload is None
+    scanner._mark_holding_unsupported.assert_called_once()
+
+
+def test_handle_register_error_response_holding_non_code2_returns_retry():
+    """Holding register error with non-code-2 and count>1 returns done=False (retry)."""
+    scanner = _make_error_scanner()
+    done, payload = _handle_register_error_response(
+        scanner,
+        register_type="holding_registers",
+        start=30,
+        end=35,
+        address=30,
+        count=6,
+        code=None,
+    )
+    assert done is False
+    assert payload is None
+
+
+def test_handle_register_error_response_holding_single_exhausted_marks_done():
+    """Holding register single-address error returns done=True after failure threshold."""
+    scanner = _make_error_scanner()
+    scanner._failed_holding = {50}
+    done, payload = _handle_register_error_response(
+        scanner,
+        register_type="holding_registers",
+        start=50,
+        end=50,
+        address=50,
+        count=1,
+        code=None,
+    )
+    assert done is True
+    assert payload is None

--- a/tests/test_scanner_safe_scan.py
+++ b/tests/test_scanner_safe_scan.py
@@ -4,6 +4,9 @@ import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from custom_components.thessla_green_modbus.scanner.selection import (
+    _split_groups_around_missing,
+)
 
 from .test_scanner_coverage import _make_scanner, _run_minimal_scan
 
@@ -423,6 +426,52 @@ async def test_scan_holding_probe_type_error_fallback():
         result = await scanner.scan()
 
     assert "fake_holding" in result["available_registers"]["holding_registers"]
+
+
+# ---------------------------------------------------------------------------
+# _split_groups_around_missing unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_split_groups_no_missing_returns_groups_unchanged():
+    """Empty known_missing_addresses leaves groups untouched."""
+    groups = [(10, 5), (20, 3)]
+    assert _split_groups_around_missing(groups, set()) == groups
+
+
+def test_split_groups_missing_at_start_of_group():
+    """Missing address at start splits it into [single, rest]."""
+    groups = [(10, 4)]  # addresses 10-13
+    result = _split_groups_around_missing(groups, {10})
+    assert result == [(10, 1), (11, 3)]
+
+
+def test_split_groups_missing_at_end_of_group():
+    """Missing address at end splits it into [prefix, single]."""
+    groups = [(10, 4)]  # addresses 10-13
+    result = _split_groups_around_missing(groups, {13})
+    assert result == [(10, 3), (13, 1)]
+
+
+def test_split_groups_missing_in_middle():
+    """Missing address in middle creates three groups."""
+    groups = [(10, 5)]  # addresses 10-14
+    result = _split_groups_around_missing(groups, {12})
+    assert result == [(10, 2), (12, 1), (13, 2)]
+
+
+def test_split_groups_multiple_missing_in_one_group():
+    """Multiple missing addresses in one group are all isolated."""
+    groups = [(0, 6)]  # addresses 0-5
+    result = _split_groups_around_missing(groups, {1, 3})
+    assert result == [(0, 1), (1, 1), (2, 1), (3, 1), (4, 2)]
+
+
+def test_split_groups_missing_not_in_group_ignored():
+    """Missing addresses outside any group range have no effect."""
+    groups = [(10, 3)]
+    result = _split_groups_around_missing(groups, {5, 20})
+    assert result == [(10, 3)]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Base branch: dev

## Summary

Four targeted, behavior-preserving extractions across the last remaining hotspot functions, plus docs refresh. All public APIs, register outputs, and scan behaviors are unchanged.

- **Phase B — `scanner/io_read.py`**: Extracted `_handle_register_error_response` from `_process_register_response` (60 → 41 lines). New function is a pure, independently-testable error-branch classifier. +4 focused tests.
- **Phase C — `coordinator/coordinator.py` + `_coordinator_init.py`**: Extracted `apply_coordinator_config` to assign normalized config attributes to a fresh coordinator instance. `__init__` reduced 61 → 47 lines. Coordinator package `__all__` unchanged.
- **Phase D — `mappings/_mapping_builders.py`**: Extracted `_route_holding_register_to_mapping` from the per-register dispatch loop in `_extend_entity_mappings_from_registers` (83 → 59 lines). Entity count stable at 366.
- **Phase E — `scanner/selection.py`**: Extracted `_split_groups_around_missing` (pure function, no scanner dependency) from `group_registers_for_batch_read` (37 → 26 lines). +6 focused unit tests.
- **Phase G — docs**: `docs/maintainability_audit.md` and `docs/refactor_status.md` refreshed with current state.

## Validation

- Python 3.13.12
- `ruff check`: pass
- `ruff check --select I`: pass
- `ruff format --check`: 0 files drift (419 already formatted)
- `compileall`: pass
- `compare_registers`: pass
- `check_maintainability`: Maintainability gate passed
- `validate_entity_mappings`: OK: 366 entities validated
- `pytest tests/`: **1948 passed, 4 skipped** (baseline was 1938; +10 new tests)
- Coordinator API invariant: `__all__ == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]` ✓
- Top-level `coordinator.py` absent ✓
- Scanner HA-independence: no `homeassistant` imports in `scanner/` ✓

## Hard invariants preserved

- No behavior changes
- No public API changes
- No register JSON changes
- Pydantic version unchanged
- PR #1567 not touched
- `main` not used — base branch is **dev**

## Files changed

| File | Change |
|---|---|
| `scanner/io_read.py` | +`_handle_register_error_response` extracted |
| `_coordinator_init.py` | +`apply_coordinator_config` added |
| `coordinator/coordinator.py` | `__init__` simplified |
| `mappings/_mapping_builders.py` | +`_route_holding_register_to_mapping` extracted |
| `scanner/selection.py` | +`_split_groups_around_missing` extracted |
| `tests/test_scanner_io.py` | +4 tests for `_handle_register_error_response` |
| `tests/test_scanner_safe_scan.py` | +6 tests for `_split_groups_around_missing` |
| `docs/maintainability_audit.md` | refreshed |
| `docs/refactor_status.md` | refreshed |


---
_Generated by [Claude Code](https://claude.ai/code/session_01C3R6Pvqap2nUudB52dPEcH)_