### PR TITLE
refactor: finalize scanner and coordinator cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -289,6 +289,38 @@ class _CoordinatorScheduleMixin:
             return response
         return await self._write_holding_single(address, scalar_value, attempt)
 
+    async def _locked_single_register_write(
+        self,
+        *,
+        register_name: str,
+        value: float | str | list[int] | tuple[int, ...],
+        offset: int,
+        refresh: bool,
+    ) -> tuple[bool, bool]:
+        """Execute single-register write within an already-acquired lock.
+
+        Returns (success, refresh_after_write).
+        """
+        definition = self._resolve_write_definition(register_name)
+        if definition is None:
+            return False, False
+
+        await self._ensure_connection()
+        self._assert_write_connection_ready()
+
+        encoded_values, scalar_value = encode_write_value(register_name, definition, value, offset)
+        if encoded_values is None and scalar_value is None:
+            return False, False
+
+        plan = SingleWritePlan(
+            register_name=register_name,
+            address=definition.address + offset,
+            encoded_values=encoded_values,
+            scalar_value=scalar_value,
+            original_value=value,
+        )
+        return await run_single_write_attempts(self, definition, plan, refresh)
+
     async def async_write_register(
         self,
         register_name: str,
@@ -303,36 +335,17 @@ class _CoordinatorScheduleMixin:
         definition's :meth:`encode` method is used to convert it to the raw
         Modbus representation before sending to the device.
         """
-
         refresh_after_write = False
         async with self._write_lock:
             try:
-                definition = self._resolve_write_definition(register_name)
-                if definition is None:
-                    return False
-
-                await self._ensure_connection()
-                self._assert_write_connection_ready()
-
-                encoded_values, scalar_value = encode_write_value(
-                    register_name, definition, value, offset
-                )
-                if encoded_values is None and scalar_value is None:
-                    return False
-
-                plan = SingleWritePlan(
+                success, refresh_after_write = await self._locked_single_register_write(
                     register_name=register_name,
-                    address=definition.address + offset,
-                    encoded_values=encoded_values,
-                    scalar_value=scalar_value,
-                    original_value=value,
-                )
-                success, refresh_after_write = await run_single_write_attempts(
-                    self, definition, plan, refresh
+                    value=value,
+                    offset=offset,
+                    refresh=refresh,
                 )
                 if not success:
                     return False
-
             except (ModbusException, ConnectionException):  # pragma: no cover - safety
                 _LOGGER.exception("Failed to write register %s", register_name)
                 return False

--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -55,15 +55,6 @@ def _handle_error_response(
     mark_failed_addresses(scanner, register_type, start, end)
 
 
-def _validate_register_response(response: Any) -> tuple[bool, int | None]:
-    """Return (is_error, exception_code) for a Modbus response-like object."""
-    if response is None:
-        return False, None
-    if response.isError():
-        return True, getattr(response, "exception_code", None)
-    return False, None
-
-
 def _should_abort_input_exception(exc: Exception) -> bool:
     """Return True when input reads should stop retries immediately."""
     if isinstance(exc, ModbusIOException):
@@ -118,16 +109,6 @@ async def _attempt_bit_reconnect(scanner: Any, client: Any) -> Any:
     ):
         pass
     return client
-
-
-def _extend_or_abort_register_results(
-    results: list[int], block: list[int] | None
-) -> tuple[bool, list[int] | None]:
-    """Append block values and indicate whether read batching should continue."""
-    can_continue = append_read_block(results, block)
-    if not can_continue:
-        return False, None
-    return True, results
 
 
 def _handle_register_error_response(
@@ -194,8 +175,8 @@ def _process_register_response(
     if response is None:
         return False, None
 
-    is_error, code = _validate_register_response(response)
-    if is_error:
+    if response.isError():
+        code = getattr(response, "exception_code", None)
         return _handle_register_error_response(
             scanner,
             register_type=register_type,
@@ -217,11 +198,6 @@ def _process_register_response(
     return True, build_success_result(response)
 
 
-def _handle_terminal_read_failure(scanner: Any, register_type: str, start: int, end: int) -> None:
-    """Mark all addresses in a terminally failed read range."""
-    mark_failed_addresses(scanner, register_type, start, end)
-
-
 def _finalize_register_read_failure(
     scanner: Any,
     *,
@@ -241,7 +217,7 @@ def _finalize_register_read_failure(
         return
 
     log_read_failure(kind, start, end, retry)
-    _handle_terminal_read_failure(scanner, register_type, start, end)
+    mark_failed_addresses(scanner, register_type, start, end)
 
 
 def _should_skip_input_range(
@@ -283,7 +259,7 @@ def _prepare_input_read(scanner: Any, start: int, end: int, skip_cache: bool) ->
     ) not in scanner._input_skip_log_ranges:
         _LOGGER.debug("Skipping cached failed input registers %d-%d", skip_start, skip_end)
         scanner._input_skip_log_ranges.add((skip_start, skip_end))
-    _handle_terminal_read_failure(scanner, "input_registers", skip_start, skip_end)
+    mark_failed_addresses(scanner, "input_registers", skip_start, skip_end)
     return True
 
 
@@ -375,6 +351,78 @@ async def _execute_word_read_attempt(
     )
 
 
+async def _run_word_read_single_attempt(
+    scanner: Any,
+    *,
+    transport: Any,
+    client: Any,
+    method_name: str,
+    address: int,
+    count: int,
+    start: int,
+    end: int,
+    skip_cache: bool,
+    register_type: str,
+    handle_attempt_exception: Any,
+    log_success: bool,
+    attempt: int,
+) -> tuple[bool, bool, bool, list[int] | None]:
+    """Execute one iteration of the word-register read retry loop.
+
+    Returns (done, aborted_transiently, stop_retries, payload).
+    """
+    try:
+        response = await _execute_word_read_attempt(
+            scanner,
+            transport=transport,
+            client=client,
+            method_name=method_name,
+            address=address,
+            count=count,
+            attempt=attempt,
+        )
+        done, payload = _process_register_response(
+            scanner,
+            response=response,
+            register_type=register_type,
+            start=start,
+            end=end,
+            address=address,
+            count=count,
+            skip_cache=skip_cache,
+        )
+        if done:
+            if log_success and payload is not None:
+                _LOGGER.debug(
+                    "Read %s %d-%d: %s",
+                    register_type.replace("_", " "),
+                    start,
+                    end,
+                    payload,
+                )
+            return True, False, False, payload
+        return False, False, False, None
+    except asyncio.CancelledError:
+        raise
+    except (
+        TimeoutError,
+        ModbusIOException,
+        OSError,
+        ModbusException,
+        ConnectionException,
+    ) as exc:
+        aborted, stop = handle_attempt_exception(
+            scanner,
+            exc,
+            start=start,
+            end=end,
+            address=address,
+            count=count,
+            attempt=attempt,
+        )
+        return False, aborted, stop, None
+
+
 async def _run_word_read_retry_loop(
     scanner: Any,
     *,
@@ -395,57 +443,26 @@ async def _run_word_read_retry_loop(
     aborted_transiently = False
     for attempt in range(1, scanner.retry + 1):
         attempted_reads = attempt
-        try:
-            response = await _execute_word_read_attempt(
-                scanner,
-                transport=transport,
-                client=client,
-                method_name=method_name,
-                address=address,
-                count=count,
-                attempt=attempt,
-            )
-            done, payload = _process_register_response(
-                scanner,
-                response=response,
-                register_type=register_type,
-                start=start,
-                end=end,
-                address=address,
-                count=count,
-                skip_cache=skip_cache,
-            )
-            if done:
-                if log_success and payload is not None:
-                    _LOGGER.debug(
-                        "Read %s %d-%d: %s",
-                        register_type.replace("_", " "),
-                        start,
-                        end,
-                        payload,
-                    )
-                return payload
-        except asyncio.CancelledError:
-            raise
-        except (
-            TimeoutError,
-            ModbusIOException,
-            OSError,
-            ModbusException,
-            ConnectionException,
-        ) as exc:
-            aborted, stop = handle_attempt_exception(
-                scanner,
-                exc,
-                start=start,
-                end=end,
-                address=address,
-                count=count,
-                attempt=attempt,
-            )
-            aborted_transiently = aborted_transiently or aborted
-            if stop:
-                break
+        done, aborted, stop, payload = await _run_word_read_single_attempt(
+            scanner,
+            transport=transport,
+            client=client,
+            method_name=method_name,
+            address=address,
+            count=count,
+            start=start,
+            end=end,
+            skip_cache=skip_cache,
+            register_type=register_type,
+            handle_attempt_exception=handle_attempt_exception,
+            log_success=log_success,
+            attempt=attempt,
+        )
+        if done:
+            return payload
+        aborted_transiently = aborted_transiently or aborted
+        if stop:
+            break
         await _sleep_retry_backoff(
             backoff=scanner.backoff,
             backoff_jitter=scanner.backoff_jitter,
@@ -551,8 +568,7 @@ async def read_register_block(
             if active_client is None
             else read_fn(active_client, chunk_start, chunk_count)
         )
-        can_continue, _ = _extend_or_abort_register_results(results, block)
-        if not can_continue:
+        if not append_read_block(results, block):
             return None
     return results
 
@@ -563,7 +579,7 @@ def _prepare_holding_read(
     """Return True when holding read should short-circuit as failed/unsupported."""
     should_skip, skip_start, skip_end = _should_skip_holding_range(scanner, start, end, skip_cache)
     if should_skip:
-        _handle_terminal_read_failure(scanner, "holding_registers", skip_start, skip_end)
+        mark_failed_addresses(scanner, "holding_registers", skip_start, skip_end)
         return True
 
     failures = scanner._holding_failures.get(address, 0)

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -1,6 +1,6 @@
 # Maintainability audit
 
-Date: 2026-05-08 (final cleanup release PR — phases A–G).
+Date: 2026-05-08 (final cleanup release PR — phases A, B, E + docs).
 
 ## Commands covered by latest successful validation
 
@@ -42,73 +42,77 @@ OK homeassistant: installed
 
 - Python 3.13.12 interpreter used.
 - All gates passed at baseline.
-- Baseline pytest: 1938 passed, 4 skipped.
+- Baseline pytest: **1948 passed, 4 skipped**.
 - Result: **kept**.
 
 ### PHASE B — scanner/io_read.py final focused cleanup
 
 Files touched: `scanner/io_read.py`, `tests/test_scanner_io.py`.
 
-Extraction: `_handle_register_error_response` pulled out of `_process_register_response`.
-- `_process_register_response` reduced: 60 → 41 lines.
-- New `_handle_register_error_response`: 42 lines (pure, testable error-branch classifier).
-- 4 new focused tests added in `test_scanner_io.py`.
-- HA-independence invariant preserved.
-- Targeted tests: 89 passed.
-- Full gates after phase: **1942 passed, 4 skipped**.
-- Result: **kept**.
-
-### PHASE C — coordinator/coordinator.py final focused cleanup
-
-Files touched: `_coordinator_init.py`, `coordinator/coordinator.py`.
-
-Extraction: `apply_coordinator_config` added to `_coordinator_init.py`.
-- `ThesslaGreenModbusCoordinator.__init__` reduced: 61 → 47 lines.
-- New `apply_coordinator_config`: 31 lines (assigns normalized config attrs to fresh instance).
-- Coordinator package API invariant preserved: `__all__ == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]`.
-- Top-level `coordinator.py` remains absent.
-- Targeted tests: 307 passed.
-- Full gates after phase: **1942 passed, 4 skipped**.
-- Result: **kept**.
-
-### PHASE D — mappings/_mapping_builders.py final focused cleanup
-
-Files touched: `mappings/_mapping_builders.py`.
-
-Extraction: `_route_holding_register_to_mapping` pulled from the per-register dispatch loop in `_extend_entity_mappings_from_registers`.
-- `_extend_entity_mappings_from_registers` reduced: 83 → 59 lines.
-- New `_route_holding_register_to_mapping`: 49 lines (routes one holding register to its bucket).
-- Entity count stable: 366 entities validated.
-- Targeted tests: 284 passed, 3 skipped.
-- Full gates after phase: **1942 passed, 4 skipped**.
-- Result: **kept**.
-
-### PHASE E — scanner/core.py final focused cleanup
-
-Files touched: `scanner/selection.py`, `tests/test_scanner_safe_scan.py`.
-
-Extraction: `_split_groups_around_missing` pulled from `group_registers_for_batch_read` in `scanner/selection.py`.
-- `group_registers_for_batch_read` reduced: 37 → 26 lines.
-- New `_split_groups_around_missing`: 17 lines (pure function, no scanner dependency).
-- 6 new focused unit tests added in `test_scanner_safe_scan.py`.
+Extractions and inlines:
+1. Extracted `_run_word_read_single_attempt` from `_run_word_read_retry_loop`.
+   - `_run_word_read_retry_loop`: 87 → 56 lines (36% reduction).
+   - New `_run_word_read_single_attempt`: 70 lines (try/except attempt body).
+2. Inlined 3 thin wrapper functions to maintain file within 820-line limit:
+   - `_validate_register_response` (7 lines) → inlined into `_process_register_response`.
+   - `_handle_terminal_read_failure` (3 lines) → inlined at 3 call sites (now direct `mark_failed_addresses`).
+   - `_extend_or_abort_register_results` (8 lines) → inlined into `read_register_block` (now direct `append_read_block`).
+3. Test updated: `test_extend_or_abort_register_results_handles_none_and_appends` renamed to
+   `test_append_read_block_handles_none_and_appends` and updated to use `append_read_block` directly.
+- `io_read.py` file: 797 → 813 lines (within 820-line strict limit).
 - HA-independence invariant preserved.
 - Targeted tests: 198 passed.
 - Full gates after phase: **1948 passed, 4 skipped**.
 - Result: **kept**.
 
-### PHASE F — release-readiness validation/audit
+### PHASE C — scanner/core.py final split
 
-- manifest.json: domain `thessla_green_modbus`, version `2.8.0`, homeassistant `2026.1.0`, integration_type `hub`.
-- pyproject.toml: version `2.8.0`, requires-python `>=3.13`.
+- Assessment: `scanner/core.py` is 478/760 line limit; `__init__` (68 lines) and `create` (52 lines)
+  are both within the 210-line function limit.
+- Both functions are already fully delegated minimal wrappers; apparent length is dominated by
+  necessary parameter lists, not extractable logic.
+- Result: **SKIPPED** — no meaningful extraction exists within safe bounds.
+
+### PHASE D — coordinator/coordinator.py final split
+
+- Assessment: `coordinator/coordinator.py` is 675/1200 line limit; `from_params` (54 lines) and
+  `__init__` (47 lines) are both well under the 220-line function limit.
+- Both functions are already fully delegated minimal wrappers; same pattern as scanner/core.py.
+- Result: **SKIPPED** — no meaningful extraction exists within safe bounds.
+
+### PHASE E — coordinator/schedule.py final split
+
+Files touched: `coordinator/schedule.py`.
+
+Extraction: `_locked_single_register_write` pulled from `async_write_register`.
+- `async_write_register`: 49 → 30 lines (39% reduction).
+- New `_locked_single_register_write`: 31 lines (prepare definition, encode, build plan, run attempts).
+- `schedule.py` file: 420 → 433 lines (well within 1300-line default limit).
+- Coordinator package API invariant preserved: `__all__ == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]`.
+- Top-level `coordinator.py` remains absent.
+- Targeted tests: 303 passed.
+- Full gates after phase: **1948 passed, 4 skipped**.
+- Result: **kept**.
+
+### PHASE F — config_flow.py final cleanup
+
+- Assessment: `config_flow.py` is 467/1000 line limit; max function `validate_input` at 36 lines
+  (limit 220). All functions within all maintainability limits.
+- Result: **SKIPPED** — optional phase; all functions within limits; diff manageable without it.
+
+### PHASE G — release-readiness audit
+
+- manifest.json: domain `thessla_green_modbus`, version `2.8.0`, homeassistant `2026.1.0`,
+  integration_type `hub`. Status: **present and consistent**.
+- pyproject.toml: version `2.8.0`, requires-python `>=3.13`. Status: **consistent with manifest**.
 - hacs.json: present — name "ThesslaGreen Modbus", content_in_root: false, render_readme: true.
-- **hassfest**: not available as installable CLI in this environment — **not proven locally**.
-- **HACS CLI**: not available as installable CLI in this environment — **not proven locally**.
-- CI (`ci.yaml`) installs `hacs` pip package during test runs; HACS/hassfest gates run via GitHub Actions.
+- **hassfest**: not available as installable CLI — **not proven locally**. CI runs it via GitHub Actions.
+- **HACS CLI**: not available as installable CLI — **not proven locally**. CI runs it via GitHub Actions.
 - Real-device validation: **not proven**.
 - Release notes/tag/changelog: **not finalized**.
-- Result: documented; no CI change made (hassfest/hacs not locally available).
+- Result: documented; no CI change made.
 
-### PHASE G — docs/status refresh
+### PHASE H — docs/status refresh
 
 - `docs/maintainability_audit.md`: refreshed with current state (this file).
 - `docs/refactor_status.md`: refreshed.
@@ -122,32 +126,28 @@ Extraction: `_split_groups_around_missing` pulled from `group_registers_for_batc
 - Coordinator package API invariant: `__all__ == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]`.
 - Entity mapping invariant: **366 entities**.
 
-## Before / after metrics
+## Before / after metrics (this PR)
 
-| File | Before this PR | After this PR |
-|---|---:|---:|
-| `scanner/io_read.py` (non-empty lines) | 690 | **713** (+23 from new helper) |
-| `scanner/io_read.py::_process_register_response` | 60 lines | **41 lines** |
-| `coordinator/coordinator.py` (non-empty lines) | 606 | **596** |
-| `coordinator/coordinator.py::__init__` | 61 lines | **47 lines** |
-| `mappings/_mapping_builders.py` (non-empty lines) | 441 | **466** (+25 from new helper) |
-| `mappings/_mapping_builders.py::_extend_entity_mappings_from_registers` | 83 lines | **59 lines** |
-| `scanner/selection.py::group_registers_for_batch_read` | 37 lines | **26 lines** |
-| `_coordinator_init.py` | 63 non-empty lines | **86 non-empty lines** (+23 from helper) |
+| File | Before (lines) | After (lines) | Notes |
+|---|---:|---:|---|
+| `scanner/io_read.py` (total) | 797 | **813** | +16 net |
+| `scanner/io_read.py::_run_word_read_retry_loop` | 87 lines | **56 lines** | 36% reduction |
+| `coordinator/schedule.py` (total) | 420 | **433** | +13 net |
+| `coordinator/schedule.py::async_write_register` | 49 lines | **30 lines** | 39% reduction |
 
 ## Remaining hotspots
 
-1. `scanner/io_read.py` — `_run_word_read_retry_loop` (87 lines) and `read_bit_registers` (64 lines) remain.
-2. `scanner/core.py` — `__init__` (68 lines) and `create` (52 lines) are parameter-list-heavy wrappers.
-3. `coordinator/coordinator.py` — `from_params` (54 lines) is a long-signature pass-through.
-4. `coordinator/schedule.py` — `async_write_register` (49 lines) and `_handle_write_attempt_exception` (45 lines).
-5. Config-flow branching (`config_flow.py`) — not touched in this cycle.
+1. `scanner/io_read.py` — `_run_word_read_single_attempt` (70 lines, new), `read_bit_registers` (64 lines).
+2. `scanner/core.py` — `__init__` (68 lines), `create` (52 lines) — long parameter lists, already minimal.
+3. `coordinator/coordinator.py` — `from_params` (54 lines) — long parameter list pass-through.
+4. `coordinator/schedule.py` — `_handle_write_attempt_exception` (45 lines).
+5. Config-flow branching: `config_flow.py` — all within limits.
 
 ## Release-readiness status
 
 | Item | Status |
 |---|---|
-| manifest.json | present, version 2.8.0 |
+| manifest.json | present, version 2.8.0, consistent |
 | hacs.json | present |
 | HACS validation | **not proven** (CLI unavailable locally; CI runs it) |
 | hassfest validation | **not proven** (CLI unavailable locally; CI runs it) |

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -1,6 +1,6 @@
 # Refactor status (current)
 
-Last reviewed: 2026-05-08 (final cleanup release PR — phases A–G, Python 3.13.12).
+Last reviewed: 2026-05-08 (final cleanup release PR — phases A, B, E + docs, Python 3.13.12).
 
 Related document: `docs/maintainability_audit.md`
 
@@ -34,27 +34,31 @@ The following constraints remain active and must be preserved:
 - HA imports in `core/transport/registers/scanner`: **none detected**.
 - Entity mapping invariant: **366 entities**.
 
-## Latest merged refactor snapshot
+## Latest PR snapshot
 
-Latest PR (this document): **final cleanup release — phases B–E + docs**.
+Latest PR (this document): **final cleanup release — phases B, E + docs**.
 
 Changes in this PR:
 
-- **Phase B** (`scanner/io_read.py`): extracted `_handle_register_error_response` from `_process_register_response`; 4 new tests.
-- **Phase C** (`coordinator/coordinator.py` + `_coordinator_init.py`): extracted `apply_coordinator_config`; `__init__` reduced 61→47 lines.
-- **Phase D** (`mappings/_mapping_builders.py`): extracted `_route_holding_register_to_mapping` from `_extend_entity_mappings_from_registers`; latter reduced 83→59 lines.
-- **Phase E** (`scanner/selection.py`): extracted `_split_groups_around_missing` from `group_registers_for_batch_read`; 6 new tests.
+- **Phase B** (`scanner/io_read.py`): extracted `_run_word_read_single_attempt` from
+  `_run_word_read_retry_loop` (87→56 lines); inlined 3 thin wrappers
+  (`_validate_register_response`, `_handle_terminal_read_failure`,
+  `_extend_or_abort_register_results`); updated `test_scanner_io.py`.
+- **Phase C** (scanner/core.py): SKIPPED — all functions within maintainability limits.
+- **Phase D** (coordinator/coordinator.py): SKIPPED — all functions within maintainability limits.
+- **Phase E** (`coordinator/schedule.py`): extracted `_locked_single_register_write` from
+  `async_write_register` (49→30 lines).
+- **Phase F** (config_flow.py): SKIPPED — all functions within maintainability limits.
 
 Current file-size snapshot:
 
-| Area | Size (non-empty lines) |
-|---|---:|
-| `coordinator/coordinator.py` | 596 |
-| `coordinator/schedule.py` | 367 |
-| `scanner/io_read.py` | 713 |
-| `scanner/selection.py` | 119 |
-| `mappings/_mapping_builders.py` | 466 |
-| `scanner/core.py` | 433 |
+| Area | Total lines | Non-empty lines |
+|---|---:|---:|
+| `coordinator/coordinator.py` | 675 | 596 |
+| `coordinator/schedule.py` | 433 | 380 |
+| `scanner/io_read.py` | 813 | 732 |
+| `scanner/core.py` | 478 | 433 |
+| `config_flow.py` | 467 | 387 |
 
 ## Required gate status snapshot
 
@@ -70,17 +74,11 @@ Last complete successful validation (Python 3.13.12):
 
 ## Remaining hotspots
 
-1. `scanner/io_read.py` — `_run_word_read_retry_loop` (87 lines), `read_bit_registers` (64 lines).
+1. `scanner/io_read.py` — `_run_word_read_single_attempt` (70 lines, new), `read_bit_registers` (64 lines).
 2. `scanner/core.py` — `__init__` (68 lines), `create` (52 lines) — mostly long parameter lists.
 3. `coordinator/coordinator.py` — `from_params` (54 lines) — long parameter list pass-through.
-4. `coordinator/schedule.py` — `async_write_register` (49 lines), `_handle_write_attempt_exception` (45 lines).
-5. Config-flow branching: `config_flow.py`.
-
-## Recommended next work
-
-1. Consider extracting `_handle_bit_attempt_exception` from `read_bit_registers` in `scanner/io_read.py`.
-2. `coordinator/schedule.py` write-path complexity still has extraction candidates.
-3. Keep each PR narrow: one production extraction plus focused tests and refreshed docs.
+4. `coordinator/schedule.py` — `_handle_write_attempt_exception` (45 lines).
+5. Config-flow branching: `config_flow.py` — all within limits.
 
 ## Non-required tool status
 

--- a/tests/test_scanner_io.py
+++ b/tests/test_scanner_io.py
@@ -12,12 +12,12 @@ from custom_components.thessla_green_modbus.modbus_exceptions import (
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 from custom_components.thessla_green_modbus.scanner.io_read import (
     _attempt_bit_reconnect,
-    _extend_or_abort_register_results,
     _finalize_register_read_failure,
     _handle_input_attempt_exception,
     _handle_register_error_response,
 )
 from custom_components.thessla_green_modbus.scanner.io_read_helpers import (
+    append_read_block,
     build_read_attempt_meta,
     build_register_chunks,
     classify_skip_range,
@@ -298,16 +298,14 @@ def test_build_register_chunks_exact_multiple():
     assert build_register_chunks(5, 6, 3) == [(5, 3), (8, 3)]
 
 
-def test_extend_or_abort_register_results_handles_none_and_appends():
-    """Result helper should abort on None and append successful blocks."""
+def test_append_read_block_handles_none_and_appends():
+    """append_read_block should return False on None block and append successful blocks."""
     results = [1]
-    can_continue, payload = _extend_or_abort_register_results(results, None)
-    assert (can_continue, payload) == (False, None)
+    assert append_read_block(results, None) is False
     assert results == [1]
 
-    can_continue, payload = _extend_or_abort_register_results(results, [2, 3])
-    assert can_continue is True
-    assert payload == [1, 2, 3]
+    assert append_read_block(results, [2, 3]) is True
+    assert results == [1, 2, 3]
 
 
 def test_build_read_attempt_meta_sets_expected_range():


### PR DESCRIPTION
## Summary

Base branch: dev

This is a controlled final cleanup PR targeting the remaining hotspots identified in the maintainability audit. All phases were validated gate-by-gate with full pytest after each change.

**Phase B — scanner/io_read.py** (`_run_word_read_retry_loop` hotspot):
- Extracted `_run_word_read_single_attempt` from `_run_word_read_retry_loop` (87 → 56 lines, 36% reduction); the new helper encapsulates the per-attempt try/except body with a clean `(done, aborted, stop, payload)` return tuple.
- Inlined 3 thin wrapper functions (`_validate_register_response`, `_handle_terminal_read_failure`, `_extend_or_abort_register_results`) to maintain `io_read.py` within its 820-line strict limit; all were trivial one-call wrappers with no independent abstraction value.
- Updated `tests/test_scanner_io.py`: replaced import of removed `_extend_or_abort_register_results` with `append_read_block` from helpers; test logic preserved.

**Phase C, D skipped** — `scanner/core.py` (478/760 lines, 68-line max function) and `coordinator/coordinator.py` (675/1200 lines, 54-line max function) are both fully within all maintainability limits. Functions' apparent length is dominated by necessary parameter lists, not extractable logic.

**Phase E — coordinator/schedule.py** (`async_write_register` hotspot):
- Extracted `_locked_single_register_write` from `async_write_register` (49 → 30 lines, 39% reduction); new helper contains the prepare-encode-plan-execute body without the lock wrapper.

**Phase F skipped** — `config_flow.py` (467/1000 lines, 36-line max function) is fully within all limits.

**Phase H — docs refresh**: `docs/maintainability_audit.md` and `docs/refactor_status.md` updated with accurate before/after metrics, skipped phases with exact reasons, and current release-readiness status.

## Validation results

- Python 3.13.12
- `ruff check`: pass
- `ruff check --select I`: pass
- `ruff format --check`: 0 files drift (419 already formatted)
- `compileall`: pass
- `compare_registers`: pass
- `check_maintainability`: Maintainability gate passed
- `validate_entity_mappings`: OK: 366 entities validated
- `pytest`: **1948 passed, 4 skipped**

## Invariants preserved

- Coordinator package API: `__all__ == ["CoordinatorConfig", "ThesslaGreenModbusCoordinator"]`
- No top-level `coordinator.py` created
- Scanner HA independence: no homeassistant imports in scanner package
- Entity count stable: 366 entities
- pydantic version unchanged (2.12.2)
- PR #1567 not touched

## Files changed

- `custom_components/thessla_green_modbus/scanner/io_read.py`
- `custom_components/thessla_green_modbus/coordinator/schedule.py`
- `tests/test_scanner_io.py`
- `docs/maintainability_audit.md`
- `docs/refactor_status.md`

https://claude.ai/code/session_01XGKHR8wqByYUi9YPq6meey

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGKHR8wqByYUi9YPq6meey)_