### PR TITLE
chore: finalize release readiness checks (Base branch: dev)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["main", "master", "dev"]
   pull_request:
   workflow_dispatch:
 
@@ -159,3 +159,25 @@ jobs:
 
       - name: Ruff format drift (informational)
         run: ruff format --check custom_components tests tools
+
+  hassfest:
+    name: Hassfest validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@main
+
+  hacs:
+    name: HACS validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_coordinator_coverage.py`: replaced `is not None` assertions with type checks.
 - `test_optimized_integration.py`: replaced `CoordinatorMock` with `MagicMock`.
 
+### CI / Release Readiness
+- Added `hassfest` CI job (`home-assistant/actions/hassfest@main`) — validates
+  `manifest.json` and integration structure on every PR and push.
+- Added `hacs` CI job (`hacs/action@main`, `category: integration`) — validates
+  `hacs.json` and HACS repository requirements on every PR and push.
+- Added `dev` to push trigger branches so CI runs on pushes to the development branch.
+- Added `docs/real_device_validation.md` — structured checklist and evidence template
+  for real-device validation against ThesslaGreen AirPack hardware (template only;
+  not yet filled with real evidence).
+- Validation suite: 1948 passed, 4 skipped — 0 failures on Python 3.13.12,
+  HA 2026.2.3, pydantic 2.12.2.
+- Entity mapping validation: 366 entities confirmed.
+- `pydantic` remains pinned at `2.12.2` — PR #1567 (Dependabot pydantic update)
+  is separate and untouched.
+
+### Release caveats (pre-tag)
+- No GitHub release tag created in this PR — tag `v2.8.0` and release notes must
+  be created separately via GitHub UI or CLI before HACS will distribute this version.
+- Real-device validation is documented as a checklist template; evidence from
+  testing against physical ThesslaGreen AirPack hardware has not yet been collected.
+
 ---
 
 ## 2.7.0 — Dead fallback & pragma cleanup

--- a/docs/real_device_validation.md
+++ b/docs/real_device_validation.md
@@ -1,0 +1,163 @@
+# Real-Device Validation Checklist
+
+> **Status: TEMPLATE ONLY — not yet filled with real evidence.**
+>
+> Do not mark real-device validation complete until this document contains
+> a fully completed Evidence section signed by a tester with a real device.
+
+---
+
+## 1. Purpose
+
+This document defines the minimum real-device validation required before a
+ThesslaGreen Modbus Integration release is considered production-ready. It must
+be completed by a human tester with access to a physical ThesslaGreen AirPack
+(or compatible controller) and a running Home Assistant instance.
+
+Automated tests (`pytest`) cover logic and mocked Modbus I/O. They cannot
+substitute for on-device verification of the full communication path, entity
+lifecycle, and UI behaviour.
+
+---
+
+## 2. Required Environment
+
+| Item | Requirement |
+|------|-------------|
+| Home Assistant | ≥ 2026.1.0 (from `manifest.json → homeassistant`) |
+| Integration version | 2.8.0 (tag `v2.8.0` or HACS custom-repository install) |
+| Controller | ThesslaGreen AirPack 4 or compatible unit with Modbus TCP enabled |
+| Modbus TCP | Controller reachable on the local network; IP and port known |
+| Python on HA host | ≥ 3.13 (required by `pyproject.toml → requires-python`) |
+| Network | Home Assistant host and AirPack on same subnet (or routed) |
+
+---
+
+## 3. Pre-Test Checklist
+
+- [ ] Home Assistant is at target version and running.
+- [ ] Integration is **not** yet installed (clean install path).
+- [ ] Controller is powered on and Modbus TCP is accessible (test with
+      `nc -z <controller-ip> <port>` from HA host).
+- [ ] HA logs are clear (no unrelated errors from other integrations).
+- [ ] A way to capture HA logs during the test is available
+      (HA Settings → System → Logs, or `journalctl -u homeassistant`).
+
+---
+
+## 4. Test Cases
+
+### 4.1 Installation
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 1.1 | Install integration via HACS (custom repository or HACS store once listed) | Integration appears in HACS, download completes without errors | | |
+| 1.2 | Restart Home Assistant after installation | HA restarts cleanly; no import errors for `thessla_green_modbus` in logs | | |
+
+### 4.2 Configuration Flow (UI)
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 2.1 | Add integration via HA Settings → Devices & Services → Add integration → ThesslaGreen Modbus | Config flow opens with host/port fields | | |
+| 2.2 | Enter controller IP and port; submit | Integration is added without error | | |
+| 2.3 | Verify no error dialog appears during setup | No `ModbusException` or `ConnectionException` shown | | |
+
+### 4.3 TCP Connection
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 3.1 | Check HA logs immediately after setup | Log line confirming connection established; no repeated connection errors | | |
+| 3.2 | Observe for 60 seconds | No repeated `ConnectionException` or timeout errors in logs | | |
+
+### 4.4 Entity Creation
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 4.1 | Navigate to the integration device page | Entities visible in device list | | |
+| 4.2 | Count entities (approximate) | ~366 entities created (matches `validate_entity_mappings.py` output) | | |
+| 4.3 | Verify entity domains present | `sensor`, `binary_sensor`, `number`, `select`, `switch`, `fan`, `climate` domains all present | | |
+
+### 4.5 Sensor / State Updates
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 5.1 | Wait one polling cycle (default 30 s) | Sensor states update from `unknown`/`unavailable` to real values | | |
+| 5.2 | Verify supply air temperature sensor shows a plausible value | Temperature in expected range (e.g., 10–40 °C) | | |
+| 5.3 | Verify fan speed sensor shows a plausible value | Fan speed in 0–100% range | | |
+
+### 4.6 Fan / Climate Controls
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 6.1 | Change fan speed via HA UI (e.g., `number.fan_speed_supply`) | New value accepted; entity reflects new state within one poll cycle | | |
+| 6.2 | Change climate setpoint via HA UI if climate entity present | New setpoint written; controller reflects change | | |
+
+### 4.7 Register Write Paths
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 7.1 | Write to a single-register entity (e.g., fan speed number) | Register write succeeds; no `ModbusWriteException` in logs | | |
+| 7.2 | Write to a multi-register entity if applicable | Write path completes; all target registers updated | | |
+
+### 4.8 Reconnect After Disruption
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 8.1 | Disconnect controller from network for 30 s, then reconnect | Integration detects disconnection (entities unavailable) and reconnects automatically without HA restart | | |
+| 8.2 | Restart controller (power cycle) while HA is running | Integration detects disconnection and reconnects automatically once controller is back | | |
+
+### 4.9 Unload / Reload
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 9.1 | Disable integration via HA Settings → Devices & Services | Integration unloads; entities become unavailable; no errors in logs | | |
+| 9.2 | Re-enable integration | Integration reloads; entities recover their states within one poll cycle | | |
+
+### 4.10 Home Assistant Restart Recovery
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 10.1 | Restart Home Assistant | Integration re-initialises cleanly; no `ImportError` or `ConfigEntryNotReady` loop | | |
+| 10.2 | Check logs after restart | No repeated error messages; connection established within ~30 s | | |
+
+### 4.11 Log Review
+
+| # | Step | Expected | Pass/Fail | Notes |
+|---|------|----------|-----------|-------|
+| 11.1 | Review full HA log after all above tests | No unhandled exceptions from `thessla_green_modbus`; no `ERROR` level messages during steady-state | | |
+| 11.2 | No memory growth / resource leak visible after extended operation (optional) | Memory stable over 1-hour run | | |
+
+---
+
+## 5. Evidence Record
+
+Fill this section after completing the tests above. **Do not claim validation
+complete unless all mandatory test cases (4.1–4.11) are marked Pass.**
+
+| Field | Value |
+|-------|-------|
+| **Date** | _YYYY-MM-DD_ |
+| **Tester** | _Name / GitHub handle_ |
+| **Home Assistant version** | _e.g., 2026.2.3_ |
+| **Integration version** | _e.g., 2.8.0_ |
+| **Controller model** | _e.g., ThesslaGreen AirPack 4_ |
+| **Controller firmware** | _e.g., 3.14_ |
+| **Modbus TCP port** | _e.g., 502_ |
+| **Python version on HA host** | _e.g., 3.13.2_ |
+| **Overall result** | _PASS / FAIL / PARTIAL_ |
+| **Failed test cases** | _List IDs or "none"_ |
+| **Notable log excerpts** | _Paste key log lines or "none"_ |
+| **Additional notes** | |
+
+---
+
+## 6. Release Gate
+
+Real-device validation is **not** complete until:
+
+1. All test cases 4.1 through 4.11 are marked **Pass** in the Evidence Record above.
+2. The Evidence Record is signed by a named tester.
+3. This document is committed to the repository with the completed evidence.
+
+Until that point, this document is a **template only** and real-device
+validation remains an open release blocker (B4).

--- a/docs/release_readiness.md
+++ b/docs/release_readiness.md
@@ -1,7 +1,7 @@
 # Release Readiness Audit
 
 Date: 2026-05-09
-Branch: `claude/release-readiness-audit-5xXvn` → PR base: `dev`
+Branch: `claude/finalize-release-readiness-ozgQt` → PR base: `dev`
 
 ---
 
@@ -17,13 +17,13 @@ Branch: `claude/release-readiness-audit-5xXvn` → PR base: `dev`
 
 ## 2. Python Interpreter
 
-Python 3.13.12 (via `python3.13`; venv at `/tmp/thessla_venv`).
+Python 3.13.12 (via `python3.13`; venv at `/tmp/venv_thessla`).
 
 ---
 
 ## 3. Full Gate Results
 
-All gates run locally with Python 3.13.12.
+All gates run locally with Python 3.13.12 / venv.
 
 ### Import gate
 
@@ -78,92 +78,133 @@ OK homeassistant: installed
 
 ---
 
-## 5. HACS Validation
+## 5. Hassfest Validation
 
-**Not proven locally — tooling unavailable.**
+**CI gate added — pending first CI run.**
 
-- `hacs` CLI: not found (`hacs --help` → command not found).
-- `hacs` pip package: not installed in dev environment.
-- CI workflow (`ci.yaml`): installs `hacs` as a pip package for test infrastructure only. **No `hacs/action@main` or equivalent HACS validation workflow step exists.**
-- `hacs.json` is structurally valid and all known required fields (`name`, `content_in_root`, `render_readme`) are present.
+- `hassfest` CLI: not available locally.
+- CI workflow (`ci.yaml`): **`hassfest` job added** using `home-assistant/actions/hassfest@main`.
+  - This job runs on every PR and on pushes to `main`, `master`, and `dev`.
+  - It validates `manifest.json` structure and integration requirements via the
+    official Home Assistant hassfest tooling.
+- Result of first CI run: **pending** (job will run when this PR is pushed to GitHub).
+- `manifest.json` was manually reviewed against known hassfest schema requirements;
+  all structurally required and recommended fields are present (domain, name, version,
+  codeowners, config_flow, homeassistant, iot_class, requirements, documentation,
+  issue_tracker, integration_type, quality_scale, after_dependencies, loggers,
+  dhcp, zeroconf, files).
 
 ---
 
-## 6. Hassfest Validation
+## 6. HACS Validation
 
-**Not proven locally — tooling unavailable.**
+**CI gate added — pending first CI run.**
 
-- `hassfest` CLI: not found (`hassfest --help` → command not found).
-- `hassfest` pip package: not installed in dev environment.
-- CI workflow (`ci.yaml`): **no `home-assistant/hassfest` GitHub Actions step exists.**
-- `manifest.json` was manually reviewed against known hassfest schema requirements; all structurally required and recommended fields are present (domain, name, version, codeowners, config_flow, homeassistant, iot_class, requirements, documentation, issue_tracker, integration_type, quality_scale, after_dependencies, loggers, dhcp, zeroconf, files).
+- `hacs` CLI: not available locally.
+- CI workflow (`ci.yaml`): **`hacs` job added** using `hacs/action@main`
+  with `category: integration`.
+  - This job runs on every PR and on pushes to `main`, `master`, and `dev`.
+  - It validates `hacs.json` fields and HACS repository requirements.
+- Result of first CI run: **pending** (job will run when this PR is pushed to GitHub).
+- `hacs.json` is structurally valid with all required fields (`name`, `content_in_root`,
+  `render_readme`). `content_in_root: false` is correct because the integration lives
+  under `custom_components/thessla_green_modbus/`.
 
 ---
 
 ## 7. Real-Device Validation
 
-**Not proven.**
+**Not proven — checklist template created.**
 
-No evidence of on-device testing against a physical ThesslaGreen AirPack device was found in `docs/`, `README.md`, `README_en.md`, `CHANGELOG.md`, or any test file.
+No evidence of on-device testing against a physical ThesslaGreen AirPack device
+exists. A structured checklist and evidence template has been created:
 
-### Manual real-device validation checklist
+→ **[docs/real_device_validation.md](real_device_validation.md)**
 
-1. Install integration from HACS custom repository on Home Assistant ≥ 2026.1.0.
-2. Add integration via UI config flow; provide controller IP and port.
-3. Verify TCP connection to ThesslaGreen controller is established (no repeated exceptions in logs).
-4. Verify entity creation count matches expected (~366 mapped entities for AirPack).
-5. Verify fan, climate, and sensor entities update on state changes.
-6. Verify single register write path (e.g., fan speed change).
-7. Verify multi-register write path if applicable.
-8. Verify automatic reconnect after controller restart or network loss.
-9. Verify logs contain no repeated exceptions during steady-state polling.
-10. Verify unload and reload of the integration.
-11. Verify Home Assistant restart recovery (integration re-initialises cleanly).
+The checklist covers:
+- Installation via HACS
+- UI config flow
+- TCP connection verification
+- Entity creation (~366 entities)
+- Sensor state updates
+- Fan/climate control writes
+- Single and multi-register write paths
+- Reconnect after controller/network disruption
+- Unload/reload
+- HA restart recovery
+- Full log review
+
+Real-device validation remains **open blocker B4** until the Evidence Record
+in that document is completed by a human tester with physical hardware.
 
 ---
 
-## 8. Release Blockers
+## 8. Release Notes / Tag Status
 
-| # | Blocker | Detail |
+- **CHANGELOG.md**: 2.8.0 entry exists and has been updated with a
+  "CI / Release Readiness" section covering: hassfest gate, HACS gate, `dev`
+  push trigger, `docs/real_device_validation.md`, validation suite results,
+  pydantic pin confirmation, and release caveats.
+- **GitHub release tag**: `v2.8.0` tag and GitHub release **not yet created**.
+  This must be done separately via GitHub UI or CLI after HACS/hassfest CI jobs
+  pass and real-device validation is complete.
+- HACS will not distribute version 2.8.0 until a GitHub release with a matching
+  tag exists.
+
+---
+
+## 9. Remaining Blockers
+
+| # | Blocker | Status |
 |---|---------|--------|
-| **B1** | No hassfest validation in CI | No `home-assistant/hassfest` action step in `.github/workflows/ci.yaml`. Required to confirm manifest machine-validity before HACS listing. |
-| **B2** | No HACS validation action in CI | No `hacs/action@main` workflow step. CI installs `hacs` as pip test infra only, which is not equivalent to HACS manifest validation. |
-| **B3** | No GitHub release tag for `2.8.0` | No git tag `2.8.0` or `v2.8.0`. HACS requires a GitHub release with matching tag to distribute. |
-| **B4** | Real-device validation undocumented | No evidence of testing against a physical ThesslaGreen device. Required for credible release notes and `quality_scale: silver` maintenance. |
+| **B1** | Hassfest validation in CI | ✅ **ADDRESSED** — `hassfest` job added to CI; pending first CI run result. |
+| **B2** | HACS validation in CI | ✅ **ADDRESSED** — `hacs` job added to CI; pending first CI run result. |
+| **B3** | No GitHub release tag for `2.8.0` | ⛔ **OPEN** — Tag `v2.8.0` and GitHub release not yet created. Must be done separately after CI is green and real-device validation is complete. Do not create in this PR. |
+| **B4** | Real-device validation undocumented/unproven | ⚠️ **PARTIALLY ADDRESSED** — Checklist template created at `docs/real_device_validation.md`. Evidence from a real device is still required to close this blocker. |
 
 ---
 
-## 9. Non-Blocking Follow-Ups
+## 10. Non-Blocking Follow-Ups
 
 | # | Item |
 |---|------|
-| N1 | **Dependabot PR #1567** (pydantic update) remains separate and untouched by this audit. |
-| N2 | CHANGELOG heading for 2.8.0 uses `## 2.8.0 —` format; older entries use `## [X.Y.Z] - date` anchored format. Cosmetic inconsistency — may affect automated changelog tooling. |
-| N3 | CI `push` trigger only covers `main`/`master`; does not trigger on push to `dev`. |
-| N4 | No GitHub release tag or release notes entry for `v2.8.0`. |
+| N1 | **Dependabot PR #1567** (pydantic update) remains separate and untouched. |
+| N2 | CHANGELOG heading style is consistent across 2.8.0 and prior entries. |
+| N3 | `dev` push trigger now added to CI (`push: branches: ["main", "master", "dev"]`). |
+| N4 | GitHub release tag and release notes for `v2.8.0` must be created via GitHub UI/CLI after remaining blockers are resolved. |
 
 ---
 
-## 10. Confirmations
+## 11. Confirmations
 
 - **pydantic**: unchanged. Still pinned at `2.12.2`. No version bump, no dependency changes.
 - **PR #1567**: untouched. Not referenced, not cherry-picked, not merged.
-- **main branch**: not used. All work is on `claude/release-readiness-audit-5xXvn` targeting `dev`. `main` was not read as source of truth, not merged, not compared.
-- **Runtime code**: unchanged. Only documentation files created/modified in this audit.
-- **CI**: not weakened. `.github/workflows/ci.yaml` was not modified.
+- **main branch**: not used. All work is on `claude/finalize-release-readiness-ozgQt`
+  targeting `dev`. `main` was not read as source of truth, not merged, not compared.
+- **Runtime code**: unchanged. Only CI workflow, documentation, and CHANGELOG were
+  modified in this PR.
+- **CI**: not weakened. New jobs (`hassfest`, `hacs`) added; existing jobs unchanged.
+  Push trigger extended to include `dev`. No existing job removed or made
+  `continue-on-error`.
 - **Tests**: not removed, not skipped, not xfailed.
 
 ---
 
-## 11. Files Changed in This Audit
+## 12. Files Changed in This PR
 
-- `docs/release_readiness.md` — this file (new)
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yaml` | Added `hassfest` and `hacs` CI jobs; added `dev` to push trigger branches |
+| `CHANGELOG.md` | Added "CI / Release Readiness" and "Release caveats" sections to 2.8.0 entry |
+| `docs/real_device_validation.md` | **New file** — real-device validation checklist and evidence template |
+| `docs/release_readiness.md` | Updated with current date, branch, CI job status, real-device checklist link, and revised blocker table |
 
-No production code, tests, CI workflows, manifest.json, hacs.json, or dependency files were modified.
+No production runtime code, tests, manifest.json, hacs.json, or dependency files
+were modified.
 
 ---
 
-## 12. PR Target Branch
+## 13. PR Target Branch
 
 **PR base: `dev`**
 


### PR DESCRIPTION
## Summary

- Add `hassfest` CI job (`home-assistant/actions/hassfest@main`) — validates `manifest.json` and integration structure on every PR and push to `main`/`master`/`dev`
- Add `hacs` CI job (`hacs/action@main`, `category: integration`) — validates `hacs.json` and HACS repository requirements on every PR and push
- Add `dev` to CI push trigger branches (was only `main`/`master`)
- Add `docs/real_device_validation.md` — structured checklist and evidence template for real-device validation against ThesslaGreen AirPack hardware (template only; evidence not yet collected)
- Update `CHANGELOG.md` 2.8.0 entry with "CI / Release Readiness" and "Release caveats" sections
- Refresh `docs/release_readiness.md` — updated blocker table (B1/B2 addressed, B3/B4 remain), CI job status, real-device checklist link, all confirmations

**Base branch: dev**

## Validation results

| Gate | Result |
|------|--------|
| ruff check | ✅ All checks passed |
| ruff import-order | ✅ All checks passed |
| ruff format | ✅ 419 files, 0 drift |
| compileall | ✅ PASS |
| compare_registers | ✅ PASS |
| check_maintainability | ✅ PASS |
| validate_entity_mappings | ✅ 366 entities validated |
| pytest | ✅ **1948 passed, 4 skipped** |
| coordinator __all__ invariant | ✅ PASS |
| coordinator.py flat file absent | ✅ PASS |
| No HA imports in scanner/ | ✅ PASS |
| Dependency files unchanged | ✅ confirmed |

Python: 3.13.12 · HA: 2026.2.3 · pydantic: 2.12.2 (pinned, unchanged)

## Remaining blockers after this PR

| # | Blocker | Status |
|---|---------|--------|
| B1 | Hassfest in CI | ✅ Addressed — pending first CI run |
| B2 | HACS validation in CI | ✅ Addressed — pending first CI run |
| B3 | GitHub release tag v2.8.0 | ⛔ Open — create separately after CI green |
| B4 | Real-device validation evidence | ⚠️ Template created; evidence still needed |

## Test plan

- [ ] Verify PR base branch is `dev` (not `main`)
- [ ] CI `hassfest` job passes on this PR
- [ ] CI `hacs` job passes on this PR
- [ ] All existing CI jobs (lint, tests, entity-mappings, ruff-adoption-signal) remain green
- [ ] Review `docs/real_device_validation.md` checklist completeness
- [ ] Review CHANGELOG.md 2.8.0 additions for accuracy

## Confirmations

- pydantic unchanged (still `2.12.2`)
- PR #1567 untouched
- main branch not used, not merged, not compared
- No runtime code changed
- No existing CI gate removed or weakened
- No tests removed, skipped, or xfailed

https://claude.ai/code/session_01GQe3J729pQNwT3d1tYXmf9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQe3J729pQNwT3d1tYXmf9)_