### PR TITLE
fix: address real-device validation findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to the ThesslaGreen Modbus Integration will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased — Real-device findings cleanup
+
+### Fixed
+- **Fan percentage clamped to 0–100**: `fan.thesslagreen_ventilation` no longer
+  reports `percentage` > 100 to Home Assistant (device can report up to 109 %).
+  Raw value is preserved in `extra_state_attributes.supply_percentage`.
+- **Active errors sensor no longer shows «unknown»**: `sensor.rekuperator_active_errors`
+  now shows `none` when the coordinator is connected and no error codes are active,
+  instead of the misleading «unknown» state.
+- **`switch.bypass_off` / `switch.gwc_off` display names corrected**:
+  These switches were named "Bypass Active" / "GWC Active" but the underlying
+  register uses inverse semantics (value 1 = deactivated). Renamed to
+  "Bypass Locked" / "GWC Locked" (PL: "Bypass zablokowany" / "GWC zablokowany").
+  Entity IDs and unique IDs are unchanged.
+- **Device `sw_version` populated from version registers**: When the firmware
+  string is unavailable, `sw_version` is now assembled from `version_major`,
+  `version_minor`, and `cf_version` registers (e.g. `3.11 CF13`).
+
+### Confirmed correct (no code change)
+- `binary_sensor.fire_alarm`: raw True = NC contact closed = no alarm = `off` state.
+  This is correct and intentional. Documented with tests.
+- `binary_sensor.dp_duct_filter_overflow`: raw True = problem detected = `on` state.
+  Correct for a filter pressure-differential overflow. Documented with tests.
+- Polish state wording "nie działa" appears only in S30/S31 error-code sensor names,
+  not in normal inactive state labels. No change needed.
+
+### Needs vendor confirmation
+- `number.airing_coef` / `number.airing_switch_coef`: device reports values
+  (50, 0) outside the declared range 100–150. No write-range change until vendor
+  docs confirm whether these are valid set-points or factory defaults.
+
+---
+
 ## 2.8.0 — Legacy removal + test infrastructure overhaul (BREAKING)
 
 ### ⚠️ Breaking

--- a/custom_components/thessla_green_modbus/coordinator_diagnostics.py
+++ b/custom_components/thessla_green_modbus/coordinator_diagnostics.py
@@ -118,6 +118,35 @@ def get_diagnostic_data(coordinator: Any) -> dict[str, Any]:
     return diagnostics
 
 
+def _resolve_sw_version(coordinator: Any) -> str:
+    """Build a human-readable sw_version string.
+
+    Prefers the firmware string from the device scan result.  When that is
+    absent or 'Unknown', falls back to assembling a version string from the
+    version_major / version_minor / cf_version registers that were read from
+    the device.  Format: ``<major>.<minor> CF<cf>`` (e.g. ``3.11 CF13``).
+    """
+    firmware = coordinator.device_info.get("firmware", "Unknown")
+    if firmware and firmware != "Unknown":
+        return firmware
+
+    data: dict[str, Any] = getattr(coordinator, "data", {}) or {}
+    major = data.get("version_major")
+    minor = data.get("version_minor")
+    cf = data.get("cf_version")
+
+    parts: list[str] = []
+    if major is not None and minor is not None:
+        parts.append(f"{int(major)}.{int(minor)}")
+    elif major is not None:
+        parts.append(str(int(major)))
+
+    if cf is not None:
+        parts.append(f"CF{int(cf)}")
+
+    return " ".join(parts) if parts else "Unknown"
+
+
 def get_device_info(coordinator: Any) -> dict[str, Any]:
     """Return device info mapping for the connected unit."""
     model = coordinator.device_info.get("model")
@@ -158,7 +187,7 @@ def get_device_info(coordinator: Any) -> dict[str, Any]:
         name=device_name(coordinator),
         manufacturer=MANUFACTURER,
         model=model,
-        sw_version=coordinator.device_info.get("firmware", "Unknown"),
+        sw_version=_resolve_sw_version(coordinator),
         configuration_url=f"http://{coordinator.config.host}",
     )
 

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -119,13 +119,20 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
 
     @property
     def percentage(self) -> int | None:
-        """Return the current speed percentage."""
+        """Return the current speed percentage, clamped to 0–100 per HA spec.
+
+        The physical device may report flow rates above 100 % (e.g. 109 %
+        when max_percentage = 109).  HA FanEntity.percentage must stay in
+        0–100; the raw device value is preserved in extra_state_attributes
+        as ``supply_percentage``.
+        """
         flow_rate = self._get_current_flow_rate()
         if flow_rate is None:
             return None
 
         _min_pct, max_pct = self._percentage_limits()
-        return max(0, min(max_pct, int(flow_rate)))
+        raw_clamped = max(0, min(max_pct, int(flow_rate)))
+        return min(100, raw_clamped)
 
     def _get_current_flow_rate(self) -> float | None:
         """Get current flow rate from available registers."""

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -408,14 +408,24 @@ class ThesslaGreenActiveErrorsSensor(ThesslaGreenEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        """Return comma-separated list of active E/S code identifiers."""
+        """Return comma-separated list of active E/S code identifiers.
+
+        Returns "none" (not Python None) when no codes are active and the
+        coordinator has been successfully updated, so HA shows a clear
+        "no active errors" state rather than the misleading "unknown".
+        Returns None only when the coordinator has not yet delivered data.
+        """
         codes = [
             key
             for key, value in self.coordinator.data.items()
             if value and _is_error_or_status_register(key)
         ]
         labels = [_format_error_status_code(code) for code in codes]
-        return ", ".join(sorted(labels)) if labels else None
+        if labels:
+            return ", ".join(sorted(labels))
+        if self.coordinator.last_update_success:
+            return "none"
+        return None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1156,10 +1156,10 @@
         "name": "Winter"
       },
       "bypass_off": {
-        "name": "Bypass Active"
+        "name": "Bypass Locked"
       },
       "gwc_off": {
-        "name": "GWC Active"
+        "name": "GWC Locked"
       },
       "hard_reset_settings": {
         "name": "Hard Reset Settings"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1156,10 +1156,10 @@
         "name": "Winter"
       },
       "bypass_off": {
-        "name": "Bypass Active"
+        "name": "Bypass Locked"
       },
       "gwc_off": {
-        "name": "GWC Active"
+        "name": "GWC Locked"
       },
       "hard_reset_settings": {
         "name": "Hard Reset Settings"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1156,10 +1156,10 @@
         "name": "Zima"
       },
       "bypass_off": {
-        "name": "Bypass aktywny"
+        "name": "Bypass zablokowany"
       },
       "gwc_off": {
-        "name": "GWC aktywny"
+        "name": "GWC zablokowany"
       },
       "hard_reset_settings": {
         "name": "Reset ustawień do domyślnych"

--- a/docs/real_device_validation.md
+++ b/docs/real_device_validation.md
@@ -151,7 +151,28 @@ complete unless all mandatory test cases (4.1–4.11) are marked Pass.**
 
 ---
 
-## 6. Release Gate
+## 6. Real-Device Findings Cleanup (2026-05-09)
+
+The following findings were identified from exported HA state data and addressed in
+this PR (`fix: address real-device validation findings`).
+
+| Finding | Status | Fix / Decision | Evidence |
+|---|---|---|---|
+| Fan percentage 109 (> 100) | FIXED | `fan.py` `percentage` property clamped to 100 per HA spec; raw value preserved in `supply_percentage` attribute | Unit test `test_fan_percentage_109_clamped_to_100`; `test_fan_percentage_limits.py` updated |
+| `number.airing_coef` state 50 outside range 100–150 | NEEDS_VENDOR_CONFIRMATION | Write range unchanged (100–150) per declared metadata. Reading 50 does not crash. Vendor confirmation needed to determine if 50 is valid or a factory default. | Tests `test_airing_coef_native_value_below_min_does_not_crash`, `test_airing_switch_coef_native_value_zero_does_not_crash` |
+| `binary_sensor.fire_alarm` raw true / state off | CONFIRMED_CORRECT | NC (normally-closed) contact: raw True = circuit closed = no alarm = `is_on=False`. Mapping has `inverted: True` with inline comment. | Tests `test_fire_alarm_raw_true_means_no_alarm`, `test_fire_alarm_inverted_flag_present` |
+| `binary_sensor.dp_duct_filter_overflow` raw true / state on | CONFIRMED_CORRECT | Raw True = problem detected. `device_class=problem` is correct. This is a real hardware problem state. | Test `test_dp_duct_filter_overflow_raw_true_is_problem` |
+| `sensor.serial_number` unavailable / device info Unknown | DEFERRED (partially improved) | `sw_version` now assembled from `version_major.version_minor CF<cf_version>` when firmware is Unknown (e.g. `3.11 CF13`). Serial decode root cause deferred — no crash occurs on bad bytes. | Tests `test_sw_version_uses_version_registers_when_firmware_unknown`, `test_get_device_info_uses_version_registers_for_sw_version` |
+| `sensor.rekuperator_active_errors` state unknown | FIXED | `native_value` now returns `"none"` (not Python None) when coordinator has been successfully updated but no error codes are active. Before first update, returns None (correctly showing «unknown»). | Tests `test_active_errors_sensor_returns_none_string_when_no_errors` |
+| `switch.bypass_off` / `switch.gwc_off` misleading names | FIXED | Translation-only fix: renamed from "Bypass Active" / "GWC Active" to "Bypass Locked" / "GWC Locked" (PL: "Bypass zablokowany" / "GWC zablokowany") to match register semantics (value 1 = deactivated). Entity IDs and unique IDs unchanged. | Translation tests pass; register JSON evidence: `enum: {0: aktywny, 1: nieaktywny (pasywny)}` |
+| Polish state wording "nie działa" | CONFIRMED_CORRECT | Phrase appears only in S30/S31 error-code sensor *names* ("S30: Wentylator nawiewny nie działa"), which accurately describes the fault condition. No state labels use this phrase. | Test `test_nie_dziala_only_in_error_code_names` |
+
+Schedule/entity-group hiding was **NOT** implemented in this PR.
+Harmonogram entity cleanup was **NOT** implemented in this PR.
+
+---
+
+## 7. Release Gate
 
 Real-device validation is **not** complete until:
 
@@ -161,3 +182,6 @@ Real-device validation is **not** complete until:
 
 Until that point, this document is a **template only** and real-device
 validation remains an open release blocker (B4).
+
+Section 6 (real-device findings cleanup) is based on exported HA state data,
+not a full on-device test run.  It does not satisfy the release gate above.

--- a/docs/release_readiness.md
+++ b/docs/release_readiness.md
@@ -113,28 +113,31 @@ OK homeassistant: installed
 
 ## 7. Real-Device Validation
 
-**Not proven — checklist template created.**
+**Not proven — checklist template created. Findings cleanup applied (2026-05-09).**
 
 No evidence of on-device testing against a physical ThesslaGreen AirPack device
 exists. A structured checklist and evidence template has been created:
 
 → **[docs/real_device_validation.md](real_device_validation.md)**
 
-The checklist covers:
-- Installation via HACS
-- UI config flow
-- TCP connection verification
-- Entity creation (~366 entities)
-- Sensor state updates
-- Fan/climate control writes
-- Single and multi-register write paths
-- Reconnect after controller/network disruption
-- Unload/reload
-- HA restart recovery
-- Full log review
+A real-device findings cleanup PR was applied based on exported HA state data:
+
+| Finding | Outcome |
+|---------|---------|
+| Fan percentage 109 (> 100 HA limit) | FIXED |
+| Active errors sensor «unknown» when no errors | FIXED |
+| bypass_off / gwc_off misleading display names | FIXED (translation only) |
+| sw_version «Unknown» with version registers available | FIXED |
+| fire_alarm NC contact semantics | CONFIRMED_CORRECT |
+| dp_duct_filter_overflow inversion check | CONFIRMED_CORRECT |
+| airing_coef state outside declared range | NEEDS_VENDOR_CONFIRMATION |
+| Polish "nie działa" in state labels | CONFIRMED_CORRECT |
+
+See `docs/real_device_validation.md § 6` for full details.
 
 Real-device validation remains **open blocker B4** until the Evidence Record
 in that document is completed by a human tester with physical hardware.
+The findings cleanup above does NOT satisfy the release gate.
 
 ---
 

--- a/tests/test_coordinator_device_info.py
+++ b/tests/test_coordinator_device_info.py
@@ -113,6 +113,67 @@ def test_get_device_info_fallback(monkeypatch):
     assert device_info["model"] == "AirPack Home"
 
 
+def test_sw_version_uses_version_registers_when_firmware_unknown():
+    """Real-device finding: sw_version built from version_major/minor/cf_version.
+
+    When device_info has no firmware string, coordinator_diagnostics should
+    assemble a version string from available data registers.
+    """
+    from custom_components.thessla_green_modbus.coordinator_diagnostics import _resolve_sw_version
+
+    coord = _make_coordinator()
+    coord.device_info = {}
+    coord.data = {"version_major": 3, "version_minor": 11, "cf_version": 13}
+
+    result = _resolve_sw_version(coord)
+    assert result == "3.11 CF13"
+
+
+def test_sw_version_prefers_firmware_string_over_registers():
+    """If firmware string is present, it takes priority over version registers."""
+    from custom_components.thessla_green_modbus.coordinator_diagnostics import _resolve_sw_version
+
+    coord = _make_coordinator()
+    coord.device_info = {"firmware": "v3.11-stable"}
+    coord.data = {"version_major": 3, "version_minor": 11, "cf_version": 13}
+
+    assert _resolve_sw_version(coord) == "v3.11-stable"
+
+
+def test_sw_version_falls_back_to_unknown_when_no_data():
+    """No firmware string and no version registers → 'Unknown'."""
+    from custom_components.thessla_green_modbus.coordinator_diagnostics import _resolve_sw_version
+
+    coord = _make_coordinator()
+    coord.device_info = {}
+    coord.data = {}
+
+    assert _resolve_sw_version(coord) == "Unknown"
+
+
+def test_sw_version_partial_registers():
+    """Only major/minor without cf_version produces 'major.minor'."""
+    from custom_components.thessla_green_modbus.coordinator_diagnostics import _resolve_sw_version
+
+    coord = _make_coordinator()
+    coord.device_info = {}
+    coord.data = {"version_major": 3, "version_minor": 11}
+
+    assert _resolve_sw_version(coord) == "3.11"
+
+
+def test_get_device_info_uses_version_registers_for_sw_version():
+    """get_device_info exposes version-register-assembled sw_version."""
+    coord = _make_coordinator()
+    coord.device_info = {}
+    coord.data = {"version_major": 3, "version_minor": 11, "cf_version": 13}
+    coord.device_scan_result = {}
+    coord.entry = None
+
+    info = coord.get_device_info()
+    assert info["sw_version"] == "3.11 CF13"
+
+
 def test_register_value_processing(coordinator):
     """Test register value processing."""
     temp_result = coordinator._process_register_value("outside_temperature", 250)

--- a/tests/test_fan_percentage_limits.py
+++ b/tests/test_fan_percentage_limits.py
@@ -9,14 +9,31 @@ from custom_components.thessla_green_modbus.coordinator import (
 from custom_components.thessla_green_modbus.fan import ThesslaGreenFan
 
 
-def test_fan_percentage_clamps_to_max():
+def test_fan_percentage_clamps_to_100():
+    """HA FanEntity.percentage must not exceed 100 regardless of device max."""
     hass = SimpleNamespace()
     coordinator = ThesslaGreenModbusCoordinator.from_params(hass, "host", 502, 1, "dev")
     coordinator.data = {"min_percentage": 10, "max_percentage": 150, "air_flow_rate_manual": 160}
 
     fan = ThesslaGreenFan(coordinator)
 
-    assert fan.percentage == 150
+    assert fan.percentage == 100
+
+
+def test_fan_percentage_over_100_device_clamps(mock_coordinator):
+    """Real-device finding: device reports supply_percentage=109 with max_percentage=109.
+
+    HA FanEntity.percentage must be clamped to 100.  The raw value is preserved
+    in extra_state_attributes['supply_percentage'].
+    """
+    mock_coordinator.data["min_percentage"] = 10
+    mock_coordinator.data["max_percentage"] = 109
+    mock_coordinator.data["supply_percentage"] = 109
+
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    assert fan.percentage == 100
+    assert fan.extra_state_attributes.get("supply_percentage") == 109
 
 
 @pytest.mark.asyncio

--- a/tests/test_real_device_findings.py
+++ b/tests/test_real_device_findings.py
@@ -1,0 +1,278 @@
+# mypy: ignore-errors
+"""Tests verifying real-device findings from exported HA state data.
+
+Each test is annotated with one of:
+  FIXED                 — bug was corrected in this PR
+  CONFIRMED_CORRECT     — behavior is intentional and correct
+  NEEDS_VENDOR_CONFIRMATION — further vendor data required before changing
+  DEFERRED              — tracked but not changed in this PR
+"""
+
+from __future__ import annotations
+
+from custom_components.thessla_green_modbus.binary_sensor import (
+    BINARY_SENSOR_DEFINITIONS,
+    ThesslaGreenBinarySensor,
+)
+from custom_components.thessla_green_modbus.fan import ThesslaGreenFan
+from custom_components.thessla_green_modbus.mappings import ENTITY_MAPPINGS
+from custom_components.thessla_green_modbus.sensor import ThesslaGreenActiveErrorsSensor
+
+from tests.helpers_entity_data_correctness import _make_number
+
+# ---------------------------------------------------------------------------
+# Finding 1: fan percentage > 100  (FIXED)
+# ---------------------------------------------------------------------------
+
+
+def test_fan_percentage_109_clamped_to_100(mock_coordinator):
+    """FIXED: Fan percentage must not exceed 100 per HA FanEntity spec.
+
+    Real device exported: percentage=109, max_percentage=109.
+    Raw value is still accessible via extra_state_attributes['supply_percentage'].
+    """
+    mock_coordinator.data["min_percentage"] = 10
+    mock_coordinator.data["max_percentage"] = 109
+    mock_coordinator.data["supply_percentage"] = 109
+
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    assert fan.percentage == 100
+    assert fan.extra_state_attributes.get("supply_percentage") == 109
+
+
+def test_fan_percentage_normal_50_unchanged(mock_coordinator):
+    """FIXED: Normal values below 100 are unchanged by the clamp."""
+    mock_coordinator.data["min_percentage"] = 10
+    mock_coordinator.data["max_percentage"] = 150
+    mock_coordinator.data["supply_percentage"] = 50
+
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    assert fan.percentage == 50
+
+
+def test_fan_percentage_exactly_100_unchanged(mock_coordinator):
+    """FIXED: Value of exactly 100 passes through the clamp unchanged."""
+    mock_coordinator.data["min_percentage"] = 10
+    mock_coordinator.data["max_percentage"] = 150
+    mock_coordinator.data["supply_percentage"] = 100
+
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    assert fan.percentage == 100
+
+
+# ---------------------------------------------------------------------------
+# Finding 2: number valid_range mismatch  (NEEDS_VENDOR_CONFIRMATION)
+# ---------------------------------------------------------------------------
+
+
+def test_airing_coef_declared_range(mock_coordinator):
+    """NEEDS_VENDOR_CONFIRMATION: airing_coef metadata range is 100–150.
+
+    The real device reported state=50.0 which is outside that range.
+    The write range is preserved as declared (100–150) until vendor
+    documentation confirms whether 0/50 are valid set-points or
+    factory-default placeholders.
+    """
+    entity = _make_number(mock_coordinator, "airing_coef")
+    assert entity._attr_native_min_value == 100
+    assert entity._attr_native_max_value == 150
+
+
+def test_airing_coef_native_value_below_min_does_not_crash(mock_coordinator):
+    """NEEDS_VENDOR_CONFIRMATION: reading a value outside the declared range
+    must not raise; the entity exposes whatever the device reports.
+    """
+    mock_coordinator.data["airing_coef"] = 50
+    entity = _make_number(mock_coordinator, "airing_coef")
+    assert entity.native_value == 50.0
+
+
+def test_airing_switch_coef_native_value_zero_does_not_crash(mock_coordinator):
+    """NEEDS_VENDOR_CONFIRMATION: airing_switch_coef state=0 is outside
+    declared range 100–150 but must not cause an exception.
+    """
+    mock_coordinator.data["airing_switch_coef"] = 0
+    entity = _make_number(mock_coordinator, "airing_switch_coef")
+    assert entity.native_value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Finding 3: fire_alarm NC logic  (CONFIRMED_CORRECT)
+# ---------------------------------------------------------------------------
+
+
+def test_fire_alarm_raw_true_means_no_alarm(mock_coordinator):
+    """CONFIRMED_CORRECT: fire_alarm uses NC (normally-closed) contact.
+
+    raw_value=True → circuit closed → no alarm → is_on=False / severity=normal.
+    raw_value=False → circuit open → alarm triggered → is_on=True / severity=warning.
+    """
+    defn = BINARY_SENSOR_DEFINITIONS["fire_alarm"]
+    reg_type = defn["register_type"]
+    address = mock_coordinator._register_maps[reg_type]["fire_alarm"]
+    sensor = ThesslaGreenBinarySensor(mock_coordinator, "fire_alarm", address, defn)
+
+    # NC closed → safe
+    mock_coordinator.data["fire_alarm"] = True
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes.get("severity") == "normal"
+
+    # NC open → alarm
+    mock_coordinator.data["fire_alarm"] = False
+    assert sensor.is_on is True
+    assert sensor.extra_state_attributes.get("severity") == "warning"
+
+
+def test_fire_alarm_inverted_flag_present():
+    """CONFIRMED_CORRECT: The mapping for fire_alarm declares inverted=True."""
+    assert BINARY_SENSOR_DEFINITIONS["fire_alarm"].get("inverted") is True
+
+
+# ---------------------------------------------------------------------------
+# Finding 4: dp_duct_filter_overflow  (CONFIRMED_CORRECT)
+# ---------------------------------------------------------------------------
+
+
+def test_dp_duct_filter_overflow_raw_true_is_problem(mock_coordinator):
+    """CONFIRMED_CORRECT: dp_duct_filter_overflow raw_value=True → state on (problem).
+
+    This is a real-device problem state — filter pressure differential overflow
+    was detected.  No inversion is expected or required.
+    """
+    defn = BINARY_SENSOR_DEFINITIONS["dp_duct_filter_overflow"]
+    reg_type = defn["register_type"]
+    address = mock_coordinator._register_maps[reg_type]["dp_duct_filter_overflow"]
+    sensor = ThesslaGreenBinarySensor(mock_coordinator, "dp_duct_filter_overflow", address, defn)
+
+    mock_coordinator.data["dp_duct_filter_overflow"] = True
+    assert sensor.is_on is True
+
+    mock_coordinator.data["dp_duct_filter_overflow"] = False
+    assert sensor.is_on is False
+
+
+def test_dp_duct_filter_overflow_has_problem_device_class():
+    """CONFIRMED_CORRECT: device_class=problem is set correctly."""
+    from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+    assert (
+        BINARY_SENSOR_DEFINITIONS["dp_duct_filter_overflow"]["device_class"]
+        == BinarySensorDeviceClass.PROBLEM
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 5: serial / device_info  (DEFERRED — see docs/real_device_validation.md)
+# ---------------------------------------------------------------------------
+
+
+def test_serial_number_sensor_unavailable_does_not_crash(mock_coordinator):
+    """DEFERRED: serial_number sensor must not raise when device_info has no serial."""
+    from custom_components.thessla_green_modbus.mappings import ENTITY_MAPPINGS
+    from custom_components.thessla_green_modbus.sensor import ThesslaGreenSerialNumberSensor
+
+    defn = ENTITY_MAPPINGS["sensor"].get("serial_number", {"translation_key": "serial_number"})
+    sensor = ThesslaGreenSerialNumberSensor(mock_coordinator, "serial_number", 100, defn)
+
+    mock_coordinator.device_info = {}
+    assert sensor.native_value is None
+
+    mock_coordinator.device_info = {"serial_number": "Unknown"}
+    assert sensor.native_value is None
+
+
+# ---------------------------------------------------------------------------
+# Finding 6: aggregate error/status sensors  (FIXED)
+# ---------------------------------------------------------------------------
+
+
+def test_active_errors_sensor_returns_none_before_first_update(mock_coordinator):
+    """FIXED: Before the coordinator has a successful update, sensor returns None.
+
+    native_value=None → HA state «unknown» is correct pre-update.
+    """
+    mock_coordinator.data = {}
+    mock_coordinator.last_update_success = False
+    sensor = ThesslaGreenActiveErrorsSensor(mock_coordinator)
+    assert sensor.native_value is None
+
+
+def test_active_errors_sensor_returns_none_string_when_no_errors(mock_coordinator):
+    """FIXED: After a successful update with no active errors, sensor returns 'none'.
+
+    This prevents the misleading «unknown» state when the coordinator is
+    healthy but no error codes are active.
+    """
+    mock_coordinator.data = {"e_100": False, "s_200": False}
+    mock_coordinator.last_update_success = True
+    sensor = ThesslaGreenActiveErrorsSensor(mock_coordinator)
+    assert sensor.native_value == "none"
+
+
+def test_active_errors_sensor_returns_code_when_active(mock_coordinator):
+    """FIXED: When an error register is active, native_value lists its code."""
+    mock_coordinator.data = {"e_100": True, "s_200": False}
+    mock_coordinator.last_update_success = True
+    sensor = ThesslaGreenActiveErrorsSensor(mock_coordinator)
+    value = sensor.native_value
+    assert value is not None
+    assert "E100" in value
+
+
+def test_active_errors_sensor_none_when_all_false_before_update(mock_coordinator):
+    """FIXED: All-false error registers before update → None (unknown is correct)."""
+    mock_coordinator.data = {"e_100": False, "s_200": False}
+    mock_coordinator.last_update_success = False
+    sensor = ThesslaGreenActiveErrorsSensor(mock_coordinator)
+    assert sensor.native_value is None
+
+
+# ---------------------------------------------------------------------------
+# Finding 7: _off switch naming  (FIXED — translation only)
+# ---------------------------------------------------------------------------
+
+
+def test_bypass_off_translation_key():
+    """FIXED: bypass_off switch uses its own translation_key."""
+    mapping = ENTITY_MAPPINGS["switch"]["bypass_off"]
+    assert mapping["translation_key"] == "bypass_off"
+
+
+def test_gwc_off_translation_key():
+    """FIXED: gwc_off switch uses its own translation_key."""
+    mapping = ENTITY_MAPPINGS["switch"]["gwc_off"]
+    assert mapping["translation_key"] == "gwc_off"
+
+
+# ---------------------------------------------------------------------------
+# Finding 8: Polish state wording  (CONFIRMED_CORRECT)
+# ---------------------------------------------------------------------------
+
+
+def test_nie_dziala_only_in_error_code_names():
+    """CONFIRMED_CORRECT: 'nie działa' appears only in S30/S31 error-code sensor
+    names (supply/exhaust fan not working), which is factually correct for
+    those fault codes.  Normal inactive states do not use this phrasing.
+    """
+    import json
+
+    with open("custom_components/thessla_green_modbus/translations/pl.json") as f:
+        pl = json.load(f)
+
+    # Collect every leaf string in the translations
+    def _leaves(obj, path=""):
+        if isinstance(obj, str):
+            yield path, obj
+        elif isinstance(obj, dict):
+            for k, v in obj.items():
+                yield from _leaves(v, f"{path}.{k}")
+
+    problematic = [
+        (path, text)
+        for path, text in _leaves(pl)
+        if "nie dzia" in text.lower() and ".state." in path
+    ]
+    assert problematic == [], f"Unexpected 'nie działa' in state labels: {problematic}"


### PR DESCRIPTION
Base branch: dev

## Summary

Real-device correctness cleanup based on exported HA state data. Fixes proven bugs, confirms correct behavior, and documents findings requiring vendor input.

- **Fan percentage clamped to 0–100**: `fan.thesslagreen_ventilation` reported `percentage=109` violating HA `FanEntity` spec (device `max_percentage=109`). Clamped at HA boundary; raw value preserved in `extra_state_attributes.supply_percentage`.
- **Active errors sensor no longer shows «unknown»**: `sensor.rekuperator_active_errors` returns `"none"` (not Python `None`) when coordinator is healthy and no error codes are active.
- **`bypass_off` / `gwc_off` display names corrected**: Register semantics confirmed from JSON (`0=aktywny, 1=nieaktywny`). Renamed from "Bypass Active"/"GWC Active" to "Bypass Locked"/"GWC Locked". Entity IDs unchanged.
- **`sw_version` assembled from version registers**: When firmware string is absent, builds `"major.minor CFxx"` from `version_major`/`version_minor`/`cf_version` (e.g. `3.11 CF13`).

## Findings status

| Finding | Status |
|---------|--------|
| Fan percentage > 100 | FIXED |
| Active errors sensor «unknown» | FIXED |
| `bypass_off`/`gwc_off` misleading names | FIXED |
| `sw_version` Unknown with version registers | FIXED |
| `fire_alarm` NC contact semantics | CONFIRMED_CORRECT |
| `dp_duct_filter_overflow` raw/state | CONFIRMED_CORRECT |
| `airing_coef`/`airing_switch_coef` out-of-range | NEEDS_VENDOR_CONFIRMATION |
| Polish "nie działa" in state labels | CONFIRMED_CORRECT |

## Out of scope (NOT implemented)
- Entity clutter / schedule hiding / entity group options
- Harmonogram entity visibility redesign
- Broad entity cleanup

## Test plan

- [ ] 24 new tests added; full suite: **1983 passed, 4 skipped** (up from 1959)
- [ ] `ruff check` / `ruff format` / `compileall` — all pass
- [ ] `validate_entity_mappings.py` — 366 entities validated
- [ ] `check_maintainability.py` — pass
- [ ] `compare_registers_with_reference.py` — pass
- [ ] No dependency files changed
- [ ] `pydantic` unchanged at 2.12.2
- [ ] `main` branch not touched
- [ ] No release/tag created

https://claude.ai/code/session_01AW9sLNkxkCuhh9LSfDxbH8

---
_Generated by [Claude Code](https://claude.ai/code/session_01AW9sLNkxkCuhh9LSfDxbH8)_