### PR TITLE
ci: restore dependency compatibility and hassfest validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run hassfest
-        uses: home-assistant/actions/hassfest@main
+        uses: home-assistant/actions/hassfest@master
 
   hacs:
     name: HACS validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
     "isort>=5.13.0",
     "ruff>=0.6.0",
     "mypy>=1.10.0",
-    "pydantic==2.13.3",
+    "pydantic==2.12.2",
     "pre-commit>=3.7.0",
     "types-PyYAML>=6.0.12",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ aiodhcpwatcher>=1.1.0
 aiodiscover>=2.6.1
 PyYAML>=6.0
 types-PyYAML>=6.0.12
-pydantic==2.13.3
+pydantic==2.12.2
 
 # Code quality tools
 black>=24.4.0


### PR DESCRIPTION
## Summary

Base branch: dev

- **pydantic pin**: Restored from `2.13.3` → `2.12.2` in `requirements-dev.txt` and `pyproject.toml`. The dependabot bump to 2.13.3 (PR #1567) broke `pytest-homeassistant-custom-component>=0.13.309,<0.13.317`, which requires `pydantic==2.12.2`.
- **hassfest action**: Fixed invalid ref `home-assistant/actions/hassfest@main` → `home-assistant/actions/hassfest@master`. The `home-assistant/actions` repository uses `master` as its default branch; `@main` does not resolve.
- **HACS**: `hacs.json` and `manifest.json` already present and well-formed. No file-level changes needed. GitHub repository topics/description must be set via GitHub repository settings (outside code); these cannot be changed via repository files.

## Files changed

| File | Change |
|------|--------|
| `requirements-dev.txt` | pydantic pin: `2.13.3` → `2.12.2` |
| `pyproject.toml` | pydantic pin: `2.13.3` → `2.12.2` (optional-dependencies.dev) |
| `.github/workflows/ci.yaml` | hassfest action ref: `@main` → `@master` |

## Test plan

- [x] `ruff check custom_components tests tools` — All checks passed
- [x] `ruff check --select I` — All checks passed
- [x] `ruff format --check` — 422 files already formatted
- [x] `python -m compileall -q custom_components/thessla_green_modbus tests tools` — OK
- [x] `python tools/check_maintainability.py` — Maintainability gate passed
- [x] Workflow YAML parsed and `hassfest` action verified as `home-assistant/actions/hassfest@master`
- [x] `pydantic==2.12.2` installs successfully and imports at correct version
- [ ] Full pytest suite and `pytest-homeassistant-custom-component` install require Python 3.13 (CI gate); local environment is Python 3.11

https://claude.ai/code/session_01YLNZeLCPQ7ML4joF8DC2yR

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLNZeLCPQ7ML4joF8DC2yR)_