### PR TITLE
feat: add safe device clock synchronization

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -75,6 +75,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_migrate_entity_unique_ids(hass, entry, coordinator)
     await async_setup_platforms(hass, entry, PLATFORM_DOMAINS)
 
+    from .clock_sync import ClockSyncManager
+
+    _clock_sync_manager = ClockSyncManager(hass, coordinator, entry)
+    _clock_sync_manager.attach()
+    coordinator._clock_sync_manager = _clock_sync_manager
+
     if len(hass.config_entries.async_entries(DOMAIN)) == 1:
         from .services import async_setup_services
 

--- a/custom_components/thessla_green_modbus/button.py
+++ b/custom_components/thessla_green_modbus/button.py
@@ -1,0 +1,77 @@
+"""Button platform for ThesslaGreen Modbus integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .clock_sync import async_perform_clock_sync
+from .const import (
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+)
+from .coordinator import ThesslaGreenModbusCoordinator
+from .entity import ThesslaGreenEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up button entities from a config entry."""
+    coordinator: ThesslaGreenModbusCoordinator = entry.runtime_data
+    async_add_entities([SyncDeviceClockButton(coordinator, entry)])
+
+
+class SyncDeviceClockButton(ThesslaGreenEntity, ButtonEntity):
+    """Button that synchronises the device RTC to HA local time."""
+
+    _attr_translation_key = "sync_device_clock"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_device_class = ButtonDeviceClass.RESTART
+
+    def __init__(
+        self,
+        coordinator: ThesslaGreenModbusCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, "sync_device_clock", None)
+        self._entry = entry
+
+    @property
+    def available(self) -> bool:
+        """Return True whenever the coordinator is connected."""
+        return self._coordinator_connected()
+
+    async def async_press(self) -> None:
+        """Handle button press: force-sync device clock to HA time."""
+        opts = getattr(self._entry, "options", {}) or {}
+        max_drift = int(
+            opts.get(
+                CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+            )
+        )
+        try:
+            ok = await async_perform_clock_sync(
+                self.coordinator,
+                force=True,
+                max_drift_seconds=max_drift,
+                logger=_LOGGER,
+            )
+        except HomeAssistantError:
+            raise
+        except Exception as exc:
+            raise HomeAssistantError(f"Clock sync failed: {exc}") from exc
+
+        if not ok:
+            raise HomeAssistantError("Failed to write device clock registers")

--- a/custom_components/thessla_green_modbus/clock_sync.py
+++ b/custom_components/thessla_green_modbus/clock_sync.py
@@ -1,0 +1,256 @@
+"""Device clock synchronization helpers for ThesslaGreen Modbus."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .coordinator import ThesslaGreenModbusCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# RTC registers start address (FC03 holding, address 0)
+RTC_START_ADDRESS = 0
+# Number of RTC registers (date_time, date_time_ddtt, date_time_ggmm, date_time_sscc)
+RTC_REGISTER_COUNT = 4
+# Read-back tolerance: max seconds between write time and read-back time
+RTC_READBACK_TOLERANCE_SECONDS = 5
+
+
+def bcd_encode(value: int) -> int:
+    """Encode integer 0-99 to packed BCD byte."""
+    return ((value // 10) << 4) | (value % 10)
+
+
+def bcd_decode(byte: int) -> int:
+    """Decode packed BCD byte to integer."""
+    return ((byte >> 4) & 0xF) * 10 + (byte & 0xF)
+
+
+def encode_rtc_registers(dt: datetime) -> list[int]:
+    """Encode a datetime into the 4 RTC holding-register values.
+
+    Register layout (FC03, addresses 0-3):
+      addr 0 (date_time):      high=BCD(year%100), low=BCD(month)
+      addr 1 (date_time_ddtt): high=BCD(day),      low=BCD(weekday 0=Mon)
+      addr 2 (date_time_ggmm): high=BCD(hour),     low=BCD(minute)
+      addr 3 (date_time_sscc): high=BCD(second),   low=0x00
+    """
+    reg_yymm = (bcd_encode(dt.year % 100) << 8) | bcd_encode(dt.month)
+    reg_ddtt = (bcd_encode(dt.day) << 8) | bcd_encode(dt.weekday())
+    reg_ggmm = (bcd_encode(dt.hour) << 8) | bcd_encode(dt.minute)
+    reg_sscc = (bcd_encode(dt.second) << 8) | 0x00
+    return [reg_yymm, reg_ddtt, reg_ggmm, reg_sscc]
+
+
+def decode_rtc_registers(
+    raw_yymm: int,
+    raw_ddtt: int,
+    raw_ggmm: int,
+    raw_sscc: int,
+) -> str | None:
+    """Decode 4 RTC register values to ISO-8601 string or None if invalid.
+
+    Mirrors the decoder in coordinator/capabilities.py for round-trip testing.
+    """
+    yy = bcd_decode((raw_yymm >> 8) & 0xFF)
+    mm = bcd_decode(raw_yymm & 0xFF)
+    dd = bcd_decode((raw_ddtt >> 8) & 0xFF)
+    hh = bcd_decode((raw_ggmm >> 8) & 0xFF)
+    mi = bcd_decode(raw_ggmm & 0xFF)
+    ss = bcd_decode((raw_sscc >> 8) & 0xFF)
+    year = 2000 + yy
+    if 1 <= mm <= 12 and 1 <= dd <= 31 and hh <= 23 and mi <= 59 and ss <= 59:
+        return f"{year:04d}-{mm:02d}-{dd:02d}T{hh:02d}:{mi:02d}:{ss:02d}"
+    return None
+
+
+def _drift_seconds(now: datetime, device_clock_str: str) -> float | None:
+    """Return absolute drift in seconds between HA time and device clock string.
+
+    Returns None when the device clock string cannot be parsed.
+    """
+    try:
+        device_dt = datetime.fromisoformat(device_clock_str)
+        now_naive = now.replace(tzinfo=None) if now.tzinfo is not None else now
+        return abs((now_naive - device_dt).total_seconds())
+    except (ValueError, TypeError):
+        return None
+
+
+async def async_perform_clock_sync(
+    coordinator: ThesslaGreenModbusCoordinator,
+    *,
+    force: bool = False,
+    max_drift_seconds: int = 300,
+    dt_now_fn: Any = None,
+    logger: logging.Logger | None = None,
+) -> bool:
+    """Synchronise device RTC to HA local time.
+
+    Returns True when sync succeeded or was skipped (drift below threshold).
+    Returns False when the write failed.
+    Raises HomeAssistantError when read-back validation fails.
+    """
+    from homeassistant.exceptions import HomeAssistantError
+    from homeassistant.util import dt as dt_util
+
+    log = logger or _LOGGER
+    now_fn = dt_now_fn if dt_now_fn is not None else dt_util.now
+    now = now_fn()
+
+    if not force:
+        device_clock_str = (coordinator.data or {}).get("device_clock")
+        if device_clock_str:
+            drift = _drift_seconds(now, device_clock_str)
+            if drift is not None and drift <= max_drift_seconds:
+                log.debug(
+                    "Clock drift %.1fs is within threshold (%ds), skipping sync",
+                    drift,
+                    max_drift_seconds,
+                )
+                return True
+
+    payload = encode_rtc_registers(now)
+    log.debug("Writing RTC registers: %s (for %s)", payload, now.strftime("%Y-%m-%d %H:%M:%S"))
+
+    try:
+        success = await coordinator.async_write_registers(
+            start_address=RTC_START_ADDRESS,
+            values=payload,
+            refresh=False,
+        )
+    except Exception:
+        log.exception("Exception while writing RTC registers")
+        return False
+
+    if not success:
+        log.error(
+            "Failed to write RTC clock registers for coordinator at %s",
+            coordinator.host if hasattr(coordinator, "host") else "unknown",
+        )
+        return False
+
+    log.info("Wrote RTC clock %s to device", now.strftime("%Y-%m-%d %H:%M:%S"))
+
+    # Read-back validation
+    try:
+        await coordinator.async_request_refresh()
+    except Exception:  # noqa: BLE001
+        log.warning("Could not trigger refresh for RTC read-back validation")
+        return True
+
+    readback_str = (coordinator.data or {}).get("device_clock")
+    if readback_str is None:
+        log.warning("Device clock unavailable after RTC write; skipping validation")
+        return True
+
+    drift_after = _drift_seconds(now, readback_str)
+    if drift_after is None:
+        raise HomeAssistantError(
+            f"RTC read-back validation failed: could not parse '{readback_str}'"
+        )
+    if drift_after > RTC_READBACK_TOLERANCE_SECONDS:
+        raise HomeAssistantError(
+            f"RTC read-back validation failed: wrote {now.strftime('%H:%M:%S')}, "
+            f"read back '{readback_str}' (drift {drift_after:.1f}s)"
+        )
+
+    log.info("RTC sync validated: read-back within %.1fs of written time", drift_after)
+    return True
+
+
+class ClockSyncManager:
+    """Manages periodic and on-start device clock synchronization.
+
+    Attaches to a coordinator as a data-change listener.
+    Automatic sync is disabled by default and only runs when
+    sync_device_clock_enabled option is True.
+    """
+
+    def __init__(
+        self,
+        hass: Any,
+        coordinator: ThesslaGreenModbusCoordinator,
+        entry: Any,
+    ) -> None:
+        self._hass = hass
+        self._coordinator = coordinator
+        self._entry = entry
+        self._last_sync: datetime | None = None
+        self._on_start_done = False
+        self._sync_in_progress = False
+
+    def attach(self) -> None:
+        """Register as a coordinator listener."""
+        self._coordinator.async_add_listener(self._on_update)
+
+    def _options(self) -> dict[str, Any]:
+        opts = getattr(self._entry, "options", {}) or {}
+        from .const import (
+            CONF_SYNC_DEVICE_CLOCK_ENABLED,
+            CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+            CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+            CONF_SYNC_DEVICE_CLOCK_ON_START,
+            DEFAULT_SYNC_DEVICE_CLOCK_ENABLED,
+            DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+            DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+            DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
+        )
+        return {
+            "enabled": bool(opts.get(CONF_SYNC_DEVICE_CLOCK_ENABLED, DEFAULT_SYNC_DEVICE_CLOCK_ENABLED)),
+            "on_start": bool(opts.get(CONF_SYNC_DEVICE_CLOCK_ON_START, DEFAULT_SYNC_DEVICE_CLOCK_ON_START)),
+            "interval_hours": int(opts.get(CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS, DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS)),
+            "max_drift": int(opts.get(CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS, DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS)),
+        }
+
+    def _on_update(self) -> None:
+        """Called by coordinator after each successful data update."""
+        opts = self._options()
+        if not opts["enabled"]:
+            return
+        if self._sync_in_progress:
+            return
+
+        data = self._coordinator.data or {}
+        if not data.get("device_clock"):
+            return
+
+        should_sync = False
+
+        if opts["on_start"] and not self._on_start_done:
+            self._on_start_done = True
+            should_sync = True
+        elif self._last_sync is None:
+            should_sync = True
+        else:
+            from homeassistant.util import dt as dt_util
+
+            elapsed = (dt_util.now().replace(tzinfo=None) - self._last_sync.replace(tzinfo=None)).total_seconds()
+            if elapsed >= opts["interval_hours"] * 3600:
+                should_sync = True
+
+        if should_sync:
+            self._hass.async_create_task(self._do_sync(opts["max_drift"]))
+
+    async def _do_sync(self, max_drift_seconds: int) -> None:
+        """Run clock sync as a background task."""
+        if self._sync_in_progress:
+            return
+        self._sync_in_progress = True
+        try:
+            ok = await async_perform_clock_sync(
+                self._coordinator,
+                force=False,
+                max_drift_seconds=max_drift_seconds,
+            )
+            if ok:
+                from homeassistant.util import dt as dt_util
+
+                self._last_sync = dt_util.now().replace(tzinfo=None)
+        except Exception:
+            _LOGGER.exception("Automatic clock sync failed")
+        finally:
+            self._sync_in_progress = False

--- a/custom_components/thessla_green_modbus/config_flow_options_form.py
+++ b/custom_components/thessla_green_modbus/config_flow_options_form.py
@@ -27,6 +27,10 @@ from .const import (
     CONF_SERIAL_PORT,
     CONF_SKIP_MISSING_REGISTERS,
     CONF_STOP_BITS,
+    CONF_SYNC_DEVICE_CLOCK_ENABLED,
+    CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    CONF_SYNC_DEVICE_CLOCK_ON_START,
     CONF_TIMEOUT,
     CONNECTION_MODE_AUTO,
     CONNECTION_MODE_TCP_RTU,
@@ -47,6 +51,10 @@ from .const import (
     DEFAULT_SERIAL_PORT,
     DEFAULT_SKIP_MISSING_REGISTERS,
     DEFAULT_STOP_BITS,
+    DEFAULT_SYNC_DEVICE_CLOCK_ENABLED,
+    DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
     DEFAULT_TIMEOUT,
     DOMAIN,
     MAX_BATCH_REGISTERS,
@@ -81,6 +89,18 @@ def build_options_defaults(
         ),
         CONF_SAFE_SCAN: entry_options.get(CONF_SAFE_SCAN, DEFAULT_SAFE_SCAN),
         CONF_LOG_LEVEL: entry_options.get(CONF_LOG_LEVEL, DEFAULT_LOG_LEVEL),
+        CONF_SYNC_DEVICE_CLOCK_ENABLED: entry_options.get(
+            CONF_SYNC_DEVICE_CLOCK_ENABLED, DEFAULT_SYNC_DEVICE_CLOCK_ENABLED
+        ),
+        CONF_SYNC_DEVICE_CLOCK_ON_START: entry_options.get(
+            CONF_SYNC_DEVICE_CLOCK_ON_START, DEFAULT_SYNC_DEVICE_CLOCK_ON_START
+        ),
+        CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS: entry_options.get(
+            CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS, DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS
+        ),
+        CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS: entry_options.get(
+            CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS, DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS
+        ),
         CONF_CONNECTION_TYPE: entry_data.get(CONF_CONNECTION_TYPE, DEFAULT_CONNECTION_TYPE),
         CONF_CONNECTION_MODE: entry_options.get(
             CONF_CONNECTION_MODE, entry_data.get(CONF_CONNECTION_MODE)
@@ -176,6 +196,24 @@ def build_options_schema(values: dict[str, Any]) -> vol.Schema:
                     "selector": {"number": {"min": 1, "max": MAX_BATCH_REGISTERS, "step": 1}},
                 },
             ): int,
+            vol.Optional(
+                CONF_SYNC_DEVICE_CLOCK_ENABLED,
+                default=values[CONF_SYNC_DEVICE_CLOCK_ENABLED],
+            ): bool,
+            vol.Optional(
+                CONF_SYNC_DEVICE_CLOCK_ON_START,
+                default=values[CONF_SYNC_DEVICE_CLOCK_ON_START],
+            ): bool,
+            vol.Optional(
+                CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+                default=values[CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS],
+                description={"selector": {"number": {"min": 1, "max": 168, "step": 1}}},
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=168)),
+            vol.Optional(
+                CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                default=values[CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS],
+                description={"selector": {"number": {"min": 30, "max": 86400, "step": 1}}},
+            ): vol.All(vol.Coerce(int), vol.Range(min=30, max=86400)),
         }
     )
 
@@ -200,6 +238,10 @@ def build_options_description_placeholders(
         "current_max_registers_per_request": str(values[CONF_MAX_REGISTERS_PER_REQUEST]),
         "safe_scan_enabled": "Yes" if values[CONF_SAFE_SCAN] else "No",
         "current_log_level": values[CONF_LOG_LEVEL],
+        "sync_clock_enabled": "Yes" if values[CONF_SYNC_DEVICE_CLOCK_ENABLED] else "No",
+        "sync_clock_on_start": "Yes" if values[CONF_SYNC_DEVICE_CLOCK_ON_START] else "No",
+        "sync_clock_interval": str(values[CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS]),
+        "sync_clock_max_drift": str(values[CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS]),
         "transport_label": transport_label,
         "transport_details": transport_details,
     }

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:  # pragma: no cover - test/runtime fallback without 
 
     class _FallbackPlatform:
         BINARY_SENSOR = "binary_sensor"
+        BUTTON = "button"
         CLIMATE = "climate"
         FAN = "fan"
         NUMBER = "number"
@@ -200,6 +201,15 @@ CONF_AIRFLOW_UNIT = "airflow_unit"
 CONF_DEEP_SCAN = "deep_scan"  # Perform exhaustive raw register scan for diagnostics
 CONF_MAX_REGISTERS_PER_REQUEST = "max_registers_per_request"
 CONF_LOG_LEVEL = "log_level"
+CONF_SYNC_DEVICE_CLOCK_ENABLED = "sync_device_clock_enabled"
+CONF_SYNC_DEVICE_CLOCK_ON_START = "sync_device_clock_on_start"
+CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS = "sync_device_clock_interval_hours"
+CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS = "sync_device_clock_max_drift_seconds"
+
+DEFAULT_SYNC_DEVICE_CLOCK_ENABLED = False
+DEFAULT_SYNC_DEVICE_CLOCK_ON_START = False
+DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS = 24
+DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS = 300
 
 AIRFLOW_UNIT_M3H = "m3h"
 AIRFLOW_UNIT_PERCENTAGE = "percentage"
@@ -260,6 +270,7 @@ PLATFORMS: list[Any] = [
     Platform.SWITCH,
     Platform.TEXT,
     Platform.TIME,
+    Platform.BUTTON,
 ]
 
 

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -142,6 +142,7 @@ SERVICE_REGISTRATION_GROUPS: tuple[ServiceRegistrationGroup, ...] = (
             "set_modbus_parameters",
             "set_device_name",
             "sync_time",
+            "sync_device_clock",
         ),
     ),
     ServiceRegistrationGroup(

--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -345,7 +345,7 @@ set_debug_logging:
           step: 60
 
 sync_time:
-  name: Sync Device Clock
+  name: Sync Device Clock (legacy)
   description: Synchronise the AirPack real-time clock to the current Home Assistant time. Useful after power loss.
   target: *tg_target
   fields:
@@ -357,3 +357,21 @@ sync_time:
         entity:
           domain: climate
           integration: thessla_green_modbus
+
+sync_device_clock:
+  name: Sync Device Clock
+  description: >-
+    Synchronise the AirPack real-time clock to the current Home Assistant local time.
+    CAUTION: this overwrites the physical device RTC clock.
+    Automatic sync is disabled by default; enable it in integration options.
+  target: *tg_target
+  fields:
+    force:
+      name: Force
+      description: >-
+        Write the clock even when drift is already below the configured threshold.
+        When false, sync is skipped if drift is within the max-drift threshold.
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -6,7 +6,13 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime as _dt
 
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 
+from .clock_sync import async_perform_clock_sync
+from .const import (
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+)
 from .modbus_exceptions import ConnectionException, ModbusException
 from .services_dispatch import (
     refresh_and_log_success,
@@ -21,6 +27,7 @@ from .services_schema import (
     SET_DEVICE_NAME_SCHEMA,
     SET_MODBUS_PARAMETERS_SCHEMA,
     START_PRESSURE_TEST_SCHEMA,
+    SYNC_DEVICE_CLOCK_SCHEMA,
     SYNC_TIME_SCHEMA,
 )
 from .services_validation import (
@@ -60,6 +67,7 @@ def _maintenance_registrations():
         ("set_modbus_parameters", SET_MODBUS_PARAMETERS_SCHEMA),
         ("set_device_name", SET_DEVICE_NAME_SCHEMA),
         ("sync_time", SYNC_TIME_SCHEMA),
+        ("sync_device_clock", SYNC_DEVICE_CLOCK_SCHEMA),
     ]
 
 
@@ -76,6 +84,7 @@ def _maintenance_handlers(
     set_modbus_parameters: object,
     set_device_name: object,
     sync_time: object,
+    sync_device_clock: object,
 ) -> dict[str, object]:
     """Return maintenance service handlers keyed by service name."""
     return {
@@ -85,6 +94,7 @@ def _maintenance_handlers(
         "set_modbus_parameters": set_modbus_parameters,
         "set_device_name": set_device_name,
         "sync_time": sync_time,
+        "sync_device_clock": sync_device_clock,
     }
 
 
@@ -304,6 +314,35 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
 
         await _run_for_targets(hass, call, deps, _sync_time_for_target)
 
+    async def sync_device_clock(call: ServiceCall) -> None:
+        force = bool(call.data.get("force", False))
+
+        async def _sync_device_clock_for_target(entity_id: str, coordinator: object) -> bool:
+            opts = {}
+            if hasattr(coordinator, "entry") and coordinator.entry is not None:
+                opts = getattr(coordinator.entry, "options", {}) or {}
+            max_drift = int(
+                opts.get(CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS, DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS)
+            )
+            try:
+                ok = await async_perform_clock_sync(
+                    coordinator,
+                    force=force,
+                    max_drift_seconds=max_drift,
+                    logger=deps.logger,
+                )
+            except HomeAssistantError:
+                raise
+            except Exception as err:  # noqa: BLE001
+                deps.logger.error("Clock sync failed for %s: %s", entity_id, err)
+                return False
+            if not ok:
+                deps.logger.error("Failed to sync device clock for %s", entity_id)
+                return False
+            return True
+
+        await _run_for_targets(hass, call, deps, _sync_device_clock_for_target)
+
     handlers = _maintenance_handlers(
         reset_filters,
         reset_settings,
@@ -311,5 +350,6 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
         set_modbus_parameters,
         set_device_name,
         sync_time,
+        sync_device_clock,
     )
     _register_maintenance_bindings(hass, deps, handlers)

--- a/custom_components/thessla_green_modbus/services_schema.py
+++ b/custom_components/thessla_green_modbus/services_schema.py
@@ -146,6 +146,12 @@ SET_DEVICE_NAME_SCHEMA = vol.Schema(
 )
 
 SYNC_TIME_SCHEMA = vol.Schema({vol.Required("entity_id"): _ENTITY_IDS_VALIDATOR})
+SYNC_DEVICE_CLOCK_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): _ENTITY_IDS_VALIDATOR,
+        vol.Optional("force", default=False): bool,
+    }
+)
 REFRESH_DEVICE_DATA_SCHEMA = vol.Schema({vol.Required("entity_id"): _ENTITY_IDS_VALIDATOR})
 SCAN_ALL_REGISTERS_SCHEMA = vol.Schema({vol.Required("entity_id"): _ENTITY_IDS_VALIDATOR})
 SET_LOG_LEVEL_SCHEMA = vol.Schema(

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -105,6 +105,11 @@
     }
   },
   "entity": {
+    "button": {
+      "sync_device_clock": {
+        "name": "Sync device clock"
+      }
+    },
     "binary_sensor": {
       "ahu_filter_protection": {
         "name": "AHU Filter Protection"
@@ -1488,6 +1493,10 @@
           "safe_scan": "Safe Scan (no grouping)",
           "scan_interval": "Scan Interval (seconds)",
           "skip_missing_registers": "Skip Known Missing Registers",
+          "sync_device_clock_enabled": "Enable automatic clock sync",
+          "sync_device_clock_interval_hours": "Clock sync interval (hours)",
+          "sync_device_clock_max_drift_seconds": "Maximum allowed clock drift (seconds)",
+          "sync_device_clock_on_start": "Sync clock on integration start",
           "timeout": "Connection Timeout (seconds)"
         },
         "data_description": {
@@ -1500,6 +1509,10 @@
           "safe_scan": "Avoid grouped register reads for compatibility",
           "scan_interval": "How often to read data from device (10-300 seconds)",
           "skip_missing_registers": "Do not poll registers known to be unavailable",
+          "sync_device_clock_enabled": "Automatically sync device RTC from HA time (disabled by default)",
+          "sync_device_clock_interval_hours": "Hours between automatic clock syncs (1-168)",
+          "sync_device_clock_max_drift_seconds": "Only sync if drift exceeds this threshold (30-86400 s)",
+          "sync_device_clock_on_start": "Sync once after first successful device connection",
           "timeout": "Maximum time to wait for response (5-60 seconds)"
         },
         "error": {
@@ -1848,6 +1861,16 @@
         }
       },
       "name": "Set Debug Logging"
+    },
+    "sync_device_clock": {
+      "description": "Synchronises the AirPack real-time clock to current HA local time. CAUTION: overwrites device RTC clock.",
+      "fields": {
+        "force": {
+          "description": "Write clock even if drift is within threshold",
+          "name": "Force"
+        }
+      },
+      "name": "Sync Device Clock"
     }
   },
   "title": "ThesslaGreen Modbus"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -105,6 +105,11 @@
     }
   },
   "entity": {
+    "button": {
+      "sync_device_clock": {
+        "name": "Sync device clock"
+      }
+    },
     "binary_sensor": {
       "ahu_filter_protection": {
         "name": "AHU Filter Protection"
@@ -1488,6 +1493,10 @@
           "safe_scan": "Safe Scan (no grouping)",
           "scan_interval": "Scan Interval (seconds)",
           "skip_missing_registers": "Skip Known Missing Registers",
+          "sync_device_clock_enabled": "Enable automatic clock sync",
+          "sync_device_clock_interval_hours": "Clock sync interval (hours)",
+          "sync_device_clock_max_drift_seconds": "Maximum allowed clock drift (seconds)",
+          "sync_device_clock_on_start": "Sync clock on integration start",
           "timeout": "Connection Timeout (seconds)"
         },
         "data_description": {
@@ -1500,6 +1509,10 @@
           "safe_scan": "Avoid grouped register reads for compatibility",
           "scan_interval": "How often to read data from device (10-300 seconds)",
           "skip_missing_registers": "Do not poll registers known to be unavailable",
+          "sync_device_clock_enabled": "Automatically sync device RTC from HA time (disabled by default)",
+          "sync_device_clock_interval_hours": "Hours between automatic clock syncs (1-168)",
+          "sync_device_clock_max_drift_seconds": "Only sync if drift exceeds this threshold (30-86400 s)",
+          "sync_device_clock_on_start": "Sync once after first successful device connection",
           "timeout": "Maximum time to wait for response (5-60 seconds)"
         },
         "error": {
@@ -1848,6 +1861,16 @@
         }
       },
       "name": "Set Debug Logging"
+    },
+    "sync_device_clock": {
+      "description": "Synchronises the AirPack real-time clock to current HA local time. CAUTION: overwrites device RTC clock.",
+      "fields": {
+        "force": {
+          "description": "Write clock even if drift is within threshold",
+          "name": "Force"
+        }
+      },
+      "name": "Sync Device Clock"
     }
   },
   "title": "ThesslaGreen Modbus"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -105,6 +105,11 @@
     }
   },
   "entity": {
+    "button": {
+      "sync_device_clock": {
+        "name": "Synchronizuj zegar urządzenia"
+      }
+    },
     "binary_sensor": {
       "ahu_filter_protection": {
         "name": "Ochrona filtra AHU"
@@ -1488,6 +1493,10 @@
           "safe_scan": "Bezpieczny skan (bez grupowania)",
           "scan_interval": "Interwał skanowania (s)",
           "skip_missing_registers": "Pomijaj znane brakujące rejestry",
+          "sync_device_clock_enabled": "Włącz automatyczną synchronizację zegara",
+          "sync_device_clock_interval_hours": "Interwał synchronizacji zegara (godziny)",
+          "sync_device_clock_max_drift_seconds": "Maksymalne dozwolone odchylenie zegara (s)",
+          "sync_device_clock_on_start": "Synchronizuj zegar przy uruchomieniu integracji",
           "timeout": "Limit czasu połączenia (s)"
         },
         "data_description": {
@@ -1500,6 +1509,10 @@
           "safe_scan": "Unikaj grupowanych odczytów rejestrów dla kompatybilności",
           "scan_interval": "Jak często odczytywać dane z urządzenia (10-300 s)",
           "skip_missing_registers": "Nie odczytuj rejestrów, które są znane jako niedostępne",
+          "sync_device_clock_enabled": "Automatyczna synchronizacja RTC urządzenia z HA (domyślnie wyłączona)",
+          "sync_device_clock_interval_hours": "Godziny między automatycznymi synchronizacjami zegara (1-168)",
+          "sync_device_clock_max_drift_seconds": "Synchronizuj tylko gdy odchylenie przekracza próg (30-86400 s)",
+          "sync_device_clock_on_start": "Synchronizuj raz po pierwszym połączeniu z urządzeniem",
           "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)"
         },
         "error": {
@@ -1848,6 +1861,16 @@
         }
       },
       "name": "Ustaw debugowanie logów"
+    },
+    "sync_device_clock": {
+      "description": "Synchronizuje zegar RTC urządzenia AirPack z aktualnym czasem lokalnym HA. UWAGA: nadpisuje fizyczny zegar RTC urządzenia.",
+      "fields": {
+        "force": {
+          "description": "Zapisz zegar nawet gdy odchylenie jest w granicach progu",
+          "name": "Wymuś"
+        }
+      },
+      "name": "Synchronizuj zegar urządzenia"
     }
   },
   "title": "ThesslaGreen Modbus"

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -1,0 +1,617 @@
+# mypy: ignore-errors
+"""Tests for device clock synchronization."""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.clock_sync import (
+    ClockSyncManager,
+    async_perform_clock_sync,
+    bcd_decode,
+    bcd_encode,
+    decode_rtc_registers,
+    encode_rtc_registers,
+)
+
+# ---------------------------------------------------------------------------
+# BCD encode/decode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 0x00),
+        (1, 0x01),
+        (9, 0x09),
+        (10, 0x10),
+        (25, 0x25),
+        (59, 0x59),
+        (99, 0x99),
+    ],
+)
+def test_bcd_encode(value, expected):
+    assert bcd_encode(value) == expected
+
+
+@pytest.mark.parametrize(
+    "byte, expected",
+    [
+        (0x00, 0),
+        (0x01, 1),
+        (0x09, 9),
+        (0x10, 10),
+        (0x25, 25),
+        (0x59, 59),
+        (0x99, 99),
+    ],
+)
+def test_bcd_decode(byte, expected):
+    assert bcd_decode(byte) == expected
+
+
+def test_bcd_round_trip():
+    for v in range(100):
+        assert bcd_decode(bcd_encode(v)) == v
+
+
+# ---------------------------------------------------------------------------
+# encode_rtc_registers
+# ---------------------------------------------------------------------------
+
+
+def test_encode_rtc_registers_known_value():
+    dt = datetime.datetime(2025, 5, 9, 14, 30, 45)  # Friday = weekday 4
+    regs = encode_rtc_registers(dt)
+    assert len(regs) == 4
+    # addr 0: yymm = (BCD(25) << 8) | BCD(5)
+    assert regs[0] == (bcd_encode(25) << 8) | bcd_encode(5)
+    # addr 1: ddww = (BCD(9) << 8) | BCD(4)
+    assert regs[1] == (bcd_encode(9) << 8) | bcd_encode(4)
+    # addr 2: hhmm = (BCD(14) << 8) | BCD(30)
+    assert regs[2] == (bcd_encode(14) << 8) | bcd_encode(30)
+    # addr 3: sscc = (BCD(45) << 8) | 0x00
+    assert regs[3] == (bcd_encode(45) << 8) | 0x00
+
+
+# ---------------------------------------------------------------------------
+# decode_rtc_registers / round-trip compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_decode_rtc_registers_known_value():
+    dt = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    regs = encode_rtc_registers(dt)
+    result = decode_rtc_registers(*regs)
+    assert result == "2025-05-09T14:30:45"
+
+
+def test_decode_rtc_round_trip():
+    """Encoder output can be decoded back to the same datetime string."""
+    for dt in [
+        datetime.datetime(2025, 1, 1, 0, 0, 0),
+        datetime.datetime(2025, 12, 31, 23, 59, 59),
+        datetime.datetime(2026, 6, 15, 12, 0, 0),
+    ]:
+        regs = encode_rtc_registers(dt)
+        decoded = decode_rtc_registers(*regs)
+        assert decoded == dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def test_decode_rtc_invalid_returns_none():
+    assert decode_rtc_registers(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF) is None
+
+
+def test_decoder_matches_capabilities_decoder():
+    """Our decoder must match the implementation in coordinator/capabilities.py."""
+    from custom_components.thessla_green_modbus.coordinator.capabilities import (
+        _CoordinatorCapabilitiesMixin,
+    )
+
+    mixin = _CoordinatorCapabilitiesMixin.__new__(_CoordinatorCapabilitiesMixin)
+    dt = datetime.datetime(2025, 3, 15, 8, 45, 30)
+    regs = encode_rtc_registers(dt)
+    data = {
+        "date_time": regs[0],
+        "date_time_ddtt": regs[1],
+        "date_time_ggmm": regs[2],
+        "date_time_sscc": regs[3],
+    }
+    caps_result = mixin._decode_device_clock(data)
+    our_result = decode_rtc_registers(*regs)
+    assert caps_result == our_result
+
+
+# ---------------------------------------------------------------------------
+# async_perform_clock_sync — helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(*, write_ok=True, data=None):
+    coord = MagicMock()
+    coord.async_write_registers = AsyncMock(return_value=write_ok)
+    coord.async_request_refresh = AsyncMock()
+    coord.data = data if data is not None else {}
+    coord.host = "192.168.1.100"
+    return coord
+
+
+def _fixed_now(dt: datetime.datetime):
+    return lambda: dt
+
+
+# ---------------------------------------------------------------------------
+# async_perform_clock_sync — force=True always writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_force_writes_registers():
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:30:46"})
+
+    result = await async_perform_clock_sync(
+        coord,
+        force=True,
+        max_drift_seconds=300,
+        dt_now_fn=_fixed_now(now),
+    )
+    assert result is True
+    coord.async_write_registers.assert_awaited_once()
+    call_kwargs = coord.async_write_registers.call_args
+    assert call_kwargs.kwargs["start_address"] == 0
+    assert len(call_kwargs.kwargs["values"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_sync_force_writes_correct_register_values():
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:30:46"})
+
+    await async_perform_clock_sync(
+        coord,
+        force=True,
+        max_drift_seconds=300,
+        dt_now_fn=_fixed_now(now),
+    )
+    values = coord.async_write_registers.call_args.kwargs["values"]
+    assert values == encode_rtc_registers(now)
+
+
+# ---------------------------------------------------------------------------
+# async_perform_clock_sync — drift check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_skipped_when_drift_below_threshold():
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:30:44"})  # 1s drift
+
+    result = await async_perform_clock_sync(
+        coord,
+        force=False,
+        max_drift_seconds=300,
+        dt_now_fn=_fixed_now(now),
+    )
+    assert result is True
+    coord.async_write_registers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_proceeds_when_drift_exceeds_threshold():
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    # Device clock is 400 seconds behind
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:23:45"})
+
+    result = await async_perform_clock_sync(
+        coord,
+        force=False,
+        max_drift_seconds=300,
+        dt_now_fn=_fixed_now(now),
+    )
+    assert result is True
+    coord.async_write_registers.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_proceeds_when_device_clock_missing():
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    coord = _make_coordinator(data={})  # no device_clock key
+
+    result = await async_perform_clock_sync(
+        coord,
+        force=False,
+        max_drift_seconds=300,
+        dt_now_fn=_fixed_now(now),
+    )
+    assert result is True
+    coord.async_write_registers.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# async_perform_clock_sync — write failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_returns_false_on_write_failure():
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    coord = _make_coordinator(write_ok=False, data={})
+
+    result = await async_perform_clock_sync(
+        coord,
+        force=True,
+        dt_now_fn=_fixed_now(now),
+    )
+    assert result is False
+    coord.async_request_refresh.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# async_perform_clock_sync — read-back validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_read_back_success():
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    coord = _make_coordinator(data={})
+
+    async def _refresh_side_effect():
+        coord.data = {"device_clock": "2025-05-09T14:30:45"}
+
+    coord.async_request_refresh.side_effect = _refresh_side_effect
+
+    result = await async_perform_clock_sync(
+        coord,
+        force=True,
+        dt_now_fn=_fixed_now(now),
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_sync_read_back_validation_failure_raises():
+    from homeassistant.exceptions import HomeAssistantError
+
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    coord = _make_coordinator(data={})
+
+    async def _refresh_side_effect():
+        coord.data = {"device_clock": "2025-05-09T12:00:00"}
+
+    coord.async_request_refresh.side_effect = _refresh_side_effect
+
+    with pytest.raises(HomeAssistantError):
+        await async_perform_clock_sync(
+            coord,
+            force=True,
+            dt_now_fn=_fixed_now(now),
+        )
+
+
+@pytest.mark.asyncio
+async def test_sync_read_back_unavailable_returns_true():
+    now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+    coord = _make_coordinator(data={})
+    # data stays empty after refresh — device_clock not populated
+
+    result = await async_perform_clock_sync(
+        coord,
+        force=True,
+        dt_now_fn=_fixed_now(now),
+    )
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# ClockSyncManager — default disabled
+# ---------------------------------------------------------------------------
+
+
+def test_clock_sync_manager_disabled_by_default():
+    hass = MagicMock()
+    coord = _make_coordinator()
+    entry = MagicMock()
+    entry.options = {}
+
+    mgr = ClockSyncManager(hass, coord, entry)
+    mgr._on_update()
+    hass.async_create_task.assert_not_called()
+
+
+def test_clock_sync_manager_disabled_explicitly():
+    hass = MagicMock()
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:00:00"})
+    entry = MagicMock()
+    entry.options = {"sync_device_clock_enabled": False}
+
+    mgr = ClockSyncManager(hass, coord, entry)
+    mgr._on_update()
+    hass.async_create_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ClockSyncManager — on_start only when enabled
+# ---------------------------------------------------------------------------
+
+
+def test_clock_sync_manager_on_start_when_enabled_and_data_present():
+    hass = MagicMock()
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:00:00"})
+    entry = MagicMock()
+    entry.options = {
+        "sync_device_clock_enabled": True,
+        "sync_device_clock_on_start": True,
+    }
+
+    mgr = ClockSyncManager(hass, coord, entry)
+    mgr._on_update()
+    hass.async_create_task.assert_called_once()
+
+
+def test_clock_sync_manager_on_start_not_triggered_without_data():
+    hass = MagicMock()
+    coord = _make_coordinator(data={})  # no device_clock yet
+    entry = MagicMock()
+    entry.options = {
+        "sync_device_clock_enabled": True,
+        "sync_device_clock_on_start": True,
+    }
+
+    mgr = ClockSyncManager(hass, coord, entry)
+    mgr._on_update()
+    hass.async_create_task.assert_not_called()
+
+
+def test_clock_sync_manager_on_start_runs_only_once():
+    hass = MagicMock()
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:00:00"})
+    entry = MagicMock()
+    entry.options = {
+        "sync_device_clock_enabled": True,
+        "sync_device_clock_on_start": True,
+    }
+
+    mgr = ClockSyncManager(hass, coord, entry)
+    mgr._on_update()
+    mgr._on_update()
+    # on_start should only trigger once; second call goes to periodic check
+    # _last_sync is None so a second task will be created for periodic
+    assert hass.async_create_task.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# ClockSyncManager — periodic sync
+# ---------------------------------------------------------------------------
+
+
+def test_clock_sync_manager_periodic_first_sync():
+    """First sync always fires when enabled (no last_sync yet)."""
+    hass = MagicMock()
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:00:00"})
+    entry = MagicMock()
+    entry.options = {
+        "sync_device_clock_enabled": True,
+        "sync_device_clock_on_start": False,
+    }
+
+    mgr = ClockSyncManager(hass, coord, entry)
+    mgr._on_update()
+    hass.async_create_task.assert_called_once()
+
+
+def test_clock_sync_manager_no_second_sync_before_interval():
+    """Second sync not triggered if interval not elapsed."""
+    hass = MagicMock()
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:00:00"})
+    entry = MagicMock()
+    entry.options = {
+        "sync_device_clock_enabled": True,
+        "sync_device_clock_on_start": False,
+        "sync_device_clock_interval_hours": 24,
+    }
+
+    mgr = ClockSyncManager(hass, coord, entry)
+    mgr._last_sync = datetime.datetime.now()  # pretend sync just happened
+    mgr._on_start_done = True
+    mgr._on_update()
+    hass.async_create_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Button entity — calls sync logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_button_press_calls_sync():
+    """Button.async_press calls async_perform_clock_sync with force=True."""
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T14:30:45"})
+    entry = MagicMock()
+    entry.options = {}
+
+    with patch(
+        "custom_components.thessla_green_modbus.button.async_perform_clock_sync",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as mock_sync:
+        from custom_components.thessla_green_modbus.button import SyncDeviceClockButton
+
+        btn = SyncDeviceClockButton.__new__(SyncDeviceClockButton)
+        btn.coordinator = coord
+        btn._entry = entry
+        btn._coordinator_connected = lambda: True
+
+        await btn.async_press()
+        mock_sync.assert_awaited_once()
+        call_kwargs = mock_sync.call_args
+        assert call_kwargs.kwargs.get("force") is True
+
+
+@pytest.mark.asyncio
+async def test_button_press_raises_on_failure():
+    """Button raises HomeAssistantError when sync returns False."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    coord = _make_coordinator()
+    entry = MagicMock()
+    entry.options = {}
+
+    with patch(
+        "custom_components.thessla_green_modbus.button.async_perform_clock_sync",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        from custom_components.thessla_green_modbus.button import SyncDeviceClockButton
+
+        btn = SyncDeviceClockButton.__new__(SyncDeviceClockButton)
+        btn.coordinator = coord
+        btn._entry = entry
+        btn._coordinator_connected = lambda: True
+
+        with pytest.raises(HomeAssistantError):
+            await btn.async_press()
+
+
+# ---------------------------------------------------------------------------
+# Options flow — exposes sync options with correct defaults
+# ---------------------------------------------------------------------------
+
+
+def test_options_form_has_clock_sync_defaults():
+    from custom_components.thessla_green_modbus.config_flow_options_form import (
+        build_options_defaults,
+    )
+    from custom_components.thessla_green_modbus.const import (
+        CONF_SYNC_DEVICE_CLOCK_ENABLED,
+        CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+        CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+        CONF_SYNC_DEVICE_CLOCK_ON_START,
+        DEFAULT_SYNC_DEVICE_CLOCK_ENABLED,
+        DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+        DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+        DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
+    )
+
+    defaults = build_options_defaults({}, {})
+    assert defaults[CONF_SYNC_DEVICE_CLOCK_ENABLED] == DEFAULT_SYNC_DEVICE_CLOCK_ENABLED
+    assert defaults[CONF_SYNC_DEVICE_CLOCK_ON_START] == DEFAULT_SYNC_DEVICE_CLOCK_ON_START
+    assert defaults[CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS] == DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS
+    assert defaults[CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS] == DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS
+
+
+def test_options_form_default_sync_enabled_is_false():
+    from custom_components.thessla_green_modbus.config_flow_options_form import (
+        build_options_defaults,
+    )
+    from custom_components.thessla_green_modbus.const import (
+        CONF_SYNC_DEVICE_CLOCK_ENABLED,
+    )
+
+    defaults = build_options_defaults({}, {})
+    assert defaults[CONF_SYNC_DEVICE_CLOCK_ENABLED] is False
+
+
+def test_options_form_has_clock_sync_schema_keys():
+    from custom_components.thessla_green_modbus.config_flow_options_form import (
+        build_options_schema,
+    )
+    from custom_components.thessla_green_modbus.const import (
+        CONF_SYNC_DEVICE_CLOCK_ENABLED,
+        CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+        CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+        CONF_SYNC_DEVICE_CLOCK_ON_START,
+        DEFAULT_SYNC_DEVICE_CLOCK_ENABLED,
+        DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+        DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+        DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
+    )
+
+    values = {
+        "scan_interval": 30,
+        "timeout": 10,
+        "retry": 3,
+        "force_full_register_list": False,
+        "enable_device_scan": True,
+        "log_level": "info",
+        "scan_uart_settings": True,
+        "skip_missing_registers": False,
+        "safe_scan": False,
+        "airflow_unit": "m3h",
+        "deep_scan": False,
+        "max_registers_per_request": 16,
+        CONF_SYNC_DEVICE_CLOCK_ENABLED: DEFAULT_SYNC_DEVICE_CLOCK_ENABLED,
+        CONF_SYNC_DEVICE_CLOCK_ON_START: DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
+        CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS: DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+        CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS: DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    }
+    schema = build_options_schema(values)
+    schema_key_strs = [str(k) for k in schema.schema]
+    assert any(CONF_SYNC_DEVICE_CLOCK_ENABLED in s for s in schema_key_strs)
+    assert any(CONF_SYNC_DEVICE_CLOCK_ON_START in s for s in schema_key_strs)
+    assert any(CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS in s for s in schema_key_strs)
+    assert any(CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS in s for s in schema_key_strs)
+
+
+# ---------------------------------------------------------------------------
+# Service registration
+# ---------------------------------------------------------------------------
+
+
+def test_sync_device_clock_service_registered():
+    from custom_components.thessla_green_modbus.services import REGISTERED_SERVICE_NAMES
+
+    assert "sync_device_clock" in REGISTERED_SERVICE_NAMES
+
+
+@pytest.mark.asyncio
+async def test_sync_device_clock_service_calls_write(monkeypatch):
+    """sync_device_clock service writes RTC registers via coordinator."""
+    from types import SimpleNamespace
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    coord = _make_coordinator(data={"device_clock": "2025-05-09T00:00:00"})
+    fixed_now = datetime.datetime(2025, 5, 9, 14, 30, 45)
+
+    async def _refresh():
+        coord.data = {"device_clock": "2025-05-09T14:30:45"}
+
+    coord.async_request_refresh.side_effect = _refresh
+
+    class _Svc:
+        def __init__(self):
+            self.handlers = {}
+            self.removed = []
+
+        def async_register(self, _d, svc, h, _s):
+            self.handlers[svc] = h
+
+        def async_remove(self, _d, svc):
+            self.removed.append(svc)
+
+    hass = SimpleNamespace()
+    hass.services = _Svc()
+    hass.data = {}
+    hass.bus = SimpleNamespace(async_fire=MagicMock())
+
+    import custom_components.thessla_green_modbus.services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda _h, c: c.data["entity_id"])
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["sync_device_clock"]
+    call = SimpleNamespace(data={"entity_id": ["climate.dev"], "force": True})
+
+    with patch("homeassistant.util.dt.now", return_value=fixed_now):
+        await handler(call)
+
+    coord.async_write_registers.assert_awaited_once()
+    values = coord.async_write_registers.call_args.kwargs["values"]
+    assert values == encode_rtc_registers(fixed_now)

--- a/tests/test_services_handlers_maintenance.py
+++ b/tests/test_services_handlers_maintenance.py
@@ -305,6 +305,7 @@ def test_maintenance_registrations_service_order_and_schema_count():
         "set_modbus_parameters",
         "set_device_name",
         "sync_time",
+        "sync_device_clock",
     ]
 
 
@@ -319,6 +320,7 @@ def test_maintenance_handlers_keys_stable_and_bound():
             "set_modbus_parameters",
             "set_device_name",
             "sync_time",
+            "sync_device_clock",
         ]
     }
 
@@ -329,6 +331,7 @@ def test_maintenance_handlers_keys_stable_and_bound():
         handlers["set_modbus_parameters"],
         handlers["set_device_name"],
         handlers["sync_time"],
+        handlers["sync_device_clock"],
     )
 
     assert list(bound) == [
@@ -338,12 +341,15 @@ def test_maintenance_handlers_keys_stable_and_bound():
         "set_modbus_parameters",
         "set_device_name",
         "sync_time",
+        "sync_device_clock",
     ]
     assert bound == handlers
 
 
 def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
     """Service binding helper keeps registration order and uses matching handler names."""
+    from custom_components.thessla_green_modbus.services_schema import SYNC_DEVICE_CLOCK_SCHEMA
+
     handlers = {
         "reset_filters": object(),
         "reset_settings": object(),
@@ -351,6 +357,7 @@ def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
         "set_modbus_parameters": object(),
         "set_device_name": object(),
         "sync_time": object(),
+        "sync_device_clock": object(),
     }
 
     assert list(_iter_maintenance_service_bindings(handlers)) == [
@@ -360,6 +367,7 @@ def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
         ("set_modbus_parameters", SET_MODBUS_PARAMETERS_SCHEMA, handlers["set_modbus_parameters"]),
         ("set_device_name", SET_DEVICE_NAME_SCHEMA, handlers["set_device_name"]),
         ("sync_time", SYNC_TIME_SCHEMA, handlers["sync_time"]),
+        ("sync_device_clock", SYNC_DEVICE_CLOCK_SCHEMA, handlers["sync_device_clock"]),
     ]
 
 


### PR DESCRIPTION
## Summary

- Adds `clock_sync.py` with BCD encode/decode helpers, `encode_rtc_registers()`, `async_perform_clock_sync()` (drift check + read-back validation via `HomeAssistantError`), and `ClockSyncManager` for periodic/on-start automatic sync
- Adds `button.py` platform with `SyncDeviceClockButton` that force-syncs the device RTC on press
- Adds `sync_device_clock` service (with optional `force` field) alongside the existing `sync_time` legacy service
- Adds four new integration options: `sync_device_clock_enabled` (default: False), `sync_device_clock_on_start` (default: False), `sync_device_clock_interval_hours` (default: 24, range 1–168), `sync_device_clock_max_drift_seconds` (default: 300, range 30–86400)
- Auto-sync is disabled by default; manual service and button are always available

## Test plan

- [ ] `tests/test_clock_sync.py` — BCD encode/decode round-trip, `encode_rtc_registers` correctness, `async_perform_clock_sync` force/drift-skip/write-failure/read-back-validation paths, `ClockSyncManager` disabled/on-start/periodic behaviour, button press success/failure, options defaults, service schema keys, service write path
- [ ] `tests/test_services_handlers_maintenance.py` — updated to include `sync_device_clock` in registration order, handler map, and binding list
- [ ] Verify `ruff check custom_components tests tools` passes (All checks passed)
- [ ] Verify all Python files compile cleanly (`python -m compileall -q`)
- [ ] Verify all JSON files are valid (`python -m json.tool`)

https://claude.ai/code/session_01EAPmE85uFDu1bdudpa33zE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAPmE85uFDu1bdudpa33zE)_