### PR TITLE
feat: add safe device clock synchronization

### DIFF
--- a/custom_components/thessla_green_modbus/__init__.py
+++ b/custom_components/thessla_green_modbus/__init__.py
@@ -18,14 +18,23 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from .coordinator import ThesslaGreenModbusCoordinator
 
+from .clock_sync import (
+    async_sync_device_clock,
+    clock_sync_options,
+    should_auto_sync,
+    should_sync_on_start,
+    sync_interval,
+)
 from .const import (
     CONF_LOG_LEVEL,
     CONF_SAFE_SCAN,
     CONF_SCAN_INTERVAL,
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
     DEFAULT_LOG_LEVEL,
     DEFAULT_NAME,
     DEFAULT_SAFE_SCAN,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
     DOMAIN,
 )
 from .const import PLATFORMS as PLATFORM_DOMAINS
@@ -81,6 +90,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await async_setup_services(hass)
 
     entry.async_on_unload(entry.add_update_listener(async_update_options))
+
+    await _async_setup_clock_sync(hass, entry, coordinator)
+
     _LOGGER.info("ThesslaGreen Modbus integration setup completed successfully")
     return True
 
@@ -142,6 +154,45 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
         await coordinator.async_request_refresh()
 
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def _async_setup_clock_sync(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: ThesslaGreenModbusCoordinator,
+) -> None:
+    """Set up automatic device clock synchronisation if enabled in options."""
+    from homeassistant.helpers.event import async_track_time_interval
+    from homeassistant.util import dt as dt_util
+
+    opts = clock_sync_options(entry.options)
+    if not should_auto_sync(opts):
+        return
+
+    max_drift = int(
+        opts.get(CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS, DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS)
+    )
+
+    if should_sync_on_start(opts):
+        _LOGGER.info("Clock sync on start: syncing device clock now")
+        now = dt_util.now().replace(tzinfo=None)
+        await async_sync_device_clock(coordinator, now, max_drift, raise_on_failure=False)
+
+    interval = sync_interval(opts)
+
+    async def _periodic_sync(_now: object) -> None:
+        if not should_auto_sync(clock_sync_options(entry.options)):
+            return
+        now = dt_util.now().replace(tzinfo=None)
+        _LOGGER.debug("Periodic device clock sync triggered")
+        await async_sync_device_clock(coordinator, now, max_drift, raise_on_failure=False)
+
+    cancel = async_track_time_interval(hass, _periodic_sync, interval)
+    entry.async_on_unload(cancel)
+    _LOGGER.info(
+        "Automatic device clock sync scheduled every %s",
+        interval,
+    )
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/thessla_green_modbus/button.py
+++ b/custom_components/thessla_green_modbus/button.py
@@ -1,0 +1,84 @@
+"""Button platform for ThesslaGreen Modbus integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from .clock_sync import async_sync_device_clock, clock_sync_options
+from .const import (
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    device_unique_id_prefix,
+)
+from .coordinator import ThesslaGreenModbusCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ThesslaGreen button entities from config entry."""
+    coordinator: ThesslaGreenModbusCoordinator = entry.runtime_data
+    async_add_entities([ThesslaGreenSyncClockButton(coordinator, entry)], update_before_add=False)
+
+
+class ThesslaGreenSyncClockButton(ButtonEntity):
+    """Button that synchronises the device RTC to Home Assistant local time.
+
+    Pressing this button always triggers a clock write regardless of whether
+    automatic synchronisation is enabled in options.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "sync_device_clock"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:clock-check"
+
+    def __init__(
+        self,
+        coordinator: ThesslaGreenModbusCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        self._coordinator = coordinator
+        self._entry = entry
+        self._attr_device_info = coordinator.get_device_info()
+        device_info = getattr(coordinator, "device_info", {}) or {}
+        serial_number = device_info.get("serial_number")
+        prefix = device_unique_id_prefix(
+            serial_number,
+            getattr(coordinator, "host", ""),
+            getattr(coordinator, "port", 0),
+        )
+        slave_id = getattr(coordinator, "slave_id", 1)
+        self._attr_unique_id = f"{prefix}_{slave_id}_sync_device_clock_button"
+
+    @property
+    def available(self) -> bool:
+        """Button is available when coordinator has last succeeded."""
+        return bool(getattr(self._coordinator, "last_update_success", False))
+
+    async def async_press(self) -> None:
+        """Write current local time to device RTC registers."""
+        opts = clock_sync_options(self._entry.options)
+        max_drift = int(
+            opts.get(CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS, DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS)
+        )
+        now = dt_util.now().replace(tzinfo=None)
+        _LOGGER.info("Manual device clock sync triggered via button")
+        await async_sync_device_clock(
+            self._coordinator,
+            now,
+            max_drift,
+            raise_on_failure=True,
+            entity_id=self.entity_id or "",
+        )

--- a/custom_components/thessla_green_modbus/clock_sync.py
+++ b/custom_components/thessla_green_modbus/clock_sync.py
@@ -1,0 +1,184 @@
+"""Device clock synchronisation helpers for ThesslaGreen Modbus."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import (
+    CONF_SYNC_DEVICE_CLOCK_ENABLED,
+    CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    CONF_SYNC_DEVICE_CLOCK_ON_START,
+    DEFAULT_SYNC_DEVICE_CLOCK_ENABLED,
+    DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
+)
+from .modbus_exceptions import ConnectionException, ModbusException
+from .utils import encode_datetime_to_rtc_registers
+
+if TYPE_CHECKING:
+    from .coordinator import ThesslaGreenModbusCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# RTC register block starts at holding register address 0.
+_RTC_START_ADDRESS = 0
+
+# Names used for coordinator data read-back after write.
+_RTC_REGISTER_NAMES = ("date_time", "date_time_ddtt", "date_time_ggmm", "date_time_sscc")
+
+
+def clock_sync_options(options: dict[str, Any]) -> dict[str, Any]:
+    """Extract clock sync options from config entry options with defaults."""
+    return {
+        CONF_SYNC_DEVICE_CLOCK_ENABLED: bool(
+            options.get(CONF_SYNC_DEVICE_CLOCK_ENABLED, DEFAULT_SYNC_DEVICE_CLOCK_ENABLED)
+        ),
+        CONF_SYNC_DEVICE_CLOCK_ON_START: bool(
+            options.get(CONF_SYNC_DEVICE_CLOCK_ON_START, DEFAULT_SYNC_DEVICE_CLOCK_ON_START)
+        ),
+        CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS: int(
+            options.get(
+                CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+                DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+            )
+        ),
+        CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS: int(
+            options.get(
+                CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+            )
+        ),
+    }
+
+
+def _parse_device_clock(device_clock: str | None) -> datetime | None:
+    """Parse ISO-format device clock string returned by coordinator data."""
+    if not device_clock:
+        return None
+    try:
+        return datetime.fromisoformat(device_clock)
+    except (ValueError, TypeError):
+        return None
+
+
+def _validate_drift(
+    written_at: datetime,
+    device_clock: str | None,
+    max_drift_seconds: int,
+    *,
+    raise_on_failure: bool,
+) -> bool:
+    """Return True when device clock drift is within the allowed threshold.
+
+    ``written_at`` is the local datetime that was written to the device.
+    ``device_clock`` is the ISO string read back from coordinator data.
+    """
+    parsed = _parse_device_clock(device_clock)
+    if parsed is None:
+        if raise_on_failure:
+            raise HomeAssistantError(
+                "Could not read device clock back after synchronisation — validation skipped"
+            )
+        _LOGGER.warning("Device clock unavailable after write; drift cannot be validated")
+        return False
+
+    drift = abs((parsed - written_at.replace(tzinfo=None)).total_seconds())
+    if drift > max_drift_seconds:
+        msg = (
+            f"Device clock drift {drift:.0f}s exceeds threshold {max_drift_seconds}s "
+            f"after synchronisation (device reports {device_clock})"
+        )
+        if raise_on_failure:
+            raise HomeAssistantError(msg)
+        _LOGGER.error(msg)
+        return False
+
+    _LOGGER.info(
+        "Device clock synchronised successfully (drift %.0fs, threshold %ds)",
+        drift,
+        max_drift_seconds,
+    )
+    return True
+
+
+async def async_sync_device_clock(
+    coordinator: ThesslaGreenModbusCoordinator,
+    now: datetime,
+    max_drift_seconds: int,
+    *,
+    raise_on_failure: bool = False,
+    entity_id: str = "",
+) -> bool:
+    """Write current local time to all four RTC registers, then validate drift.
+
+    Returns True on success.  On failure logs an error and optionally raises
+    HomeAssistantError (when ``raise_on_failure`` is True).
+    """
+    if not getattr(coordinator, "last_update_success", False):
+        msg = "Coordinator is offline; skipping device clock synchronisation"
+        _LOGGER.warning(msg)
+        if raise_on_failure:
+            raise HomeAssistantError(msg)
+        return False
+
+    values = encode_datetime_to_rtc_registers(now)
+    label = f" for {entity_id}" if entity_id else ""
+
+    try:
+        success = await coordinator.async_write_registers(
+            start_address=_RTC_START_ADDRESS,
+            values=values,
+            refresh=True,
+        )
+    except (ModbusException, ConnectionException) as err:
+        msg = f"Failed to write RTC registers{label}: {err}"
+        _LOGGER.error(msg)
+        if raise_on_failure:
+            raise HomeAssistantError(msg) from err
+        return False
+
+    if not success:
+        msg = f"Write of RTC registers returned failure{label}"
+        _LOGGER.error(msg)
+        if raise_on_failure:
+            raise HomeAssistantError(msg)
+        return False
+
+    _LOGGER.debug(
+        "Wrote RTC payload %s (start_address=%d)%s",
+        values,
+        _RTC_START_ADDRESS,
+        label,
+    )
+
+    device_clock = (getattr(coordinator, "data", None) or {}).get("device_clock")
+    return _validate_drift(
+        now,
+        device_clock,
+        max_drift_seconds,
+        raise_on_failure=raise_on_failure,
+    )
+
+
+def should_auto_sync(options: dict[str, Any]) -> bool:
+    """Return True when automatic clock sync is enabled in options."""
+    return bool(options.get(CONF_SYNC_DEVICE_CLOCK_ENABLED, DEFAULT_SYNC_DEVICE_CLOCK_ENABLED))
+
+
+def should_sync_on_start(options: dict[str, Any]) -> bool:
+    """Return True when clock sync on coordinator start is enabled."""
+    return bool(options.get(CONF_SYNC_DEVICE_CLOCK_ON_START, DEFAULT_SYNC_DEVICE_CLOCK_ON_START))
+
+
+def sync_interval(options: dict[str, Any]) -> timedelta:
+    """Return the configured clock sync interval as a timedelta."""
+    hours = int(
+        options.get(CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS, DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS)
+    )
+    return timedelta(hours=max(1, min(168, hours)))

--- a/custom_components/thessla_green_modbus/config_flow_options_form.py
+++ b/custom_components/thessla_green_modbus/config_flow_options_form.py
@@ -27,6 +27,10 @@ from .const import (
     CONF_SERIAL_PORT,
     CONF_SKIP_MISSING_REGISTERS,
     CONF_STOP_BITS,
+    CONF_SYNC_DEVICE_CLOCK_ENABLED,
+    CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    CONF_SYNC_DEVICE_CLOCK_ON_START,
     CONF_TIMEOUT,
     CONNECTION_MODE_AUTO,
     CONNECTION_MODE_TCP_RTU,
@@ -47,6 +51,10 @@ from .const import (
     DEFAULT_SERIAL_PORT,
     DEFAULT_SKIP_MISSING_REGISTERS,
     DEFAULT_STOP_BITS,
+    DEFAULT_SYNC_DEVICE_CLOCK_ENABLED,
+    DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
     DEFAULT_TIMEOUT,
     DOMAIN,
     MAX_BATCH_REGISTERS,
@@ -81,6 +89,18 @@ def build_options_defaults(
         ),
         CONF_SAFE_SCAN: entry_options.get(CONF_SAFE_SCAN, DEFAULT_SAFE_SCAN),
         CONF_LOG_LEVEL: entry_options.get(CONF_LOG_LEVEL, DEFAULT_LOG_LEVEL),
+        CONF_SYNC_DEVICE_CLOCK_ENABLED: entry_options.get(
+            CONF_SYNC_DEVICE_CLOCK_ENABLED, DEFAULT_SYNC_DEVICE_CLOCK_ENABLED
+        ),
+        CONF_SYNC_DEVICE_CLOCK_ON_START: entry_options.get(
+            CONF_SYNC_DEVICE_CLOCK_ON_START, DEFAULT_SYNC_DEVICE_CLOCK_ON_START
+        ),
+        CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS: entry_options.get(
+            CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS, DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS
+        ),
+        CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS: entry_options.get(
+            CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS, DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS
+        ),
         CONF_CONNECTION_TYPE: entry_data.get(CONF_CONNECTION_TYPE, DEFAULT_CONNECTION_TYPE),
         CONF_CONNECTION_MODE: entry_options.get(
             CONF_CONNECTION_MODE, entry_data.get(CONF_CONNECTION_MODE)
@@ -176,6 +196,28 @@ def build_options_schema(values: dict[str, Any]) -> vol.Schema:
                     "selector": {"number": {"min": 1, "max": MAX_BATCH_REGISTERS, "step": 1}},
                 },
             ): int,
+            vol.Optional(
+                CONF_SYNC_DEVICE_CLOCK_ENABLED,
+                default=values[CONF_SYNC_DEVICE_CLOCK_ENABLED],
+            ): bool,
+            vol.Optional(
+                CONF_SYNC_DEVICE_CLOCK_ON_START,
+                default=values[CONF_SYNC_DEVICE_CLOCK_ON_START],
+            ): bool,
+            vol.Optional(
+                CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+                default=values[CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS],
+                description={
+                    "selector": {"number": {"min": 1, "max": 168, "step": 1}},
+                },
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=168)),
+            vol.Optional(
+                CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                default=values[CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS],
+                description={
+                    "selector": {"number": {"min": 30, "max": 86400, "step": 1}},
+                },
+            ): vol.All(vol.Coerce(int), vol.Range(min=30, max=86400)),
         }
     )
 

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -201,6 +201,17 @@ CONF_DEEP_SCAN = "deep_scan"  # Perform exhaustive raw register scan for diagnos
 CONF_MAX_REGISTERS_PER_REQUEST = "max_registers_per_request"
 CONF_LOG_LEVEL = "log_level"
 
+# Clock synchronization options
+CONF_SYNC_DEVICE_CLOCK_ENABLED = "sync_device_clock_enabled"
+CONF_SYNC_DEVICE_CLOCK_ON_START = "sync_device_clock_on_start"
+CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS = "sync_device_clock_interval_hours"
+CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS = "sync_device_clock_max_drift_seconds"
+
+DEFAULT_SYNC_DEVICE_CLOCK_ENABLED = False
+DEFAULT_SYNC_DEVICE_CLOCK_ON_START = False
+DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS = 24
+DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS = 300
+
 AIRFLOW_UNIT_M3H = "m3h"
 AIRFLOW_UNIT_PERCENTAGE = "percentage"
 DEFAULT_AIRFLOW_UNIT = AIRFLOW_UNIT_M3H

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:  # pragma: no cover - test/runtime fallback without 
 
     class _FallbackPlatform:
         BINARY_SENSOR = "binary_sensor"
+        BUTTON = "button"
         CLIMATE = "climate"
         FAN = "fan"
         NUMBER = "number"
@@ -264,6 +265,7 @@ KNOWN_MISSING_REGISTERS = {
 PLATFORMS: list[Any] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.FAN,
     Platform.SELECT,

--- a/custom_components/thessla_green_modbus/services.py
+++ b/custom_components/thessla_green_modbus/services.py
@@ -142,6 +142,7 @@ SERVICE_REGISTRATION_GROUPS: tuple[ServiceRegistrationGroup, ...] = (
             "set_modbus_parameters",
             "set_device_name",
             "sync_time",
+            "sync_device_clock",
         ),
     ),
     ServiceRegistrationGroup(

--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -357,3 +357,21 @@ sync_time:
         entity:
           domain: climate
           integration: thessla_green_modbus
+
+sync_device_clock:
+  name: Sync Device Clock (Safe)
+  description: >
+    Synchronise the AirPack real-time clock to the current Home Assistant local
+    time. Writes all four RTC registers, reads back the device clock and
+    validates the drift against the configured threshold.
+    WARNING: this writes to the device RTC.
+  target: *tg_target
+  fields:
+    entity_id:
+      name: Entity
+      description: The climate entity of the AirPack device.
+      required: true
+      selector:
+        entity:
+          domain: climate
+          integration: thessla_green_modbus

--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -7,6 +7,11 @@ from datetime import datetime as _dt
 
 from homeassistant.core import HomeAssistant, ServiceCall
 
+from .clock_sync import async_sync_device_clock
+from .const import (
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+)
 from .modbus_exceptions import ConnectionException, ModbusException
 from .services_dispatch import (
     refresh_and_log_success,
@@ -21,6 +26,7 @@ from .services_schema import (
     SET_DEVICE_NAME_SCHEMA,
     SET_MODBUS_PARAMETERS_SCHEMA,
     START_PRESSURE_TEST_SCHEMA,
+    SYNC_DEVICE_CLOCK_SCHEMA,
     SYNC_TIME_SCHEMA,
 )
 from .services_validation import (
@@ -60,6 +66,7 @@ def _maintenance_registrations():
         ("set_modbus_parameters", SET_MODBUS_PARAMETERS_SCHEMA),
         ("set_device_name", SET_DEVICE_NAME_SCHEMA),
         ("sync_time", SYNC_TIME_SCHEMA),
+        ("sync_device_clock", SYNC_DEVICE_CLOCK_SCHEMA),
     ]
 
 
@@ -76,6 +83,7 @@ def _maintenance_handlers(
     set_modbus_parameters: object,
     set_device_name: object,
     sync_time: object,
+    sync_device_clock: object,
 ) -> dict[str, object]:
     """Return maintenance service handlers keyed by service name."""
     return {
@@ -85,6 +93,7 @@ def _maintenance_handlers(
         "set_modbus_parameters": set_modbus_parameters,
         "set_device_name": set_device_name,
         "sync_time": sync_time,
+        "sync_device_clock": sync_device_clock,
     }
 
 
@@ -304,6 +313,30 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
 
         await _run_for_targets(hass, call, deps, _sync_time_for_target)
 
+    def _build_sync_device_clock_handler(hass: HomeAssistant, deps: ServiceHandlerDeps):
+        async def sync_device_clock(call: ServiceCall) -> None:
+            for entity_id, coordinator in _iter_targets(hass, call, deps):
+                now = deps.dt_now().replace(tzinfo=None)
+                max_drift = int(
+                    (getattr(coordinator, "entry", None)
+                    and coordinator.entry.options.get(
+                        CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                        DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                    ))
+                    or DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS
+                )
+                await async_sync_device_clock(
+                    coordinator,
+                    now,
+                    max_drift,
+                    raise_on_failure=True,
+                    entity_id=entity_id,
+                )
+
+        return sync_device_clock
+
+    sync_device_clock_handler = _build_sync_device_clock_handler(hass, deps)
+
     handlers = _maintenance_handlers(
         reset_filters,
         reset_settings,
@@ -311,5 +344,6 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
         set_modbus_parameters,
         set_device_name,
         sync_time,
+        sync_device_clock_handler,
     )
     _register_maintenance_bindings(hass, deps, handlers)

--- a/custom_components/thessla_green_modbus/services_schema.py
+++ b/custom_components/thessla_green_modbus/services_schema.py
@@ -146,6 +146,7 @@ SET_DEVICE_NAME_SCHEMA = vol.Schema(
 )
 
 SYNC_TIME_SCHEMA = vol.Schema({vol.Required("entity_id"): _ENTITY_IDS_VALIDATOR})
+SYNC_DEVICE_CLOCK_SCHEMA = vol.Schema({vol.Required("entity_id"): _ENTITY_IDS_VALIDATOR})
 REFRESH_DEVICE_DATA_SCHEMA = vol.Schema({vol.Required("entity_id"): _ENTITY_IDS_VALIDATOR})
 SCAN_ALL_REGISTERS_SCHEMA = vol.Schema({vol.Required("entity_id"): _ENTITY_IDS_VALIDATOR})
 SET_LOG_LEVEL_SCHEMA = vol.Schema(

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1417,6 +1417,11 @@
       "device_name": {
         "name": "Device Name"
       }
+    },
+    "button": {
+      "sync_device_clock": {
+        "name": "Sync Device Clock"
+      }
     }
   },
   "codes": {
@@ -1488,7 +1493,11 @@
           "safe_scan": "Safe Scan (no grouping)",
           "scan_interval": "Scan Interval (seconds)",
           "skip_missing_registers": "Skip Known Missing Registers",
-          "timeout": "Connection Timeout (seconds)"
+          "timeout": "Connection Timeout (seconds)",
+          "sync_device_clock_enabled": "Sync Device Clock (auto)",
+          "sync_device_clock_on_start": "Sync Clock on Start",
+          "sync_device_clock_interval_hours": "Clock Sync Interval (hours)",
+          "sync_device_clock_max_drift_seconds": "Clock Sync Max Drift (seconds)"
         },
         "data_description": {
           "deep_scan": "Read raw registers 0-300 for diagnostics",
@@ -1500,7 +1509,11 @@
           "safe_scan": "Avoid grouped register reads for compatibility",
           "scan_interval": "How often to read data from device (10-300 seconds)",
           "skip_missing_registers": "Do not poll registers known to be unavailable",
-          "timeout": "Maximum time to wait for response (5-60 seconds)"
+          "timeout": "Maximum time to wait for response (5-60 seconds)",
+          "sync_device_clock_enabled": "Automatically synchronise device RTC at the configured interval",
+          "sync_device_clock_on_start": "Synchronise device clock when integration starts",
+          "sync_device_clock_interval_hours": "How often to sync the device clock (1-168 hours)",
+          "sync_device_clock_max_drift_seconds": "Maximum allowed drift after sync before raising an error (30-86400 seconds)"
         },
         "error": {
           "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
@@ -1848,6 +1861,16 @@
         }
       },
       "name": "Set Debug Logging"
+    },
+    "sync_device_clock": {
+      "description": "Synchronise the AirPack real-time clock to current Home Assistant local time. Reads back the device clock and validates drift. WARNING: writes to device RTC.",
+      "fields": {
+        "entity_id": {
+          "description": "The climate entity of the AirPack device.",
+          "name": "Entity"
+        }
+      },
+      "name": "Sync Device Clock (Safe)"
     }
   },
   "title": "ThesslaGreen Modbus"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1417,6 +1417,11 @@
       "device_name": {
         "name": "Device Name"
       }
+    },
+    "button": {
+      "sync_device_clock": {
+        "name": "Sync Device Clock"
+      }
     }
   },
   "codes": {
@@ -1488,7 +1493,11 @@
           "safe_scan": "Safe Scan (no grouping)",
           "scan_interval": "Scan Interval (seconds)",
           "skip_missing_registers": "Skip Known Missing Registers",
-          "timeout": "Connection Timeout (seconds)"
+          "timeout": "Connection Timeout (seconds)",
+          "sync_device_clock_enabled": "Sync Device Clock (auto)",
+          "sync_device_clock_on_start": "Sync Clock on Start",
+          "sync_device_clock_interval_hours": "Clock Sync Interval (hours)",
+          "sync_device_clock_max_drift_seconds": "Clock Sync Max Drift (seconds)"
         },
         "data_description": {
           "deep_scan": "Read raw registers 0-300 for diagnostics",
@@ -1500,7 +1509,11 @@
           "safe_scan": "Avoid grouped register reads for compatibility",
           "scan_interval": "How often to read data from device (10-300 seconds)",
           "skip_missing_registers": "Do not poll registers known to be unavailable",
-          "timeout": "Maximum time to wait for response (5-60 seconds)"
+          "timeout": "Maximum time to wait for response (5-60 seconds)",
+          "sync_device_clock_enabled": "Automatically synchronise device RTC at the configured interval",
+          "sync_device_clock_on_start": "Synchronise device clock when integration starts",
+          "sync_device_clock_interval_hours": "How often to sync the device clock (1-168 hours)",
+          "sync_device_clock_max_drift_seconds": "Maximum allowed drift after sync before raising an error (30-86400 seconds)"
         },
         "error": {
           "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
@@ -1848,6 +1861,16 @@
         }
       },
       "name": "Set Debug Logging"
+    },
+    "sync_device_clock": {
+      "description": "Synchronise the AirPack real-time clock to current Home Assistant local time. Reads back the device clock and validates drift. WARNING: writes to device RTC.",
+      "fields": {
+        "entity_id": {
+          "description": "The climate entity of the AirPack device.",
+          "name": "Entity"
+        }
+      },
+      "name": "Sync Device Clock (Safe)"
     }
   },
   "title": "ThesslaGreen Modbus"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1417,6 +1417,11 @@
       "device_name": {
         "name": "Nazwa urządzenia"
       }
+    },
+    "button": {
+      "sync_device_clock": {
+        "name": "Synchronizuj zegar urządzenia"
+      }
     }
   },
   "codes": {
@@ -1488,7 +1493,11 @@
           "safe_scan": "Bezpieczny skan (bez grupowania)",
           "scan_interval": "Interwał skanowania (s)",
           "skip_missing_registers": "Pomijaj znane brakujące rejestry",
-          "timeout": "Limit czasu połączenia (s)"
+          "timeout": "Limit czasu połączenia (s)",
+          "sync_device_clock_enabled": "Synchronizuj zegar urządzenia (auto)",
+          "sync_device_clock_on_start": "Synchronizuj zegar przy starcie",
+          "sync_device_clock_interval_hours": "Interwał synchronizacji zegara (godziny)",
+          "sync_device_clock_max_drift_seconds": "Maks. dryft synchronizacji zegara (sekundy)"
         },
         "data_description": {
           "deep_scan": "Odczyt surowych rejestrów 0-300 do diagnostyki",
@@ -1500,7 +1509,11 @@
           "safe_scan": "Unikaj grupowanych odczytów rejestrów dla kompatybilności",
           "scan_interval": "Jak często odczytywać dane z urządzenia (10-300 s)",
           "skip_missing_registers": "Nie odczytuj rejestrów, które są znane jako niedostępne",
-          "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)"
+          "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)",
+          "sync_device_clock_enabled": "Automatycznie synchronizuj zegar RTC urządzenia w skonfigurowanym interwale",
+          "sync_device_clock_on_start": "Synchronizuj zegar urządzenia przy starcie integracji",
+          "sync_device_clock_interval_hours": "Jak często synchronizować zegar (1-168 godzin)",
+          "sync_device_clock_max_drift_seconds": "Maksymalny dopuszczalny dryft po synchronizacji (30-86400 sekund)"
         },
         "error": {
           "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-16)"
@@ -1848,6 +1861,16 @@
         }
       },
       "name": "Ustaw debugowanie logów"
+    },
+    "sync_device_clock": {
+      "description": "Synchronizuje zegar RTC urządzenia AirPack z aktualnym lokalnym czasem Home Assistant. Odczytuje zegar i waliduje dryft. UWAGA: zapisuje do zegara RTC urządzenia.",
+      "fields": {
+        "entity_id": {
+          "description": "Encja klimatyzatora urządzenia AirPack.",
+          "name": "Encja"
+        }
+      },
+      "name": "Synchronizuj zegar urządzenia (bezpiecznie)"
     }
   },
   "title": "ThesslaGreen Modbus"

--- a/custom_components/thessla_green_modbus/utils.py
+++ b/custom_components/thessla_green_modbus/utils.py
@@ -14,6 +14,7 @@ __all__ = [
     "decode_temp_01c",
     "default_connection_mode",
     "encode_bcd_time",
+    "encode_datetime_to_rtc_registers",
     "resolve_connection_settings",
     "utcnow",
 ]
@@ -135,6 +136,29 @@ def encode_bcd_time(value: time) -> int:
         return ((val // 10) << 4) | (val % 10)
 
     return (_int_to_bcd(value.hour) << 8) | _int_to_bcd(value.minute)
+
+
+def _to_bcd(value: int) -> int:
+    """Encode an integer (0-99) into a two-nibble BCD byte."""
+    return ((value // 10) << 4) | (value % 10)
+
+
+def encode_datetime_to_rtc_registers(dt: datetime) -> list[int]:
+    """Encode a local datetime into the four RTC holding registers.
+
+    Register layout (consistent with the existing decoder in
+    ``_CoordinatorCapabilitiesMixin._decode_device_clock``):
+
+    * reg 0 (date_time):     YY MM  — BCD tens/units of year, BCD month
+    * reg 1 (date_time_ddtt): DD WW  — BCD day of month, BCD weekday (Mon=0)
+    * reg 2 (date_time_ggmm): HH mm  — BCD hour, BCD minute
+    * reg 3 (date_time_sscc): SS cc  — BCD second, BCD centiseconds (always 0)
+    """
+    reg_yymm = (_to_bcd(dt.year % 100) << 8) | _to_bcd(dt.month)
+    reg_ddtt = (_to_bcd(dt.day) << 8) | _to_bcd(dt.weekday())
+    reg_ggmm = (_to_bcd(dt.hour) << 8) | _to_bcd(dt.minute)
+    reg_sscc = (_to_bcd(dt.second) << 8) | 0x00
+    return [reg_yymm, reg_ddtt, reg_ggmm, reg_sscc]
 
 
 def _decode_aatt(value: int) -> dict[str, float | int] | None:

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -1,0 +1,594 @@
+# mypy: ignore-errors
+"""Tests for device clock synchronisation feature."""
+
+from __future__ import annotations
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus.clock_sync import (
+    _parse_device_clock,
+    _validate_drift,
+    async_sync_device_clock,
+    clock_sync_options,
+    should_auto_sync,
+    should_sync_on_start,
+    sync_interval,
+)
+from custom_components.thessla_green_modbus.const import (
+    CONF_SYNC_DEVICE_CLOCK_ENABLED,
+    CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    CONF_SYNC_DEVICE_CLOCK_ON_START,
+    DEFAULT_SYNC_DEVICE_CLOCK_ENABLED,
+    DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS,
+    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+    DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
+)
+from custom_components.thessla_green_modbus.utils import encode_datetime_to_rtc_registers
+
+# ---------------------------------------------------------------------------
+# BCD encoding — known datetime values
+# ---------------------------------------------------------------------------
+
+
+def _to_bcd(value: int) -> int:
+    return ((value // 10) << 4) | (value % 10)
+
+
+def test_encode_datetime_bcd_structure():
+    """encode_datetime_to_rtc_registers returns 4 uint16 register values."""
+    dt = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    payload = encode_datetime_to_rtc_registers(dt)
+    assert len(payload) == 4  # nosec B101
+    assert all(isinstance(v, int) for v in payload)  # nosec B101
+    assert all(0 <= v <= 0xFFFF for v in payload)  # nosec B101
+
+
+def test_encode_datetime_yymm():
+    """reg 0 encodes BCD year (2-digit) in high byte and BCD month in low byte."""
+    dt = datetime.datetime(2024, 3, 15, 0, 0, 0)
+    payload = encode_datetime_to_rtc_registers(dt)
+    reg_yymm = payload[0]
+    yy_bcd = (reg_yymm >> 8) & 0xFF
+    mm_bcd = reg_yymm & 0xFF
+    assert yy_bcd == _to_bcd(24)  # nosec B101
+    assert mm_bcd == _to_bcd(3)   # nosec B101
+
+
+def test_encode_datetime_ddtt():
+    """reg 1 encodes BCD day in high byte and BCD weekday (Mon=0) in low byte."""
+    dt = datetime.datetime(2024, 3, 15, 0, 0, 0)  # Friday = weekday 4
+    payload = encode_datetime_to_rtc_registers(dt)
+    reg_ddtt = payload[1]
+    dd_bcd = (reg_ddtt >> 8) & 0xFF
+    tt_bcd = reg_ddtt & 0xFF
+    assert dd_bcd == _to_bcd(15)  # nosec B101
+    assert tt_bcd == _to_bcd(4)   # Friday  # nosec B101
+
+
+def test_encode_datetime_ggmm():
+    """reg 2 encodes BCD hour in high byte and BCD minute in low byte."""
+    dt = datetime.datetime(2024, 3, 15, 14, 30, 0)
+    payload = encode_datetime_to_rtc_registers(dt)
+    reg_ggmm = payload[2]
+    hh_bcd = (reg_ggmm >> 8) & 0xFF
+    mm_bcd = reg_ggmm & 0xFF
+    assert hh_bcd == _to_bcd(14)  # nosec B101
+    assert mm_bcd == _to_bcd(30)  # nosec B101
+
+
+def test_encode_datetime_sscc():
+    """reg 3 encodes BCD second in high byte; centiseconds always 0."""
+    dt = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    payload = encode_datetime_to_rtc_registers(dt)
+    reg_sscc = payload[3]
+    ss_bcd = (reg_sscc >> 8) & 0xFF
+    cc_bcd = reg_sscc & 0xFF
+    assert ss_bcd == _to_bcd(45)  # nosec B101
+    assert cc_bcd == 0x00         # nosec B101
+
+
+def test_encode_datetime_midnight():
+    """Midnight (00:00:00) encodes without errors."""
+    dt = datetime.datetime(2000, 1, 1, 0, 0, 0)
+    payload = encode_datetime_to_rtc_registers(dt)
+    assert len(payload) == 4  # nosec B101
+
+
+def test_encode_datetime_end_of_day():
+    """23:59:59 encodes correctly."""
+    dt = datetime.datetime(2099, 12, 31, 23, 59, 59)
+    payload = encode_datetime_to_rtc_registers(dt)
+    reg_ggmm = payload[2]
+    hh = (reg_ggmm >> 8) & 0xFF
+    mi = reg_ggmm & 0xFF
+    assert hh == _to_bcd(23)  # nosec B101
+    assert mi == _to_bcd(59)  # nosec B101
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: encode → decoder in coordinator/capabilities.py
+# ---------------------------------------------------------------------------
+
+
+def _decode_rtc(values: list[int]) -> str | None:
+    """Replicate _decode_device_clock from coordinator/capabilities.py."""
+    raw_yymm, raw_ddtt, raw_ggmm, raw_sscc = values
+
+    def _bcd(b: int) -> int:
+        return ((b >> 4) & 0xF) * 10 + (b & 0xF)
+
+    yy = _bcd((raw_yymm >> 8) & 0xFF)
+    mm = _bcd(raw_yymm & 0xFF)
+    dd = _bcd((raw_ddtt >> 8) & 0xFF)
+    hh = _bcd((raw_ggmm >> 8) & 0xFF)
+    mi = _bcd(raw_ggmm & 0xFF)
+    ss = _bcd((raw_sscc >> 8) & 0xFF)
+    year = 2000 + yy
+    if 1 <= mm <= 12 and 1 <= dd <= 31 and hh <= 23 and mi <= 59 and ss <= 59:
+        return f"{year:04d}-{mm:02d}-{dd:02d}T{hh:02d}:{mi:02d}:{ss:02d}"
+    return None
+
+
+@pytest.mark.parametrize(
+    "dt_str",
+    [
+        "2024-03-15T14:30:45",
+        "2000-01-01T00:00:00",
+        "2099-12-31T23:59:59",
+        "2026-05-09T08:15:30",
+    ],
+)
+def test_round_trip_encode_decode(dt_str: str):
+    """Encoding then decoding with the existing decoder returns the same datetime."""
+    dt = datetime.datetime.fromisoformat(dt_str)
+    payload = encode_datetime_to_rtc_registers(dt)
+    decoded = _decode_rtc(payload)
+    assert decoded == dt_str  # nosec B101
+
+
+# ---------------------------------------------------------------------------
+# _parse_device_clock
+# ---------------------------------------------------------------------------
+
+
+def test_parse_device_clock_valid():
+    assert _parse_device_clock("2024-03-15T14:30:45") == datetime.datetime(2024, 3, 15, 14, 30, 45)
+
+
+def test_parse_device_clock_none():
+    assert _parse_device_clock(None) is None
+
+
+def test_parse_device_clock_empty():
+    assert _parse_device_clock("") is None
+
+
+def test_parse_device_clock_malformed():
+    assert _parse_device_clock("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# _validate_drift
+# ---------------------------------------------------------------------------
+
+
+def test_validate_drift_within_threshold():
+    written_at = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    device_clock = "2024-03-15T14:30:46"  # 1 second off
+    assert _validate_drift(written_at, device_clock, 300, raise_on_failure=False)
+
+
+def test_validate_drift_exceeds_threshold():
+    written_at = datetime.datetime(2024, 3, 15, 14, 30, 0)
+    device_clock = "2024-03-15T14:40:00"  # 600 seconds off
+    result = _validate_drift(written_at, device_clock, 300, raise_on_failure=False)
+    assert result is False  # nosec B101
+
+
+def test_validate_drift_raises_on_failure():
+    from homeassistant.exceptions import HomeAssistantError
+
+    written_at = datetime.datetime(2024, 3, 15, 14, 30, 0)
+    device_clock = "2024-03-15T14:40:00"  # 600 seconds off
+    with pytest.raises(HomeAssistantError, match="drift"):
+        _validate_drift(written_at, device_clock, 300, raise_on_failure=True)
+
+
+def test_validate_drift_unavailable_no_raise():
+    result = _validate_drift(
+        datetime.datetime(2024, 3, 15, 14, 30, 0),
+        None,
+        300,
+        raise_on_failure=False,
+    )
+    assert result is False  # nosec B101
+
+
+def test_validate_drift_unavailable_raise():
+    from homeassistant.exceptions import HomeAssistantError
+
+    with pytest.raises(HomeAssistantError, match="read device clock"):
+        _validate_drift(
+            datetime.datetime(2024, 3, 15, 14, 30, 0),
+            None,
+            300,
+            raise_on_failure=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# async_sync_device_clock
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(
+    *,
+    online: bool = True,
+    write_result: bool = True,
+    device_clock: str | None = "2024-03-15T14:30:45",
+) -> MagicMock:
+    coord = MagicMock()
+    coord.last_update_success = online
+    coord.async_write_registers = AsyncMock(return_value=write_result)
+    coord.data = {"device_clock": device_clock}
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_sync_skipped_when_offline():
+    """sync should return False and not write when coordinator is offline."""
+    coord = _make_coordinator(online=False)
+    now = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    result = await async_sync_device_clock(coord, now, 300, raise_on_failure=False)
+    assert result is False  # nosec B101
+    coord.async_write_registers.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_skipped_offline_raises():
+    """Manual service raises HomeAssistantError when coordinator is offline."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    coord = _make_coordinator(online=False)
+    now = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    with pytest.raises(HomeAssistantError, match="offline"):
+        await async_sync_device_clock(coord, now, 300, raise_on_failure=True)
+    coord.async_write_registers.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_writes_expected_registers():
+    """sync writes the correct BCD payload starting at address 0."""
+    now = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    expected_values = encode_datetime_to_rtc_registers(now)
+    # device clock matches written time exactly
+    coord = _make_coordinator(device_clock="2024-03-15T14:30:45")
+    result = await async_sync_device_clock(coord, now, 300)
+    assert result is True  # nosec B101
+    coord.async_write_registers.assert_called_once_with(
+        start_address=0,
+        values=expected_values,
+        refresh=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_returns_false_on_write_failure():
+    """sync returns False when write returns failure."""
+    coord = _make_coordinator(write_result=False)
+    now = datetime.datetime(2024, 3, 15, 14, 30, 0)
+    result = await async_sync_device_clock(coord, now, 300, raise_on_failure=False)
+    assert result is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_sync_raises_on_write_failure():
+    """sync raises HomeAssistantError when write fails and raise_on_failure=True."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    coord = _make_coordinator(write_result=False)
+    now = datetime.datetime(2024, 3, 15, 14, 30, 0)
+    with pytest.raises(HomeAssistantError, match="failure"):
+        await async_sync_device_clock(coord, now, 300, raise_on_failure=True)
+
+
+@pytest.mark.asyncio
+async def test_sync_raises_on_modbus_exception():
+    """sync raises HomeAssistantError when ModbusException occurs."""
+    from custom_components.thessla_green_modbus.modbus_exceptions import ModbusException
+    from homeassistant.exceptions import HomeAssistantError
+
+    coord = _make_coordinator()
+    coord.async_write_registers = AsyncMock(side_effect=ModbusException("boom"))
+    now = datetime.datetime(2024, 3, 15, 14, 30, 0)
+    with pytest.raises(HomeAssistantError, match="boom"):
+        await async_sync_device_clock(coord, now, 300, raise_on_failure=True)
+
+
+@pytest.mark.asyncio
+async def test_sync_returns_false_on_modbus_exception_no_raise():
+    """sync returns False on ModbusException when raise_on_failure=False."""
+    from custom_components.thessla_green_modbus.modbus_exceptions import ModbusException
+
+    coord = _make_coordinator()
+    coord.async_write_registers = AsyncMock(side_effect=ModbusException("boom"))
+    now = datetime.datetime(2024, 3, 15, 14, 30, 0)
+    result = await async_sync_device_clock(coord, now, 300, raise_on_failure=False)
+    assert result is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_sync_drift_validation_failure():
+    """sync returns False when device clock drift exceeds threshold."""
+    # device reports a time 1 hour off from written time
+    coord = _make_coordinator(device_clock="2024-03-15T15:30:45")
+    now = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    result = await async_sync_device_clock(coord, now, 300, raise_on_failure=False)
+    assert result is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_sync_drift_validation_raise():
+    """sync raises HomeAssistantError when drift exceeds threshold and raise_on_failure=True."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    coord = _make_coordinator(device_clock="2024-03-15T15:30:45")
+    now = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    with pytest.raises(HomeAssistantError, match="drift"):
+        await async_sync_device_clock(coord, now, 300, raise_on_failure=True)
+
+
+@pytest.mark.asyncio
+async def test_sync_device_clock_unavailable_after_write():
+    """sync returns False when device clock is None after write (no raise)."""
+    coord = _make_coordinator(device_clock=None)
+    now = datetime.datetime(2024, 3, 15, 14, 30, 45)
+    result = await async_sync_device_clock(coord, now, 300, raise_on_failure=False)
+    assert result is False  # nosec B101
+
+
+# ---------------------------------------------------------------------------
+# Options helpers
+# ---------------------------------------------------------------------------
+
+
+def test_clock_sync_options_defaults():
+    opts = clock_sync_options({})
+    assert opts[CONF_SYNC_DEVICE_CLOCK_ENABLED] == DEFAULT_SYNC_DEVICE_CLOCK_ENABLED  # nosec B101
+    assert opts[CONF_SYNC_DEVICE_CLOCK_ON_START] == DEFAULT_SYNC_DEVICE_CLOCK_ON_START  # nosec B101
+    assert opts[CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS] == DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS  # nosec B101
+    assert opts[CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS] == DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS  # nosec B101
+
+
+def test_clock_sync_options_custom():
+    opts = clock_sync_options(
+        {
+            CONF_SYNC_DEVICE_CLOCK_ENABLED: True,
+            CONF_SYNC_DEVICE_CLOCK_ON_START: True,
+            CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS: 12,
+            CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS: 60,
+        }
+    )
+    assert opts[CONF_SYNC_DEVICE_CLOCK_ENABLED] is True  # nosec B101
+    assert opts[CONF_SYNC_DEVICE_CLOCK_ON_START] is True  # nosec B101
+    assert opts[CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS] == 12  # nosec B101
+    assert opts[CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS] == 60  # nosec B101
+
+
+def test_should_auto_sync_disabled_by_default():
+    assert should_auto_sync({}) is False  # nosec B101
+
+
+def test_should_auto_sync_enabled():
+    assert should_auto_sync({CONF_SYNC_DEVICE_CLOCK_ENABLED: True}) is True  # nosec B101
+
+
+def test_should_sync_on_start_disabled_by_default():
+    assert should_sync_on_start({}) is False  # nosec B101
+
+
+def test_should_sync_on_start_enabled():
+    assert should_sync_on_start({CONF_SYNC_DEVICE_CLOCK_ON_START: True}) is True  # nosec B101
+
+
+def test_sync_interval_default():
+    from datetime import timedelta
+
+    assert sync_interval({}) == timedelta(hours=DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS)  # nosec B101
+
+
+def test_sync_interval_custom():
+    from datetime import timedelta
+
+    assert sync_interval({CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS: 48}) == timedelta(hours=48)  # nosec B101
+
+
+def test_sync_interval_clamped_min():
+    from datetime import timedelta
+
+    assert sync_interval({CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS: 0}) == timedelta(hours=1)  # nosec B101
+
+
+def test_sync_interval_clamped_max():
+    from datetime import timedelta
+
+    assert sync_interval({CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS: 999}) == timedelta(hours=168)  # nosec B101
+
+
+# ---------------------------------------------------------------------------
+# Service registration
+# ---------------------------------------------------------------------------
+
+
+def test_sync_device_clock_service_registered():
+    """sync_device_clock service is in REGISTERED_SERVICE_NAMES."""
+    from custom_components.thessla_green_modbus.services import REGISTERED_SERVICE_NAMES
+
+    assert "sync_device_clock" in REGISTERED_SERVICE_NAMES  # nosec B101
+
+
+def test_sync_time_service_still_registered():
+    """sync_time service is preserved for backward compatibility."""
+    from custom_components.thessla_green_modbus.services import REGISTERED_SERVICE_NAMES
+
+    assert "sync_time" in REGISTERED_SERVICE_NAMES  # nosec B101
+
+
+# ---------------------------------------------------------------------------
+# Manual service call — writes correct register values
+# ---------------------------------------------------------------------------
+
+
+class _Services:
+    def __init__(self):
+        self.handlers: dict = {}
+
+    def async_register(self, _domain, service, handler, _schema):
+        self.handlers[service] = handler
+
+    def async_remove(self, _domain, service):
+        pass
+
+
+class _WritableCoordinator:
+    def __init__(self, *, write_result=True, device_clock="2024-03-15T14:30:45"):
+        self.last_update_success = True
+        self.async_write_registers = AsyncMock(return_value=write_result)
+        self.async_write_register = AsyncMock(return_value=write_result)
+        self.async_request_refresh = AsyncMock()
+        self.data = {"device_clock": device_clock}
+        self.entry = SimpleNamespace(
+            options={CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS: 300}
+        )
+        self.effective_batch = 2
+        self.available_registers = {"holding_registers": set()}
+        self.host = "127.0.0.1"
+        self.port = 502
+        self.slave_id = 1
+        self.timeout = 5
+        self.retry = 3
+        self.scan_uart_settings = False
+        self.unknown_registers = {}
+        self.scanned_registers = {}
+
+
+def _make_hass(coordinator=None):
+    hass = SimpleNamespace()
+    hass.services = _Services()
+    hass.data = {}
+    hass.bus = SimpleNamespace(async_fire=MagicMock())
+    if coordinator is not None:
+        from custom_components.thessla_green_modbus.const import DOMAIN
+        hass.data = {DOMAIN: {"entry1": coordinator}}
+    return hass
+
+
+def _make_call(data: dict):
+    return SimpleNamespace(data=data)
+
+
+async def _setup_and_get(hass, service_name, coordinator, monkeypatch):
+    from custom_components.thessla_green_modbus import services as svc_mod
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coordinator)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda _h, c: c.data["entity_id"])
+    from custom_components.thessla_green_modbus.services import async_setup_services
+    await async_setup_services(hass)
+    return hass.services.handlers[service_name]
+
+
+@pytest.mark.asyncio
+async def test_sync_device_clock_service_writes_correct_payload(monkeypatch):
+    """sync_device_clock service calls write_registers with the BCD payload."""
+    import datetime as _dt_mod
+
+    fake_now = _dt_mod.datetime(2024, 3, 15, 14, 30, 45)
+    coord = _WritableCoordinator(device_clock="2024-03-15T14:30:45")
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(
+        svc_mod,
+        "dt_util",
+        type("DT", (), {"now": staticmethod(lambda: fake_now)})(),
+    )
+    handler = await _setup_and_get(hass, "sync_device_clock", coord, monkeypatch)
+    call = _make_call({"entity_id": ["climate.dev"]})
+    await handler(call)
+
+    expected = encode_datetime_to_rtc_registers(fake_now)
+    coord.async_write_registers.assert_called_once_with(
+        start_address=0,
+        values=expected,
+        refresh=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_device_clock_service_offline_raises(monkeypatch):
+    """sync_device_clock raises HomeAssistantError when device is offline."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    coord = _WritableCoordinator()
+    coord.last_update_success = False
+    hass = _make_hass()
+
+    handler = await _setup_and_get(hass, "sync_device_clock", coord, monkeypatch)
+    call = _make_call({"entity_id": ["climate.dev"]})
+    with pytest.raises(HomeAssistantError):
+        await handler(call)
+    coord.async_write_registers.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_device_clock_service_drift_exceeded_raises(monkeypatch):
+    """sync_device_clock raises HomeAssistantError when drift exceeds threshold."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    # device clock is 1 hour ahead — exceeds 300s threshold
+    coord = _WritableCoordinator(device_clock="2024-03-15T15:30:45")
+    hass = _make_hass()
+
+    import datetime as _dt_mod
+
+    fake_now = _dt_mod.datetime(2024, 3, 15, 14, 30, 45)
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(
+        svc_mod,
+        "dt_util",
+        type("DT", (), {"now": staticmethod(lambda: fake_now)})(),
+    )
+    handler = await _setup_and_get(hass, "sync_device_clock", coord, monkeypatch)
+    call = _make_call({"entity_id": ["climate.dev"]})
+    with pytest.raises(HomeAssistantError, match="drift"):
+        await handler(call)
+
+
+# ---------------------------------------------------------------------------
+# Auto-sync options — should_auto_sync / should_sync_on_start
+# ---------------------------------------------------------------------------
+
+
+def test_auto_sync_does_not_run_when_disabled():
+    """Automatic sync must not occur when the option is disabled (default)."""
+    # Default options — sync disabled
+    opts = {}
+    assert not should_auto_sync(opts)  # nosec B101
+    # Explicit disable
+    opts2 = {CONF_SYNC_DEVICE_CLOCK_ENABLED: False}
+    assert not should_auto_sync(opts2)  # nosec B101
+
+
+def test_on_start_sync_does_not_run_when_disabled():
+    opts = {CONF_SYNC_DEVICE_CLOCK_ENABLED: True, CONF_SYNC_DEVICE_CLOCK_ON_START: False}
+    assert not should_sync_on_start(opts)  # nosec B101
+
+
+def test_on_start_sync_runs_when_enabled():
+    opts = {CONF_SYNC_DEVICE_CLOCK_ENABLED: True, CONF_SYNC_DEVICE_CLOCK_ON_START: True}
+    assert should_sync_on_start(opts)  # nosec B101

--- a/tests/test_services_handlers_maintenance.py
+++ b/tests/test_services_handlers_maintenance.py
@@ -305,6 +305,7 @@ def test_maintenance_registrations_service_order_and_schema_count():
         "set_modbus_parameters",
         "set_device_name",
         "sync_time",
+        "sync_device_clock",
     ]
 
 
@@ -319,6 +320,7 @@ def test_maintenance_handlers_keys_stable_and_bound():
             "set_modbus_parameters",
             "set_device_name",
             "sync_time",
+            "sync_device_clock",
         ]
     }
 
@@ -329,6 +331,7 @@ def test_maintenance_handlers_keys_stable_and_bound():
         handlers["set_modbus_parameters"],
         handlers["set_device_name"],
         handlers["sync_time"],
+        handlers["sync_device_clock"],
     )
 
     assert list(bound) == [
@@ -338,12 +341,15 @@ def test_maintenance_handlers_keys_stable_and_bound():
         "set_modbus_parameters",
         "set_device_name",
         "sync_time",
+        "sync_device_clock",
     ]
     assert bound == handlers
 
 
 def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
     """Service binding helper keeps registration order and uses matching handler names."""
+    from custom_components.thessla_green_modbus.services_schema import SYNC_DEVICE_CLOCK_SCHEMA
+
     handlers = {
         "reset_filters": object(),
         "reset_settings": object(),
@@ -351,6 +357,7 @@ def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
         "set_modbus_parameters": object(),
         "set_device_name": object(),
         "sync_time": object(),
+        "sync_device_clock": object(),
     }
 
     assert list(_iter_maintenance_service_bindings(handlers)) == [
@@ -360,6 +367,7 @@ def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
         ("set_modbus_parameters", SET_MODBUS_PARAMETERS_SCHEMA, handlers["set_modbus_parameters"]),
         ("set_device_name", SET_DEVICE_NAME_SCHEMA, handlers["set_device_name"]),
         ("sync_time", SYNC_TIME_SCHEMA, handlers["sync_time"]),
+        ("sync_device_clock", SYNC_DEVICE_CLOCK_SCHEMA, handlers["sync_device_clock"]),
     ]
 
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -146,6 +146,10 @@ OPTION_KEYS = [
     "timeout",
     "deep_scan",
     "max_registers_per_request",
+    "sync_device_clock_enabled",
+    "sync_device_clock_on_start",
+    "sync_device_clock_interval_hours",
+    "sync_device_clock_max_drift_seconds",
 ]
 
 OPTION_ERROR_KEYS = [


### PR DESCRIPTION
Base branch: dev

## Summary

- Adds safe Home Assistant → device RTC clock synchronization with BCD encoding, read-back validation, and drift threshold enforcement
- New `thessla_green_modbus.sync_device_clock` service (manual, always available, raises `HomeAssistantError` on failure)
- New `button.thesslagreen_sync_device_clock` entity for one-tap sync from the UI
- Integration Options Flow extended with four new options (all disabled by default)
- Automatic periodic sync via `async_track_time_interval` (only when explicitly enabled)
- 48 new tests covering BCD encoding, round-trip compatibility, service registration, drift threshold, offline handling, write failure, and read-back validation failure

## Options added

| Option | Type | Default | Range |
|---|---|---|---|
| `sync_device_clock_enabled` | bool | `false` | — |
| `sync_device_clock_on_start` | bool | `false` | — |
| `sync_device_clock_interval_hours` | int | `24` | 1–168 |
| `sync_device_clock_max_drift_seconds` | int | `300` | 30–86400 |

## Service/button added

- **Service**: `thessla_green_modbus.sync_device_clock`
- **Button**: `button.thesslagreen_sync_device_clock` (EntityCategory.CONFIG)

## RTC registers written

All four RTC holding registers in one `async_write_registers` call at `start_address=0`:

| Offset | Register name | Layout |
|---|---|---|
| 0 | `date_time` | BCD YYMM |
| 1 | `date_time_ddtt` | BCD DDWW |
| 2 | `date_time_ggmm` | BCD HHMM |
| 3 | `date_time_sscc` | BCD SS00 |

## BCD encoding

Each byte is encoded as `((value // 10) << 4) | (value % 10)`. Two BCD bytes are packed into one 16-bit holding register. This is round-trip compatible with the existing `_decode_device_clock` in `coordinator/capabilities.py`.

## Safety behavior

- **No write when offline**: coordinator `last_update_success` is checked before any write
- **No write on every poll**: writes only happen on explicit service call or timed interval
- **Drift validation**: after write + refresh, `device_clock` is read back and drift computed; fails if drift > `max_drift_seconds`
- **Manual service raises HomeAssistantError** on any failure (offline, write failure, drift exceeded)
- **Auto-sync only runs when `sync_device_clock_enabled: true`**
- **Existing `sync_time` service preserved** for backward compatibility
- **Existing `device_clock` sensor unchanged** (read-only, no modifications)

## Validation results

- `ruff check custom_components tests`: All checks passed
- `python -m compileall -q custom_components tests tools`: No errors
- `python tools/check_maintainability.py`: Maintainability gate passed
- `python tools/validate_entity_mappings.py`: 366 entities validated
- `pytest tests/ -q`: **2031 passed, 4 skipped, 0 failed**

https://claude.ai/code/session_011hSQ6m5Y6fY8YKTrd37Gzm

---
_Generated by [Claude Code](https://claude.ai/code/session_011hSQ6m5Y6fY8YKTrd37Gzm)_