### PR TITLE
chore: polish translations and user-facing text

### DIFF
--- a/custom_components/thessla_green_modbus/clock_sync.py
+++ b/custom_components/thessla_green_modbus/clock_sync.py
@@ -199,11 +199,25 @@ class ClockSyncManager:
             DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
             DEFAULT_SYNC_DEVICE_CLOCK_ON_START,
         )
+
         return {
-            "enabled": bool(opts.get(CONF_SYNC_DEVICE_CLOCK_ENABLED, DEFAULT_SYNC_DEVICE_CLOCK_ENABLED)),
-            "on_start": bool(opts.get(CONF_SYNC_DEVICE_CLOCK_ON_START, DEFAULT_SYNC_DEVICE_CLOCK_ON_START)),
-            "interval_hours": int(opts.get(CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS, DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS)),
-            "max_drift": int(opts.get(CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS, DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS)),
+            "enabled": bool(
+                opts.get(CONF_SYNC_DEVICE_CLOCK_ENABLED, DEFAULT_SYNC_DEVICE_CLOCK_ENABLED)
+            ),
+            "on_start": bool(
+                opts.get(CONF_SYNC_DEVICE_CLOCK_ON_START, DEFAULT_SYNC_DEVICE_CLOCK_ON_START)
+            ),
+            "interval_hours": int(
+                opts.get(
+                    CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS, DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS
+                )
+            ),
+            "max_drift": int(
+                opts.get(
+                    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                )
+            ),
         }
 
     def _on_update(self) -> None:
@@ -228,7 +242,9 @@ class ClockSyncManager:
         else:
             from homeassistant.util import dt as dt_util
 
-            elapsed = (dt_util.now().replace(tzinfo=None) - self._last_sync.replace(tzinfo=None)).total_seconds()
+            elapsed = (
+                dt_util.now().replace(tzinfo=None) - self._last_sync.replace(tzinfo=None)
+            ).total_seconds()
             if elapsed >= opts["interval_hours"] * 3600:
                 should_sync = True
 

--- a/custom_components/thessla_green_modbus/services.yaml
+++ b/custom_components/thessla_green_modbus/services.yaml
@@ -345,8 +345,10 @@ set_debug_logging:
           step: 60
 
 sync_time:
-  name: Sync Device Clock (legacy)
-  description: Synchronise the AirPack real-time clock to the current Home Assistant time. Useful after power loss.
+  name: Sync Device Clock (Legacy)
+  description: >-
+    Synchronize the AirPack real-time clock with the current Home Assistant time.
+    Useful after power loss. This is a legacy service; use sync_device_clock instead.
   target: *tg_target
   fields:
     entity_id:
@@ -361,16 +363,16 @@ sync_time:
 sync_device_clock:
   name: Sync Device Clock
   description: >-
-    Synchronise the AirPack real-time clock to the current Home Assistant local time.
-    CAUTION: this overwrites the physical device RTC clock.
+    Synchronize the AirPack real-time clock with the current Home Assistant local time.
+    This writes to the physical device RTC clock.
     Automatic sync is disabled by default; enable it in integration options.
   target: *tg_target
   fields:
     force:
       name: Force
       description: >-
-        Write the clock even when drift is already below the configured threshold.
-        When false, sync is skipped if drift is within the max-drift threshold.
+        Write the clock even when drift is already within the configured threshold.
+        When false, sync is skipped if drift is within the maximum drift limit.
       required: false
       default: false
       selector:

--- a/custom_components/thessla_green_modbus/services_handlers_maintenance.py
+++ b/custom_components/thessla_green_modbus/services_handlers_maintenance.py
@@ -322,7 +322,10 @@ def register_maintenance_services(hass: HomeAssistant, deps: ServiceHandlerDeps)
             if hasattr(coordinator, "entry") and coordinator.entry is not None:
                 opts = getattr(coordinator.entry, "options", {}) or {}
             max_drift = int(
-                opts.get(CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS, DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS)
+                opts.get(
+                    CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                    DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS,
+                )
             )
             try:
                 ok = await async_perform_clock_sync(

--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -88,7 +88,7 @@
           "parity": "Parity setting for Modbus RTU communication",
           "stop_bits": "Stop bits for Modbus RTU communication",
           "deep_scan": "Read all registers for diagnostics (may be slow)",
-          "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
+          "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
         },
         "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP or Modbus RTU. The integration automatically detects device functions and registers.",
         "title": "ThesslaGreen Modbus Configuration"
@@ -133,10 +133,10 @@
         "name": "Contamination Sensor"
       },
       "dp_ahu_filter_overflow": {
-        "name": "AHU Filter Overflow"
+        "name": "AHU Filter Pressure Alarm"
       },
       "dp_duct_filter_overflow": {
-        "name": "Duct Filter Overflow"
+        "name": "Duct Filter Pressure Alarm"
       },
       "duct_heater_protection": {
         "name": "Duct Heater Protection"
@@ -190,10 +190,10 @@
         "name": "Error E199"
       },
       "e_200": {
-        "name": "E200: Central Heater Overprotection"
+        "name": "E200: Central Heater Thermal Protection"
       },
       "e_201": {
-        "name": "E201: Duct Heater Overprotection"
+        "name": "E201: Duct Heater Thermal Protection"
       },
       "e_202": {
         "name": "E202: Secondary Heater Control Failure"
@@ -256,7 +256,7 @@
         "name": "Unit Operation Confirmation"
       },
       "power_supply_fans": {
-        "name": "Power Supply Fans"
+        "name": "Fan Power Supply"
       },
       "s_10": {
         "name": "S10: Fire Protection Sensor Activated"
@@ -271,7 +271,7 @@
         "name": "S15: Water Heater Anti-Freeze Not Effective"
       },
       "s_16": {
-        "name": "S16: Electric Heater Overprotection (FPX Active)"
+        "name": "S16: Electric Heater Thermal Protection (FPX Active)"
       },
       "s_17": {
         "name": "S17: AHU Filters Not Replaced (With Pressure Switch)"
@@ -313,7 +313,7 @@
         "name": "S32: No TG-02 Module Communication"
       },
       "s_6": {
-        "name": "S6: FPX Heater Overprotection"
+        "name": "S6: FPX Heater Thermal Protection"
       },
       "s_7": {
         "name": "S7: Calibration Not Possible (Low Outdoor Temp)"
@@ -416,31 +416,31 @@
     },
     "number": {
       "air_flow_rate_manual": {
-        "name": "Air Flow Rate Manual"
+        "name": "Manual Air Flow Rate"
       },
       "air_flow_rate_temporary": {
         "name": "Temporary Air Flow Rate"
       },
       "air_flow_rate_temporary_4401": {
-        "name": "Temporary Air Flow Rate (Ext.)"
+        "name": "Temporary Air Flow Rate (Extended)"
       },
       "air_temperature_summer_free_cooling": {
-        "name": "Air Temperature Summer Free Cooling"
+        "name": "Bypass Temperature (Free Cooling)"
       },
       "air_temperature_summer_free_heating": {
-        "name": "Air Temperature Summer Free Heating"
+        "name": "Bypass Temperature (Free Heating)"
       },
       "airing_bathroom_coef": {
-        "name": "Airing Bathroom Coef"
+        "name": "Airing Bathroom Coefficient"
       },
       "airing_coef": {
-        "name": "Airing Coef"
+        "name": "Airing Coefficient"
       },
       "airing_panel_mode_time": {
         "name": "Airing Panel Mode Time"
       },
       "airing_switch_coef": {
-        "name": "Airing Switch Coef"
+        "name": "Airing Switch Coefficient"
       },
       "airing_switch_mode_off_delay": {
         "name": "Airing Switch Mode Off Delay"
@@ -452,19 +452,19 @@
         "name": "Airing Switch Mode Time"
       },
       "bypass_coef_1": {
-        "name": "Bypass Coef 1"
+        "name": "Bypass Coefficient 1"
       },
       "bypass_coef_2": {
-        "name": "Bypass Coef 2"
+        "name": "Bypass Coefficient 2"
       },
       "contamination_coef": {
-        "name": "Contamination Coef"
+        "name": "Contamination Coefficient"
       },
       "delta_t_gwc": {
         "name": "GWC Activation Temperature Differential"
       },
       "empty_house_coef": {
-        "name": "Empty House Coef"
+        "name": "Empty House Coefficient"
       },
       "fan_speed_1_coef": {
         "name": "Fan Speed 1 Coefficient"
@@ -479,7 +479,7 @@
         "name": "Fireplace Mode Time"
       },
       "fireplace_supply_coef": {
-        "name": "Fireplace Supply Coef"
+        "name": "Fireplace Supply Coefficient"
       },
       "gwc_regen_period": {
         "name": "GWC Regeneration Period"
@@ -491,7 +491,7 @@
         "name": "Hood Supply Coefficient"
       },
       "lock_pass": {
-        "name": "Lock Pass"
+        "name": "Lock Code"
       },
       "max_exhaust_air_flow_rate": {
         "name": "Max Exhaust Air Flow Rate"
@@ -527,19 +527,19 @@
         "name": "Nominal Supply Air Flow (GWC)"
       },
       "open_window_coef": {
-        "name": "Open Window Coef"
+        "name": "Open Window Coefficient"
       },
       "rtc_cal": {
-        "name": "Rtc Cal"
+        "name": "RTC Calibration"
       },
       "supply_air_temperature_manual": {
-        "name": "Supply Air Temperature Manual"
+        "name": "Manual Supply Air Temperature"
       },
       "supply_air_temperature_temporary": {
         "name": "Temporary Supply Air Temperature"
       },
       "supply_air_temperature_temporary_4404": {
-        "name": "Temporary Supply Air Temperature (Ext.)"
+        "name": "Temporary Supply Air Temperature (Extended)"
       },
       "uart_0_id": {
         "name": "Port 0 Device ID"
@@ -632,7 +632,7 @@
         }
       },
       "pres_check_day_4432": {
-        "name": "Filter Check Day of Week (Ext.)",
+        "name": "Filter Check Day of Week (Extended)",
         "state": {
           "monday": "Monday",
           "tuesday": "Tuesday",
@@ -927,10 +927,10 @@
         "name": "Required Temperature"
       },
       "air_temperature_summer_free_cooling": {
-        "name": "Air Temperature Summer Free Cooling"
+        "name": "Bypass Temperature (Free Cooling)"
       },
       "air_temperature_summer_free_heating": {
-        "name": "Air Temperature Summer Free Heating"
+        "name": "Bypass Temperature (Free Heating)"
       },
       "ambient_temperature": {
         "name": "Ambient Temperature"
@@ -1066,7 +1066,7 @@
         "name": "Supply Air Flow"
       },
       "supply_air_temperature_manual": {
-        "name": "Supply Air Temperature Manual"
+        "name": "Manual Supply Air Temperature"
       },
       "supply_flow_rate_m3h": {
         "name": "Supply Flow Rate (m³/h)"
@@ -1190,52 +1190,52 @@
         "name": "Filter Check Start Time"
       },
       "pres_check_time_ggmm": {
-        "name": "Filter Check Start Time (Ext.)"
+        "name": "Filter Check Start Time (Extended)"
       },
       "manual_airing_time_to_start": {
         "name": "Manual Airing Time To Start"
       },
       "airing_summer_mon": {
-        "name": "Airing Summer Mon"
+        "name": "Airing Summer Monday"
       },
       "airing_summer_tue": {
-        "name": "Airing Summer Tue"
+        "name": "Airing Summer Tuesday"
       },
       "airing_summer_wed": {
-        "name": "Airing Summer Wed"
+        "name": "Airing Summer Wednesday"
       },
       "airing_summer_thu": {
-        "name": "Airing Summer Thu"
+        "name": "Airing Summer Thursday"
       },
       "airing_summer_fri": {
-        "name": "Airing Summer Fri"
+        "name": "Airing Summer Friday"
       },
       "airing_summer_sat": {
-        "name": "Airing Summer Sat"
+        "name": "Airing Summer Saturday"
       },
       "airing_summer_sun": {
-        "name": "Airing Summer Sun"
+        "name": "Airing Summer Sunday"
       },
       "airing_winter_mon": {
-        "name": "Airing Winter Mon"
+        "name": "Airing Winter Monday"
       },
       "airing_winter_tue": {
-        "name": "Airing Winter Tue"
+        "name": "Airing Winter Tuesday"
       },
       "airing_winter_wed": {
-        "name": "Airing Winter Wed"
+        "name": "Airing Winter Wednesday"
       },
       "airing_winter_thu": {
-        "name": "Airing Winter Thu"
+        "name": "Airing Winter Thursday"
       },
       "airing_winter_fri": {
-        "name": "Airing Winter Fri"
+        "name": "Airing Winter Friday"
       },
       "airing_winter_sat": {
-        "name": "Airing Winter Sat"
+        "name": "Airing Winter Saturday"
       },
       "airing_winter_sun": {
-        "name": "Airing Winter Sun"
+        "name": "Airing Winter Sunday"
       },
       "start_gwc_regen_summer_time": {
         "name": "GWC Regeneration Start (Summer)"
@@ -1497,26 +1497,30 @@
           "sync_device_clock_interval_hours": "Clock sync interval (hours)",
           "sync_device_clock_max_drift_seconds": "Maximum allowed clock drift (seconds)",
           "sync_device_clock_on_start": "Sync clock on integration start",
-          "timeout": "Connection Timeout (seconds)"
+          "timeout": "Connection Timeout (seconds)",
+          "scan_uart_settings": "Scan UART Port Settings",
+          "airflow_unit": "Airflow Unit"
         },
         "data_description": {
           "deep_scan": "Read raw registers 0-300 for diagnostics",
           "enable_device_scan": "Enable automatic device scan during setup",
           "force_full_register_list": "Skip scanning and load all registers (may cause errors)",
           "log_level": "Set integration log verbosity",
-          "max_registers_per_request": "Select maximum registers per request (1-16)",
+          "max_registers_per_request": "Select maximum registers per request (1–16)",
           "retry": "How many times to retry failed reads (1-5 attempts)",
           "safe_scan": "Avoid grouped register reads for compatibility",
           "scan_interval": "How often to read data from device (10-300 seconds)",
           "skip_missing_registers": "Do not poll registers known to be unavailable",
-          "sync_device_clock_enabled": "Automatically sync device RTC from HA time (disabled by default)",
-          "sync_device_clock_interval_hours": "Hours between automatic clock syncs (1-168)",
+          "sync_device_clock_enabled": "Automatically sync device RTC clock from HA time. Disabled by default. When enabled, this writes to the physical device RTC clock.",
+          "sync_device_clock_interval_hours": "Hours between automatic clock syncs (1–168)",
           "sync_device_clock_max_drift_seconds": "Only sync if drift exceeds this threshold (30-86400 s)",
           "sync_device_clock_on_start": "Sync once after first successful device connection",
-          "timeout": "Maximum time to wait for response (5-60 seconds)"
+          "timeout": "Maximum time to wait for response (5-60 seconds)",
+          "scan_uart_settings": "Read UART port configuration registers from the device during scanning",
+          "airflow_unit": "Unit for displaying airflow values (percentage or cubic metres per hour)"
         },
         "error": {
-          "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
+          "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
         },
         "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Device scan enabled: {device_scan_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Safe scan: {safe_scan_enabled}. Max registers per request: {current_max_registers_per_request}. Log level: {current_log_level}. Transport: {transport_label}{transport_details}.",
         "title": "ThesslaGreen Modbus Options"
@@ -1817,14 +1821,14 @@
       "name": "Set Device Name"
     },
     "sync_time": {
-      "description": "Synchronise the AirPack real-time clock to the current Home Assistant time. Useful after power loss.",
+      "description": "Synchronize the AirPack real-time clock with the current Home Assistant time. Useful after power loss. This is a legacy service; use sync_device_clock instead.",
       "fields": {
         "entity_id": {
           "description": "The climate entity of the AirPack device.",
           "name": "Entity"
         }
       },
-      "name": "Sync Device Clock"
+      "name": "Sync Device Clock (Legacy)"
     },
     "refresh_device_data": {
       "description": "Force immediate data refresh.",
@@ -1863,10 +1867,10 @@
       "name": "Set Debug Logging"
     },
     "sync_device_clock": {
-      "description": "Synchronises the AirPack real-time clock to current HA local time. CAUTION: overwrites device RTC clock.",
+      "description": "Synchronize the AirPack real-time clock with the current Home Assistant local time. This writes to the physical device RTC clock. Automatic sync is disabled by default; enable it in integration options.",
       "fields": {
         "force": {
-          "description": "Write clock even if drift is within threshold",
+          "description": "Write the clock even when drift is already within the configured threshold. When false, sync is skipped if drift is within the maximum drift limit.",
           "name": "Force"
         }
       },

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -88,7 +88,7 @@
           "parity": "Parity setting for Modbus RTU communication",
           "stop_bits": "Stop bits for Modbus RTU communication",
           "deep_scan": "Read all registers for diagnostics (may be slow)",
-          "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
+          "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
         },
         "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP or Modbus RTU. The integration automatically detects device functions and registers.",
         "title": "ThesslaGreen Modbus Configuration"
@@ -133,10 +133,10 @@
         "name": "Contamination Sensor"
       },
       "dp_ahu_filter_overflow": {
-        "name": "AHU Filter Overflow"
+        "name": "AHU Filter Pressure Alarm"
       },
       "dp_duct_filter_overflow": {
-        "name": "Duct Filter Overflow"
+        "name": "Duct Filter Pressure Alarm"
       },
       "duct_heater_protection": {
         "name": "Duct Heater Protection"
@@ -190,10 +190,10 @@
         "name": "Error E199"
       },
       "e_200": {
-        "name": "E200: Central Heater Overprotection"
+        "name": "E200: Central Heater Thermal Protection"
       },
       "e_201": {
-        "name": "E201: Duct Heater Overprotection"
+        "name": "E201: Duct Heater Thermal Protection"
       },
       "e_202": {
         "name": "E202: Secondary Heater Control Failure"
@@ -256,7 +256,7 @@
         "name": "Unit Operation Confirmation"
       },
       "power_supply_fans": {
-        "name": "Power Supply Fans"
+        "name": "Fan Power Supply"
       },
       "s_10": {
         "name": "S10: Fire Protection Sensor Activated"
@@ -271,7 +271,7 @@
         "name": "S15: Water Heater Anti-Freeze Not Effective"
       },
       "s_16": {
-        "name": "S16: Electric Heater Overprotection (FPX Active)"
+        "name": "S16: Electric Heater Thermal Protection (FPX Active)"
       },
       "s_17": {
         "name": "S17: AHU Filters Not Replaced (With Pressure Switch)"
@@ -313,7 +313,7 @@
         "name": "S32: No TG-02 Module Communication"
       },
       "s_6": {
-        "name": "S6: FPX Heater Overprotection"
+        "name": "S6: FPX Heater Thermal Protection"
       },
       "s_7": {
         "name": "S7: Calibration Not Possible (Low Outdoor Temp)"
@@ -416,13 +416,13 @@
     },
     "number": {
       "air_flow_rate_manual": {
-        "name": "Air Flow Rate Manual"
+        "name": "Manual Air Flow Rate"
       },
       "air_flow_rate_temporary": {
         "name": "Temporary Air Flow Rate"
       },
       "air_flow_rate_temporary_4401": {
-        "name": "Temporary Air Flow Rate (Ext.)"
+        "name": "Temporary Air Flow Rate (Extended)"
       },
       "air_temperature_summer_free_cooling": {
         "name": "Bypass Temperature (Free Cooling)"
@@ -431,16 +431,16 @@
         "name": "Bypass Temperature (Free Heating)"
       },
       "airing_bathroom_coef": {
-        "name": "Airing Bathroom Coef"
+        "name": "Airing Bathroom Coefficient"
       },
       "airing_coef": {
-        "name": "Airing Coef"
+        "name": "Airing Coefficient"
       },
       "airing_panel_mode_time": {
         "name": "Airing Panel Mode Time"
       },
       "airing_switch_coef": {
-        "name": "Airing Switch Coef"
+        "name": "Airing Switch Coefficient"
       },
       "airing_switch_mode_off_delay": {
         "name": "Airing Switch Mode Off Delay"
@@ -452,13 +452,13 @@
         "name": "Airing Switch Mode Time"
       },
       "contamination_coef": {
-        "name": "Contamination Coef"
+        "name": "Contamination Coefficient"
       },
       "delta_t_gwc": {
         "name": "GWC Activation Temperature Differential"
       },
       "empty_house_coef": {
-        "name": "Empty House Coef"
+        "name": "Empty House Coefficient"
       },
       "fan_speed_1_coef": {
         "name": "Fan Speed 1 Coefficient"
@@ -473,7 +473,7 @@
         "name": "Fireplace Mode Time"
       },
       "fireplace_supply_coef": {
-        "name": "Fireplace Supply Coef"
+        "name": "Fireplace Supply Coefficient"
       },
       "gwc_regen_period": {
         "name": "GWC Regeneration Period"
@@ -485,7 +485,7 @@
         "name": "Hood Supply Coefficient"
       },
       "lock_pass": {
-        "name": "Lock Pass"
+        "name": "Lock Code"
       },
       "max_exhaust_air_flow_rate": {
         "name": "Max Exhaust Air Flow Rate"
@@ -521,19 +521,19 @@
         "name": "Nominal Supply Air Flow (GWC)"
       },
       "open_window_coef": {
-        "name": "Open Window Coef"
+        "name": "Open Window Coefficient"
       },
       "rtc_cal": {
-        "name": "Rtc Cal"
+        "name": "RTC Calibration"
       },
       "supply_air_temperature_manual": {
-        "name": "Supply Air Temperature Manual"
+        "name": "Manual Supply Air Temperature"
       },
       "supply_air_temperature_temporary": {
         "name": "Temporary Supply Air Temperature"
       },
       "supply_air_temperature_temporary_4404": {
-        "name": "Temporary Supply Air Temperature (Ext.)"
+        "name": "Temporary Supply Air Temperature (Extended)"
       },
       "uart_0_id": {
         "name": "Port 0 Device ID"
@@ -548,10 +548,10 @@
         "name": "Exhaust Filter Wear"
       },
       "bypass_coef_1": {
-        "name": "Bypass Coef 1"
+        "name": "Bypass Coefficient 1"
       },
       "bypass_coef_2": {
-        "name": "Bypass Coef 2"
+        "name": "Bypass Coefficient 2"
       }
     },
     "select": {
@@ -632,7 +632,7 @@
         }
       },
       "pres_check_day_4432": {
-        "name": "Filter Check Day of Week (Ext.)",
+        "name": "Filter Check Day of Week (Extended)",
         "state": {
           "monday": "Monday",
           "tuesday": "Tuesday",
@@ -1066,7 +1066,7 @@
         "name": "Supply Air Flow"
       },
       "supply_air_temperature_manual": {
-        "name": "Supply Air Temperature Manual"
+        "name": "Manual Supply Air Temperature"
       },
       "supply_flow_rate_m3h": {
         "name": "Supply Flow Rate (m³/h)"
@@ -1190,52 +1190,52 @@
         "name": "Filter Check Start Time"
       },
       "pres_check_time_ggmm": {
-        "name": "Filter Check Start Time (Ext.)"
+        "name": "Filter Check Start Time (Extended)"
       },
       "manual_airing_time_to_start": {
         "name": "Manual Airing Time To Start"
       },
       "airing_summer_mon": {
-        "name": "Airing Summer Mon"
+        "name": "Airing Summer Monday"
       },
       "airing_summer_tue": {
-        "name": "Airing Summer Tue"
+        "name": "Airing Summer Tuesday"
       },
       "airing_summer_wed": {
-        "name": "Airing Summer Wed"
+        "name": "Airing Summer Wednesday"
       },
       "airing_summer_thu": {
-        "name": "Airing Summer Thu"
+        "name": "Airing Summer Thursday"
       },
       "airing_summer_fri": {
-        "name": "Airing Summer Fri"
+        "name": "Airing Summer Friday"
       },
       "airing_summer_sat": {
-        "name": "Airing Summer Sat"
+        "name": "Airing Summer Saturday"
       },
       "airing_summer_sun": {
-        "name": "Airing Summer Sun"
+        "name": "Airing Summer Sunday"
       },
       "airing_winter_mon": {
-        "name": "Airing Winter Mon"
+        "name": "Airing Winter Monday"
       },
       "airing_winter_tue": {
-        "name": "Airing Winter Tue"
+        "name": "Airing Winter Tuesday"
       },
       "airing_winter_wed": {
-        "name": "Airing Winter Wed"
+        "name": "Airing Winter Wednesday"
       },
       "airing_winter_thu": {
-        "name": "Airing Winter Thu"
+        "name": "Airing Winter Thursday"
       },
       "airing_winter_fri": {
-        "name": "Airing Winter Fri"
+        "name": "Airing Winter Friday"
       },
       "airing_winter_sat": {
-        "name": "Airing Winter Sat"
+        "name": "Airing Winter Saturday"
       },
       "airing_winter_sun": {
-        "name": "Airing Winter Sun"
+        "name": "Airing Winter Sunday"
       },
       "start_gwc_regen_summer_time": {
         "name": "GWC Regeneration Start (Summer)"
@@ -1497,26 +1497,30 @@
           "sync_device_clock_interval_hours": "Clock sync interval (hours)",
           "sync_device_clock_max_drift_seconds": "Maximum allowed clock drift (seconds)",
           "sync_device_clock_on_start": "Sync clock on integration start",
-          "timeout": "Connection Timeout (seconds)"
+          "timeout": "Connection Timeout (seconds)",
+          "scan_uart_settings": "Scan UART Port Settings",
+          "airflow_unit": "Airflow Unit"
         },
         "data_description": {
           "deep_scan": "Read raw registers 0-300 for diagnostics",
           "enable_device_scan": "Enable automatic device scan during setup",
           "force_full_register_list": "Skip scanning and load all registers (may cause errors)",
           "log_level": "Set integration log verbosity",
-          "max_registers_per_request": "Select maximum registers per request (1-16)",
+          "max_registers_per_request": "Select maximum registers per request (1–16)",
           "retry": "How many times to retry failed reads (1-5 attempts)",
           "safe_scan": "Avoid grouped register reads for compatibility",
           "scan_interval": "How often to read data from device (10-300 seconds)",
           "skip_missing_registers": "Do not poll registers known to be unavailable",
-          "sync_device_clock_enabled": "Automatically sync device RTC from HA time (disabled by default)",
-          "sync_device_clock_interval_hours": "Hours between automatic clock syncs (1-168)",
+          "sync_device_clock_enabled": "Automatically sync device RTC clock from HA time. Disabled by default. When enabled, this writes to the physical device RTC clock.",
+          "sync_device_clock_interval_hours": "Hours between automatic clock syncs (1–168)",
           "sync_device_clock_max_drift_seconds": "Only sync if drift exceeds this threshold (30-86400 s)",
           "sync_device_clock_on_start": "Sync once after first successful device connection",
-          "timeout": "Maximum time to wait for response (5-60 seconds)"
+          "timeout": "Maximum time to wait for response (5-60 seconds)",
+          "scan_uart_settings": "Read UART port configuration registers from the device during scanning",
+          "airflow_unit": "Unit for displaying airflow values (percentage or cubic metres per hour)"
         },
         "error": {
-          "max_registers_per_request": "Maximum registers per Modbus request (1-16)"
+          "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
         },
         "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Device scan enabled: {device_scan_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Safe scan: {safe_scan_enabled}. Max registers per request: {current_max_registers_per_request}. Log level: {current_log_level}. Transport: {transport_label}{transport_details}.",
         "title": "ThesslaGreen Modbus Options"
@@ -1817,14 +1821,14 @@
       "name": "Set Device Name"
     },
     "sync_time": {
-      "description": "Synchronise the AirPack real-time clock to the current Home Assistant time. Useful after power loss.",
+      "description": "Synchronize the AirPack real-time clock with the current Home Assistant time. Useful after power loss. This is a legacy service; use sync_device_clock instead.",
       "fields": {
         "entity_id": {
           "description": "The climate entity of the AirPack device.",
           "name": "Entity"
         }
       },
-      "name": "Sync Device Clock"
+      "name": "Sync Device Clock (Legacy)"
     },
     "refresh_device_data": {
       "description": "Force immediate data refresh.",
@@ -1863,10 +1867,10 @@
       "name": "Set Debug Logging"
     },
     "sync_device_clock": {
-      "description": "Synchronises the AirPack real-time clock to current HA local time. CAUTION: overwrites device RTC clock.",
+      "description": "Synchronize the AirPack real-time clock with the current Home Assistant local time. This writes to the physical device RTC clock. Automatic sync is disabled by default; enable it in integration options.",
       "fields": {
         "force": {
-          "description": "Write clock even if drift is within threshold",
+          "description": "Write the clock even when drift is already within the configured threshold. When false, sync is skipped if drift is within the maximum drift limit.",
           "name": "Force"
         }
       },

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -46,14 +46,14 @@
       "invalid_stop_bits": "Wybrano nieprawidłową liczbę bitów stopu.",
       "dns_failure": "Nie można rozwiązać nazwy hosta.",
       "connection_refused": "Połączenie zostało odrzucone przez hosta.",
-      "missing_method": "Brak wymaganej metody w skanerze. Sprawdź logi po szczegóły.",
+      "missing_method": "Brak wymaganej metody w skanerze. Sprawdź logi, aby zobaczyć szczegóły.",
       "io_error": "Błąd wejścia/wyjścia podczas komunikacji z urządzeniem. Sprawdź okablowanie i połączenie sieciowe.",
       "invalid_capabilities": "Nieprawidłowe dane możliwości urządzenia.",
       "invalid_format": "Odebrano dane w nieoczekiwanym formacie z urządzenia.",
       "modbus_error": "Błąd komunikacji Modbus. Sprawdź okablowanie i ustawienia.",
-      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1-16.",
+      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1–16.",
       "timeout": "Urządzenie nie odpowiedziało na czas. Sprawdź połączenie sieciowe i adres.",
-      "unknown": "Nieoczekiwany błąd. Sprawdź logi po szczegóły."
+      "unknown": "Nieoczekiwany błąd. Sprawdź logi, aby zobaczyć szczegóły."
     },
     "step": {
       "confirm": {
@@ -67,7 +67,7 @@
           "connection_mode": "Tryb połączenia",
           "host": "Adres IP",
           "port": "Port",
-          "slave_id": "ID Urządzenia",
+          "slave_id": "ID urządzenia",
           "name": "Nazwa",
           "serial_port": "Port szeregowy",
           "baud_rate": "Prędkość (baud)",
@@ -89,7 +89,7 @@
           "parity": "Ustawienie parzystości dla Modbus RTU",
           "stop_bits": "Liczba bitów stopu dla Modbus RTU",
           "deep_scan": "Odczytaj wszystkie rejestry do diagnostyki (może być wolne)",
-          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-16)"
+          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1–16)"
         },
         "description": "Skonfiguruj połączenie z ThesslaGreen AirPack przez Modbus TCP lub Modbus RTU. Integracja automatycznie wykryje funkcje i rejestry urządzenia."
       },
@@ -133,10 +133,10 @@
         "name": "Czujnik zanieczyszczeń"
       },
       "dp_ahu_filter_overflow": {
-        "name": "Przepełnienie filtra AHU"
+        "name": "Alarm ciśnieniowy filtra AHU"
       },
       "dp_duct_filter_overflow": {
-        "name": "Przepełnienie filtra kanałowego"
+        "name": "Alarm ciśnieniowy filtra kanałowego"
       },
       "duct_heater_protection": {
         "name": "Ochrona nagrzewnicy kanałowej"
@@ -211,7 +211,7 @@
         "name": "E251: Wymagana wymiana filtra kanałowego"
       },
       "e_252": {
-        "name": "E252: Wymagana wymiana filtrów (z presostarem)"
+        "name": "E252: Wymagana wymiana filtrów (z presostatem)"
       },
       "e_99": {
         "name": "E99: Wymagany klucz produktu AirPack"
@@ -223,7 +223,7 @@
         "name": "Błąd S"
       },
       "expansion": {
-        "name": "Ekspansja"
+        "name": "Moduł rozszerzeń"
       },
       "fan_speed_1": {
         "name": "Prędkość wentylatora 1"
@@ -274,7 +274,7 @@
         "name": "S16: Ochrona termiczna nagrzewnicy el. (FPX aktywny)"
       },
       "s_17": {
-        "name": "S17: Filtry niezmienione (z presostarem)"
+        "name": "S17: Filtry niezmienione (z presostatem)"
       },
       "s_19": {
         "name": "S19: Filtry niezmienione (bez presostatu)"
@@ -416,7 +416,7 @@
     },
     "number": {
       "air_flow_rate_manual": {
-        "name": "Przepływ powietrza manualnie"
+        "name": "Ręczny przepływ powietrza"
       },
       "air_flow_rate_temporary": {
         "name": "Intensywność wentylacji (tryb chwilowy)"
@@ -527,7 +527,7 @@
         "name": "Kalibracja zegara RTC"
       },
       "supply_air_temperature_manual": {
-        "name": "Temperatura nawiewu manualnie"
+        "name": "Ręczna temperatura nawiewu"
       },
       "supply_air_temperature_temporary": {
         "name": "Temperatura nawiewu (tryb chwilowy)"
@@ -599,16 +599,16 @@
         "name": "Tryb konfiguracji 1",
         "state": {
           "auto": "Automatyczny",
-          "manual": "Manualny",
-          "temporary": "Chwilowy"
+          "manual": "Ręczny",
+          "temporary": "Tymczasowy"
         }
       },
       "cfg_mode_2": {
         "name": "Tryb konfiguracji 2",
         "state": {
           "auto": "Automatyczny",
-          "manual": "Manualny",
-          "temporary": "Chwilowy"
+          "manual": "Ręczny",
+          "temporary": "Tymczasowy"
         }
       },
       "configuration_mode": {
@@ -663,7 +663,7 @@
           "airing_air_quality": "Wietrzenie (czujnik jakości pow.)",
           "airing_manual": "Wietrzenie (aktywacja ręczna)",
           "airing_auto": "Wietrzenie (tryb automatyczny)",
-          "airing_manual_timed": "Wietrzenie (tryb manualny)",
+          "airing_manual_timed": "Wietrzenie (tryb ręczny)",
           "open_windows": "Otwarte okna",
           "empty_house": "Pusty dom"
         }
@@ -1066,7 +1066,7 @@
         "name": "Strumień powietrza nawiewnego"
       },
       "supply_air_temperature_manual": {
-        "name": "Temperatura nawiewu manualnie"
+        "name": "Ręczna temperatura nawiewu"
       },
       "supply_flow_rate_m3h": {
         "name": "Przepływ nawiewu (m³/h)"
@@ -1479,7 +1479,7 @@
   },
   "options": {
     "error": {
-      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1-16."
+      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1–16."
     },
     "step": {
       "init": {
@@ -1497,26 +1497,30 @@
           "sync_device_clock_interval_hours": "Interwał synchronizacji zegara (godziny)",
           "sync_device_clock_max_drift_seconds": "Maksymalne dozwolone odchylenie zegara (s)",
           "sync_device_clock_on_start": "Synchronizuj zegar przy uruchomieniu integracji",
-          "timeout": "Limit czasu połączenia (s)"
+          "timeout": "Limit czasu połączenia (s)",
+          "scan_uart_settings": "Skanuj ustawienia portów UART",
+          "airflow_unit": "Jednostka przepływu powietrza"
         },
         "data_description": {
           "deep_scan": "Odczyt surowych rejestrów 0-300 do diagnostyki",
           "enable_device_scan": "Włącz automatyczne skanowanie urządzenia podczas konfiguracji",
           "force_full_register_list": "Pomiń skanowanie i załaduj wszystkie rejestry (może powodować błędy)",
           "log_level": "Ustaw poziom szczegółowości logów integracji",
-          "max_registers_per_request": "Wybierz maksymalną liczbę rejestrów w zapytaniu (1-16)",
+          "max_registers_per_request": "Wybierz maksymalną liczbę rejestrów w zapytaniu (1–16)",
           "retry": "Liczba powtórzeń nieudanych odczytów (1-5)",
           "safe_scan": "Unikaj grupowanych odczytów rejestrów dla kompatybilności",
           "scan_interval": "Jak często odczytywać dane z urządzenia (10-300 s)",
           "skip_missing_registers": "Nie odczytuj rejestrów, które są znane jako niedostępne",
-          "sync_device_clock_enabled": "Automatyczna synchronizacja RTC urządzenia z HA (domyślnie wyłączona)",
-          "sync_device_clock_interval_hours": "Godziny między automatycznymi synchronizacjami zegara (1-168)",
+          "sync_device_clock_enabled": "Automatyczna synchronizacja zegara RTC urządzenia z czasem HA. Domyślnie wyłączona. Gdy włączona, zapisuje czas do fizycznego zegara RTC urządzenia.",
+          "sync_device_clock_interval_hours": "Godziny między automatycznymi synchronizacjami zegara (1–168)",
           "sync_device_clock_max_drift_seconds": "Synchronizuj tylko gdy odchylenie przekracza próg (30-86400 s)",
           "sync_device_clock_on_start": "Synchronizuj raz po pierwszym połączeniu z urządzeniem",
-          "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)"
+          "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)",
+          "scan_uart_settings": "Odczytuj rejestry konfiguracji portów UART z urządzenia podczas skanowania",
+          "airflow_unit": "Jednostka wyświetlania wartości przepływu (procenty lub metry sześcienne na godzinę)"
         },
         "error": {
-          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1-16)"
+          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1–16)"
         },
         "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Skanowanie urządzenia włączone: {device_scan_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Bezpieczny skan: {safe_scan_enabled}. Maksymalna liczba rejestrów na żądanie: {current_max_registers_per_request}. Poziom logowania: {current_log_level}. Transport: {transport_label}{transport_details}.",
         "title": "Opcje ThesslaGreen Modbus"
@@ -1817,14 +1821,14 @@
       "name": "Ustaw nazwę urządzenia"
     },
     "sync_time": {
-      "description": "Synchronizuje zegar rekuperatora AirPack z aktualnym czasem Home Assistant. Przydatne po zaniku zasilania.",
+      "description": "Synchronizuje zegar rekuperatora AirPack z aktualnym czasem Home Assistant. Przydatne po zaniku zasilania. Ta usługa jest przestarzała; użyj sync_device_clock.",
       "fields": {
         "entity_id": {
           "description": "Encja climate urządzenia AirPack.",
           "name": "Encja"
         }
       },
-      "name": "Synchronizuj zegar urządzenia"
+      "name": "Synchronizuj zegar urządzenia (przestarzałe)"
     },
     "refresh_device_data": {
       "description": "Wymuś natychmiastowe odświeżenie danych.",
@@ -1863,10 +1867,10 @@
       "name": "Ustaw debugowanie logów"
     },
     "sync_device_clock": {
-      "description": "Synchronizuje zegar RTC urządzenia AirPack z aktualnym czasem lokalnym HA. UWAGA: nadpisuje fizyczny zegar RTC urządzenia.",
+      "description": "Synchronizuje zegar RTC urządzenia AirPack z aktualnym czasem lokalnym HA. Zapisuje czas do fizycznego zegara RTC urządzenia. Automatyczna synchronizacja jest domyślnie wyłączona; włącz ją w opcjach integracji.",
       "fields": {
         "force": {
-          "description": "Zapisz zegar nawet gdy odchylenie jest w granicach progu",
+          "description": "Zapisz zegar nawet gdy odchylenie mieści się w skonfigurowanym progu. Gdy wyłączone, synchronizacja jest pomijana jeśli odchylenie jest w granicach progu.",
           "name": "Wymuś"
         }
       },

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -501,8 +501,13 @@ def test_options_form_has_clock_sync_defaults():
     defaults = build_options_defaults({}, {})
     assert defaults[CONF_SYNC_DEVICE_CLOCK_ENABLED] == DEFAULT_SYNC_DEVICE_CLOCK_ENABLED
     assert defaults[CONF_SYNC_DEVICE_CLOCK_ON_START] == DEFAULT_SYNC_DEVICE_CLOCK_ON_START
-    assert defaults[CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS] == DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS
-    assert defaults[CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS] == DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS
+    assert (
+        defaults[CONF_SYNC_DEVICE_CLOCK_INTERVAL_HOURS] == DEFAULT_SYNC_DEVICE_CLOCK_INTERVAL_HOURS
+    )
+    assert (
+        defaults[CONF_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS]
+        == DEFAULT_SYNC_DEVICE_CLOCK_MAX_DRIFT_SECONDS
+    )
 
 
 def test_options_form_default_sync_enabled_is_false():

--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -24,6 +24,12 @@ OPTION_KEYS = [
     "enable_device_scan",
     "log_level",
     "safe_scan",
+    "scan_uart_settings",
+    "airflow_unit",
+    "sync_device_clock_enabled",
+    "sync_device_clock_on_start",
+    "sync_device_clock_interval_hours",
+    "sync_device_clock_max_drift_seconds",
 ]
 
 OPTION_ERROR_KEYS = [


### PR DESCRIPTION
## Summary

Base branch: dev

- **English entity names** cleaned up: `Coef` → `Coefficient` throughout, `Rtc Cal` → `RTC Calibration`, `Lock Pass` → `Lock Code`, `Overprotection` → `Thermal Protection`, `AHU/Duct Filter Overflow` → `AHU/Duct Filter Pressure Alarm`, `Power Supply Fans` → `Fan Power Supply`, `Air Flow Rate Manual` → `Manual Air Flow Rate`, `Supply Air Temperature Manual` → `Manual Supply Air Temperature`, `(Ext.)` → `(Extended)` for all extended-register entities, abbreviated day names expanded (`Mon` → `Monday` etc.) in Airing time entities
- **Options flow**: added missing `scan_uart_settings` and `airflow_unit` translations (EN + PL); numeric ranges use en dash (`1–16`, `1–168`); `sync_device_clock_enabled` description clarified to mention physical RTC write
- **Services**: `Synchronise` → `Synchronize` throughout; `sync_time` name updated to `Sync Device Clock (Legacy)`; `sync_device_clock` description reworded to remove shouty `CAUTION`, `force` field description clarified
- **Polish fixes**: `presostarem` → `presostatem` (e_252, s_17); `Ekspansja` → `Moduł rozszerzeń`; `ID Urządzenia` → `ID urządzenia`; `po szczegóły` → `sprawdź logi, aby zobaczyć szczegóły`; `Manualny` → `Ręczny` and `Chwilowy` → `Tymczasowy` in cfg_mode_1/cfg_mode_2; `1-16` → `1–16` in all range strings
- **`tools/check_translations.py`**: expanded `OPTION_KEYS` from 10 to 16 to cover all options-flow fields including clock sync options
- **ruff format**: applied formatting to 3 pre-existing unformatted files (no logic change)

## Test plan

- [x] All 3 JSON files parse without errors (`json.loads`)
- [x] services.yaml is valid YAML
- [x] `tools/check_translations.py` → `All translation keys present.`
- [x] `tools/compare_registers_with_reference.py` → passed
- [x] `tools/check_maintainability.py` → `Maintainability gate passed.`
- [x] `ruff check custom_components tests tools` → `All checks passed!`
- [x] `ruff check --select I` → `All checks passed!`
- [x] `ruff format --check` → all files formatted
- [x] `python -m compileall -q` → clean
- [ ] `pytest tests/ -q` — requires Python 3.13 + HA test framework not available in this environment (documented in README)

https://claude.ai/code/session_01RFYcUyAZwZfibvhF4QkoaH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFYcUyAZwZfibvhF4QkoaH)_