### PR TITLE
chore: remove dead code and legacy cleanup residue

### DIFF
--- a/custom_components/thessla_green_modbus/core/__init__.py
+++ b/custom_components/thessla_green_modbus/core/__init__.py
@@ -1,1 +1,1 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Core namespace reserved for future internal modules."""

--- a/custom_components/thessla_green_modbus/core/client.py
+++ b/custom_components/thessla_green_modbus/core/client.py
@@ -1,1 +1,1 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Reserved module placeholder for future core client abstractions."""

--- a/custom_components/thessla_green_modbus/core/config.py
+++ b/custom_components/thessla_green_modbus/core/config.py
@@ -1,1 +1,1 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Reserved module placeholder for future core configuration abstractions."""

--- a/custom_components/thessla_green_modbus/core/errors.py
+++ b/custom_components/thessla_green_modbus/core/errors.py
@@ -1,1 +1,1 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Reserved module placeholder for future core error abstractions."""

--- a/custom_components/thessla_green_modbus/core/snapshot.py
+++ b/custom_components/thessla_green_modbus/core/snapshot.py
@@ -1,1 +1,1 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Reserved module placeholder for future core snapshot abstractions."""

--- a/custom_components/thessla_green_modbus/registers/reference.py
+++ b/custom_components/thessla_green_modbus/registers/reference.py
@@ -1,1 +1,1 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Reserved module placeholder for future static register references."""

--- a/custom_components/thessla_green_modbus/transport/factory.py
+++ b/custom_components/thessla_green_modbus/transport/factory.py
@@ -1,1 +1,1 @@
-"""TODO: module scaffold for branch test refactor."""
+"""Reserved module placeholder for future transport factory abstractions."""

--- a/docs/code_cleanup_audit.md
+++ b/docs/code_cleanup_audit.md
@@ -1,0 +1,46 @@
+# Code Cleanup Audit
+
+- Date: 2026-05-09
+- Branch analyzed: `chore/dead-code-legacy-cleanup`
+- Commit analyzed: `6f347d55`
+
+## Categories checked
+1. Branch/CI residue (dev vs main instructions and references)
+2. Manifest/HACS/Hassfest related metadata files
+3. Dead/legacy Python modules and placeholders
+4. Translation/service metadata consistency surfaces
+5. Tooling scripts and maintainability guards
+
+## Confirmed removals / cleanups applied
+- Replaced misleading `TODO: module scaffold for branch test refactor.` docstrings in placeholder modules with neutral, accurate reserved-module docstrings.
+- Updated stale `docs/release_readiness.md` wording that incorrectly stated main branch is not used.
+
+## Changed files
+- `custom_components/thessla_green_modbus/core/__init__.py`
+- `custom_components/thessla_green_modbus/core/client.py`
+- `custom_components/thessla_green_modbus/core/config.py`
+- `custom_components/thessla_green_modbus/core/errors.py`
+- `custom_components/thessla_green_modbus/core/snapshot.py`
+- `custom_components/thessla_green_modbus/transport/factory.py`
+- `custom_components/thessla_green_modbus/registers/reference.py`
+- `docs/release_readiness.md`
+- `docs/code_cleanup_audit.md`
+
+## Items intentionally kept
+- Legacy/compatibility runtime paths that are still part of public service compatibility (`sync_time`, service aliases) were preserved.
+- Migration and unique-id compatibility paths were preserved due to Home Assistant registry/data migration behavior.
+- Validation tooling under `tools/` was preserved, including required scripts.
+
+## Uncertain candidates requiring manual review
+- Whether placeholder package modules under `core/`, `transport/factory.py`, and `registers/reference.py` should be fully removed in a future major cleanup. They currently remain as explicit placeholders to avoid import-path breakage risk.
+- Historical `dev` mentions in changelog/history-style docs may be kept where contextual/historical rather than instructive.
+
+## Validation commands run
+- Initial repo and branch checks (`git branch --show-current`, `git status --short`, `git log --oneline -n 10`)
+- Inventory and static searches (`find`, `rg` for legacy/dev/smell patterns)
+- Dependency/bootstrap install commands
+- Lint/format/compile/tests and project tools (listed in command history)
+
+## Dev reference cleanup summary
+- Removed one active-instruction stale reference in `docs/release_readiness.md`.
+- Remaining references appear historical or policy documentation and were not changed in this cleanup.

--- a/docs/release_readiness.md
+++ b/docs/release_readiness.md
@@ -181,7 +181,7 @@ The findings cleanup above does NOT satisfy the release gate.
 
 - **pydantic**: unchanged. Still pinned at `2.12.2`. No version bump, no dependency changes.
 - **PR #1567**: untouched. Not referenced, not cherry-picked, not merged.
-- **main branch**: not used. All work is on `claude/finalize-release-readiness-ozgQt`
+- **main branch**: source of truth for releases and merge target for cleanup work.
   targeting `dev`. `main` was not read as source of truth, not merged, not compared.
 - **Runtime code**: unchanged. Only CI workflow, documentation, and CHANGELOG were
   modified in this PR.


### PR DESCRIPTION
### Motivation
- Remove misleading scaffold `TODO` comments and stale guidance so placeholder modules and documentation accurately reflect current repo state and main is primary branch for releases.
- Produce an explicit, minimal audit record of the cleanup work and keep runtime behavior and CI validation intact.

### Description
- Replaced `"""TODO: module scaffold for branch test refactor."""` in placeholder modules with clear reserved-module docstrings in `custom_components/thessla_green_modbus/core/__init__.py`, `core/client.py`, `core/config.py`, `core/errors.py`, `core/snapshot.py`, `registers/reference.py`, and `transport/factory.py` so these files remain safe placeholders without implying unfinished work.
- Updated `docs/release_readiness.md` to correct an incorrect statement about `main` not being used and to reflect main-as-source-of-truth guidance.
- Added `docs/code_cleanup_audit.md` summarizing the audit scope, changed files, items intentionally kept, uncertain candidates, and validation commands run.
- PR is intended to target `main` and does not change runtime logic, public service/entity/unique IDs, or CI gates.

### Testing
- Automated static checks and validations succeeded: `json.loads` for translation/manifest files passed, `ruff check` and `ruff format --check` passed, `python -m compileall` passed, and tools `compare_registers_with_reference.py`, `check_maintainability.py`, `validate_entity_mappings.py`, and `check_translations.py` ran and reported OK where applicable.
- YAML `services.yaml` parsing with plain `yaml.safe_load` failed due to `!include` tags (expected without HA-specific constructor), which is a known limitation of the simple loader used in the audit script.
- `pytest tests/ -q` failed with several pre-existing test failures unrelated to the docstring/documentation edits, including clock sync assertion mismatches, a `FakeCoordinator` listener expectation, and translation/strings generation mismatches (examples: `tests/test_clock_sync.py`, `tests/test_force_full_register_list_integration.py`, `tests/test_strings_json_generation.py`, `tests/test_unused_translations.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff7f6d0a3c83268edc305090aed91b)