### PR TITLE
fix: stabilize tests and translation validation

### DIFF
--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -207,6 +207,11 @@ async def test_sync_proceeds_when_drift_exceeds_threshold():
     # Device clock is 400 seconds behind
     coord = _make_coordinator(data={"device_clock": "2025-05-09T14:23:45"})
 
+    async def _refresh_side_effect():
+        coord.data = {"device_clock": "2025-05-09T14:30:45"}
+
+    coord.async_request_refresh.side_effect = _refresh_side_effect
+
     result = await async_perform_clock_sync(
         coord,
         force=False,

--- a/tests/test_force_full_register_list_integration.py
+++ b/tests/test_force_full_register_list_integration.py
@@ -89,6 +89,7 @@ class FakeCoordinator:
         self.data: dict[str, int] = {}
         self.last_update_success = True
         self.capabilities = _Capabilities()
+        self._listeners: list = []
 
     async def async_setup(self):  # pragma: no cover - simple stub
         return True
@@ -111,6 +112,14 @@ class FakeCoordinator:
 
     async def async_request_refresh(self):  # pragma: no cover - simple stub
         return None
+
+    def async_add_listener(self, update_callback):
+        self._listeners.append(update_callback)
+
+        def _remove_listener():
+            self._listeners.remove(update_callback)
+
+        return _remove_listener
 
     def get_device_info(self):  # pragma: no cover - simple stub
         return {"identifiers": {(DOMAIN, "fake")}, "name": self.device_name}

--- a/tests/test_full_register_list_option.py
+++ b/tests/test_full_register_list_option.py
@@ -80,6 +80,7 @@ class FakeCoordinator:
         self.data: dict[str, int] = {}
         self.last_update_success = True
         self.capabilities = _Capabilities()
+        self._listeners: list = []
 
     async def async_setup(self):
         return True
@@ -101,6 +102,14 @@ class FakeCoordinator:
 
     async def async_request_refresh(self):
         return None
+
+    def async_add_listener(self, update_callback):
+        self._listeners.append(update_callback)
+
+        def _remove_listener():
+            self._listeners.remove(update_callback)
+
+        return _remove_listener
 
     def get_device_info(self):
         return {"identifiers": {(DOMAIN, "fake")}, "name": self.device_name}

--- a/tests/test_strings_json_generation.py
+++ b/tests/test_strings_json_generation.py
@@ -1,8 +1,6 @@
 import json
 from pathlib import Path
 
-from tools import generate_strings
-
 ROOT = Path(__file__).resolve().parents[1]
 STRINGS = ROOT / "custom_components" / "thessla_green_modbus" / "strings.json"
 EN = ROOT / "custom_components" / "thessla_green_modbus" / "translations" / "en.json"
@@ -14,33 +12,25 @@ def _load(path):
 
 
 def test_strings_in_sync():
-    opts = generate_strings.build()
     strings = _load(STRINGS)
     en = _load(EN)
     pl = _load(PL)
 
     fields = strings["services"]["set_modbus_parameters"]["fields"]
-    assert fields["baud_rate"]["selector"]["select"]["options"] == opts["baud_rate"][0]
-    assert fields["parity"]["selector"]["select"]["options"] == opts["parity"][0]
-    assert fields["port"]["selector"]["select"]["options"] == opts["port"][0]
-    assert fields["stop_bits"]["selector"]["select"]["options"] == opts["stop_bits"][0]
-    mode_opts = strings["services"]["set_special_mode"]["fields"]["mode"]["selector"]["select"][
-        "options"
-    ]
-    assert mode_opts == opts["special_mode"][0]
+    assert set(fields["baud_rate"]) == {"name", "description"}
+    assert set(fields["parity"]) == {"name", "description"}
+    assert set(fields["port"]) == {"name", "description"}
+    assert set(fields["stop_bits"]) == {"name", "description"}
+    mode_field = strings["services"]["set_special_mode"]["fields"]["mode"]
+    assert set(mode_field) == {"name", "description"}
 
     en_fields = en["services"]["set_modbus_parameters"]["fields"]
-    assert en_fields["baud_rate"]["selector"]["select"]["options"] == opts["baud_rate"][0]
-    assert en_fields["parity"]["selector"]["select"]["options"] == opts["parity"][0]
-    assert en_fields["port"]["selector"]["select"]["options"] == opts["port"][0]
-    assert en_fields["stop_bits"]["selector"]["select"]["options"] == opts["stop_bits"][0]
-    en_mode = en["services"]["set_special_mode"]["fields"]["mode"]["selector"]["select"]["options"]
-    assert en_mode == opts["special_mode"][0]
+    assert en_fields == fields
+    assert en["services"]["set_special_mode"]["fields"]["mode"] == mode_field
 
     pl_fields = pl["services"]["set_modbus_parameters"]["fields"]
-    assert pl_fields["baud_rate"]["selector"]["select"]["options"] == opts["baud_rate"][1]
-    assert pl_fields["parity"]["selector"]["select"]["options"] == opts["parity"][1]
-    assert pl_fields["port"]["selector"]["select"]["options"] == opts["port"][1]
-    assert pl_fields["stop_bits"]["selector"]["select"]["options"] == opts["stop_bits"][1]
-    pl_mode = pl["services"]["set_special_mode"]["fields"]["mode"]["selector"]["select"]["options"]
-    assert pl_mode == opts["special_mode"][1]
+    assert set(pl_fields["baud_rate"]) == {"name", "description"}
+    assert set(pl_fields["parity"]) == {"name", "description"}
+    assert set(pl_fields["port"]) == {"name", "description"}
+    assert set(pl_fields["stop_bits"]) == {"name", "description"}
+    assert set(pl["services"]["set_special_mode"]["fields"]["mode"]) == {"name", "description"}

--- a/tests/test_unused_translations.py
+++ b/tests/test_unused_translations.py
@@ -1,5 +1,9 @@
 """Ensure translation files don't contain unused keys."""
 
+from custom_components.thessla_green_modbus.config_flow_options_form import (
+    build_options_defaults,
+    build_options_schema,
+)
 from custom_components.thessla_green_modbus.const import SPECIAL_FUNCTION_MAP
 
 from tests.test_translations import (
@@ -9,7 +13,6 @@ from tests.test_translations import (
     ISSUE_KEYS,
     NUMBER_KEYS,
     OPTION_ERROR_KEYS,
-    OPTION_KEYS,
     PL,
     SELECT_KEYS,
     SERVICES,
@@ -30,9 +33,11 @@ def _assert_no_extra_keys(trans, entity_type, valid_keys) -> None:
 
 def _assert_no_extra_option_keys(trans) -> None:
     opts = trans["options"]["step"]["init"]
-    extra = [k for k in opts["data"] if k not in OPTION_KEYS]
+    schema = build_options_schema(build_options_defaults({}, {}))
+    valid_option_keys = {key.schema for key in schema.schema}
+    extra = [k for k in opts["data"] if k not in valid_option_keys]
     assert not extra, f"Unused option translations: {extra}"  # nosec B101
-    extra_desc = [k for k in opts["data_description"] if k not in OPTION_KEYS]
+    extra_desc = [k for k in opts["data_description"] if k not in valid_option_keys]
     assert not extra_desc, f"Unused option descriptions: {extra_desc}"  # nosec B101
     errors = trans["options"].get("error", {})
     extra_err = [k for k in errors if k not in OPTION_ERROR_KEYS]


### PR DESCRIPTION
### Motivation

- Tests regressed after recent cleanup causing failures in clock sync behavior, fake coordinator listener semantics, and translation/schema expectations.
- The goal is to fix test fakes and test assertions (not production behavior) so CI and translation validation are consistent and strict hassfest-compatible keys are preserved.

### Description

- Fixed `tests/test_clock_sync.py` to make the fake coordinator `async_request_refresh` return the written `device_clock` during the success-path test so read-back validation is modeled realistically and production read-back validation remains unchanged.
- Implemented `async_add_listener` (with unsubscribe callable) on FakeCoordinator test doubles in `tests/test_force_full_register_list_integration.py` and `tests/test_full_register_list_option.py` so `ClockSyncManager.attach` works with the fakes like the real coordinator.
- Relaxed outdated selector-based expectations in `tests/test_strings_json_generation.py` to assert the current hassfest-compatible service field structure (`name` and `description`) and ensured `translations/en.json` and `translations/pl.json` remain consistent with `strings.json`.
- Updated `tests/test_unused_translations.py` to derive valid option keys from the canonical options-flow schema by using `build_options_defaults` + `build_options_schema` from `custom_components/thessla_green_modbus/config_flow_options_form.py` so real option fields are accepted while still catching unused keys.
- No production runtime behavior was weakened and no unsupported hassfest translation keys were restored, and no PNG/binary brand assets were added in this PR.

### Testing

- Installed dev dependencies and the package with `python -m pip install -r requirements-dev.txt` and `python -m pip install -e .` successfully.
- Ran targeted tests `pytest tests/test_clock_sync.py`, `pytest tests/test_force_full_register_list_integration.py`, `pytest tests/test_strings_json_generation.py`, and `pytest tests/test_unused_translations.py`, all of which passed after the fixes (only existing, documented skips remain).
- Ran full suite validations including `ruff` checks, `python -m compileall`, `python tools/compare_registers_with_reference.py`, `python tools/check_maintainability.py`, `python tools/validate_entity_mappings.py`, and `python tools/check_translations.py`, and observed successful results with no new issues.
- Verified JSON validity for `manifest.json`, `strings.json`, and both translation files and confirmed the branch targets `main` (PR base branch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff82eccea483269b79dfceda3c1e33)