### PR TITLE
fix: clean low-risk runtime and UX issues

### DIFF
--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -284,20 +284,6 @@ class ThesslaGreenClimate(ThesslaGreenEntity, ClimateEntity):
             await self.coordinator.async_request_refresh()
 
     @property
-    def name(self) -> str:
-        scan_name = (
-            getattr(self.coordinator, "device_scan_result", {})
-            .get("device_info", {})
-            .get("device_name")
-        )
-        base = scan_name or getattr(
-            self.coordinator,
-            "device_name",
-            getattr(self.coordinator, "_device_name", "ThesslaGreen"),
-        )
-        return f"{base} Rekuperator"
-
-    @property
     def hvac_modes(self) -> list[HVACMode]:
         return list(getattr(self, "_attr_hvac_modes", [HVACMode.OFF, HVACMode.AUTO]))
 

--- a/custom_components/thessla_green_modbus/config_flow_runtime.py
+++ b/custom_components/thessla_green_modbus/config_flow_runtime.py
@@ -34,7 +34,7 @@ async def run_with_retry(
             if inspect.isawaitable(result):
                 return await result
             return result
-        except BaseException as exc:
+        except BaseException as exc:  # intentional: must see asyncio.CancelledError to re-raise it
             decision = classify_transport_error(exc)
             if decision.kind is ErrorKind.CANCELLED:
                 raise

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -5,7 +5,6 @@ Includes the same translated error and status codes as exposed by the ``error_co
 
 from __future__ import annotations
 
-import asyncio
 import copy
 import ipaddress
 import logging
@@ -114,9 +113,7 @@ async def _load_translations(hass: HomeAssistant) -> dict[str, str]:
         )
     except (OSError, ValueError, HomeAssistantError, RuntimeError) as err:
         _LOGGER.debug("Translation load failed: %s", err)
-    except BaseException as err:  # pragma: no cover
-        if isinstance(err, KeyboardInterrupt | SystemExit | asyncio.CancelledError):
-            raise
+    except Exception as err:  # pragma: no cover  # noqa: BLE001
         _LOGGER.debug("Translation load failed unexpectedly: %s", err)
     return {}
 

--- a/docs/maintainability_audit.md
+++ b/docs/maintainability_audit.md
@@ -117,11 +117,10 @@ Date: 2026-05-05
 
 ## Branch note (authoritative target)
 
-- The working target branch is **dev**.
-- **main** is not authoritative for this refactor/audit track.
-- No `main -> dev` merge is recommended as part of this audit.
+- The authoritative target branch is **main**.
+- All active development and PR bases target `main` directly.
 
 ## Release readiness caveats
 
-- **HACS/hassfest readiness is not proven** in this audit because those validations were not run.
-- **Real-device validation is not proven** in this audit unless explicitly documented with device evidence.
+- **HACS/hassfest readiness:** CI runs hassfest and HACS validation on every push; check the Actions tab for the current status.
+- **Real-device validation:** the `quality_scale: silver` in `manifest.json` is a self-assessed declaration. Independent real-device evidence has not been collected as part of this audit. Evidence should be documented in a dedicated section before claiming a higher quality scale.

--- a/docs/refactor_status.md
+++ b/docs/refactor_status.md
@@ -63,11 +63,10 @@ The following constraints remain active and must be preserved:
 
 ## Branch note
 
-- Target branch for ongoing work and PR base is **dev**.
-- `main` is not authoritative for this stream.
-- No `main -> dev` merge is recommended by this audit.
+- Target branch for all ongoing work and PR bases is **main**.
+- `main` is the authoritative branch for this integration.
 
 ## Readiness caveats
 
-- **HACS/hassfest readiness:** not claimable (not executed in this run).
-- **Real-device readiness:** not claimable from this verification run; no new on-device evidence captured.
+- **HACS/hassfest readiness:** CI validates these on every push; check the Actions tab for current status.
+- **Real-device readiness:** no on-device evidence was captured during this audit run. The `quality_scale: silver` in `manifest.json` is a self-assessed value.

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -322,3 +322,27 @@ def test_climate_imports_real_ha_symbols() -> None:
     assert hasattr(climate.HVACMode, "OFF")
     assert hasattr(climate.HVACAction, "HEATING")
     assert climate.ClimateEntity.__name__ == climate_mod.ClimateEntity.__name__
+
+
+def test_climate_name_uses_ha_translation_not_hardcoded_polish() -> None:
+    """Climate entity must not return a hardcoded Polish name.
+
+    _attr_has_entity_name=True and _attr_translation_key delegate naming
+    to HA; there must be no overriding name property that embeds 'Rekuperator'.
+    """
+    from datetime import timedelta
+    from types import SimpleNamespace
+
+    coordinator = ThesslaGreenModbusCoordinator.from_params(
+        SimpleNamespace(), "host", 502, 1, "dev", timedelta(seconds=1)
+    )
+    coordinator.data = {}
+    climate = ThesslaGreenClimate(coordinator)
+
+    assert climate._attr_has_entity_name is True  # nosec B101
+    assert climate._attr_translation_key == "thessla_green_climate"  # nosec B101
+    # No overriding name property — HA owns the display name.
+    assert "name" not in ThesslaGreenClimate.__dict__  # nosec B101
+    # Guard: entity name must never be the Polish word for heat-recovery unit.
+    raw_name = ThesslaGreenClimate.__dict__.get("name")
+    assert raw_name is None or "Rekuperator" not in str(raw_name)  # nosec B101

--- a/tests/test_optimized_integration_entities.py
+++ b/tests/test_optimized_integration_entities.py
@@ -48,7 +48,11 @@ class TestThesslaGreenClimate:
         from homeassistant.components.climate import HVACMode
 
         climate = ThesslaGreenClimate(mock_climate_coordinator)
-        assert climate.name == "Test AirPack Rekuperator"
+        # Name is delegated to HA via _attr_has_entity_name + _attr_translation_key;
+        # the entity must not hard-code a Polish device-type label.
+        assert climate._attr_has_entity_name is True  # nosec B101
+        assert climate._attr_translation_key == "thessla_green_climate"  # nosec B101
+        assert "Rekuperator" not in (climate.__dict__.get("_attr_name") or "")  # nosec B101
         assert HVACMode.AUTO in climate.hvac_modes
         assert HVACMode.FAN_ONLY in climate.hvac_modes
         assert HVACMode.OFF in climate.hvac_modes

--- a/tests/test_register_pdf_mapping.py
+++ b/tests/test_register_pdf_mapping.py
@@ -153,7 +153,7 @@ def test_local_airpack4_pdf_fn_addr_coverage() -> None:
 
     try:
         pypdf = pytest.importorskip("pypdf")
-    except BaseException as exc:
+    except Exception as exc:
         pytest.skip(f"pypdf not usable: {exc}")
 
     pdf_path = Path(__file__).resolve().parents[1] / "ProtokolModbusRTU_AirPack4.pdf"


### PR DESCRIPTION
## Summary

Base branch: main

This PR performs a focused, low-risk cleanup of four categories of obvious issues. No transport, coordinator, config_flow, services, or const.py refactoring. No entity IDs, unique IDs, register names, or service IDs changed.

---

## 1. Climate entity name fix

`ThesslaGreenClimate` previously overrode `name` to return `f"{device_name} Rekuperator"` — a hardcoded Polish word meaning "heat-recovery unit". The entity already declared `_attr_has_entity_name = True` and `_attr_translation_key = "thessla_green_climate"`, making the `name` property override redundant and harmful (it short-circuited HA's translation/naming machinery).

**Change:** Remove the `name` property entirely. HA now resolves the display name through the translation key and device registry, as intended.

**Tests updated:**
- `tests/test_climate.py` — new test `test_climate_name_uses_ha_translation_not_hardcoded_polish` asserts `_attr_has_entity_name=True`, correct `_attr_translation_key`, and no `name` property in the class dict.
- `tests/test_optimized_integration_entities.py` — replaced `assert climate.name == "Test AirPack Rekuperator"` with assertions on the HA-delegation attributes.

---

## 2. Exception handling cleanup

Three `except BaseException` sites were reviewed:

| File | Action |
|---|---|
| `custom_components/thessla_green_modbus/diagnostics.py:117` | Changed to `except Exception # noqa: BLE001`. The old block re-raised `KeyboardInterrupt / SystemExit / CancelledError` explicitly; with `except Exception` those propagate naturally, achieving the same outcome with less indirection. Removed now-unused `import asyncio`. |
| `custom_components/thessla_green_modbus/config_flow_runtime.py:37` | Left as `except BaseException` — intentional: the retry wrapper must intercept `asyncio.CancelledError` (a `BaseException` in Python 3.8+) to call `classify_transport_error` before re-raising. Added an inline comment documenting this. |
| `tests/test_register_pdf_mapping.py:156` | Changed to `except Exception` — this is a pypdf import guard for an optional test; suppressing `KeyboardInterrupt` here was unintentional. |

---

## 3. quality_scale / docs decision

`manifest.json` retains `"quality_scale": "silver"` (self-assessed). Two audit docs previously contradicted this by claiming "real-device validation is not proven" without context.

**Updated docs:**
- `docs/maintainability_audit.md` — clarifies that `quality_scale: silver` is self-assessed, that CI validates HACS/hassfest on every push, and that real-device evidence should be documented before a higher scale is claimed.
- `docs/refactor_status.md` — same clarification; replaced the vague "not claimable" language with actionable notes.

No fake evidence added. No unsupported claims.

---

## 4. Stale dev branch references cleaned up

Both audit docs contained active instructions ("target branch is **dev**", "main is not authoritative") that contradicted the repository's actual workflow.

**Changed:** "Target branch is **dev**" → "Target branch is **main**" in both `docs/maintainability_audit.md` and `docs/refactor_status.md`. Historical CHANGELOG entries are untouched.

---

## Validation results

```
ruff check custom_components tests tools         → All checks passed
ruff check --select I custom_components tests tools → All checks passed
python -m compileall -q custom_components tests tools → no errors
python tools/compare_registers_with_reference.py → Name mismatches on common addresses: 242 (pre-existing, not introduced here)
python tools/check_maintainability.py            → Maintainability gate passed
python tools/validate_entity_mappings.py         → OK: 366 entities validated
python tools/check_translations.py              → All translation keys present
pytest tests/ -q                                → 729 passed, 4 skipped (pre-existing optional skips)
```

No new test failures. No new format violations (7 pre-existing format issues in unrelated files are unchanged).

---

## Confirmation

- No transport, coordinator, config_flow, services, or const.py refactoring done.
- No entity IDs changed.
- No unique IDs changed.
- No register names changed.
- No service IDs changed.
- No binary brand assets added.
- No HACS/hassfest validation removed.
- No tests skipped, xfailed, or deleted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DLvwBNssFfDBg94TWC8sWy)_