### PR TITLE
refactor: resolve unused core package

### DIFF
--- a/custom_components/thessla_green_modbus/core/__init__.py
+++ b/custom_components/thessla_green_modbus/core/__init__.py
@@ -1,1 +1,0 @@
-"""Core namespace reserved for future internal modules."""

--- a/custom_components/thessla_green_modbus/core/client.py
+++ b/custom_components/thessla_green_modbus/core/client.py
@@ -1,1 +1,0 @@
-"""Reserved module placeholder for future core client abstractions."""

--- a/custom_components/thessla_green_modbus/core/config.py
+++ b/custom_components/thessla_green_modbus/core/config.py
@@ -1,1 +1,0 @@
-"""Reserved module placeholder for future core configuration abstractions."""

--- a/custom_components/thessla_green_modbus/core/errors.py
+++ b/custom_components/thessla_green_modbus/core/errors.py
@@ -1,1 +1,0 @@
-"""Reserved module placeholder for future core error abstractions."""

--- a/custom_components/thessla_green_modbus/core/snapshot.py
+++ b/custom_components/thessla_green_modbus/core/snapshot.py
@@ -1,1 +1,0 @@
-"""Reserved module placeholder for future core snapshot abstractions."""

--- a/docs/code_cleanup_audit.md
+++ b/docs/code_cleanup_audit.md
@@ -185,3 +185,63 @@ All service names (`set_special_mode`, `set_mode`, `set_airflow_schedule`, etc.)
 - `tools/check_maintainability.py`: maintainability gate passed
 - `tools/check_translations.py`: all translation keys present
 - All moved-file imports verified (sibling-aware import checker): all correct
+
+---
+
+# core/ Package Removal Audit
+
+- Date: 2026-05-10
+- Branch: `refactor/resolve-core-package`
+
+## Decision: Path B — Remove unused core/ placeholders
+
+## Evidence
+
+All five files in `core/` contained only a single-line module docstring. No class definitions,
+no functions, no imports, no runtime logic:
+
+```
+core/__init__.py   — "Core namespace reserved for future internal modules."
+core/client.py     — "Reserved module placeholder for future core client abstractions."
+core/config.py     — "Reserved module placeholder for future core configuration abstractions."
+core/errors.py     — "Reserved module placeholder for future core error abstractions."
+core/snapshot.py   — "Reserved module placeholder for future core snapshot abstractions."
+```
+
+Runtime import search (`rg "from \.core|ThesslaGreenClient|DeviceSnapshot" custom_components tests`):
+- **Zero runtime imports** from `thessla_green_modbus.core`.
+- **Zero test imports** from the `core/` package.
+- `ThesslaGreenClient` and `DeviceSnapshot` appear only in architecture/guidelines docs as
+  descriptions of a **planned future layer**.
+- All `scanner.core` / `io_core` references in tests target `scanner/core.py` and
+  `scanner/io_core.py` — different, fully functioning modules.
+
+## Files changed
+
+| Action | Path |
+|--------|------|
+| Removed | `custom_components/thessla_green_modbus/core/__init__.py` |
+| Removed | `custom_components/thessla_green_modbus/core/client.py` |
+| Removed | `custom_components/thessla_green_modbus/core/config.py` |
+| Removed | `custom_components/thessla_green_modbus/core/errors.py` |
+| Removed | `custom_components/thessla_green_modbus/core/snapshot.py` |
+| Updated | `docs/thesslagreen_architecture.md` |
+| Updated | `docs/thesslagreen_guidelines.md` |
+
+## Runtime behavior impact
+
+None. Removed files contained only docstrings. No runtime code deleted. No imports broken.
+
+## Future work
+
+The `core/` layer (ThesslaGreenClient, DeviceSnapshot) remains a valid architectural target.
+Implement it in a dedicated future PR with real code, tests, and coordinator integration.
+Do not create placeholder files in advance.
+
+## Validation results
+
+- `ruff check custom_components tests tools`: all checks passed
+- `ruff check --select I custom_components tests tools`: all checks passed
+- `ruff format --check custom_components tests tools`: all files formatted correctly
+- `python -m compileall -q custom_components tests tools`: no syntax errors
+- `rg "ThesslaGreenClient|DeviceSnapshot|core/" custom_components tests`: zero runtime references

--- a/docs/thesslagreen_architecture.md
+++ b/docs/thesslagreen_architecture.md
@@ -30,7 +30,7 @@ Logika domenowa urządzenia nie zależy od Home Assistant.
 ---
 
 
-## Stan bieżący (2026-04-28)
+## Stan bieżący (2026-05-10)
 
 Repozytorium jest w trakcie etapowej refaktoryzacji. Obok struktury docelowej współistnieją jeszcze elementy przejściowe.
 
@@ -38,6 +38,7 @@ Wymóg bieżący:
 
 ```text
 coordinator package migration is completed and active.
+core/ package placeholder removed — not yet implemented.
 ```
 
 Stan przejściowy (aktualny):
@@ -45,9 +46,12 @@ Stan przejściowy (aktualny):
 ```text
 custom_components/thessla_green_modbus/coordinator/         # obecna aktywna lokalizacja (canonical)
 custom_components/thessla_green_modbus/coordinator.py       # usunięty
+custom_components/thessla_green_modbus/core/                # USUNIĘTY (2026-05-10) — były to same placeholdery bez kodu
 ```
 
 Migracja do `coordinator/` została wykonana w dedykowanym PR. Importy powinny wskazywać moduły kanoniczne bez shimów/proxy/re-export-only modules.
+
+Warstwa `core/` (ThesslaGreenClient, DeviceSnapshot) jest **planowaną przyszłą warstwą**, która nie istnieje jeszcze w kodzie. Placeholder files zostały usunięte jako mylące. Implementacja tej warstwy to osobny PR.
 
 Niezmiennie obowiązuje zakaz tworzenia:
 
@@ -146,15 +150,18 @@ raw register decoding
 
 ---
 
-### 3. Core — domena urządzenia
+### 3. Core — domena urządzenia (planowana, nie zaimplementowana)
 
-Docelowy katalog:
+> **Status 2026-05-10**: Warstwa `core/` nie istnieje w kodzie. Placeholder files zostały usunięte.
+> Implementacja tej warstwy to osobny przyszły PR.
+
+Docelowy katalog (planowany):
 
 ```text
 core/
 ```
 
-Główne pliki:
+Planowane pliki:
 
 ```text
 core/client.py
@@ -163,7 +170,7 @@ core/config.py
 core/errors.py
 ```
 
-Odpowiedzialność:
+Planowana odpowiedzialność:
 
 ```text
 - ThesslaGreenClient,
@@ -245,8 +252,9 @@ Scanner może używać:
 ```text
 transport/
 registers/
-core/errors.py
 ```
+
+(core/errors.py — planowane, nie zaimplementowane)
 
 Scanner nie importuje Home Assistant.
 
@@ -361,7 +369,7 @@ platformy   → raw Modbus / raw register decoding
 - jest adapterem HA,
 - nie wykonuje direct Modbus I/O,
 - nie dekoduje raw rejestrów,
-- deleguje do core/client.py.
+- docelowo deleguje do core/client.py (warstwa core/ planowana, nie zaimplementowana).
 ```
 
 ### `mappings/`

--- a/docs/thesslagreen_guidelines.md
+++ b/docs/thesslagreen_guidelines.md
@@ -44,7 +44,7 @@ pymodbus / raw socket
 ## Twarde reguły
 
 ```text
-1. core/, transport/, registers/ i scanner/ nie mogą importować Home Assistant.
+1. transport/, registers/ i scanner/ nie mogą importować Home Assistant. (core/ planowana, nie istnieje)
 2. coordinator/ nie wykonuje bezpośrednio Modbus I/O.
 3. Platformy HA nie dekodują raw register values.
 4. transport/ nie zna nazw rejestrów ThesslaGreen.
@@ -58,6 +58,7 @@ pymodbus / raw socket
 12. Po przepisaniu kodu na nową warstwę usunąć stary odpowiednik.
 13. migracja do pakietu coordinator/ została wykonana i jest stanem bieżącym.
 14. nie odtwarzamy top-level `coordinator.py`; importy kierujemy do modułów kanonicznych.
+15. core/ placeholder files zostały usunięte (2026-05-10); nie tworzymy nowych placeholderów.
 ```
 
 ---
@@ -286,9 +287,12 @@ Zakazane:
 
 ---
 
-### core/
+### core/ (planowana, nie zaimplementowana)
 
-Odpowiedzialność:
+> **Status 2026-05-10**: Warstwa `core/` nie istnieje w kodzie. Placeholder files zostały usunięte.
+> Implementacja to osobny przyszły PR.
+
+Planowana odpowiedzialność:
 
 ```text
 - ThesslaGreenClient,
@@ -299,7 +303,7 @@ Odpowiedzialność:
 - orkiestracja read/write/scan.
 ```
 
-Zakazane:
+Zakazane (gdy zostanie zaimplementowana):
 
 ```text
 - import Home Assistant,


### PR DESCRIPTION
Base branch: main

## Summary

- **Path chosen: Path B — Remove unused core/ placeholders**
- Removed 5 placeholder files from `custom_components/thessla_green_modbus/core/`
- Updated architecture and guidelines docs to accurately reflect core/ as a planned-but-not-implemented future layer

## Evidence for decision

All five files in `core/` contained only a single-line docstring — no classes, no functions, no imports, no runtime logic:

```
core/__init__.py   → "Core namespace reserved for future internal modules."
core/client.py     → "Reserved module placeholder for future core client abstractions."
core/config.py     → "Reserved module placeholder for future core configuration abstractions."
core/errors.py     → "Reserved module placeholder for future core error abstractions."
core/snapshot.py   → "Reserved module placeholder for future core snapshot abstractions."
```

Runtime import search confirmed:
- **Zero runtime imports** from `thessla_green_modbus.core` anywhere in `custom_components/`
- **Zero test imports** from the `core/` package
- `ThesslaGreenClient` and `DeviceSnapshot` appear only in docs describing a **planned future layer**
- All `scanner.core` / `io_core` references in tests target `scanner/core.py` and `scanner/io_core.py` — separate, fully functioning modules unaffected by this change

This satisfies guidelines rule 11 ("Nie tworzyć legacy modules, compatibility shims ani re-export shimów") and the explicit task rule: "Do not keep misleading placeholder modules."

## Files changed

| Action | File |
|--------|------|
| Removed | `custom_components/thessla_green_modbus/core/__init__.py` |
| Removed | `custom_components/thessla_green_modbus/core/client.py` |
| Removed | `custom_components/thessla_green_modbus/core/config.py` |
| Removed | `custom_components/thessla_green_modbus/core/errors.py` |
| Removed | `custom_components/thessla_green_modbus/core/snapshot.py` |
| Updated | `docs/thesslagreen_architecture.md` — core/ section marked as planned/not implemented |
| Updated | `docs/thesslagreen_guidelines.md` — core/ section marked planned; added rule 15 |
| Updated | `docs/code_cleanup_audit.md` — new section documenting this audit and decision |

## Runtime behavior impact

**None.** All removed files contained only docstrings. No executable code was deleted. No imports were broken. The test suite is unaffected.

## Full validation results

```
ruff check custom_components tests tools              → All checks passed
ruff check --select I custom_components tests tools   → All checks passed
ruff format --check custom_components tests tools     → 431 files already formatted
python -m compileall -q custom_components tests tools → No syntax errors
tools/compare_registers_with_reference.py             → Passed (pre-existing name-mismatch warnings unchanged)
tools/check_maintainability.py                        → Maintainability gate passed
rg ThesslaGreenClient|DeviceSnapshot custom_components tests → Zero runtime references
```

(`validate_entity_mappings.py` and `pytest` require Python ≥ 3.13 / pydantic — pre-existing environment constraint, unrelated to this change.)

## Future work

The `core/` layer (ThesslaGreenClient, DeviceSnapshot, DeviceIdentity) remains a valid architectural target. When the coordinator is ready to delegate domain logic out of HA, implement `core/` in a dedicated future PR with real code and tests. Do not pre-create placeholder files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ld2jW7Q5HRzQcES2DhE2iq)_