### PR TITLE
fix: repair broken transport imports and remove modbus_transport shim

### DIFF
--- a/custom_components/thessla_green_modbus/modbus_transport.py
+++ b/custom_components/thessla_green_modbus/modbus_transport.py
@@ -1,5 +1,0 @@
-"""Compatibility shim – canonical implementation is in transport.retry."""
-
-from .transport.retry import classify_transport_error
-
-__all__ = ["classify_transport_error"]

--- a/custom_components/thessla_green_modbus/transport/retry_logging.py
+++ b/custom_components/thessla_green_modbus/transport/retry_logging.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from .error_contract import log_retry_attempt
-from .transport.retry import calculate_backoff
+from ..error_contract import log_retry_attempt
+from .retry import calculate_backoff
 
 
 def log_transport_retry(

--- a/tests/test_error_contract.py
+++ b/tests/test_error_contract.py
@@ -33,11 +33,7 @@ def test_classify_error_reasons() -> None:
 def test_cross_layer_classification_contract() -> None:
     from custom_components.thessla_green_modbus.coordinator.retry import classify_retry_error
     from custom_components.thessla_green_modbus.scanner.io_runtime import classify_scanner_error
-
-    transport_module = pytest.importorskip(
-        "custom_components.thessla_green_modbus.modbus_transport"
-    )
-    classify_transport_error = transport_module.classify_transport_error
+    from custom_components.thessla_green_modbus.transport.retry import classify_transport_error
 
     exc = ModbusIOException("temporary failure")
     expected = classify_error(exc)
@@ -100,11 +96,7 @@ def test_cross_layer_classification_contract_matrix(
 ) -> None:
     from custom_components.thessla_green_modbus.coordinator.retry import classify_retry_error
     from custom_components.thessla_green_modbus.scanner.io_runtime import classify_scanner_error
-
-    transport_module = pytest.importorskip(
-        "custom_components.thessla_green_modbus.modbus_transport"
-    )
-    classify_transport_error = transport_module.classify_transport_error
+    from custom_components.thessla_green_modbus.transport.retry import classify_transport_error
 
     expected = classify_error(exc)
     assert (expected.kind, expected.reason) == (expected_kind, expected_reason)

--- a/tests/test_transport_package.py
+++ b/tests/test_transport_package.py
@@ -4,7 +4,6 @@ Proves that transport/ is the authoritative source and that:
 - BaseModbusTransport comes from transport.base
 - Raw response classes live in transport.raw and behave correctly
 - TcpModbusTransport and RtuModbusTransport can be instantiated from transport.*
-- modbus_transport shim still re-exports everything
 """
 
 from __future__ import annotations
@@ -33,13 +32,6 @@ from custom_components.thessla_green_modbus.transport.tcp_rtu import RawRtuOverT
 # ---------------------------------------------------------------------------
 # Canonical class identity
 # ---------------------------------------------------------------------------
-
-
-def test_canonical_base_is_from_transport_package():
-    """BaseModbusTransport imported from transport.base is the canonical class."""
-    import custom_components.thessla_green_modbus.modbus_transport as shim
-
-    assert shim.BaseModbusTransport is BaseModbusTransport
 
 
 def test_tcp_transport_inherits_canonical_base():
@@ -147,16 +139,3 @@ def test_timeout_classified_transient():
     assert decision.retry is True
 
 
-# ---------------------------------------------------------------------------
-# Shim re-exports are identical objects
-# ---------------------------------------------------------------------------
-
-
-def test_shim_re_exports_match_canonical():
-    import custom_components.thessla_green_modbus.modbus_transport as shim
-
-    assert shim.TcpModbusTransport is TcpModbusTransport
-    assert shim.RtuModbusTransport is RtuModbusTransport
-    assert shim.RawRtuOverTcpTransport is RawRtuOverTcpTransport
-    assert shim.RawModbusResponse is RawModbusResponse
-    assert shim.RawModbusWriteResponse is RawModbusWriteResponse


### PR DESCRIPTION
## Base branch: main

Two bugs introduced in the previous refactoring cycle (#1624), fixed here against the current main.

---

## Changes

### Bug fix — `transport/retry_logging.py` broken imports

`retry_logging.py` was moved from the root package into `transport/` but its relative imports were not updated.  The old paths resolved to non-existent modules:

| Before (broken) | After (fixed) |
|---|---|
| `from .error_contract import log_retry_attempt` | `from ..error_contract import log_retry_attempt` |
| `from .transport.retry import calculate_backoff` | `from .retry import calculate_backoff` |

Effect: the entire `transport/` package was unimportable — any `from thessla_green_modbus.transport import …` raised `ModuleNotFoundError: No module named 'thessla_green_modbus.transport.error_contract'`.

### Shim removal — `modbus_transport.py`

`modbus_transport.py` was a 5-line file that re-exported only `classify_transport_error` from `transport.retry`.  It had zero production callers.  The two tests that verified shim re-exports (`test_canonical_base_is_from_transport_package`, `test_shim_re_exports_match_canonical`) were already stale — the shim no longer exported `BaseModbusTransport` or the transport classes they asserted on.

Removed:
- `custom_components/thessla_green_modbus/modbus_transport.py`
- `tests/test_transport_package.py` — two shim-verification functions removed; all other transport tests kept
- `tests/test_error_contract.py` — `pytest.importorskip("modbus_transport")` replaced with a direct import of `classify_transport_error` from `transport.retry`

---

## Validation

- `ruff check custom_components/ tests/` — **All checks passed**
- `python -m compileall custom_components/ tests/ -q` — **No errors**
- All transport imports verified via `python -c "from thessla_green_modbus.transport import …"` ✓

## No-change confirmation

Entity IDs, unique IDs, service IDs, register names, and Modbus protocol behaviour are unchanged.  This PR only fixes import paths and removes a dead shim.

https://claude.ai/code/session_01FHykhfHMfCi2JgtwmEGfYb