### PR TITLE
fix: repair post-cleanup pytest collection imports

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from typing import Any
 
 # ---------------------------------------------------------------------------
+# Entity lookup — implementation lives in entity_lookup.py.
+# ---------------------------------------------------------------------------
+from .entity_lookup import _ENTITY_LOOKUP as _ENTITY_LOOKUP
+from .entity_lookup import _build_entity_lookup as _build_entity_lookup
+
+# ---------------------------------------------------------------------------
 # Options loading — implementation lives in options/__init__.py.
 # Re-exported here for backward compatibility.  Prefer importing from
 # .options in new code.
@@ -36,6 +42,12 @@ from .registers.maps import discrete_input_registers as discrete_input_registers
 from .registers.maps import holding_registers as holding_registers
 from .registers.maps import input_registers as input_registers
 from .registers.maps import multi_register_sizes as multi_register_sizes
+
+# ---------------------------------------------------------------------------
+# Unique-ID helpers — thin façades over unique_id_migration.
+# ---------------------------------------------------------------------------
+from .unique_id_migration import device_unique_id_prefix as _device_unique_id_prefix_impl
+from .unique_id_migration import migrate_unique_id as _migrate_unique_id_impl
 
 try:
     from homeassistant.const import Platform as _HAPlatform
@@ -258,6 +270,52 @@ PLATFORMS: list[Any] = [
 ]
 
 
-# ---------------------------------------------------------------------------
-# Entity lookup — implementation lives in entity_lookup.py.
-#
+# Special function enum index mappings for services.
+# Values match the sequential enum indices in special_modes.json (0=none, 1=boost, ...).
+SPECIAL_FUNCTION_MAP = {
+    "boost": 1,
+    "eco": 2,
+    "away": 3,
+    "sleep": 4,
+    "fireplace": 5,
+    "hood": 6,
+    "party": 7,
+    "bathroom": 8,
+    "kitchen": 9,
+    "summer": 10,
+    "winter": 11,
+}
+
+
+def device_unique_id_prefix(
+    serial_number: str | None,
+    host: str,
+    port: int,
+) -> str:
+    """Return the device specific prefix used in entity unique IDs."""
+    return _device_unique_id_prefix_impl(serial_number, host, port)
+
+
+def migrate_unique_id(
+    unique_id: str,
+    *,
+    serial_number: str | None,
+    host: str,
+    port: int,
+    slave_id: int,
+) -> str:
+    """Migrate a historical unique_id to the current format."""
+    return _migrate_unique_id_impl(
+        unique_id,
+        serial_number=serial_number,
+        host=host,
+        port=port,
+        slave_id=slave_id,
+        domain=DOMAIN,
+        airflow_units=(AIRFLOW_UNIT_M3H, AIRFLOW_UNIT_PERCENTAGE),
+        get_entity_lookup=_build_entity_lookup,
+        holding_registers=holding_registers,
+        input_registers=input_registers,
+        coil_registers=coil_registers,
+        discrete_input_registers=discrete_input_registers,
+    )

--- a/custom_components/thessla_green_modbus/modbus/call.py
+++ b/custom_components/thessla_green_modbus/modbus/call.py
@@ -252,6 +252,31 @@ async def _apply_attempt_delay(
         raise
 
 
+def _log_call_attempt(
+    prepared: _PreparedCall,
+    *,
+    slave_id: int,
+    attempt: int,
+    max_attempts: int,
+    kwargs: dict[str, Any],
+) -> None:
+    """Log the outgoing call summary and request frame."""
+    _LOGGER.debug(
+        "Calling %s on slave %s (batch=%s attempt %s/%s)",
+        prepared.func_name,
+        slave_id,
+        prepared.batch_size,
+        attempt,
+        max_attempts,
+    )
+    _log_modbus_request(
+        func_name=prepared.func_name,
+        slave_id=slave_id,
+        positional=prepared.positional,
+        kwargs=kwargs,
+    )
+
+
 def _raise_mapped_call_exception(
     err: Exception,
     *,
@@ -310,19 +335,11 @@ async def _call_modbus(
         max_attempts=max_attempts,
     )
 
-    _LOGGER.debug(
-        "Calling %s on slave %s (batch=%s attempt %s/%s)",
-        prepared.func_name,
-        slave_id,
-        prepared.batch_size,
-        attempt,
-        max_attempts,
-    )
-
-    _log_modbus_request(
-        func_name=prepared.func_name,
+    _log_call_attempt(
+        prepared,
         slave_id=slave_id,
-        positional=prepared.positional,
+        attempt=attempt,
+        max_attempts=max_attempts,
         kwargs=kwargs,
     )
 

--- a/custom_components/thessla_green_modbus/modbus_helpers.py
+++ b/custom_components/thessla_green_modbus/modbus_helpers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from .modbus.call import (
     _KWARG_CACHE,
+    _LOGGER,
     _SIG_CACHE,
     _apply_attempt_delay,
     _calculate_backoff_delay,
@@ -17,6 +18,7 @@ from .modbus.call import (
     _dispatch_modbus_call,
     _get_signature,
     _invoke_with_slave_kwarg,
+    _log_call_attempt,
     _normalize_positional_and_keyword_args,
     _prepare_modbus_call,
     _PreparedCall,
@@ -32,16 +34,52 @@ from .modbus.frame_logging import (
     _log_modbus_response,
     _mask_frame,
 )
-from .modbus.framer import get_rtu_framer
+from .modbus.framer import FramerType, ModbusRtuFramer
 from .registers.read_planner import (
     chunk_register_range,
     chunk_register_values,
     group_reads,
 )
 
+_FUNC_CODE_TO_NAME: dict[int, str] = {
+    1: "read_coils",
+    2: "read_discrete_inputs",
+    3: "read_holding_registers",
+    4: "read_input_registers",
+    6: "write_register",
+    16: "write_registers",
+}
+
+
+def _encode_read_frame(
+    slave_id: int,
+    func_code: int,
+    positional: list,
+    kwargs: dict,
+) -> bytes:
+    """Build a Modbus request frame from numeric function code."""
+    func_name = _FUNC_CODE_TO_NAME.get(func_code, str(func_code))
+    return _build_request_frame(func_name, slave_id, positional, kwargs)
+
+
+def get_rtu_framer() -> object | None:
+    """Return a Modbus RTU framer class/enum when available."""
+    if FramerType is not None:
+        try:
+            return FramerType.RTU
+        except (AttributeError, ValueError):  # pragma: no cover
+            return None
+    if ModbusRtuFramer is not None:
+        return ModbusRtuFramer
+    return None
+
+
 __all__ = [
     "_KWARG_CACHE",
+    "_LOGGER",
     "_SIG_CACHE",
+    "FramerType",
+    "ModbusRtuFramer",
     "_PreparedCall",
     "_apply_attempt_delay",
     "_build_request_frame",
@@ -50,8 +88,10 @@ __all__ = [
     "_call_modbus",
     "_classify_modbus_exception",
     "_dispatch_modbus_call",
+    "_encode_read_frame",
     "_get_signature",
     "_invoke_with_slave_kwarg",
+    "_log_call_attempt",
     "_log_modbus_request",
     "_log_modbus_response",
     "_mask_frame",

--- a/custom_components/thessla_green_modbus/scanner/device_info.py
+++ b/custom_components/thessla_green_modbus/scanner/device_info.py
@@ -7,7 +7,7 @@ import dataclasses
 from dataclasses import dataclass, field
 from typing import Any
 
-from .const import UNKNOWN_MODEL
+from ..const import UNKNOWN_MODEL
 
 
 @dataclass(slots=True)

--- a/custom_components/thessla_green_modbus/scanner/helpers.py
+++ b/custom_components/thessla_green_modbus/scanner/helpers.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from .const import (
+from ..const import (
     MAX_BATCH_REGISTERS,
     SENSOR_UNAVAILABLE,
     UART_OPTIONAL_REG_END,
     UART_OPTIONAL_REG_START,
 )
-from .utils import (
+from ..utils import (
     BCD_TIME_PREFIXES,
     TIME_REGISTER_PREFIXES,
     _decode_aatt,

--- a/custom_components/thessla_green_modbus/scanner/register_maps.py
+++ b/custom_components/thessla_green_modbus/scanner/register_maps.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .registers.cache import async_registers_sha256, registers_sha256
-from .registers.loader import async_get_all_registers, get_all_registers, get_registers_path
+from ..registers.cache import async_registers_sha256, registers_sha256
+from ..registers.loader import async_get_all_registers, get_all_registers, get_registers_path
 
 REGISTER_DEFINITIONS: dict[str, Any] = {}
 

--- a/custom_components/thessla_green_modbus/scanner/registers.py
+++ b/custom_components/thessla_green_modbus/scanner/registers.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 from ..const import HOLDING_BATCH_BOUNDARIES, KNOWN_MISSING_REGISTERS
 from ..scanner.helpers import UART_OPTIONAL_REGS
-from ..scanner.register_maps import MULTI_REGISTER_SIZES
+from .register_maps import MULTI_REGISTER_SIZES
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -55,7 +55,7 @@ async def test_backoff_delay(method, address, count, primary_attr, fallback_attr
 
     sleep_mock = AsyncMock()
     with patch(
-        "custom_components.thessla_green_modbus.modbus_helpers.asyncio.sleep",
+        "custom_components.thessla_green_modbus.modbus.call.asyncio.sleep",
         sleep_mock,
     ):
         result = await method(scanner, mock_client, address, count)
@@ -109,7 +109,7 @@ async def test_backoff_zero_no_delay(method, address, count, primary_attr, fallb
 
     sleep_mock = AsyncMock()
     with patch(
-        "custom_components.thessla_green_modbus.modbus_helpers.asyncio.sleep",
+        "custom_components.thessla_green_modbus.modbus.call.asyncio.sleep",
         sleep_mock,
     ):
         result = await method(scanner, mock_client, address, count)
@@ -132,11 +132,11 @@ async def test_backoff_with_jitter():
     sleep_mock = AsyncMock()
     with (
         patch(
-            "custom_components.thessla_green_modbus.modbus_helpers.random.uniform",
+            "custom_components.thessla_green_modbus.modbus.call.random.uniform",
             side_effect=[0.05, 0.05],
         ),
         patch(
-            "custom_components.thessla_green_modbus.modbus_helpers.asyncio.sleep",
+            "custom_components.thessla_green_modbus.modbus.call.asyncio.sleep",
             sleep_mock,
         ),
     ):

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -489,7 +489,7 @@ async def test_button_press_raises_on_failure():
 
 
 def test_options_form_has_clock_sync_defaults():
-    from custom_components.thessla_green_modbus.config_flow_options_form import (
+    from custom_components.thessla_green_modbus.config_flow.options_form import (
         build_options_defaults,
     )
     from custom_components.thessla_green_modbus.const import (
@@ -516,7 +516,7 @@ def test_options_form_has_clock_sync_defaults():
 
 
 def test_options_form_default_sync_enabled_is_false():
-    from custom_components.thessla_green_modbus.config_flow_options_form import (
+    from custom_components.thessla_green_modbus.config_flow.options_form import (
         build_options_defaults,
     )
     from custom_components.thessla_green_modbus.const import (
@@ -528,7 +528,7 @@ def test_options_form_default_sync_enabled_is_false():
 
 
 def test_options_form_has_clock_sync_schema_keys():
-    from custom_components.thessla_green_modbus.config_flow_options_form import (
+    from custom_components.thessla_green_modbus.config_flow.options_form import (
         build_options_schema,
     )
     from custom_components.thessla_green_modbus.const import (

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -536,7 +536,7 @@ async def test_call_with_optional_timeout_sync_function():
 def test_build_reconfigure_schema_returns_schema_with_defaults():
     """Schema built from entry data should carry host/port/slave defaults."""
     import voluptuous as vol
-    from custom_components.thessla_green_modbus.config_flow_schema import (
+    from custom_components.thessla_green_modbus.config_flow.schema import (
         build_reconfigure_schema,
     )
     from custom_components.thessla_green_modbus.const import CONF_SLAVE_ID
@@ -555,7 +555,7 @@ def test_build_reconfigure_schema_returns_schema_with_defaults():
 def test_build_reconfigure_schema_empty_entry_data_uses_defaults():
     """Empty entry data falls back to module-level defaults."""
     import voluptuous as vol
-    from custom_components.thessla_green_modbus.config_flow_schema import (
+    from custom_components.thessla_green_modbus.config_flow.schema import (
         build_reconfigure_schema,
     )
     from custom_components.thessla_green_modbus.const import (
@@ -578,7 +578,7 @@ def test_build_reconfigure_schema_empty_entry_data_uses_defaults():
 def test_build_reconfigure_schema_rejects_port_out_of_range():
     """Port outside 1-65535 should raise Invalid."""
     import voluptuous as vol
-    from custom_components.thessla_green_modbus.config_flow_schema import (
+    from custom_components.thessla_green_modbus.config_flow.schema import (
         build_reconfigure_schema,
     )
     from custom_components.thessla_green_modbus.const import CONF_SLAVE_ID
@@ -592,7 +592,7 @@ def test_build_reconfigure_schema_rejects_port_out_of_range():
 def test_build_reconfigure_schema_rejects_slave_id_out_of_range():
     """Slave ID outside 1-247 should raise Invalid."""
     import voluptuous as vol
-    from custom_components.thessla_green_modbus.config_flow_schema import (
+    from custom_components.thessla_green_modbus.config_flow.schema import (
         build_reconfigure_schema,
     )
     from custom_components.thessla_green_modbus.const import CONF_SLAVE_ID
@@ -606,7 +606,7 @@ def test_build_reconfigure_schema_rejects_slave_id_out_of_range():
 def test_build_reconfigure_schema_none_entry_data_treated_as_empty():
     """Passing None for entry_data should not raise."""
     import voluptuous as vol
-    from custom_components.thessla_green_modbus.config_flow_schema import (
+    from custom_components.thessla_green_modbus.config_flow.schema import (
         build_reconfigure_schema,
     )
 

--- a/tests/test_config_flow_runtime_loader.py
+++ b/tests/test_config_flow_runtime_loader.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from custom_components.thessla_green_modbus.config_flow_runtime import (
+from custom_components.thessla_green_modbus.config_flow.runtime import (
     load_scanner_module,
 )
 
@@ -19,7 +19,7 @@ async def test_load_scanner_module_none_hass_imports_synchronously():
     """When hass is None the import is performed synchronously."""
     fake_module = MagicMock()
     with patch(
-        "custom_components.thessla_green_modbus.config_flow_runtime.import_module",
+        "custom_components.thessla_green_modbus.config_flow.runtime.import_module",
         return_value=fake_module,
     ) as mock_import:
         result = await load_scanner_module(None)
@@ -35,7 +35,7 @@ async def test_load_scanner_module_hass_without_executor_imports_synchronously()
     hass_stub = object()  # no async_add_executor_job attribute
 
     with patch(
-        "custom_components.thessla_green_modbus.config_flow_runtime.import_module",
+        "custom_components.thessla_green_modbus.config_flow.runtime.import_module",
         return_value=fake_module,
     ) as mock_import:
         result = await load_scanner_module(hass_stub)
@@ -71,7 +71,7 @@ async def test_load_scanner_module_uses_executor_when_hass_available():
 @pytest.mark.asyncio
 async def test_load_scanner_module_executor_receives_correct_path():
     """The exact module path is passed to the executor import."""
-    from custom_components.thessla_green_modbus.config_flow_runtime import (
+    from custom_components.thessla_green_modbus.config_flow.runtime import (
         _SCANNER_MODULE_PATH,
     )
 

--- a/tests/test_config_flow_validation_bound.py
+++ b/tests/test_config_flow_validation_bound.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 import voluptuous as vol
-from custom_components.thessla_green_modbus.config_flow_validation import (
+from custom_components.thessla_green_modbus.config_flow.validation import (
     process_scan_capabilities_bound,
     validate_rtu_config_bound,
     validate_tcp_config_bound,

--- a/tests/test_device_scanner_firmware.py
+++ b/tests/test_device_scanner_firmware.py
@@ -57,7 +57,9 @@ async def test_scan_device_firmware_unavailable(caplog):
             _, _, count = args
         return [False] * count
 
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+    ) as mock_client_class:
         mock_client = AsyncMock()
         mock_client.connect.return_value = True
         mock_client_class.return_value = mock_client
@@ -120,7 +122,9 @@ async def test_scan_device_firmware_bulk_fallback():
             _, _, count = args
         return [False] * count
 
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+    ) as mock_client_class:
         mock_client = AsyncMock()
         mock_client.connect.return_value = True
         mock_client_class.return_value = mock_client
@@ -183,7 +187,9 @@ async def test_scan_device_firmware_partial_bulk_fallback():
             _, _, count = args
         return [False] * count
 
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+    ) as mock_client_class:
         mock_client = AsyncMock()
         mock_client.connect.return_value = True
         mock_client_class.return_value = mock_client

--- a/tests/test_device_scanner_orchestration.py
+++ b/tests/test_device_scanner_orchestration.py
@@ -43,7 +43,9 @@ async def test_scan_device_success_dynamic():
     async def fake_read_discrete(client, address, count, **kwargs):
         return [False] * count
 
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+    ) as mock_client_class:
         mock_client = AsyncMock()
         mock_client.connect.return_value = True
         mock_client.read_input_registers = AsyncMock(
@@ -99,7 +101,9 @@ async def test_scan_device_success_static(mock_modbus_response):
     ):
         scanner = await ThesslaGreenDeviceScanner.create("192.168.1.100", 502, 10)
 
-        with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+        with patch(
+            "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+        ) as mock_client_class:
             mock_client = AsyncMock()
             mock_client.connect.return_value = True
             mock_client.read_input_registers.return_value = mock_modbus_response
@@ -162,7 +166,9 @@ async def test_temperature_register_unavailable_kept():
             _, _, count = args
         return [False] * count
 
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+    ) as mock_client_class:
         mock_client = AsyncMock()
         mock_client.connect.return_value = True
         mock_client_class.return_value = mock_client

--- a/tests/test_input_range_fallback.py
+++ b/tests/test_input_range_fallback.py
@@ -58,7 +58,9 @@ async def test_input_range_read_after_block_failure():
     }
     scanner._update_known_missing_addresses()
 
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+    ) as mock_client_class:
         mock_client = MagicMock()
         mock_client.connect = AsyncMock(return_value=True)
         mock_client.close = AsyncMock()
@@ -129,7 +131,9 @@ async def test_block_exception_allows_single_register_reads():
     }
     scanner._update_known_missing_addresses()
 
-    with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+    ) as mock_client_class:
         mock_client = MagicMock()
         mock_client.connect = AsyncMock(return_value=True)
         mock_client.close = AsyncMock()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -26,7 +26,7 @@ async def test_call_modbus_logs(caplog):
     async def read_holding_registers(address, *, count, unit=None):
         return Response()
 
-    caplog.set_level(logging.DEBUG, logger="custom_components.thessla_green_modbus.modbus_helpers")
+    caplog.set_level(logging.DEBUG, logger="custom_components.thessla_green_modbus.modbus")
     await _call_modbus(
         read_holding_registers,
         1,
@@ -79,7 +79,7 @@ async def test_read_retries_logged(monkeypatch, caplog):
     coord._register_groups["input_registers"] = [(0, 2)]
     coord._process_register_value = lambda name, value: value
 
-    caplog.set_level(logging.DEBUG, logger="custom_components.thessla_green_modbus.modbus_helpers")
+    caplog.set_level(logging.DEBUG, logger="custom_components.thessla_green_modbus.modbus")
     data = await coord._read_input_registers_optimized()
     assert data == {"reg0": 1, "reg1": 1}
     assert any(

--- a/tests/test_migrate_unique_id.py
+++ b/tests/test_migrate_unique_id.py
@@ -1,6 +1,6 @@
 import custom_components.thessla_green_modbus.entity_lookup as lookup_mod
-from custom_components.thessla_green_modbus.const import DOMAIN
-from custom_components.thessla_green_modbus.unique_id_migration import (
+from custom_components.thessla_green_modbus.const import (
+    DOMAIN,
     device_unique_id_prefix,
     migrate_unique_id,
 )

--- a/tests/test_misc_helpers.py
+++ b/tests/test_misc_helpers.py
@@ -161,7 +161,7 @@ def test_format_time_register_path_invalid(monkeypatch):
     BCD_TIME_PREFIXES is cleared so the BCD branch is skipped; only the
     TIME_REGISTER_PREFIXES branch executes.  0x1960 has hour=25 (invalid).
     """
-    from custom_components.thessla_green_modbus import scanner_helpers
+    from custom_components.thessla_green_modbus.scanner import helpers as scanner_helpers
 
     monkeypatch.setattr(scanner_helpers, "BCD_TIME_PREFIXES", ())
     monkeypatch.setattr(scanner_helpers, "TIME_REGISTER_PREFIXES", ("schedule_",))
@@ -172,7 +172,7 @@ def test_format_time_register_path_invalid(monkeypatch):
 
 def test_format_time_register_path_valid(monkeypatch):
     """TIME_REGISTER_PREFIXES path: valid decoded time returns 'HH:MM' (lines 49-50)."""
-    from custom_components.thessla_green_modbus import scanner_helpers
+    from custom_components.thessla_green_modbus.scanner import helpers as scanner_helpers
 
     monkeypatch.setattr(scanner_helpers, "BCD_TIME_PREFIXES", ())
     monkeypatch.setattr(scanner_helpers, "TIME_REGISTER_PREFIXES", ("schedule_",))
@@ -184,7 +184,7 @@ def test_format_time_register_path_valid(monkeypatch):
 
 def test_format_time_register_none_when_sensor_unavailable(monkeypatch):
     """TIME_REGISTER_PREFIXES path: SENSOR_UNAVAILABLE returns None (line 48)."""
-    from custom_components.thessla_green_modbus import scanner_helpers
+    from custom_components.thessla_green_modbus.scanner import helpers as scanner_helpers
 
     monkeypatch.setattr(scanner_helpers, "BCD_TIME_PREFIXES", ())
     monkeypatch.setattr(scanner_helpers, "TIME_REGISTER_PREFIXES", ("schedule_",))

--- a/tests/test_modbus_helpers_call_flow.py
+++ b/tests/test_modbus_helpers_call_flow.py
@@ -450,7 +450,7 @@ async def test_call_modbus_debug_logs_response_object_when_no_encode(caplog):
     async def func_no_encode(slave):
         return NoEncodeResponse()
 
-    with caplog.at_level(logging.DEBUG, logger=modbus_helpers._LOGGER.name):
+    with caplog.at_level(logging.DEBUG, logger="custom_components.thessla_green_modbus.modbus"):
         await modbus_helpers._call_modbus(func_no_encode, 1)
 
     assert any("Received from" in r.message for r in caplog.records)  # nosec B101
@@ -524,7 +524,7 @@ async def test_call_modbus_logs_request_frame_at_debug(caplog):
     async def read_coils(address, *, count=1, **kwargs):
         return "resp"
 
-    with caplog.at_level(_logging.DEBUG, logger=_mh._LOGGER.name):
+    with caplog.at_level(_logging.DEBUG, logger="custom_components.thessla_green_modbus.modbus"):
         result = await _call_modbus(read_coils, 1, 10, 2)
     assert result == "resp"
     assert any("Modbus request" in r.message for r in caplog.records)
@@ -541,7 +541,7 @@ async def test_call_modbus_response_encode_error_logged(caplog):
     async def bad_func(**kwargs):
         return BadResponse()
 
-    with caplog.at_level(_logging.DEBUG, logger=_mh._LOGGER.name):
+    with caplog.at_level(_logging.DEBUG, logger="custom_components.thessla_green_modbus.modbus"):
         result = await _call_modbus(bad_func, 1)
     assert isinstance(result, BadResponse)
     assert any("Failed to encode" in r.message for r in caplog.records)
@@ -580,7 +580,7 @@ def test_log_call_attempt_emits_calling_message(caplog):
 def test_log_call_attempt_emits_request_frame_when_known(caplog):
     """_log_call_attempt logs a masked request frame for known function names."""
     prepared = _make_prepared(func_name="read_input_registers", positional=[20], batch_size=2)
-    with caplog.at_level(_logging.DEBUG, logger=_mh._LOGGER.name):
+    with caplog.at_level(_logging.DEBUG, logger="custom_components.thessla_green_modbus.modbus"):
         _log_call_attempt(prepared, slave_id=1, attempt=1, max_attempts=1, kwargs={"count": 2})
     messages = [r.message for r in caplog.records]
     assert any("Modbus request" in m for m in messages)

--- a/tests/test_modbus_transport_tcp.py
+++ b/tests/test_modbus_transport_tcp.py
@@ -50,8 +50,6 @@ def test_tcp_is_connected_true():
 
 
 def test_build_tcp_client_fallback_stripped_kwargs():
-    import sys
-
     t = _make_tcp()
     call_count = [0]
 
@@ -63,20 +61,17 @@ def test_build_tcp_client_fallback_stripped_kwargs():
         client.connected = True
         return client
 
-    original = sys.modules["pymodbus.client"].AsyncModbusTcpClient
-    sys.modules["pymodbus.client"].AsyncModbusTcpClient = patched_tcp_client
-    try:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient",
+        patched_tcp_client,
+    ):
         client = t._build_tcp_client()
-    finally:
-        sys.modules["pymodbus.client"].AsyncModbusTcpClient = original
 
     assert client is not None
     assert call_count[0] == 2
 
 
 def test_build_tcp_client_final_fallback():
-    import sys
-
     t = _make_tcp()
     bare_instance = MagicMock()
     call_count = [0]
@@ -87,20 +82,17 @@ def test_build_tcp_client_final_fallback():
             raise TypeError("no kwargs")
         return bare_instance
 
-    original = sys.modules["pymodbus.client"].AsyncModbusTcpClient
-    sys.modules["pymodbus.client"].AsyncModbusTcpClient = patched
-    try:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient",
+        patched,
+    ):
         client = t._build_tcp_client()
-    finally:
-        sys.modules["pymodbus.client"].AsyncModbusTcpClient = original
 
     assert client is bare_instance
     assert call_count[0] == 3
 
 
 def test_build_tcp_client_with_framer_first_attempt():
-    import sys
-
     t = _make_tcp()
     fake_framer = object()
     received_kwargs: dict = {}
@@ -109,19 +101,16 @@ def test_build_tcp_client_with_framer_first_attempt():
         received_kwargs.update(kwargs)
         return MagicMock()
 
-    original = sys.modules["pymodbus.client"].AsyncModbusTcpClient
-    sys.modules["pymodbus.client"].AsyncModbusTcpClient = patched
-    try:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient",
+        patched,
+    ):
         t._build_tcp_client(framer=fake_framer)
-    finally:
-        sys.modules["pymodbus.client"].AsyncModbusTcpClient = original
 
     assert received_kwargs.get("framer") is fake_framer
 
 
 def test_build_tcp_client_with_framer_fallback():
-    import sys
-
     t = _make_tcp()
     fake_framer = object()
     calls: list[dict] = []
@@ -132,12 +121,11 @@ def test_build_tcp_client_with_framer_fallback():
             raise TypeError("no reconnect params")
         return MagicMock()
 
-    original = sys.modules["pymodbus.client"].AsyncModbusTcpClient
-    sys.modules["pymodbus.client"].AsyncModbusTcpClient = patched
-    try:
+    with patch(
+        "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient",
+        patched,
+    ):
         t._build_tcp_client(framer=fake_framer)
-    finally:
-        sys.modules["pymodbus.client"].AsyncModbusTcpClient = original
 
     assert len(calls) == 2
     assert calls[1].get("framer") is fake_framer
@@ -149,7 +137,7 @@ async def test_tcp_connect_tcp_rtu_framer_none():
 
     with (
         patch(
-            "custom_components.thessla_green_modbus.modbus_transport.get_rtu_framer",
+            "custom_components.thessla_green_modbus.transport.tcp.get_rtu_framer",
             return_value=None,
         ),
         pytest.raises(ConnectionException, match="RTU framer"),
@@ -168,7 +156,7 @@ async def test_tcp_connect_tcp_rtu_success():
 
     with (
         patch(
-            "custom_components.thessla_green_modbus.modbus_transport.get_rtu_framer",
+            "custom_components.thessla_green_modbus.transport.tcp.get_rtu_framer",
             return_value=mock_framer,
         ),
         patch.object(t, "_build_tcp_client", return_value=mock_client),

--- a/tests/test_options_loading.py
+++ b/tests/test_options_loading.py
@@ -59,8 +59,7 @@ def test_multi_register_sizes_returns_dict():
 
 def test_migrate_unique_id_base_uid_already_has_prefix():
     """migrate_unique_id returns base_uid unchanged when it already starts with prefix (line 350)."""
-    from custom_components.thessla_green_modbus.const import DOMAIN
-    from custom_components.thessla_green_modbus.unique_id_migration import migrate_unique_id
+    from custom_components.thessla_green_modbus.const import DOMAIN, migrate_unique_id
 
     # serial_number="1" → prefix="1"; slave_id=1 → base_uid="1_fan_0"
     # "1_fan_0".startswith("1") is True → returns base_uid unchanged

--- a/tests/test_rtu_transport.py
+++ b/tests/test_rtu_transport.py
@@ -21,7 +21,7 @@ async def test_rtu_transport_initializes_serial_client(monkeypatch):
             self.connected = False
 
     monkeypatch.setattr(
-        "custom_components.thessla_green_modbus.modbus_transport._AsyncModbusSerialClient",
+        "custom_components.thessla_green_modbus.transport.rtu._AsyncModbusSerialClient",
         DummySerialClient,
     )
 

--- a/tests/test_scanner_capabilities.py
+++ b/tests/test_scanner_capabilities.py
@@ -137,7 +137,9 @@ async def test_capability_count_includes_booleans(caplog):
     )
 
     with patch.object(scanner, "_analyze_capabilities", return_value=caps):
-        with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+        with patch(
+            "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+        ) as mock_client_class:
             mock_client = AsyncMock()
             mock_client.connect.return_value = True
             mock_client_class.return_value = mock_client

--- a/tests/test_scanner_register_cache_invalidation.py
+++ b/tests/test_scanner_register_cache_invalidation.py
@@ -51,7 +51,9 @@ async def test_full_register_scan_batches_reads() -> None:
         return [0] * count
 
     with (
-        patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class,
+        patch(
+            "custom_components.thessla_green_modbus.transport.tcp.AsyncModbusTcpClient"
+        ) as mock_client_class,
         patch.object(scanner, "_read_input", AsyncMock(side_effect=fake_read_input)),
         patch.object(scanner, "_read_holding", AsyncMock(side_effect=fake_read_holding)),
         patch.object(scanner, "_read_coil", AsyncMock(return_value=[False])),

--- a/tests/test_services_handlers_maintenance.py
+++ b/tests/test_services_handlers_maintenance.py
@@ -348,7 +348,7 @@ def test_maintenance_handlers_keys_stable_and_bound():
 
 def test_iter_maintenance_service_bindings_keeps_order_and_schema_binding():
     """Service binding helper keeps registration order and uses matching handler names."""
-    from custom_components.thessla_green_modbus.services_schema import SYNC_DEVICE_CLOCK_SCHEMA
+    from custom_components.thessla_green_modbus.services.schema import SYNC_DEVICE_CLOCK_SCHEMA
 
     handlers = {
         "reset_filters": object(),

--- a/tests/test_transport_package.py
+++ b/tests/test_transport_package.py
@@ -137,5 +137,3 @@ def test_timeout_classified_transient():
     decision = classify_transport_error(TimeoutError("t/o"))
     assert decision.kind is ErrorKind.TRANSIENT
     assert decision.retry is True
-
-

--- a/tests/test_unused_translations.py
+++ b/tests/test_unused_translations.py
@@ -1,6 +1,6 @@
 """Ensure translation files don't contain unused keys."""
 
-from custom_components.thessla_green_modbus.config_flow_options_form import (
+from custom_components.thessla_green_modbus.config_flow.options_form import (
     build_options_defaults,
     build_options_schema,
 )


### PR DESCRIPTION
Fixes all pytest collection/import regressions introduced by the
refactor-final-cleanup commit (e7a1b912) and its follow-up:

Production fixes
- scanner/helpers.py: correct relative imports (.const → ..const,
  .utils → ..utils) — scanner-local modules never existed
- scanner/device_info.py: .const → ..const
- scanner/register_maps.py: break circular import by using ..registers.cache
  and ..registers.loader instead of .registers.* (which resolved to
  scanner/registers.py and looped back)
- scanner/registers.py: fix back-reference .register_maps (was
  ..scanner.register_maps — redundant double traversal)
- const.py: restore SPECIAL_FUNCTION_MAP constant, device_unique_id_prefix
  wrapper, and migrate_unique_id wrapper (removed in cleanup but still
  imported by _setup.py and tests)
- modbus/call.py: extract _log_call_attempt function (inline logic
  was lost; without it test_modbus_helpers_call_flow.py failed to import,
  leaving stub modules in sys.modules and poisoning later tests)
- modbus_helpers.py: re-export _LOGGER, _log_call_attempt, FramerType,
  ModbusRtuFramer, _encode_read_frame; define get_rtu_framer locally
  so monkeypatch.setattr(modbus_helpers, "FramerType", …) takes effect

Test patch-target fixes (module paths changed during cleanup)
- test_backoff.py: modbus_helpers.asyncio → modbus.call.asyncio,
  modbus_helpers.random → modbus.call.random
- test_config_flow_*.py: config_flow_runtime → config_flow.runtime,
  config_flow_validation → config_flow.validation,
  config_flow_options_form → config_flow.options_form,
  config_flow_schema → config_flow.schema
- test_misc_helpers.py: scanner_helpers flat import → scanner.helpers submod
- test_services_handlers_maintenance.py: services_schema → services.schema
- test_migrate_unique_id.py, test_options_loading.py: import from const
- test_logging.py: set_level logger "modbus_helpers" → "modbus" (covers
  both modbus.call and modbus.frame_logging after _apply_log_level contam.)
- test_modbus_helpers_call_flow.py: caplog.at_level logger updated for
  four tests that check frame_logging messages
- test_modbus_transport_tcp.py: patch targets updated:
  pymodbus.client.AsyncModbusTcpClient → transport.tcp.AsyncModbusTcpClient;
  modbus_transport.get_rtu_framer → transport.tcp.get_rtu_framer
- test_rtu_transport.py: modbus_transport._AsyncModbusSerialClient →
  transport.rtu._AsyncModbusSerialClient
- test_device_scanner_firmware.py, test_device_scanner_orchestration.py,
  test_scanner_capabilities.py, test_scanner_register_cache_invalidation.py,
  test_input_range_fallback.py: same AsyncModbusTcpClient patch fix

Result: 2043 tests collected (0 collection errors), 2033 passed, 4 skipped,
6 pre-existing failures (error_contract return-type mismatch ×5 + coordinator
await-expression bug ×1) — none introduced by this branch.

No coordinator redesign, no entity/register/service ID changes, no Modbus
behavior changes.