### PR TITLE
fix: resolve CI dependency and hassfest translation issues

### DIFF
--- a/custom_components/thessla_green_modbus/strings.json
+++ b/custom_components/thessla_green_modbus/strings.json
@@ -1437,7 +1437,8 @@
   },
   "options": {
     "error": {
-      "max_registers_range": "Max registers per request must be between 1 and 16."
+      "max_registers_range": "Max registers per request must be between 1 and 16.",
+      "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
     },
     "step": {
       "init": {
@@ -1476,9 +1477,6 @@
           "timeout": "Maximum time to wait for response (5-60 seconds)",
           "scan_uart_settings": "Read UART port configuration registers from the device during scanning",
           "airflow_unit": "Unit for displaying airflow values (percentage or cubic metres per hour)"
-        },
-        "error": {
-          "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
         },
         "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Device scan enabled: {device_scan_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Safe scan: {safe_scan_enabled}. Max registers per request: {current_max_registers_per_request}. Log level: {current_log_level}. Transport: {transport_label}{transport_details}.",
         "title": "ThesslaGreen Modbus Options"

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -1437,7 +1437,8 @@
   },
   "options": {
     "error": {
-      "max_registers_range": "Max registers per request must be between 1 and 16."
+      "max_registers_range": "Max registers per request must be between 1 and 16.",
+      "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
     },
     "step": {
       "init": {
@@ -1476,9 +1477,6 @@
           "timeout": "Maximum time to wait for response (5-60 seconds)",
           "scan_uart_settings": "Read UART port configuration registers from the device during scanning",
           "airflow_unit": "Unit for displaying airflow values (percentage or cubic metres per hour)"
-        },
-        "error": {
-          "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
         },
         "description": "Configure advanced integration options. Current settings: Scan interval: {current_scan_interval}s. Timeout: {current_timeout}s. Retry count: {current_retry}. Force full register list: {force_full_enabled}. Device scan enabled: {device_scan_enabled}. Skip known missing registers: {skip_missing_enabled}. Deep scan: {deep_scan_enabled}. Safe scan: {safe_scan_enabled}. Max registers per request: {current_max_registers_per_request}. Log level: {current_log_level}. Transport: {transport_label}{transport_details}.",
         "title": "ThesslaGreen Modbus Options"

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -1437,7 +1437,8 @@
   },
   "options": {
     "error": {
-      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1–16."
+      "max_registers_range": "Maksymalna liczba rejestrów na żądanie musi mieścić się w zakresie 1–16.",
+      "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1–16)"
     },
     "step": {
       "init": {
@@ -1476,9 +1477,6 @@
           "timeout": "Maksymalny limit czasu oczekiwania na odpowiedź (5-60 s)",
           "scan_uart_settings": "Odczytuj rejestry konfiguracji portów UART z urządzenia podczas skanowania",
           "airflow_unit": "Jednostka wyświetlania wartości przepływu (procenty lub metry sześcienne na godzinę)"
-        },
-        "error": {
-          "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1–16)"
         },
         "description": "Skonfiguruj zaawansowane opcje integracji. Aktualne ustawienia: Częstotliwość odczytu: {current_scan_interval} s, Limit czasu połączenia: {current_timeout} s, Liczba powtórzeń nieudanych odczytów: {current_retry}, Wymuś pełną listę rejestrów: {force_full_enabled}. Skanowanie urządzenia włączone: {device_scan_enabled}. Pomijaj znane brakujące rejestry: {skip_missing_enabled}. Głęboki skan: {deep_scan_enabled}. Bezpieczny skan: {safe_scan_enabled}. Maksymalna liczba rejestrów na żądanie: {current_max_registers_per_request}. Poziom logowania: {current_log_level}. Transport: {transport_label}{transport_details}.",
         "title": "Opcje ThesslaGreen Modbus"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,9 @@ aiodhcpwatcher>=1.1.0
 aiodiscover>=2.6.1
 PyYAML>=6.0
 types-PyYAML>=6.0.12
-pydantic==2.13.4
+# pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.12.2.
+# Keep this in sync until the HA test plugin supports newer pydantic.
+pydantic==2.12.2
 
 # Code quality tools
 black>=24.4.0

--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -34,6 +34,7 @@ OPTION_KEYS = [
 
 OPTION_ERROR_KEYS = [
     "max_registers_range",
+    "max_registers_per_request",
 ]
 
 


### PR DESCRIPTION
## Summary

- **Base branch:** `main`
- Fixed pydantic pin back to `2.12.2` (was `2.13.4`) — `pytest-homeassistant-custom-component>=0.13.309,<0.13.317` requires exactly `pydantic==2.12.2`
- Moved `options.step.init.error.max_registers_per_request` to `options.error.max_registers_per_request` in `strings.json`, `translations/en.json`, and `translations/pl.json` — Hassfest rejects `error` under `options.step.init`
- Updated `tools/check_translations.py` `OPTION_ERROR_KEYS` to include `max_registers_per_request` alongside `max_registers_range` so the local validator stays in sync

## Pre-change verification (confirmed on current main)

- `config_flow.py` exists ✅
- `config_flow/` directory does not exist ✅
- Manifest key order is correct (`domain`, `name`, then alphabetical) ✅
- No top-level `codes` key in any translation file ✅
- `options.step.init.error` was present and has now been removed ✅

## Validation results

```
python -m json.tool manifest.json        → OK
python -m json.tool strings.json         → OK
python -m json.tool translations/en.json → OK
python -m json.tool translations/pl.json → OK

python -m compileall -q custom_components tests tools → OK (no errors)

ruff check custom_components tests tools       → All checks passed!
ruff check --select I custom_components ...    → All checks passed!
ruff format --check custom_components ...      → 427 files already formatted

python tools/check_translations.py  → All translation keys present.
python tools/validate_entity_mappings.py → OK: 366 entities validated

Phase 3 assertion script:
  OK custom_components/thessla_green_modbus/strings.json
  OK custom_components/thessla_green_modbus/translations/en.json
  OK custom_components/thessla_green_modbus/translations/pl.json

Phase 4 manifest key order: OK

git diff --check → OK (no whitespace errors)
```

`pytest` and `pip install -r requirements-dev.txt` cannot be run locally because the container runs Python 3.11 while `pytest-homeassistant-custom-component>=0.13.309,<0.13.317` and the package itself require Python >=3.13. CI is authoritative for those checks. Pydantic 2.12.2 installs and imports correctly on the local Python.

Hassfest is not available as a local PyPI package; CI is authoritative.

## Deferred work

- Coordinator / DeviceClient redesign: **not touched**, deferred per scope rules
- No production runtime code changed
- No entity IDs, unique IDs, service IDs, register names, register addresses, or Modbus behavior changed

## Changed files

| File | Change |
|---|---|
| `requirements-dev.txt` | `pydantic==2.13.4` → `pydantic==2.12.2` with explanatory comment |
| `custom_components/thessla_green_modbus/strings.json` | Move `options.step.init.error` → `options.error` |
| `custom_components/thessla_green_modbus/translations/en.json` | Same |
| `custom_components/thessla_green_modbus/translations/pl.json` | Same |
| `tools/check_translations.py` | Add `max_registers_per_request` to `OPTION_ERROR_KEYS` |

https://claude.ai/code/session_019Ph5VLqTs37MdQiRL61ZNu

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ph5VLqTs37MdQiRL61ZNu)_