### PR TITLE
fix: update config flow helper test imports

### DIFF
--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import custom_components.thessla_green_modbus.config_flow as config_flow
+import custom_components.thessla_green_modbus._config_flow as _config_flow_impl
 import custom_components.thessla_green_modbus.coordinator as coordinator
 import custom_components.thessla_green_modbus.scanner.core as scanner_core
 import custom_components.thessla_green_modbus.services as services
@@ -52,14 +52,16 @@ def test_services_module_reexports_schema_constants() -> None:
 
 
 def test_config_flow_keeps_helper_surface() -> None:
-    """Config-flow helper symbols should stay importable for existing tests."""
+    """Private config-flow helpers live in _config_flow, not the public entrypoint."""
     for helper_name in (
         "_is_request_cancelled_error",
         "_looks_like_hostname",
         "_run_with_retry",
         "_call_with_optional_timeout",
     ):
-        assert hasattr(config_flow, helper_name)
+        assert hasattr(_config_flow_impl, helper_name), (
+            f"_config_flow is missing expected helper: {helper_name}"
+        )
 
 
 def test_scanner_package_exports_cancelled_error_helper() -> None:

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -7,6 +7,18 @@ from custom_components.thessla_green_modbus._config_flow.device_validation impor
     _build_success_payload,
     _validate_scan_result,
 )
+from custom_components.thessla_green_modbus._config_flow.options import (
+    normalize_baud_rate as _normalize_baud_rate,
+)
+from custom_components.thessla_green_modbus._config_flow.options import (
+    normalize_parity as _normalize_parity,
+)
+from custom_components.thessla_green_modbus._config_flow.options import (
+    normalize_stop_bits as _normalize_stop_bits,
+)
+from custom_components.thessla_green_modbus._config_flow.runtime import (
+    run_with_retry as _run_with_retry,
+)
 from custom_components.thessla_green_modbus._config_flow.schema import (
     _build_serial_defaults_and_validators,
 )
@@ -18,13 +30,7 @@ from custom_components.thessla_green_modbus._config_flow.steps import (
     resolve_reauth_entry,
     resolve_reauth_form_state,
 )
-from custom_components.thessla_green_modbus.config_flow import (
-    ConfigFlow,
-    _normalize_baud_rate,
-    _normalize_parity,
-    _normalize_stop_bits,
-    _run_with_retry,
-)
+from custom_components.thessla_green_modbus.config_flow import ConfigFlow
 from custom_components.thessla_green_modbus.errors import CannotConnect
 from pymodbus.exceptions import ModbusIOException
 
@@ -202,16 +208,16 @@ async def test_run_with_retry_sync_func_returns_value():
 @pytest.mark.asyncio
 async def test_build_connection_schema_empty_option_lists():
     """Cover the fallback branches when MODBUS_BAUD_RATES/PARITY/STOP_BITS are empty."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    import custom_components.thessla_green_modbus._config_flow as _cf_impl
 
-    original_baud = cf_mod.MODBUS_BAUD_RATES
-    original_parity = cf_mod.MODBUS_PARITY
-    original_stop_bits = cf_mod.MODBUS_STOP_BITS
+    original_baud = _cf_impl.MODBUS_BAUD_RATES
+    original_parity = _cf_impl.MODBUS_PARITY
+    original_stop_bits = _cf_impl.MODBUS_STOP_BITS
 
     try:
-        cf_mod.MODBUS_BAUD_RATES = []
-        cf_mod.MODBUS_PARITY = []
-        cf_mod.MODBUS_STOP_BITS = []
+        _cf_impl.MODBUS_BAUD_RATES = []
+        _cf_impl.MODBUS_PARITY = []
+        _cf_impl.MODBUS_STOP_BITS = []
 
         flow = ConfigFlow()
         flow.hass = None
@@ -219,9 +225,9 @@ async def test_build_connection_schema_empty_option_lists():
         # Should not raise — just verifies the empty-list branches are reached
         assert schema is not None
     finally:
-        cf_mod.MODBUS_BAUD_RATES = original_baud
-        cf_mod.MODBUS_PARITY = original_parity
-        cf_mod.MODBUS_STOP_BITS = original_stop_bits
+        _cf_impl.MODBUS_BAUD_RATES = original_baud
+        _cf_impl.MODBUS_PARITY = original_parity
+        _cf_impl.MODBUS_STOP_BITS = original_stop_bits
 
 
 @pytest.mark.asyncio
@@ -249,17 +255,17 @@ async def test_build_connection_schema_tcp_rtu_connection_default():
 @pytest.mark.asyncio
 async def test_build_connection_schema_empty_baud_rates_bad_baud_default():
     """Cover except (TypeError, ValueError) when int(baud_default) fails (lines 670-671)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    import custom_components.thessla_green_modbus._config_flow as _cf_impl
 
-    original_baud = cf_mod.MODBUS_BAUD_RATES
+    original_baud = _cf_impl.MODBUS_BAUD_RATES
     try:
-        cf_mod.MODBUS_BAUD_RATES = []
+        _cf_impl.MODBUS_BAUD_RATES = []
         flow = ConfigFlow()
         flow.hass = None
         schema = flow._build_connection_schema({"baud_rate": "invalid_baud"})
         assert schema is not None
     finally:
-        cf_mod.MODBUS_BAUD_RATES = original_baud
+        _cf_impl.MODBUS_BAUD_RATES = original_baud
 
 
 def test_validate_scan_result_rejects_empty():
@@ -402,34 +408,42 @@ def test_normalize_baud_rate_string_zero():
 
 def test_denormalize_option_none():
     """_denormalize_option with None returns None (line 249)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.options import (
+        denormalize_option as _denormalize_option,
+    )
 
-    result = cf_mod._denormalize_option("prefix_", None)
+    result = _denormalize_option("prefix_", None)
     assert result is None
 
 
 def test_denormalize_option_already_prefixed():
     """_denormalize_option with domain-prefixed value returns it unchanged (line 251)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.options import (
+        denormalize_option as _denormalize_option,
+    )
     from custom_components.thessla_green_modbus.const import DOMAIN
 
     val = f"{DOMAIN}.some_value"
-    result = cf_mod._denormalize_option("prefix_", val)
+    result = _denormalize_option("prefix_", val)
     assert result == val
 
 
 def test_looks_like_hostname_empty():
     """_looks_like_hostname with empty string returns False (line 258)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.network import (
+        looks_like_hostname as _looks_like_hostname,
+    )
 
-    assert cf_mod._looks_like_hostname("") is False
+    assert _looks_like_hostname("") is False
 
 
 def test_looks_like_hostname_starts_with_dash():
     """_looks_like_hostname with leading dash returns False (line 264)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.network import (
+        looks_like_hostname as _looks_like_hostname,
+    )
 
-    assert cf_mod._looks_like_hostname("-invalid.host") is False
+    assert _looks_like_hostname("-invalid.host") is False
 
 
 # ---------------------------------------------------------------------------
@@ -439,10 +453,12 @@ def test_looks_like_hostname_starts_with_dash():
 
 def test_strip_translation_prefix_with_domain_prefix():
     """Value with domain prefix gets stripped (line 189)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.options import (
+        strip_translation_prefix as _strip_translation_prefix,
+    )
     from custom_components.thessla_green_modbus.const import DOMAIN
 
-    result = cf_mod._strip_translation_prefix(f"{DOMAIN}.some_value")
+    result = _strip_translation_prefix(f"{DOMAIN}.some_value")
     assert result == "some_value"
 
 
@@ -466,46 +482,54 @@ def test_caps_to_dict_dataclass_no_as_dict():
     """dataclass without as_dict uses dataclasses.asdict (line 322)."""
     import dataclasses
 
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.payloads import (
+        caps_to_dict as _caps_to_dict,
+    )
 
     @dataclasses.dataclass
     class Cap:
         has_feature: bool = True
 
-    result = cf_mod._caps_to_dict(Cap())
+    result = _caps_to_dict(Cap())
     assert result["has_feature"] is True
 
 
 def test_caps_to_dict_dict_with_set_value():
     """dict input with set value converts to sorted list (lines 326, 330)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.payloads import (
+        caps_to_dict as _caps_to_dict,
+    )
 
-    result = cf_mod._caps_to_dict({"a": 1, "b": {3, 1, 2}})
+    result = _caps_to_dict({"a": 1, "b": {3, 1, 2}})
     assert result["a"] == 1
     assert result["b"] == [1, 2, 3]
 
 
 def test_caps_to_dict_plain_object():
     """Object with __dict__ uses getattr fallback (line 311 else branch)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.payloads import (
+        caps_to_dict as _caps_to_dict,
+    )
 
     class Obj:
         def __init__(self):
             self.y = 42
 
-    result = cf_mod._caps_to_dict(Obj())
+    result = _caps_to_dict(Obj())
     assert result.get("y") == 42
 
 
 def test_caps_to_dict_obj_with_as_dict():
     """Object with as_dict() method uses it (line 322 elif)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.payloads import (
+        caps_to_dict as _caps_to_dict,
+    )
 
     class ObjWithAsDict:
         def as_dict(self):
             return {"x": 99}
 
-    result = cf_mod._caps_to_dict(ObjWithAsDict())
+    result = _caps_to_dict(ObjWithAsDict())
     assert result["x"] == 99
 
 
@@ -517,9 +541,11 @@ def test_caps_to_dict_obj_with_as_dict():
 @pytest.mark.asyncio
 async def test_call_with_optional_timeout_sync_function():
     """Sync function returns result without awaiting (line 311)."""
-    import custom_components.thessla_green_modbus.config_flow as cf_mod
+    from custom_components.thessla_green_modbus._config_flow.runtime import (
+        call_with_optional_timeout as _call_with_optional_timeout,
+    )
 
-    result = await cf_mod._call_with_optional_timeout(lambda: 42, timeout=5.0)
+    result = await _call_with_optional_timeout(lambda: 42, timeout=5.0)
     assert result == 42
 
 


### PR DESCRIPTION
## Summary

- `config_flow.py` remains the unmodified Hassfest-required public entrypoint; no symbols were added or removed from it
- Private helper tests now import from their canonical `_config_flow` submodules instead of from the public `config_flow` wrapper
- Monkey-patching in schema-option tests corrected to target `_config_flow` namespace (where `ConfigFlow._build_connection_schema` actually reads `MODBUS_BAUD_RATES/PARITY/STOP_BITS`)

## Root cause

`tests/test_config_flow_helpers.py` had a top-level import:

```python
from custom_components.thessla_green_modbus.config_flow import (
    ConfigFlow,
    _normalize_baud_rate,   # not exported from config_flow.py
    _normalize_parity,      # not exported from config_flow.py
    _normalize_stop_bits,   # not exported from config_flow.py
    _run_with_retry,        # not exported from config_flow.py
)
```

`config_flow.py` is the Hassfest entrypoint wrapper and only re-exports public HA symbols (`ConfigFlow`, `OptionsFlow`, `validate_input`, `CannotConnect`, `InvalidAuth`, `VOL_INVALID`, etc.). The private helpers live in `_config_flow` submodules.

The same file also accessed `cf_mod.MODBUS_BAUD_RATES`, `cf_mod._denormalize_option`, `cf_mod._looks_like_hostname`, `cf_mod._strip_translation_prefix`, `cf_mod._caps_to_dict`, and `cf_mod._call_with_optional_timeout` via `import config_flow as cf_mod` — none of which exist on the public module.

`tests/test_api_contracts.py` additionally asserted these private helpers were attributes of the public `config_flow` module.

## Changes

**`tests/test_config_flow_helpers.py`**
- Replaced broken top-level import with canonical imports:
  - `_normalize_baud_rate/parity/stop_bits` ← `_config_flow.options`
  - `_run_with_retry` ← `_config_flow.runtime`
  - `ConfigFlow` ← `config_flow` (public entrypoint, unchanged)
- Replaced inline `cf_mod.{private_helper}` calls with direct imports from canonical submodules:
  - `_denormalize_option` ← `_config_flow.options`
  - `_looks_like_hostname` ← `_config_flow.network`
  - `_strip_translation_prefix` ← `_config_flow.options`
  - `_caps_to_dict` ← `_config_flow.payloads`
  - `_call_with_optional_timeout` ← `_config_flow.runtime`
- Corrected monkey-patching of `MODBUS_BAUD_RATES/PARITY/STOP_BITS` to target `_config_flow` (the module that actually owns those names and passes them to `_build_connection_schema`)

**`tests/test_api_contracts.py`**
- Updated `test_config_flow_keeps_helper_surface` to assert helpers exist on `_config_flow` (canonical) instead of on `config_flow` (public wrapper)

## Validation results

```
ruff check custom_components tests tools          → All checks passed!
ruff check --select I custom_components tests tools → All checks passed!
ruff format --check custom_components tests tools  → 427 files already formatted
python -m compileall -q custom_components/thessla_green_modbus tests tools → (no output, success)
python tools/check_translations.py               → All translation keys present.
python tools/validate_entity_mappings.py         → OK: 366 entities validated
```

## Scope confirmation

- Coordinator DeviceClient redesign: **deferred, not touched**
- Production runtime behavior: **unchanged**
- Entity IDs: **unchanged**
- Unique IDs: **unchanged**
- Service IDs: **unchanged**
- Register names: **unchanged**
- Register addresses: **unchanged**
- Modbus behavior: **unchanged**
- `config_flow.py` structure: **unchanged** (Hassfest entrypoint intact)
- `_config_flow/` package implementation: **unchanged**


---
_Generated by [Claude Code](https://claude.ai/code/session_01444gTiM1PrdZFZnMrL3Ar7)_