### PR TITLE
feat(core): introduce ThesslaGreenDeviceClient and wire into coordinator

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -16,15 +16,10 @@ from pymodbus.client import AsyncModbusTcpClient
 
 from ..const import (
     CONNECTION_MODE_AUTO,
-    CONNECTION_MODE_TCP,
-    CONNECTION_MODE_TCP_RTU,
-    CONNECTION_TYPE_RTU,
-    CONNECTION_TYPE_TCP,
     DEFAULT_BACKOFF,
     DEFAULT_BACKOFF_JITTER,
     DEFAULT_BAUD_RATE,
     DEFAULT_CONNECTION_TYPE,
-    DEFAULT_MAX_BACKOFF,
     DEFAULT_MAX_REGISTERS_PER_REQUEST,
     DEFAULT_NAME,
     DEFAULT_PARITY,
@@ -33,20 +28,17 @@ from ..const import (
     DEFAULT_SERIAL_PORT,
     DEFAULT_STOP_BITS,
     DOMAIN,
-    HOLDING_BATCH_BOUNDARIES,
     KNOWN_MISSING_REGISTERS,
-    SERIAL_PARITY_MAP,
-    SERIAL_STOP_BITS_MAP,
     UNKNOWN_MODEL,
     input_registers,
 )
+from ..core.client import ThesslaGreenDeviceClient
 from ..errors import CannotConnect
 from ..register_defs_cache import get_register_definitions
-from ..registers.read_planner import group_reads
 from ..registers.register_def import RegisterDef
 from ..scanner import (
     DeviceCapabilities,
-    ThesslaGreenDeviceScanner,
+    ThesslaGreenDeviceScanner,  # noqa: F401 – patch target for tests
     is_request_cancelled_error,
 )
 from ..transport.base import BaseModbusTransport
@@ -55,38 +47,7 @@ from .capabilities import _CoordinatorCapabilitiesMixin
 from .config_normalization import normalize_scan_interval as _normalize_scan_interval_impl
 from .config_properties import _CoordinatorConfigPropertiesMixin
 from .connection import (
-    build_rtu_transport as _build_rtu_transport_impl,
-)
-from .connection import (
-    build_tcp_transport as _build_tcp_transport_impl,
-)
-from .connection import (
-    connect_direct_tcp_client as _connect_direct_tcp_client_impl,
-)
-from .connection import (
-    connect_transport_or_client as _connect_transport_or_client_impl,
-)
-from .connection import (
-    ensure_connected_runtime as _ensure_connected_runtime_impl,
-)
-from .connection import (
-    ensure_transport_selected as _ensure_transport_selected_impl,
-)
-from .connection import (
-    reconnect_client_if_needed as _reconnect_client_if_needed_impl,
-)
-from .connection import (
     setup_client_with_retry as _setup_client_with_retry_impl,
-)
-from .connection_lifecycle import ensure_connected_lifecycle as _ensure_connected_lifecycle_impl
-from .connection_state import (
-    mark_connection_disconnected as _mark_connection_disconnected_impl,
-)
-from .connection_state import (
-    mark_connection_established as _mark_connection_established_impl,
-)
-from .connection_state import (
-    mark_connection_failure as _mark_connection_failure_impl,
 )
 from .connection_test import run_connection_test as _run_connection_test_impl
 from .device_info import run_device_scan as _run_device_scan_impl
@@ -106,17 +67,12 @@ from .diagnostics import (
 from .diagnostics import (
     status_overview as _status_overview_impl,
 )
-from .disconnect import close_client_connection as _close_client_connection_impl
-from .disconnect import disconnect_locked as _disconnect_locked_impl
 from .factory import build_config_from_params as _build_config_from_params_impl
 from .init_config import apply_coordinator_config as _apply_coordinator_config_impl
 from .init_config import normalize_runtime_config as _normalize_runtime_config_impl
 from .io import _ModbusIOMixin
 from .lifecycle import async_setup as _async_setup_impl
 from .models import CoordinatorConfig
-from .register_groups import (
-    compute_register_groups as _compute_register_groups_impl,
-)
 from .register_processing import (
     find_register_name as _find_register_name_impl,
 )
@@ -153,14 +109,12 @@ from .scan import (
     store_scan_cache as _store_scan_cache_impl,
 )
 from .scan_result import apply_scan_result as _apply_scan_result_impl
-from .scanner_kwargs import build_scanner_kwargs as _build_scanner_kwargs_impl
 from .schedule import _CoordinatorScheduleMixin
 from .state import (
     initialize_runtime_state as _initialize_runtime_state_impl,
 )
 from .state import normalize_serial_settings as _normalize_serial_settings_impl
 from .state import resolve_effective_batch as _resolve_effective_batch_impl
-from .transport_select import select_auto_transport as _select_auto_transport_impl
 from .update import async_update_data as _async_update_data_impl
 
 __all__ = [
@@ -197,11 +151,359 @@ class ThesslaGreenModbusCoordinator(
     _CoordinatorScheduleMixin,
     DataUpdateCoordinator[dict[str, Any]],
 ):
-    """Optimized data coordinator for ThesslaGreen Modbus device."""
+    """Optimized data coordinator for ThesslaGreen Modbus device.
 
-    offline_state: bool
+    Acts as the Home Assistant integration boundary.  All device-domain
+    operations are delegated to ``self._device_client`` which is a
+    ``ThesslaGreenDeviceClient`` instance.  The coordinator's device-state
+    attributes (transport, capabilities, register maps, statistics, …) are
+    properties that proxy to the device client, so existing coordinator
+    submodule functions continue to work unchanged via duck-typing.
+    """
+
     _reauth_scheduled: bool
     _stop_listener: Callable[..., Any] | None
+
+    # ------------------------------------------------------------------
+    # Device-state property proxies
+    #
+    # All mutable device-domain state lives in ``self._device_client``.
+    # The properties below allow existing coordinator submodule functions
+    # (and tests) to continue accessing coordinator.X and have those
+    # accesses transparently read/write the DeviceClient's state.
+    # ------------------------------------------------------------------
+
+    @property
+    def config(self) -> CoordinatorConfig:
+        return self._device_client.config
+
+    @config.setter
+    def config(self, value: CoordinatorConfig) -> None:
+        self._device_client.config = value
+
+    @property
+    def _device_name(self) -> str:
+        return self._device_client._device_name
+
+    @_device_name.setter
+    def _device_name(self, value: str) -> None:
+        self._device_client._device_name = value
+
+    @property
+    def _resolved_connection_mode(self) -> str | None:
+        return self._device_client._resolved_connection_mode
+
+    @_resolved_connection_mode.setter
+    def _resolved_connection_mode(self, value: str | None) -> None:
+        self._device_client._resolved_connection_mode = value
+
+    @property
+    def timeout(self) -> int:
+        return self._device_client.timeout
+
+    @timeout.setter
+    def timeout(self, value: int) -> None:
+        self._device_client.timeout = value
+
+    @property
+    def retry(self) -> int:
+        return self._device_client.retry
+
+    @retry.setter
+    def retry(self, value: int) -> None:
+        self._device_client.retry = value
+
+    @property
+    def backoff(self) -> float:
+        return self._device_client.backoff
+
+    @backoff.setter
+    def backoff(self, value: float) -> None:
+        self._device_client.backoff = value
+
+    @property
+    def backoff_jitter(self) -> float | tuple[float, float] | None:
+        return self._device_client.backoff_jitter
+
+    @backoff_jitter.setter
+    def backoff_jitter(self, value: float | tuple[float, float] | None) -> None:
+        self._device_client.backoff_jitter = value
+
+    @property
+    def force_full_register_list(self) -> bool:
+        return self._device_client.force_full_register_list
+
+    @force_full_register_list.setter
+    def force_full_register_list(self, value: bool) -> None:
+        self._device_client.force_full_register_list = value
+
+    @property
+    def scan_uart_settings(self) -> bool:
+        return self._device_client.scan_uart_settings
+
+    @scan_uart_settings.setter
+    def scan_uart_settings(self, value: bool) -> None:
+        self._device_client.scan_uart_settings = value
+
+    @property
+    def deep_scan(self) -> bool:
+        return self._device_client.deep_scan
+
+    @deep_scan.setter
+    def deep_scan(self, value: bool) -> None:
+        self._device_client.deep_scan = value
+
+    @property
+    def safe_scan(self) -> bool:
+        return self._device_client.safe_scan
+
+    @safe_scan.setter
+    def safe_scan(self, value: bool) -> None:
+        self._device_client.safe_scan = value
+
+    @property
+    def skip_missing_registers(self) -> bool:
+        return self._device_client.skip_missing_registers
+
+    @skip_missing_registers.setter
+    def skip_missing_registers(self, value: bool) -> None:
+        self._device_client.skip_missing_registers = value
+
+    @property
+    def effective_batch(self) -> int:
+        return self._device_client.effective_batch
+
+    @effective_batch.setter
+    def effective_batch(self, value: int) -> None:
+        self._device_client.effective_batch = value
+
+    @property
+    def max_registers_per_request(self) -> int:
+        return self._device_client.max_registers_per_request
+
+    @max_registers_per_request.setter
+    def max_registers_per_request(self, value: int) -> None:
+        self._device_client.max_registers_per_request = value
+
+    # -- Connection state --
+
+    @property
+    def client(self) -> Any:
+        return self._device_client.client
+
+    @client.setter
+    def client(self, value: Any) -> None:
+        self._device_client.client = value
+
+    @property
+    def _transport(self) -> Any:
+        return self._device_client._transport
+
+    @_transport.setter
+    def _transport(self, value: Any) -> None:
+        self._device_client._transport = value
+
+    @property
+    def _client_lock(self) -> Any:
+        return self._device_client._client_lock
+
+    @_client_lock.setter
+    def _client_lock(self, value: Any) -> None:
+        self._device_client._client_lock = value
+
+    @property
+    def _write_lock(self) -> Any:
+        return self._device_client._write_lock
+
+    @_write_lock.setter
+    def _write_lock(self, value: Any) -> None:
+        self._device_client._write_lock = value
+
+    @property
+    def _update_in_progress(self) -> bool:
+        return self._device_client._update_in_progress
+
+    @_update_in_progress.setter
+    def _update_in_progress(self, value: bool) -> None:
+        self._device_client._update_in_progress = value
+
+    @property
+    def offline_state(self) -> bool:
+        return self._device_client.offline_state
+
+    @offline_state.setter
+    def offline_state(self, value: bool) -> None:
+        self._device_client.offline_state = value
+
+    # -- Device info / capabilities --
+
+    @property
+    def capabilities(self) -> Any:
+        return self._device_client.capabilities
+
+    @capabilities.setter
+    def capabilities(self, value: Any) -> None:
+        self._device_client.capabilities = value
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return self._device_client.device_info
+
+    @device_info.setter
+    def device_info(self, value: dict[str, Any]) -> None:
+        self._device_client.device_info = value
+
+    # -- Register maps and groups --
+
+    @property
+    def available_registers(self) -> dict[str, Any]:
+        return self._device_client.available_registers
+
+    @available_registers.setter
+    def available_registers(self, value: dict[str, Any]) -> None:
+        self._device_client.available_registers = value
+
+    @property
+    def _register_maps(self) -> dict[str, Any]:
+        return self._device_client._register_maps
+
+    @_register_maps.setter
+    def _register_maps(self, value: dict[str, Any]) -> None:
+        self._device_client._register_maps = value
+
+    @property
+    def _reverse_maps(self) -> dict[str, Any]:
+        return self._device_client._reverse_maps
+
+    @_reverse_maps.setter
+    def _reverse_maps(self, value: dict[str, Any]) -> None:
+        self._device_client._reverse_maps = value
+
+    @property
+    def _input_registers_rev(self) -> dict[int, str]:
+        return self._device_client._input_registers_rev
+
+    @_input_registers_rev.setter
+    def _input_registers_rev(self, value: dict[int, str]) -> None:
+        self._device_client._input_registers_rev = value
+
+    @property
+    def _holding_registers_rev(self) -> dict[int, str]:
+        return self._device_client._holding_registers_rev
+
+    @_holding_registers_rev.setter
+    def _holding_registers_rev(self, value: dict[int, str]) -> None:
+        self._device_client._holding_registers_rev = value
+
+    @property
+    def _coil_registers_rev(self) -> dict[int, str]:
+        return self._device_client._coil_registers_rev
+
+    @_coil_registers_rev.setter
+    def _coil_registers_rev(self, value: dict[int, str]) -> None:
+        self._device_client._coil_registers_rev = value
+
+    @property
+    def _discrete_inputs_rev(self) -> dict[int, str]:
+        return self._device_client._discrete_inputs_rev
+
+    @_discrete_inputs_rev.setter
+    def _discrete_inputs_rev(self, value: dict[int, str]) -> None:
+        self._device_client._discrete_inputs_rev = value
+
+    @property
+    def _register_groups(self) -> dict[str, Any]:
+        return self._device_client._register_groups
+
+    @_register_groups.setter
+    def _register_groups(self, value: dict[str, Any]) -> None:
+        self._device_client._register_groups = value
+
+    @property
+    def _failed_registers(self) -> set[str]:
+        return self._device_client._failed_registers
+
+    @_failed_registers.setter
+    def _failed_registers(self, value: set[str]) -> None:
+        self._device_client._failed_registers = value
+
+    # -- Statistics and failure tracking --
+
+    @property
+    def statistics(self) -> dict[str, Any]:
+        return self._device_client.statistics
+
+    @statistics.setter
+    def statistics(self, value: dict[str, Any]) -> None:
+        self._device_client.statistics = value
+
+    @property
+    def _consecutive_failures(self) -> int:
+        return self._device_client._consecutive_failures
+
+    @_consecutive_failures.setter
+    def _consecutive_failures(self, value: int) -> None:
+        self._device_client._consecutive_failures = value
+
+    @property
+    def _max_failures(self) -> int:
+        return self._device_client._max_failures
+
+    @_max_failures.setter
+    def _max_failures(self, value: int) -> None:
+        self._device_client._max_failures = value
+
+    # -- Scan state --
+
+    @property
+    def device_scan_result(self) -> dict[str, Any] | None:
+        return self._device_client.device_scan_result
+
+    @device_scan_result.setter
+    def device_scan_result(self, value: dict[str, Any] | None) -> None:
+        self._device_client.device_scan_result = value
+
+    @property
+    def unknown_registers(self) -> dict[str, Any]:
+        return self._device_client.unknown_registers
+
+    @unknown_registers.setter
+    def unknown_registers(self, value: dict[str, Any]) -> None:
+        self._device_client.unknown_registers = value
+
+    @property
+    def scanned_registers(self) -> dict[str, Any]:
+        return self._device_client.scanned_registers
+
+    @scanned_registers.setter
+    def scanned_registers(self, value: dict[str, Any]) -> None:
+        self._device_client.scanned_registers = value
+
+    @property
+    def last_scan(self) -> Any:
+        return self._device_client.last_scan
+
+    @last_scan.setter
+    def last_scan(self, value: Any) -> None:
+        self._device_client.last_scan = value
+
+    # -- Post-processing state (capabilities mixin) --
+
+    @property
+    def _last_power_timestamp(self) -> Any:
+        return self._device_client._last_power_timestamp
+
+    @_last_power_timestamp.setter
+    def _last_power_timestamp(self, value: Any) -> None:
+        self._device_client._last_power_timestamp = value
+
+    @property
+    def _total_energy(self) -> float:
+        return self._device_client._total_energy
+
+    @_total_energy.setter
+    def _total_energy(self, value: float) -> None:
+        self._device_client._total_energy = value
 
     def __init__(
         self,
@@ -222,6 +524,27 @@ class ThesslaGreenModbusCoordinator(
         update_interval = timedelta(seconds=interval_seconds)
         self.scan_interval = interval_seconds
 
+        # Compute effective_batch early so DeviceClient can be created before
+        # _apply_coordinator_config_impl runs (which sets attrs via property proxies).
+        _pre_effective_batch = _resolve_effective_batch_impl(
+            entry, normalized_cfg.max_registers_per_request
+        )
+        _pre_backoff = _normalize_backoff_impl(normalized_cfg.backoff)
+        _pre_jitter = _parse_backoff_jitter_impl(normalized_cfg.backoff_jitter)
+
+        # Create DeviceClient first — all device-state properties proxy to it.
+        self._device_client = ThesslaGreenDeviceClient(
+            normalized_cfg,
+            hass=hass,
+            effective_batch=_pre_effective_batch,
+            resolved_connection_mode=resolved_connection_mode
+            if resolved_connection_mode != CONNECTION_MODE_AUTO
+            else None,
+            backoff=_pre_backoff,
+            backoff_jitter=_pre_jitter,
+            entry=entry,
+        )
+
         try:
             super().__init__(
                 hass,
@@ -239,6 +562,7 @@ class ThesslaGreenModbusCoordinator(
             )
         self.hass = hass
 
+        # Apply coordinator config — writes go through property proxies to DeviceClient.
         _apply_coordinator_config_impl(
             self,
             normalized_cfg,
@@ -249,6 +573,7 @@ class ThesslaGreenModbusCoordinator(
             resolve_effective_batch_fn=_resolve_effective_batch_impl,
         )
 
+        # Initialize runtime state — writes go through property proxies to DeviceClient.
         _initialize_runtime_state_impl(self, entry=entry)
 
     @classmethod
@@ -345,15 +670,11 @@ class ThesslaGreenModbusCoordinator(
 
     def _build_scanner_kwargs(self) -> dict[str, Any]:
         """Return constructor kwargs shared by all scanner creation paths."""
-        return _build_scanner_kwargs_impl(
-            self,
-            resolved_connection_mode=self._resolved_connection_mode,
-        )
+        return self._device_client._build_scanner_kwargs()
 
     async def _create_scanner(self) -> Any:
         """Instantiate a ThesslaGreenDeviceScanner using its create() factory."""
-        kwargs = self._build_scanner_kwargs()
-        return await ThesslaGreenDeviceScanner.create(**kwargs)
+        return await self._device_client.async_create_scanner()
 
     def _apply_scan_result(self, scan_result: dict[str, Any]) -> None:
         """Store and process a completed device scan result."""
@@ -370,9 +691,13 @@ class ThesslaGreenModbusCoordinator(
         )
 
     async def _run_device_scan(self) -> None:
-        """Run a full device scan and apply the result."""
+        """Run a full device scan and apply the result.
+
+        Device scanning is delegated to DeviceClient; the coordinator keeps
+        ownership of applying the result (which writes to HA entry options).
+        """
         await _run_device_scan_impl(
-            create_scanner=self._create_scanner,
+            create_scanner=self._device_client.async_create_scanner,
             apply_scan_result=self._apply_scan_result,
             logger=_LOGGER,
         )
@@ -428,13 +753,8 @@ class ThesslaGreenModbusCoordinator(
         _store_scan_cache_impl(self)
 
     def _compute_register_groups(self) -> None:
-        """Pre-compute register groups for optimized batch reading."""
-        _compute_register_groups_impl(
-            self,
-            get_register_definition=get_register_definition,
-            group_reads=group_reads,
-            holding_batch_boundaries=HOLDING_BATCH_BOUNDARIES,
-        )
+        """Pre-compute register groups — delegates to DeviceClient."""
+        self._device_client.compute_register_groups()
 
     def _mark_registers_failed(self, names: Iterable[str | None]) -> None:
         """Record registers that failed to read."""
@@ -450,7 +770,7 @@ class ThesslaGreenModbusCoordinator(
             await _run_connection_test_impl(
                 ensure_connection=self._ensure_connection,
                 get_transport=lambda: self._transport,
-                slave_id=self.config.slave_id,
+                slave_id=self.slave_id,
                 test_addresses=list(input_registers().values())[:3],
                 is_cancelled_error=is_request_cancelled_error,
                 logger=_LOGGER,
@@ -469,132 +789,29 @@ class ThesslaGreenModbusCoordinator(
         )
 
     async def _ensure_connection(self) -> None:
-        """Ensure Modbus connection is established."""
-
+        """Ensure Modbus connection is established (alias used by coordinator submodules)."""
         await self._ensure_connected()
 
     def _build_tcp_transport(
         self,
         mode: str,
     ) -> BaseModbusTransport:
-        return _build_tcp_transport_impl(
-            mode=mode,
-            host=self.config.host,
-            port=self.config.port,
-            retry=self.retry,
-            backoff=self.backoff,
-            max_backoff=DEFAULT_MAX_BACKOFF,
-            timeout=self.timeout,
-            offline_state=self.offline_state,
-            connection_type_tcp=CONNECTION_TYPE_TCP,
-            connection_mode_tcp_rtu=CONNECTION_MODE_TCP_RTU,
-        )
+        """Delegate TCP transport building to DeviceClient."""
+        return self._device_client._build_tcp_transport(mode)
 
     async def _try_direct_client_connect(self, *, allow_parameterless_ctor: bool) -> bool:
-        """Try connecting via AsyncModbusTcpClient and store the connected client."""
-        from custom_components.thessla_green_modbus import coordinator as coordinator_pkg
-
-        tcp_client_cls = getattr(coordinator_pkg, "AsyncModbusTcpClient", AsyncModbusTcpClient)
-        direct_client = await _connect_direct_tcp_client_impl(
-            host=self.config.host,
-            port=self.config.port,
-            timeout=self.timeout,
-            tcp_client_cls=tcp_client_cls,
-            allow_parameterless_ctor=allow_parameterless_ctor,
+        """Try connecting via AsyncModbusTcpClient — delegates to DeviceClient."""
+        return await self._device_client._try_direct_client_connect(
+            allow_parameterless_ctor=allow_parameterless_ctor
         )
-        if direct_client is not None:
-            self.client = direct_client
-            self._transport = None
-            return True
-        return False
-
-    async def _select_auto_transport(self) -> None:
-        """Attempt auto-detection between RTU-over-TCP and Modbus TCP."""
-
-        transport, mode = await _select_auto_transport_impl(
-            resolved_connection_mode=self._resolved_connection_mode,
-            build_tcp_transport=self._build_tcp_transport,
-            try_direct_client_connect=lambda allow_parameterless_ctor: (
-                self._try_direct_client_connect(allow_parameterless_ctor=allow_parameterless_ctor)
-            ),
-            port=self.config.port,
-            timeout=self.timeout,
-            slave_id=self.config.slave_id,
-            host=self.config.host,
-            logger=_LOGGER,
-        )
-        if transport is not None:
-            self._transport = transport
-        if mode is not None:
-            self._resolved_connection_mode = mode
 
     def _build_transport_selector_fn(self) -> Any:
-        """Return the transport selector callable for the connection lifecycle.
-
-        Computes parity and stop-bits from current config at call time so that
-        the returned callable always reflects the live coordinator settings.
-        """
-        parity = SERIAL_PARITY_MAP.get(self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
-        stop_bits = SERIAL_STOP_BITS_MAP.get(
-            self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
-        )
-
-        async def _ensure_transport_selected() -> Any:
-            return await _ensure_transport_selected_impl(
-                current_transport=self._transport,
-                connection_type=self.config.connection_type,
-                connection_mode=self.config.connection_mode,
-                host=self.config.host,
-                port=self.config.port,
-                serial_port=self.config.serial_port,
-                baudrate=self.config.baud_rate,
-                parity=parity,
-                stopbits=stop_bits,
-                retry=self.retry,
-                backoff=self.backoff,
-                max_backoff=DEFAULT_MAX_BACKOFF,
-                timeout=self.timeout,
-                offline_state=self.offline_state,
-                connection_type_rtu=CONNECTION_TYPE_RTU,
-                connection_mode_auto=CONNECTION_MODE_AUTO,
-                connection_mode_tcp=CONNECTION_MODE_TCP,
-                build_rtu_transport_fn=_build_rtu_transport_impl,
-                build_tcp_transport_fn=self._build_tcp_transport,
-                select_auto_transport_fn=lambda: _select_auto_transport_impl(
-                    resolved_connection_mode=self._resolved_connection_mode,
-                    build_tcp_transport=self._build_tcp_transport,
-                    try_direct_client_connect=lambda allow_parameterless_ctor: (
-                        self._try_direct_client_connect(
-                            allow_parameterless_ctor=allow_parameterless_ctor
-                        )
-                    ),
-                    port=self.config.port,
-                    timeout=self.timeout,
-                    slave_id=self.config.slave_id,
-                    host=self.config.host,
-                    logger=_LOGGER,
-                ),
-            )
-
-        return _ensure_transport_selected
+        """Return the transport selector callable — delegates to DeviceClient."""
+        return self._device_client._build_transport_selector_fn()
 
     async def _ensure_connected(self) -> None:
-        """Ensure Modbus connection is established using the shared client."""
-        await _ensure_connected_lifecycle_impl(
-            self,
-            ensure_connected_runtime_fn=_ensure_connected_runtime_impl,
-            reconnect_client_if_needed_fn=_reconnect_client_if_needed_impl,
-            ensure_transport_selected_fn_factory=self._build_transport_selector_fn,
-            connect_transport_or_client_fn=_connect_transport_or_client_impl,
-            mark_connection_established_fn=lambda: _mark_connection_established_impl(
-                offline_state_setter=lambda value: setattr(self, "offline_state", value)
-            ),
-            mark_connection_failure_fn=lambda: _mark_connection_failure_impl(
-                statistics=self.statistics,
-                offline_state_setter=lambda value: setattr(self, "offline_state", value),
-            ),
-            logger=_LOGGER,
-        )
+        """Ensure Modbus connection is established — delegates to DeviceClient."""
+        await self._device_client.async_ensure_connected()
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the device with optimized batch reading.
@@ -613,26 +830,15 @@ class ThesslaGreenModbusCoordinator(
         return _process_register_value_impl(register_name, value)
 
     async def _disconnect_locked(self) -> None:
-        """Disconnect from Modbus device without acquiring locks."""
-
-        await _disconnect_locked_impl(
-            transport=self._transport,
-            client=self.client,
-            close_client_connection_fn=_close_client_connection_impl,
-            mark_connection_disconnected_fn=lambda: _mark_connection_disconnected_impl(
-                offline_state_setter=lambda value: setattr(self, "offline_state", value)
-            ),
-            logger=_LOGGER,
-        )
-        self.client = None
+        """Disconnect from Modbus device without acquiring locks — delegates to DeviceClient."""
+        await self._device_client._disconnect_locked()
 
     async def _close_client_connection(self) -> None:
-        """Close client object safely for sync or async close implementations."""
-        await _close_client_connection_impl(client=self.client, logger=_LOGGER)
+        """Close client object safely — delegates to DeviceClient."""
+        await self._device_client._close_client_connection()
 
     async def _disconnect(self) -> None:
         """Disconnect from Modbus device."""
-
         async with self._client_lock:
             await self._disconnect_locked()
 

--- a/custom_components/thessla_green_modbus/core/__init__.py
+++ b/custom_components/thessla_green_modbus/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core device-domain layer for ThesslaGreen Modbus integration."""
+
+from .client import ThesslaGreenDeviceClient
+
+__all__ = ["ThesslaGreenDeviceClient"]

--- a/custom_components/thessla_green_modbus/core/client.py
+++ b/custom_components/thessla_green_modbus/core/client.py
@@ -1,0 +1,543 @@
+"""Device-domain client for ThesslaGreen Modbus integration.
+
+ThesslaGreenDeviceClient owns all device-domain state and operations,
+keeping the coordinator as a thin Home Assistant adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Iterable
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, cast
+
+from pymodbus.client import AsyncModbusTcpClient
+
+from ..const import (
+    CONNECTION_MODE_AUTO,
+    CONNECTION_MODE_TCP,
+    CONNECTION_MODE_TCP_RTU,
+    CONNECTION_TYPE_RTU,
+    CONNECTION_TYPE_TCP,
+    DEFAULT_MAX_BACKOFF,
+    DEFAULT_PARITY,
+    DEFAULT_STOP_BITS,
+    HOLDING_BATCH_BOUNDARIES,
+    SERIAL_PARITY_MAP,
+    SERIAL_STOP_BITS_MAP,
+    coil_registers,
+    discrete_input_registers,
+    holding_registers,
+    input_registers,
+)
+from ..coordinator.capabilities import _CoordinatorCapabilitiesMixin
+from ..coordinator.connection import (
+    build_rtu_transport as _build_rtu_transport_impl,
+)
+from ..coordinator.connection import (
+    build_tcp_transport as _build_tcp_transport_impl,
+)
+from ..coordinator.connection import (
+    connect_direct_tcp_client as _connect_direct_tcp_client_impl,
+)
+from ..coordinator.connection import (
+    connect_transport_or_client as _connect_transport_or_client_impl,
+)
+from ..coordinator.connection import (
+    ensure_connected_runtime as _ensure_connected_runtime_impl,
+)
+from ..coordinator.connection import (
+    ensure_transport_selected as _ensure_transport_selected_impl,
+)
+from ..coordinator.connection import (
+    reconnect_client_if_needed as _reconnect_client_if_needed_impl,
+)
+from ..coordinator.connection_lifecycle import (
+    ensure_connected_lifecycle as _ensure_connected_lifecycle_impl,
+)
+from ..coordinator.connection_state import (
+    mark_connection_disconnected as _mark_connection_disconnected_impl,
+)
+from ..coordinator.connection_state import (
+    mark_connection_established as _mark_connection_established_impl,
+)
+from ..coordinator.connection_state import (
+    mark_connection_failure as _mark_connection_failure_impl,
+)
+from ..coordinator.connection_test import run_connection_test as _run_connection_test_impl
+from ..coordinator.disconnect import (
+    close_client_connection as _close_client_connection_impl,
+)
+from ..coordinator.disconnect import (
+    disconnect_locked as _disconnect_locked_impl,
+)
+from ..coordinator.io import _ModbusIOMixin
+from ..coordinator.models import CoordinatorConfig
+from ..coordinator.register_groups import (
+    compute_register_groups as _compute_register_groups_impl,
+)
+from ..coordinator.register_processing import (
+    find_register_name as _find_register_name_impl,
+)
+from ..coordinator.register_processing import (
+    process_register_value as _process_register_value_impl,
+)
+from ..coordinator.runtime_state import (
+    clear_register_failure as _clear_register_failure_impl,
+)
+from ..coordinator.runtime_state import (
+    mark_registers_failed as _mark_registers_failed_impl,
+)
+from ..coordinator.scan import (
+    normalise_available_registers as _normalise_available_registers_impl,
+)
+from ..coordinator.scanner_kwargs import build_scanner_kwargs as _build_scanner_kwargs_impl
+from ..coordinator.transport_select import (
+    select_auto_transport as _select_auto_transport_impl,
+)
+from ..register_defs_cache import get_register_definitions
+from ..registers.read_planner import group_reads
+from ..registers.register_def import RegisterDef
+from ..scanner import (
+    DeviceCapabilities,
+    ThesslaGreenDeviceScanner,
+    is_request_cancelled_error,
+)
+from ..transport.base import BaseModbusTransport
+from ..utils import utcnow as _utcnow
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+_ORIGINAL_ASYNC_MODBUS_TCP_CLIENT = AsyncModbusTcpClient
+
+
+def _get_register_definition(name: str) -> RegisterDef:
+    return get_register_definitions()[name]
+
+
+class ThesslaGreenDeviceClient(_ModbusIOMixin, _CoordinatorCapabilitiesMixin):
+    """Device-domain operations client for ThesslaGreen Modbus integration.
+
+    Owns all device-domain mutable state and provides device operations.
+    The coordinator acts as a thin HA adapter that delegates to this client.
+    """
+
+    #: Asyncio locks owned by this client (coordinator proxies access these).
+    _client_lock: asyncio.Lock
+    _write_lock: asyncio.Lock
+
+    def __init__(
+        self,
+        config: CoordinatorConfig,
+        *,
+        hass: HomeAssistant,
+        effective_batch: int,
+        resolved_connection_mode: str | None,
+        backoff: float,
+        backoff_jitter: float | tuple[float, float] | None,
+        entry: ConfigEntry | None = None,
+    ) -> None:
+        """Initialize device client from coordinator config."""
+        self.config = config
+        self.hass = hass
+
+        # Convenience aliases for frequently-accessed config fields.
+        self.slave_id = config.slave_id
+        self.timeout = config.timeout
+        self.retry = config.retry
+        self.backoff = backoff
+        self.backoff_jitter = backoff_jitter
+        self.force_full_register_list = config.force_full_register_list
+        self.scan_uart_settings = config.scan_uart_settings
+        self.deep_scan = config.deep_scan
+        self.safe_scan = config.safe_scan
+        self.skip_missing_registers = config.skip_missing_registers
+        self.effective_batch = effective_batch
+        self.max_registers_per_request = effective_batch
+        self._resolved_connection_mode = resolved_connection_mode
+        self._device_name: str = config.name
+
+        # Connection state.
+        self.client: Any | None = None
+        self._transport: BaseModbusTransport | None = None
+        self._client_lock = asyncio.Lock()
+        self._write_lock = asyncio.Lock()
+        self._update_in_progress: bool = False
+        self.offline_state: bool = False
+
+        # Device state.
+        self.capabilities = DeviceCapabilities()
+        if entry is not None and isinstance(entry.data.get("capabilities"), dict):
+            with suppress(TypeError, ValueError):
+                self.capabilities = DeviceCapabilities(**entry.data["capabilities"])
+        self.device_info: dict[str, Any] = {}
+
+        # Register availability and mappings.
+        self.available_registers: dict[str, set[str]] = {
+            "input_registers": set(),
+            "holding_registers": set(),
+            "coil_registers": set(),
+            "discrete_inputs": set(),
+            "calculated": {"estimated_power", "total_energy"},
+        }
+        self._register_maps: dict[str, dict[str, int]] = {
+            "input_registers": input_registers().copy(),
+            "holding_registers": holding_registers().copy(),
+            "coil_registers": coil_registers().copy(),
+            "discrete_inputs": discrete_input_registers().copy(),
+        }
+        self._reverse_maps: dict[str, dict[int, str]] = {
+            key: {addr: name for name, addr in mapping.items()}
+            for key, mapping in self._register_maps.items()
+        }
+        self._input_registers_rev = self._reverse_maps["input_registers"]
+        self._holding_registers_rev = self._reverse_maps["holding_registers"]
+        self._coil_registers_rev = self._reverse_maps["coil_registers"]
+        self._discrete_inputs_rev = self._reverse_maps["discrete_inputs"]
+        self._register_groups: dict[str, list[tuple[int, int]]] = {}
+        self._failed_registers: set[str] = set()
+
+        # Scan state.
+        self.device_scan_result: dict[str, Any] | None = None
+        self.unknown_registers: dict[str, Any] = {}
+        self.scanned_registers: dict[str, Any] = {}
+        self.last_scan: Any = None
+
+        # Statistics.
+        self.statistics: dict[str, Any] = {
+            "successful_reads": 0,
+            "failed_reads": 0,
+            "connection_errors": 0,
+            "timeout_errors": 0,
+            "last_error": None,
+            "last_successful_update": None,
+            "average_response_time": 0.0,
+            "total_registers_read": 0,
+        }
+        self._consecutive_failures: int = 0
+        self._max_failures: int = 5
+
+        # Post-processing state (used by _CoordinatorCapabilitiesMixin).
+        self._last_power_timestamp = _utcnow()
+        self._total_energy: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_ensure_connected(self) -> None:
+        """Ensure Modbus connection is established."""
+        await _ensure_connected_lifecycle_impl(
+            self,
+            ensure_connected_runtime_fn=_ensure_connected_runtime_impl,
+            reconnect_client_if_needed_fn=_reconnect_client_if_needed_impl,
+            ensure_transport_selected_fn_factory=self._build_transport_selector_fn,
+            connect_transport_or_client_fn=_connect_transport_or_client_impl,
+            mark_connection_established_fn=lambda: _mark_connection_established_impl(
+                offline_state_setter=lambda value: setattr(self, "offline_state", value)
+            ),
+            mark_connection_failure_fn=lambda: _mark_connection_failure_impl(
+                statistics=self.statistics,
+                offline_state_setter=lambda value: setattr(self, "offline_state", value),
+            ),
+            logger=_LOGGER,
+        )
+
+    async def async_disconnect(self) -> None:
+        """Disconnect from Modbus device."""
+        async with self._client_lock:
+            await self._disconnect_locked()
+
+    async def async_close(self) -> None:
+        """Close all resources (alias for async_disconnect)."""
+        await self.async_disconnect()
+
+    async def async_test_connection(self) -> None:
+        """Test initial connection to the device."""
+        async with self._write_lock:
+            await _run_connection_test_impl(
+                ensure_connection=self.async_ensure_connected,
+                get_transport=lambda: self._transport,
+                slave_id=self.config.slave_id,
+                test_addresses=list(input_registers().values())[:3],
+                is_cancelled_error=is_request_cancelled_error,
+                logger=_LOGGER,
+            )
+
+    async def _disconnect_locked(self) -> None:
+        """Disconnect without acquiring the client lock."""
+        await _disconnect_locked_impl(
+            transport=self._transport,
+            client=self.client,
+            close_client_connection_fn=_close_client_connection_impl,
+            mark_connection_disconnected_fn=lambda: _mark_connection_disconnected_impl(
+                offline_state_setter=lambda value: setattr(self, "offline_state", value)
+            ),
+            logger=_LOGGER,
+        )
+        self.client = None
+
+    async def _ensure_connection(self) -> None:
+        """Internal alias used by coordinator submodule duck-typing."""
+        await self.async_ensure_connected()
+
+    async def _disconnect(self) -> None:
+        """Internal alias used by coordinator submodule duck-typing."""
+        await self.async_disconnect()
+
+    async def _close_client_connection(self) -> None:
+        """Close client object safely for sync or async close implementations."""
+        await _close_client_connection_impl(client=self.client, logger=_LOGGER)
+
+    # ------------------------------------------------------------------
+    # Transport construction
+    # ------------------------------------------------------------------
+
+    def _build_tcp_transport(self, mode: str) -> BaseModbusTransport:
+        """Build a TCP (or RTU-over-TCP) transport for the given mode."""
+        return _build_tcp_transport_impl(
+            mode=mode,
+            host=self.config.host,
+            port=self.config.port,
+            retry=self.retry,
+            backoff=self.backoff,
+            max_backoff=DEFAULT_MAX_BACKOFF,
+            timeout=self.timeout,
+            offline_state=self.offline_state,
+            connection_type_tcp=CONNECTION_TYPE_TCP,
+            connection_mode_tcp_rtu=CONNECTION_MODE_TCP_RTU,
+        )
+
+    async def _try_direct_client_connect(self, *, allow_parameterless_ctor: bool) -> bool:
+        """Try connecting via AsyncModbusTcpClient and store the connected client.
+
+        Looks up AsyncModbusTcpClient through the coordinator module so that
+        tests can patch ``coordinator.coordinator.AsyncModbusTcpClient`` and
+        have it take effect here.
+        """
+        from custom_components.thessla_green_modbus import coordinator as coordinator_pkg
+
+        # Access the coordinator.py module via the package to pick up any
+        # test patches on coordinator.coordinator.AsyncModbusTcpClient.
+        coord_module = getattr(coordinator_pkg, "coordinator", None)
+        tcp_client_cls = (
+            getattr(coord_module, "AsyncModbusTcpClient", None)
+            if coord_module is not None
+            else None
+        ) or _ORIGINAL_ASYNC_MODBUS_TCP_CLIENT
+
+        direct_client = await _connect_direct_tcp_client_impl(
+            host=self.config.host,
+            port=self.config.port,
+            timeout=self.timeout,
+            tcp_client_cls=tcp_client_cls,
+            allow_parameterless_ctor=allow_parameterless_ctor,
+        )
+        if direct_client is not None:
+            self.client = direct_client
+            self._transport = None
+            return True
+        return False
+
+    def _build_transport_selector_fn(self) -> Any:
+        """Return the transport selector callable for the connection lifecycle."""
+        parity = SERIAL_PARITY_MAP.get(self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
+        stop_bits = SERIAL_STOP_BITS_MAP.get(
+            self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
+        )
+
+        async def _ensure_transport_selected() -> Any:
+            return await _ensure_transport_selected_impl(
+                current_transport=self._transport,
+                connection_type=self.config.connection_type,
+                connection_mode=self.config.connection_mode,
+                host=self.config.host,
+                port=self.config.port,
+                serial_port=self.config.serial_port,
+                baudrate=self.config.baud_rate,
+                parity=parity,
+                stopbits=stop_bits,
+                retry=self.retry,
+                backoff=self.backoff,
+                max_backoff=DEFAULT_MAX_BACKOFF,
+                timeout=self.timeout,
+                offline_state=self.offline_state,
+                connection_type_rtu=CONNECTION_TYPE_RTU,
+                connection_mode_auto=CONNECTION_MODE_AUTO,
+                connection_mode_tcp=CONNECTION_MODE_TCP,
+                build_rtu_transport_fn=_build_rtu_transport_impl,
+                build_tcp_transport_fn=self._build_tcp_transport,
+                select_auto_transport_fn=lambda: _select_auto_transport_impl(
+                    resolved_connection_mode=self._resolved_connection_mode,
+                    build_tcp_transport=self._build_tcp_transport,
+                    try_direct_client_connect=lambda allow_pc: self._try_direct_client_connect(
+                        allow_parameterless_ctor=allow_pc
+                    ),
+                    port=self.config.port,
+                    timeout=self.timeout,
+                    slave_id=self.config.slave_id,
+                    host=self.config.host,
+                    logger=_LOGGER,
+                ),
+            )
+
+        return _ensure_transport_selected
+
+    # ------------------------------------------------------------------
+    # Scanner / device scan
+    # ------------------------------------------------------------------
+
+    def _build_scanner_kwargs(self) -> dict[str, Any]:
+        """Return constructor kwargs for scanner creation."""
+        return _build_scanner_kwargs_impl(
+            self,
+            resolved_connection_mode=self._resolved_connection_mode,
+        )
+
+    async def async_create_scanner(self) -> ThesslaGreenDeviceScanner:
+        """Instantiate a ThesslaGreenDeviceScanner using its create() factory."""
+        return await ThesslaGreenDeviceScanner.create(**self._build_scanner_kwargs())
+
+    async def async_scan_device(self) -> dict[str, Any]:
+        """Run a full device scan and return the raw scan result.
+
+        The caller (coordinator) is responsible for applying the result via
+        ``apply_scan_result`` / ``_apply_scan_result_impl``.
+        """
+        scanner = await self.async_create_scanner()
+        return await scanner.scan_device()
+
+    def _normalise_available_registers(
+        self, available: dict[str, list[str] | set[str]]
+    ) -> dict[str, set[str]]:
+        """Return available register names in canonical form."""
+        return _normalise_available_registers_impl(self, available)
+
+    # ------------------------------------------------------------------
+    # Register groups
+    # ------------------------------------------------------------------
+
+    def compute_register_groups(self) -> None:
+        """Pre-compute register groups for optimized batch reading."""
+        _compute_register_groups_impl(
+            self,
+            get_register_definition=_get_register_definition,
+            group_reads=group_reads,
+            holding_batch_boundaries=HOLDING_BATCH_BOUNDARIES,
+        )
+
+    # ------------------------------------------------------------------
+    # IO mixin required helpers (satisfy _ModbusIOMixin protocol)
+    # ------------------------------------------------------------------
+
+    def _find_register_name(self, register_type: str, address: int) -> str | None:
+        """Find register name by address using pre-built reverse maps."""
+        return _find_register_name_impl(self._reverse_maps, register_type, address)
+
+    def _process_register_value(self, register_name: str, value: int) -> Any:
+        """Decode a raw register value via register-processing helpers."""
+        return _process_register_value_impl(register_name, value)
+
+    def _mark_registers_failed(self, names: Iterable[str | None]) -> None:
+        """Record registers that failed to read."""
+        _mark_registers_failed_impl(self, names)
+
+    def _clear_register_failure(self, name: str) -> None:
+        """Remove register from failed list on successful read."""
+        _clear_register_failure_impl(self, name)
+
+    def _get_client_method(self, name: str) -> Callable[..., Any]:
+        """Return a Modbus method from transport/client or a no-op placeholder."""
+        for obj in (self._transport, self.client):
+            if obj is None:
+                continue
+            method = getattr(obj, name, None)
+            if callable(method):
+                return cast(Callable[..., Any], method)
+
+        async def _missing_method(*_args: Any, **_kwargs: Any) -> Any:
+            return None
+
+        _missing_method.__name__ = name
+        return _missing_method
+
+    # ------------------------------------------------------------------
+    # Write support (minimal, mirrors coordinator write helpers)
+    # ------------------------------------------------------------------
+
+    async def async_write_register(
+        self,
+        register_name: str,
+        value: Any,
+        *,
+        entity_id: str = "",
+        call_description: str = "",
+        offset: int = 0,
+    ) -> bool:
+        """Write a single register by name.
+
+        Delegates to the coordinator's write helpers. Intended for use
+        by external callers (services, tests) once the DeviceClient is
+        the canonical write path.
+        """
+        from ..coordinator.write_path import (
+            SingleWritePlan,
+            encode_write_value,
+            run_single_write_attempts,
+        )
+
+        definition = _get_register_definition(register_name)
+        address = self._register_maps.get("holding_registers", {}).get(register_name)
+        if address is None:
+            _LOGGER.error("Register %s not found in holding registers map", register_name)
+            return False
+
+        encoded_values, scalar_value = encode_write_value(register_name, definition, value, offset)
+        if encoded_values is None and scalar_value is None:
+            return False
+
+        plan = SingleWritePlan(
+            register_name=register_name,
+            address=address,
+            definition=definition,
+            encoded_values=encoded_values,
+            scalar_value=scalar_value,
+            offset=offset,
+            entity_id=entity_id,
+            call_description=call_description,
+        )
+        return await run_single_write_attempts(self, plan)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_device_info(self) -> dict[str, Any]:
+        """Return device info mapping for the connected unit."""
+        return dict(self.device_info)
+
+    def get_capabilities(self) -> DeviceCapabilities:
+        """Return current device capabilities."""
+        return self.capabilities
+
+    def get_register_map(self, register_type: str) -> dict[str, int]:
+        """Return the register map for the given register type."""
+        return cast(dict[str, int], self._register_maps.get(register_type, {}))
+
+    @property
+    def is_connected(self) -> bool:
+        """Return True if the device connection is currently active."""
+        transport = self._transport
+        if transport is not None:
+            return transport.is_connected()
+        return self.client is not None
+
+    @property
+    def selected_transport(self) -> str | None:
+        """Return the currently selected transport/connection mode."""
+        return self._resolved_connection_mode

--- a/docs/device_client_redesign.md
+++ b/docs/device_client_redesign.md
@@ -1,0 +1,180 @@
+# Coordinator → DeviceClient Redesign
+
+## Date: 2026-05-16
+## Branch: claude/coordinator-deviceclient-redesign-ls3tr
+
+---
+
+## Architecture Summary
+
+`ThesslaGreenModbusCoordinator` has been refactored into a thin Home Assistant
+adapter.  All device-domain state and operations live in
+`ThesslaGreenDeviceClient` (`core/client.py`).  The coordinator proxies its
+device-state attributes to the client via Python data descriptors so that
+existing coordinator submodule functions continue to work unchanged through
+duck-typing.
+
+### Ownership after refactor
+
+| Layer | Responsibility |
+|---|---|
+| `ThesslaGreenDeviceClient` | Device state, connection lifecycle, transport selection, scanner orchestration, register read/write/groups, capabilities, diagnostics helpers |
+| `ThesslaGreenModbusCoordinator` | HA integration boundary: `DataUpdateCoordinator`, config entry, reauth, `async_setup`/`async_shutdown`, property proxies |
+
+---
+
+## DeviceClient Public Interface
+
+### Constructor
+```python
+ThesslaGreenDeviceClient(
+    config: CoordinatorConfig,
+    *,
+    hass: HomeAssistant,
+    effective_batch: int,
+    resolved_connection_mode: str | None,
+    backoff: float,
+    backoff_jitter: float | tuple[float, float] | None,
+    entry: ConfigEntry | None = None,
+)
+```
+
+### Connection lifecycle
+| Method | Description |
+|---|---|
+| `async_ensure_connected()` | Establish connection via lifecycle impl |
+| `async_disconnect()` | Graceful disconnect behind `_client_lock` |
+| `async_close()` | Alias for `async_disconnect` |
+| `async_test_connection()` | Probe connection via `_write_lock` |
+| `_disconnect_locked()` | Disconnect without acquiring lock |
+| `_ensure_connection()` | Duck-typing alias |
+| `_disconnect()` | Duck-typing alias |
+| `_close_client_connection()` | Close client object safely |
+
+### Transport construction
+| Method | Description |
+|---|---|
+| `_build_tcp_transport(mode)` | Build TCP/RTU-over-TCP transport |
+| `_try_direct_client_connect(*, allow_parameterless_ctor)` | Connect via AsyncModbusTcpClient |
+| `_build_transport_selector_fn()` | Return transport selector callable |
+
+### Scanner / capabilities
+| Method | Description |
+|---|---|
+| `_build_scanner_kwargs()` | Return scanner constructor kwargs |
+| `async_create_scanner()` | Instantiate ThesslaGreenDeviceScanner |
+| `async_scan_device()` | Run full device scan |
+| `_normalise_available_registers(available)` | Canonicalise register name sets |
+
+### Register operations
+| Method | Description |
+|---|---|
+| `compute_register_groups()` | Pre-compute batch read groups |
+| `_find_register_name(register_type, address)` | Reverse-map address → name |
+| `_process_register_value(register_name, value)` | Decode raw register value |
+| `_mark_registers_failed(names)` | Record failed register names |
+| `_clear_register_failure(name)` | Remove from failed set |
+| `_get_client_method(name)` | Get Modbus method or no-op |
+| `async_write_register(register_name, value, ...)` | Write single register |
+
+### Public API
+| Method/Property | Description |
+|---|---|
+| `get_device_info()` | Returns copy of `device_info` dict |
+| `get_capabilities()` | Returns `DeviceCapabilities` instance |
+| `get_register_map(register_type)` | Returns register name→address map |
+| `is_connected` | Property: transport/client connected status |
+| `selected_transport` | Property: resolved connection mode |
+
+### Owned state
+| Attribute | Type | Description |
+|---|---|---|
+| `config` | `CoordinatorConfig` | Full config dataclass |
+| `hass` | `HomeAssistant` | HA instance (for scanner) |
+| `client` | `Any \| None` | pymodbus async client |
+| `_transport` | `BaseModbusTransport \| None` | Active transport |
+| `_client_lock` | `asyncio.Lock` | Serialises connection changes |
+| `_write_lock` | `asyncio.Lock` | Serialises writes/tests |
+| `offline_state` | `bool` | Whether device is known offline |
+| `capabilities` | `DeviceCapabilities` | Scanned device capabilities |
+| `device_info` | `dict` | Model, firmware, etc. |
+| `available_registers` | `dict[str, set[str]]` | Per-type available register names |
+| `_register_maps` | `dict[str, dict[str, int]]` | name → address maps |
+| `_reverse_maps` | `dict[str, dict[int, str]]` | address → name maps |
+| `_register_groups` | `dict[str, list[tuple]]` | Pre-computed batch groups |
+| `_failed_registers` | `set[str]` | Registers that failed last read |
+| `statistics` | `dict` | Read/error counters |
+| `_consecutive_failures` | `int` | Consecutive update failures |
+| `_max_failures` | `int` | Failure threshold |
+| `_last_power_timestamp` | `datetime` | For energy calculation |
+| `_total_energy` | `float` | Accumulated energy |
+
+---
+
+## Coordinator Property Proxies
+
+All 40 device-domain attributes on the coordinator are data descriptors
+(property with both getter and setter) that forward to `self._device_client`.
+This means:
+
+1. `coordinator.X = value` routes through the setter → stored in DeviceClient.
+2. `coordinator.X` returns DeviceClient's value.
+3. Instance `__dict__` assignment is prevented for proxied attributes.
+4. Tests can still mock methods (non-data descriptors, not proxied) via instance
+   attribute shadowing.
+
+Proxied attributes (40 total):
+`config`, `_device_name`, `_resolved_connection_mode`, `timeout`, `retry`,
+`backoff`, `backoff_jitter`, `effective_batch`, `max_registers_per_request`,
+`force_full_register_list`, `scan_uart_settings`, `deep_scan`, `safe_scan`,
+`skip_missing_registers`, `client`, `_transport`, `_client_lock`, `_write_lock`,
+`offline_state`, `_update_in_progress`, `capabilities`, `device_info`,
+`available_registers`, `_register_maps`, `_reverse_maps`,
+`_input_registers_rev`, `_holding_registers_rev`, `_coil_registers_rev`,
+`_discrete_inputs_rev`, `_register_groups`, `_failed_registers`,
+`device_scan_result`, `unknown_registers`, `scanned_registers`, `last_scan`,
+`statistics`, `_consecutive_failures`, `_max_failures`,
+`_last_power_timestamp`, `_total_energy`.
+
+---
+
+## Test Patch Compatibility
+
+Tests that patch coordinator-level names continue to work:
+
+- `coordinator.coordinator.AsyncModbusTcpClient` — DeviceClient's
+  `_try_direct_client_connect` looks up this class through the coordinator
+  package at call time so patches are visible.
+- `coordinator.coordinator.ThesslaGreenDeviceScanner.create` — re-exported
+  in coordinator.py namespace (`# noqa: F401`); patching the class method
+  affects all callers including DeviceClient.
+- `coord._ensure_connection = AsyncMock(...)` — coordinator method (not a
+  property), instance attribute shadows the class method.
+- `coord._disconnect_locked = AsyncMock(...)` — same pattern.
+
+---
+
+## Validation Results
+
+| Gate | Result |
+|---|---|
+| `python -m compileall` | Clean |
+| `pytest tests/` | 2082 passed, 4 skipped (baseline 2039 + 43 new) |
+| `ruff check` | All checks passed |
+| `ruff format --check` | 430 files already formatted |
+| `check_translations.py` | All translation keys present |
+| `validate_entity_mappings.py` | OK: 366 entities validated |
+| `check_maintainability.py` | Maintainability gate passed |
+| `compare_registers_with_reference.py` | Exit code 0 |
+
+---
+
+## Non-Goals / Out-of-Scope
+
+- Entity IDs, unique IDs, service IDs — unchanged
+- Register names, register addresses — unchanged
+- Modbus protocol behaviour, scan behaviour — unchanged
+- Translation structure, manifest structure — unchanged
+- Coordinator submodule functions — unchanged (duck-typing still works)
+- Clock sync behaviour — unchanged
+- `modbus_helpers.py` compatibility surface — unchanged

--- a/docs/device_client_redesign_baseline.md
+++ b/docs/device_client_redesign_baseline.md
@@ -1,0 +1,34 @@
+# DeviceClient Redesign Baseline
+
+## Date: 2026-05-16
+## Branch: claude/coordinator-deviceclient-redesign-ls3tr
+
+## Test Results
+```
+2039 passed, 4 skipped, 90 warnings
+```
+
+Skipped tests:
+- test_entity_data_correctness_number.py:56 - All number registers have explicit 'min'
+- test_entity_data_correctness_number.py:65 - All number registers have explicit 'max'
+- test_entity_data_correctness_number.py:74 - All number registers have explicit 'step'
+- test_register_pdf_mapping.py:155 - could not import 'pypdf'
+
+## Lint Results
+- `ruff check custom_components tests tools` → All checks passed!
+- `ruff check --select I custom_components tests tools` → All checks passed!
+- `ruff format --check custom_components tests tools` → 427 files already formatted
+
+## Tools Results
+- `python tools/check_translations.py` → All translation keys present.
+- `python tools/validate_entity_mappings.py` → OK: 366 entities validated
+- `python tools/check_maintainability.py` → Maintainability gate passed.
+- `python tools/compare_registers_with_reference.py` → Exit code 0 (242 name mismatches are pre-existing, vendor naming)
+
+## Compile
+- `python -m compileall -q custom_components/thessla_green_modbus tests tools` → Clean
+
+## Notes
+- Python 3.13.12 in venv at /tmp/venv313
+- pytest-homeassistant-custom-component 0.13.109 (Python 3.13 compatible)
+- pydantic 2.12.2

--- a/docs/device_client_redesign_plan.md
+++ b/docs/device_client_redesign_plan.md
@@ -1,0 +1,203 @@
+# Coordinator → DeviceClient Redesign Plan
+
+## Date: 2026-05-16
+## Branch: claude/coordinator-deviceclient-redesign-ls3tr
+## Baseline commit: main (2039 passed, 4 skipped)
+
+---
+
+## Coordinator Public Methods/Properties to Preserve
+
+| Method/Property | Description |
+|---|---|
+| `__init__(hass, config, *, entry)` | Constructor |
+| `from_params(hass, host, port, slave_id, ...)` | Factory classmethod |
+| `_parse_backoff_jitter(value)` | Static method |
+| `get_register_map(register_type)` | Return register name→address mapping |
+| `async_setup()` | Device scan / setup |
+| `async_shutdown()` | Shutdown and disconnect |
+| `get_diagnostic_data()` | Diagnostics dict |
+| `get_device_info()` | Device info dict |
+| `status_overview` | Property: online/offline summary |
+| `performance_stats` | Property: performance statistics |
+| `device_name` | Property: display name |
+| `host/port/slave_id/connection_type/etc.` | Config properties via _CoordinatorConfigPropertiesMixin |
+
+## Coordinator Direct Imports Before Refactor (from scanner/transport/registers)
+
+```python
+from ..scanner import (DeviceCapabilities, ThesslaGreenDeviceScanner, is_request_cancelled_error)
+from ..transport.base import BaseModbusTransport
+from ..registers.read_planner import group_reads
+from ..registers.register_def import RegisterDef
+from ..register_defs_cache import get_register_definitions
+from ..errors import CannotConnect
+```
+
+These are the imports to eliminate from coordinator.py by moving the operations into DeviceClient.
+
+## Current Helper Modules Used by Coordinator
+
+Coordinator imports from ~35 coordinator submodule files:
+- `capabilities.py` - _CoordinatorCapabilitiesMixin (post-processing, power, efficiency)
+- `config_normalization.py` - scan interval normalization
+- `config_properties.py` - _CoordinatorConfigPropertiesMixin (host/port/etc. properties)
+- `connection.py` - transport building, direct TCP client connect
+- `connection_lifecycle.py` - ensure_connected_lifecycle orchestration
+- `connection_state.py` - connection state transitions
+- `connection_test.py` - initial connection test
+- `device_info.py` - device scan orchestration
+- `diagnostics.py` - status_overview, performance_stats, get_diagnostic_data
+- `disconnect.py` - graceful disconnect
+- `errors.py` - update error handling
+- `factory.py` - build_config_from_params
+- `init_config.py` - normalize_runtime_config, apply_coordinator_config
+- `io.py` - _ModbusIOMixin (all register read methods)
+- `lifecycle.py` - async_setup orchestration
+- `models.py` - CoordinatorConfig
+- `register_groups.py` - compute_register_groups
+- `register_processing.py` - find_register_name, process_register_value
+- `retry.py` - _PermanentModbusError, read_with_retry
+- `runtime.py` - normalize_backoff, parse_backoff_jitter
+- `runtime_io.py` - call_modbus, read_all_register_data
+- `runtime_state.py` - mark_registers_failed, clear_register_failure
+- `scan.py` - scan cache management
+- `scan_result.py` - apply_scan_result
+- `scanner_kwargs.py` - build_scanner_kwargs
+- `schedule.py` - _CoordinatorScheduleMixin (write path)
+- `state.py` - initialize_runtime_state, normalize_serial_settings
+- `transport_select.py` - select_auto_transport
+- `update.py` - async_update_data, run_update_cycle
+- `update_result.py` - apply_success_result
+- `update_state.py` - begin_update_cycle, finish_update_cycle
+- `write_path.py` - encode_write_value, write orchestration
+
+## Proposed DeviceClient Responsibilities
+
+The `ThesslaGreenDeviceClient` (at `core/client.py`) owns:
+
+### Connection Lifecycle
+- `async_ensure_connected()` - establish connection via transport/client
+- `async_disconnect()` - graceful disconnect with lock
+- `async_close()` - force close resources
+- `_disconnect_locked()` - disconnect without acquiring locks
+- Transport building: `_build_tcp_transport()`, `_build_rtu_transport()`
+- Transport selection: `_build_transport_selector_fn()`, `_try_direct_client_connect()`
+
+### Scanner/Capabilities
+- `async_scan_device()` - run ThesslaGreenDeviceScanner, return result
+- `apply_scan_result()` - store scan results in device state
+- Capabilities access: `get_capabilities()`
+
+### Register Read Path
+- Inherits `_ModbusIOMixin` for batch read methods
+- `async_update_data()` - run full update cycle
+- `_read_all_register_data()` - read all register groups
+
+### Register Write Path
+- Inherits `_CoordinatorScheduleMixin` for write methods
+- `async_write_register()` - write single register with retry
+- `async_write_registers()` - write multiple registers
+
+### Data Post-Processing
+- Inherits `_CoordinatorCapabilitiesMixin` for post-processing, power, efficiency
+
+### Device State
+Owns all device-domain mutable state:
+- Connection: `client`, `_transport`, `_client_lock`, `_write_lock`, `offline_state`
+- Device info: `capabilities`, `device_info`, `_device_name`
+- Register maps: `_register_maps`, `_reverse_maps`, `_register_groups`, `_failed_registers`
+- Scan results: `available_registers`, `device_scan_result`, `scanned_registers`, `unknown_registers`, `last_scan`
+- Statistics: `statistics`, `_consecutive_failures`, `_max_failures`
+- Post-process: `_last_power_timestamp`, `_total_energy`, `_total_energy`
+- Config: `config`, `timeout`, `retry`, `backoff`, `backoff_jitter`, `effective_batch`, etc.
+
+## Coordinator Responsibilities After Refactor
+
+The `ThesslaGreenModbusCoordinator` retains:
+
+### HA Integration Boundary
+- `DataUpdateCoordinator` base class, `_async_update_data()` override
+- `async_setup()`, `async_shutdown()` - HA lifecycle
+- Config entry management: `self.entry`, stop listener
+- Reauthentication: `_trigger_reauth()`
+- `enable_device_scan` (from entry options)
+
+### Public API Preservation
+- All public methods/properties from the "to preserve" table above
+- Private methods that coordinator submodule functions call (delegating to DeviceClient)
+- Properties that proxy device state to DeviceClient
+
+### Coordinator-Specific Helpers
+- `_CoordinatorConfigPropertiesMixin` (host/port/etc. accessors)
+- HA diagnostics formatting
+- HA-specific setup/unload
+
+## Coordinator Property Proxies (for backward compat)
+
+These coordinator properties delegate to `self._device_client`:
+```
+client, _transport, _client_lock, _write_lock, offline_state,
+capabilities, device_info, available_registers,
+_register_maps, _reverse_maps, _register_groups, _failed_registers,
+_input_registers_rev, _holding_registers_rev, _coil_registers_rev, _discrete_inputs_rev,
+statistics, _consecutive_failures, _max_failures,
+device_scan_result, unknown_registers, scanned_registers, last_scan,
+_last_power_timestamp, _total_energy, _update_in_progress,
+_resolved_connection_mode, config,
+timeout, retry, backoff, backoff_jitter,
+effective_batch, max_registers_per_request,
+force_full_register_list, scan_uart_settings, deep_scan, safe_scan, skip_missing_registers,
+_device_name
+```
+
+## Out-of-Scope Items
+
+- Changing Modbus protocol behavior
+- Changing entity/unique/service/register IDs
+- Changing translations or manifest
+- Changing dependencies
+- Removing coordinator submodule functions
+- Removing coordinator public API
+- Changing clock sync behavior
+- Removing modbus_helpers.py compatibility surface
+
+## Risk List
+
+1. **Property proxy breaks HA DataUpdateCoordinator**: Properties with setters on coordinator may conflict with HA internals → Mitigated by keeping HA-specific attrs as plain attributes
+2. **Mixin MRO conflicts**: DeviceClient inheriting from coordinator mixins may cause import cycles → Mitigated by careful import ordering
+3. **Circular imports**: core.client imports from coordinator.*, coordinator.* imports from core.client → Avoided by not having coordinator submodule functions import from core
+4. **asyncio.Lock sharing**: Properties returning same Lock object from DeviceClient → Safe, same object is returned
+5. **Missed property setter**: Coordinator submodule function assigns to coordinator attribute without a setter → Caught by tests
+6. **scan_result._normalise_available_registers**: Called on coordinator from apply_scan_result → Kept as coordinator method that delegates to impl
+7. **hass in DeviceClient**: Scanner needs hass → DeviceClient stores hass reference
+
+## Validation Plan
+
+For each phase:
+1. `python -m compileall` - no import errors
+2. `pytest tests/ -q` - all 2039 tests pass
+3. `ruff check` - no lint errors
+4. `ruff format --check` - properly formatted
+5. Tools: `check_translations`, `validate_entity_mappings`, `check_maintainability`, `compare_registers_with_reference`
+
+## Removed Code (to track)
+
+None removed in Phase 4. Phase 5 cleanup will remove:
+- Direct coordinator imports of scanner/transport/registers (moved to DeviceClient)
+- Redundant coordinator wrapper methods once DeviceClient is fully wired
+
+---
+
+## Phase Status
+
+- [x] Phase 0: Baseline verified (2039 passed, 4 skipped)
+- [x] Phase 1: Inventory documented
+- [ ] Phase 2: DeviceClient interface defined (core/client.py)
+- [ ] Phase 3: Contract tests added
+- [ ] Phase 4: DeviceClient wired into coordinator
+- [ ] Phase 5: Responsibility migration
+- [ ] Phase 6: Public API preserved and verified
+- [ ] Phase 7: Dead code removed (if any)
+- [ ] Phase 8: Architecture quality gates
+- [ ] Phase 9: Full validation

--- a/docs/device_client_redesign_plan.md
+++ b/docs/device_client_redesign_plan.md
@@ -193,11 +193,11 @@ None removed in Phase 4. Phase 5 cleanup will remove:
 
 - [x] Phase 0: Baseline verified (2039 passed, 4 skipped)
 - [x] Phase 1: Inventory documented
-- [ ] Phase 2: DeviceClient interface defined (core/client.py)
-- [ ] Phase 3: Contract tests added
-- [ ] Phase 4: DeviceClient wired into coordinator
-- [ ] Phase 5: Responsibility migration
-- [ ] Phase 6: Public API preserved and verified
-- [ ] Phase 7: Dead code removed (if any)
-- [ ] Phase 8: Architecture quality gates
-- [ ] Phase 9: Full validation
+- [x] Phase 2: DeviceClient interface defined (core/client.py)
+- [x] Phase 3: Contract tests added (tests/test_device_client.py, 43 tests)
+- [x] Phase 4: DeviceClient wired into coordinator
+- [x] Phase 5: Responsibility migration (DeviceClient owns all device-domain state)
+- [x] Phase 6: Public API preserved and verified (all 40 proxies, all public methods)
+- [x] Phase 7: Dead code removed (unused imports cleaned by ruff)
+- [x] Phase 8: Architecture quality gates (docs/device_client_redesign.md)
+- [x] Phase 9: Full validation (2082 passed, 4 skipped, all tools green)

--- a/tests/test_device_client.py
+++ b/tests/test_device_client.py
@@ -1,0 +1,460 @@
+"""Contract tests for ThesslaGreenDeviceClient.
+
+These tests verify that DeviceClient:
+  1. Initialises with the correct default state.
+  2. Exposes the public interface expected by the coordinator and by tests.
+  3. Properly stores/retrieves device state (connection, registers, stats, …).
+  4. Coordinator property proxies correctly delegate to the DeviceClient.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus.coordinator import (
+    ThesslaGreenModbusCoordinator,
+)
+from custom_components.thessla_green_modbus.coordinator.models import CoordinatorConfig
+from custom_components.thessla_green_modbus.core.client import ThesslaGreenDeviceClient
+from custom_components.thessla_green_modbus.scanner import DeviceCapabilities
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**kwargs) -> CoordinatorConfig:
+    defaults = dict(
+        host="192.168.1.1",
+        port=502,
+        slave_id=1,
+        name="test-device",
+        timeout=5,
+        retry=3,
+        scan_interval=30,
+    )
+    defaults.update(kwargs)
+    return CoordinatorConfig(**defaults)
+
+
+def _make_client(**kwargs) -> ThesslaGreenDeviceClient:
+    config = _make_config()
+    hass = MagicMock()
+    return ThesslaGreenDeviceClient(
+        config,
+        hass=hass,
+        effective_batch=100,
+        resolved_connection_mode=None,
+        backoff=0.5,
+        backoff_jitter=None,
+        **kwargs,
+    )
+
+
+def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
+    hass = MagicMock()
+    hass.async_add_executor_job = None
+    return ThesslaGreenModbusCoordinator.from_params(
+        hass=hass,
+        host="192.168.1.1",
+        port=502,
+        slave_id=1,
+        name="test",
+        scan_interval=30,
+        timeout=3,
+        retry=2,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Instantiation
+# ---------------------------------------------------------------------------
+
+
+def test_device_client_instantiation():
+    client = _make_client()
+    assert client is not None
+    assert isinstance(client, ThesslaGreenDeviceClient)
+
+
+def test_device_client_config_stored():
+    config = _make_config(host="10.0.0.1", port=8502, slave_id=5)
+    hass = MagicMock()
+    client = ThesslaGreenDeviceClient(
+        config,
+        hass=hass,
+        effective_batch=50,
+        resolved_connection_mode=None,
+        backoff=1.0,
+        backoff_jitter=(0.1, 0.5),
+    )
+    assert client.config is config
+    assert client.slave_id == 5
+    assert client.timeout == config.timeout
+    assert client.retry == config.retry
+    assert client.backoff == 1.0
+    assert client.backoff_jitter == (0.1, 0.5)
+    assert client.effective_batch == 50
+    assert client.max_registers_per_request == 50
+
+
+def test_device_client_initial_connection_state():
+    client = _make_client()
+    assert client.client is None
+    assert client._transport is None
+    assert isinstance(client._client_lock, asyncio.Lock)
+    assert isinstance(client._write_lock, asyncio.Lock)
+    assert client.offline_state is False
+    assert client._update_in_progress is False
+
+
+def test_device_client_initial_device_state():
+    client = _make_client()
+    assert isinstance(client.capabilities, DeviceCapabilities)
+    assert client.device_info == {}
+    assert client.device_scan_result is None
+    assert client.unknown_registers == {}
+    assert client.scanned_registers == {}
+    assert client.last_scan is None
+
+
+def test_device_client_initial_register_maps():
+    client = _make_client()
+    assert "input_registers" in client._register_maps
+    assert "holding_registers" in client._register_maps
+    assert "coil_registers" in client._register_maps
+    assert "discrete_inputs" in client._register_maps
+    assert len(client._register_maps["input_registers"]) > 0
+
+    assert "input_registers" in client._reverse_maps
+    assert "input_registers" in client.available_registers
+    assert "calculated" in client.available_registers
+
+
+def test_device_client_initial_statistics():
+    client = _make_client()
+    stats = client.statistics
+    assert stats["successful_reads"] == 0
+    assert stats["failed_reads"] == 0
+    assert stats["connection_errors"] == 0
+    assert stats["timeout_errors"] == 0
+    assert stats["last_error"] is None
+    assert stats["average_response_time"] == 0.0
+
+
+def test_device_client_consecutive_failures_initialized():
+    client = _make_client()
+    assert client._consecutive_failures == 0
+    assert client._max_failures == 5
+
+
+def test_device_client_resolved_connection_mode_stored():
+    config = _make_config()
+    hass = MagicMock()
+    client = ThesslaGreenDeviceClient(
+        config,
+        hass=hass,
+        effective_batch=100,
+        resolved_connection_mode="tcp",
+        backoff=0.5,
+        backoff_jitter=None,
+    )
+    assert client._resolved_connection_mode == "tcp"
+
+
+# ---------------------------------------------------------------------------
+# 2. Properties
+# ---------------------------------------------------------------------------
+
+
+def test_is_connected_false_with_no_client():
+    client = _make_client()
+    assert client.is_connected is False
+
+
+def test_is_connected_true_with_client():
+    client = _make_client()
+    client.client = MagicMock()
+    assert client.is_connected is True
+
+
+def test_is_connected_uses_transport_when_set():
+    client = _make_client()
+    transport = MagicMock()
+    transport.is_connected.return_value = True
+    client._transport = transport
+    assert client.is_connected is True
+    transport.is_connected.assert_called_once()
+
+
+def test_is_connected_transport_disconnected():
+    client = _make_client()
+    transport = MagicMock()
+    transport.is_connected.return_value = False
+    client._transport = transport
+    assert client.is_connected is False
+
+
+def test_selected_transport_none_by_default():
+    client = _make_client()
+    assert client.selected_transport is None
+
+
+def test_selected_transport_reflects_resolved_mode():
+    config = _make_config()
+    hass = MagicMock()
+    client = ThesslaGreenDeviceClient(
+        config,
+        hass=hass,
+        effective_batch=100,
+        resolved_connection_mode="tcp_rtu",
+        backoff=0.5,
+        backoff_jitter=None,
+    )
+    assert client.selected_transport == "tcp_rtu"
+
+
+# ---------------------------------------------------------------------------
+# 3. Public API methods exist and return expected types
+# ---------------------------------------------------------------------------
+
+
+def test_get_device_info_returns_dict():
+    client = _make_client()
+    client.device_info = {"model": "GreenUnit", "firmware": "1.0"}
+    result = client.get_device_info()
+    assert result == {"model": "GreenUnit", "firmware": "1.0"}
+    # Must return a copy, not the internal dict
+    result["extra"] = "X"
+    assert "extra" not in client.device_info
+
+
+def test_get_capabilities_returns_device_capabilities():
+    client = _make_client()
+    result = client.get_capabilities()
+    assert isinstance(result, DeviceCapabilities)
+    assert result is client.capabilities
+
+
+def test_get_register_map_input_registers():
+    client = _make_client()
+    reg_map = client.get_register_map("input_registers")
+    assert isinstance(reg_map, dict)
+    assert len(reg_map) > 0
+
+
+def test_get_register_map_missing_type():
+    client = _make_client()
+    result = client.get_register_map("nonexistent_type")
+    assert result == {}
+
+
+def test_compute_register_groups_runs():
+    client = _make_client()
+    # compute_register_groups iterates available_registers; exclude "calculated"
+    # pseudo-key since it has no entry in _register_maps (same as coordinator tests).
+    client.available_registers = {
+        "input_registers": set(),
+        "holding_registers": set(),
+        "coil_registers": set(),
+        "discrete_inputs": set(),
+    }
+    client.compute_register_groups()
+
+
+def test_find_register_name_returns_name():
+    client = _make_client()
+    # Use a known address from the input_registers map
+    reg_map = client._register_maps["input_registers"]
+    some_name, some_addr = next(iter(reg_map.items()))
+    found = client._find_register_name("input_registers", some_addr)
+    assert found == some_name
+
+
+def test_find_register_name_unknown_address():
+    client = _make_client()
+    result = client._find_register_name("input_registers", 99999)
+    assert result is None
+
+
+def test_mark_and_clear_register_failure():
+    client = _make_client()
+    reg_name = "fan_speed"
+    assert reg_name not in client._failed_registers
+    client._mark_registers_failed([reg_name])
+    assert reg_name in client._failed_registers
+    client._clear_register_failure(reg_name)
+    assert reg_name not in client._failed_registers
+
+
+def test_get_client_method_no_client_returns_callable():
+    client = _make_client()
+    method = client._get_client_method("read_input_registers")
+    assert callable(method)
+
+
+@pytest.mark.asyncio
+async def test_get_client_method_no_client_noop():
+    client = _make_client()
+    method = client._get_client_method("read_input_registers")
+    result = await method(1, 0, count=1)
+    assert result is None
+
+
+def test_get_client_method_uses_transport():
+    client = _make_client()
+    transport = MagicMock()
+    client._transport = transport
+    method = client._get_client_method("read_input_registers")
+    assert method is transport.read_input_registers
+
+
+def test_get_client_method_falls_back_to_client():
+    client = _make_client()
+    mock_client = MagicMock()
+    client._transport = None
+    client.client = mock_client
+    method = client._get_client_method("read_holding_registers")
+    assert method is mock_client.read_holding_registers
+
+
+# ---------------------------------------------------------------------------
+# 4. disconnect/close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_disconnect_clears_client():
+    client = _make_client()
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    client.client = mock_client
+    await client.async_disconnect()
+    assert client.client is None
+
+
+@pytest.mark.asyncio
+async def test_async_close_is_alias_for_disconnect():
+    client = _make_client()
+    client.async_disconnect = AsyncMock()
+    await client.async_close()
+    client.async_disconnect.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 5. Coordinator property proxies route to DeviceClient
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_client_proxy():
+    coord = _make_coordinator()
+    mock_client = MagicMock()
+    coord.client = mock_client
+    assert coord._device_client.client is mock_client
+    assert coord.client is mock_client
+
+
+def test_coordinator_transport_proxy():
+    coord = _make_coordinator()
+    mock_transport = MagicMock()
+    coord._transport = mock_transport
+    assert coord._device_client._transport is mock_transport
+    assert coord._transport is mock_transport
+
+
+def test_coordinator_locks_proxy_to_device_client_locks():
+    coord = _make_coordinator()
+    assert coord._client_lock is coord._device_client._client_lock
+    assert coord._write_lock is coord._device_client._write_lock
+
+
+def test_coordinator_statistics_proxy():
+    coord = _make_coordinator()
+    coord.statistics["successful_reads"] = 99
+    assert coord._device_client.statistics["successful_reads"] == 99
+
+
+def test_coordinator_capabilities_proxy():
+    coord = _make_coordinator()
+    new_caps = DeviceCapabilities()
+    coord.capabilities = new_caps
+    assert coord._device_client.capabilities is new_caps
+
+
+def test_coordinator_offline_state_proxy():
+    coord = _make_coordinator()
+    assert coord.offline_state is False
+    coord.offline_state = True
+    assert coord._device_client.offline_state is True
+
+
+def test_coordinator_timeout_proxy():
+    coord = _make_coordinator()
+    coord.timeout = 99
+    assert coord._device_client.timeout == 99
+
+
+def test_coordinator_retry_proxy():
+    coord = _make_coordinator()
+    coord.retry = 7
+    assert coord._device_client.retry == 7
+
+
+def test_coordinator_consecutive_failures_proxy():
+    coord = _make_coordinator()
+    coord._consecutive_failures = 3
+    assert coord._device_client._consecutive_failures == 3
+
+
+def test_coordinator_config_proxy():
+    coord = _make_coordinator()
+    original_config = coord.config
+    assert coord._device_client.config is original_config
+
+
+def test_coordinator_register_maps_proxy():
+    coord = _make_coordinator()
+    maps = coord._register_maps
+    assert maps is coord._device_client._register_maps
+    assert "input_registers" in maps
+
+
+def test_coordinator_failed_registers_proxy():
+    coord = _make_coordinator()
+    coord._failed_registers.add("fan_speed")
+    assert "fan_speed" in coord._device_client._failed_registers
+
+
+def test_coordinator_device_name_proxy():
+    coord = _make_coordinator()
+    coord._device_name = "custom-name"
+    assert coord._device_client._device_name == "custom-name"
+
+
+# ---------------------------------------------------------------------------
+# 6. DeviceClient owns state independently of coordinator
+# ---------------------------------------------------------------------------
+
+
+def test_device_client_has_independent_locks():
+    client_a = _make_client()
+    client_b = _make_client()
+    assert client_a._client_lock is not client_b._client_lock
+    assert client_a._write_lock is not client_b._write_lock
+
+
+def test_device_client_hass_stored():
+    hass = MagicMock()
+    config = _make_config()
+    client = ThesslaGreenDeviceClient(
+        config,
+        hass=hass,
+        effective_batch=100,
+        resolved_connection_mode=None,
+        backoff=0.5,
+        backoff_jitter=None,
+    )
+    assert client.hass is hass


### PR DESCRIPTION
Phase 2 — DeviceClient interface:
- Add core/client.py: ThesslaGreenDeviceClient owns all device-domain
  state (connection, transport, register maps, capabilities, statistics)
  and implements connection lifecycle, scanner orchestration, register
  read/write, and batch-read helpers via mixin inheritance.
- Add core/__init__.py exporting ThesslaGreenDeviceClient.

Phase 3 — Coordinator wiring:
- coordinator.py: create DeviceClient in __init__ before applying config;
  add 35+ property proxies (data descriptors) so existing coordinator
  submodule functions continue to work unchanged via duck-typing.
- Coordinator methods _test_connection and _disconnect preserve their
  delegation chain so test mocks intercept at coordinator level.
- Keep ThesslaGreenDeviceScanner in coordinator namespace (noqa: F401)
  as patch target for scanner close tests.

Phase 3 — Contract tests:
- tests/test_device_client.py: 43 contract tests covering instantiation,
  properties, public API, and coordinator property proxy correctness.

Baseline: 2039 passed → 2082 passed (2039 + 43 new), 4 skipped.
All lint, format, tools, and compile checks pass.

https://claude.ai/code/session_014znqGTEZjosoA3MVHPsRHM