### PR TITLE
fix: lower quality_scale to bronze — real-device validation not yet completed

### DIFF
--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -22,7 +22,7 @@
   "loggers": [
     "custom_components.thessla_green_modbus"
   ],
-  "quality_scale": "silver",
+  "quality_scale": "bronze",
   "requirements": [
     "pymodbus>=3.6.0"
   ],

--- a/docs/release_readiness.md
+++ b/docs/release_readiness.md
@@ -45,7 +45,7 @@ Branch: `main`
 | `version` | `2.8.0` ✅ |
 | `iot_class` | `local_polling` ✅ |
 | `integration_type` | `hub` ✅ |
-| `quality_scale` | `silver` (self-assessed; see §8) |
+| `quality_scale` | `bronze` (lowered from `silver`; see §8) |
 | `requirements` | `["pymodbus>=3.6.0"]` ✅ |
 | No unsupported `homeassistant` key | ✅ (removed in prior PR) |
 | No unsupported `files` key | ✅ (removed in prior PR) |
@@ -115,13 +115,14 @@ No entity IDs, service IDs, register names, or unique IDs were changed.
 
 ## 8. quality_scale Decision
 
-`manifest.json` declares `quality_scale: "silver"`. This is a self-assessed claim.
+`manifest.json` declares `quality_scale: "bronze"` (lowered from `silver`).
 
-Silver requires (among other things) real-device validation. Real-device validation
-has not been formally completed with a physical device (see §9). The claim is accepted
-as aspirational self-assessment pending that evidence. If hassfest or HACS CI rejects
-the silver claim, it should be lowered to `bronze` or removed as appropriate based on
-the CI failure message.
+Silver requires documented real-device validation. No completed on-device evidence
+exists in this repository (see §9 and `docs/real_device_validation.md`). The scale
+was therefore lowered to `bronze` until `docs/real_device_validation.md` §5 Evidence
+Record is filled by a named tester with a physical ThesslaGreen AirPack device and
+committed to the repository. At that point `quality_scale` may be raised back to
+`silver` provided all silver criteria are met.
 
 ---
 
@@ -146,7 +147,7 @@ This remains **open release blocker B4**.
 | **B1** | Hassfest CI | ✅ Expected to pass — `files` key removed in prior PR; manifest structure is correct |
 | **B2** | HACS CI | ✅ Expected to pass — `hacs.json` valid; `files` key removed |
 | **B3** | GitHub release tag `v2.8.0` | ⛔ OPEN — Tag and GitHub release not yet created |
-| **B4** | Real-device validation | ⛔ OPEN — Checklist template at `docs/real_device_validation.md`; evidence record pending |
+| **B4** | Real-device validation | ⛔ OPEN — Checklist template at `docs/real_device_validation.md`; evidence record pending. `quality_scale` lowered to `bronze` until evidence is provided. |
 
 ---
 
@@ -171,4 +172,4 @@ This remains **open release blocker B4**.
 - Tests not skipped, xfailed, or deleted.
 - No broad refactoring performed.
 - No new binary brand assets added or replaced (existing assets validated only).
-- `quality_scale: silver` retained as self-assessed; subject to CI validation.
+- `quality_scale` lowered from `silver` to `bronze`; real-device evidence required before restoring `silver`.


### PR DESCRIPTION
manifest.json declared quality_scale: "silver" but docs/real_device_validation.md
is explicitly a TEMPLATE ONLY with no completed Evidence Record and no on-device
test results. Silver requires documented real-device validation; without it the
declaration is misleading.

Lowered to bronze until docs/real_device_validation.md §5 is filled by a named
tester with a physical ThesslaGreen AirPack device. docs/release_readiness.md §8
and blocker B4 updated to document the rationale and the path back to silver.

No runtime behaviour changed. No entity IDs, service IDs, register names,
register addresses, or Modbus behaviour changed.

https://claude.ai/code/session_01FMkzXrQ1ekyeUofubtuDgQ