### PR TITLE
refactor: continue device client architecture cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -6,7 +6,7 @@ import inspect
 import logging
 from collections.abc import Callable, Iterable
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -73,17 +73,9 @@ from .init_config import normalize_runtime_config as _normalize_runtime_config_i
 from .io import _ModbusIOMixin
 from .lifecycle import async_setup as _async_setup_impl
 from .models import CoordinatorConfig
-from .register_processing import (
-    find_register_name as _find_register_name_impl,
-)
-from .register_processing import (
-    process_register_value as _process_register_value_impl,
-)
 from .retry import _PermanentModbusError
 from .runtime import normalize_backoff as _normalize_backoff_impl
 from .runtime import parse_backoff_jitter as _parse_backoff_jitter_impl
-from .runtime_state import clear_register_failure as _clear_register_failure_impl
-from .runtime_state import mark_registers_failed as _mark_registers_failed_impl
 from .scan import (
     apply_scan_cache as _apply_scan_cache_impl,
 )
@@ -168,9 +160,24 @@ class ThesslaGreenModbusCoordinator(
     # Device-state property proxies
     #
     # All mutable device-domain state lives in ``self._device_client``.
-    # The properties below allow existing coordinator submodule functions
-    # (and tests) to continue accessing coordinator.X and have those
-    # accesses transparently read/write the DeviceClient's state.
+    # The properties below allow coordinator submodule functions (which
+    # receive the coordinator via duck-typing) and tests to continue
+    # accessing coordinator.X and have those accesses transparently
+    # read/write DeviceClient state.
+    #
+    # Retention rationale (applies to every proxy below):
+    #   - Coordinator submodules (runtime_io, read_batches, read_bits,
+    #     register_groups, scan_result, state, etc.) receive ``self``
+    #     (the coordinator) as their duck-typed owner and access these
+    #     attributes directly.
+    #   - Test files access these attributes on the coordinator directly
+    #     (e.g. coordinator.client, coordinator.available_registers).
+    #   - Entity platform files access coordinator.available_registers,
+    #     coordinator.capabilities, coordinator.statistics, etc.
+    #
+    # Future removal path: When a submodule is updated to accept a
+    # DeviceClient instead of the coordinator, the corresponding proxy
+    # can be removed at that point.
     # ------------------------------------------------------------------
 
     @property
@@ -651,22 +658,11 @@ class ThesslaGreenModbusCoordinator(
 
     def get_register_map(self, register_type: str) -> dict[str, int]:
         """Return the register map for the given register type."""
-        return cast(dict[str, int], self._register_maps.get(register_type, {}))
+        return self._device_client.get_register_map(register_type)
 
     def _get_client_method(self, name: str) -> Callable[..., Any]:
         """Return a Modbus method from transport/client or a no-op placeholder."""
-        for obj in (self._transport, self.client):
-            if obj is None:
-                continue
-            method = getattr(obj, name, None)
-            if callable(method):
-                return cast(Callable[..., Any], method)
-
-        async def _missing_method(*_args: Any, **_kwargs: Any) -> Any:
-            return None
-
-        _missing_method.__name__ = name
-        return _missing_method
+        return self._device_client._get_client_method(name)
 
     def _build_scanner_kwargs(self) -> dict[str, Any]:
         """Return constructor kwargs shared by all scanner creation paths."""
@@ -758,11 +754,11 @@ class ThesslaGreenModbusCoordinator(
 
     def _mark_registers_failed(self, names: Iterable[str | None]) -> None:
         """Record registers that failed to read."""
-        _mark_registers_failed_impl(self, names)
+        self._device_client._mark_registers_failed(names)
 
     def _clear_register_failure(self, name: str) -> None:
         """Remove register from failed list on successful read."""
-        _clear_register_failure_impl(self, name)
+        self._device_client._clear_register_failure(name)
 
     async def _test_connection(self) -> None:
         """Test initial connection to the device."""
@@ -823,11 +819,11 @@ class ThesslaGreenModbusCoordinator(
 
     def _find_register_name(self, register_type: str, address: int) -> str | None:
         """Find register name by address using pre-built reverse maps."""
-        return _find_register_name_impl(self._reverse_maps, register_type, address)
+        return self._device_client._find_register_name(register_type, address)
 
     def _process_register_value(self, register_name: str, value: int) -> Any:
         """Decode a raw register value via dedicated register-processing helpers."""
-        return _process_register_value_impl(register_name, value)
+        return self._device_client._process_register_value(register_name, value)
 
     async def _disconnect_locked(self) -> None:
         """Disconnect from Modbus device without acquiring locks — delegates to DeviceClient."""

--- a/custom_components/thessla_green_modbus/core/client.py
+++ b/custom_components/thessla_green_modbus/core/client.py
@@ -2,110 +2,35 @@
 
 ThesslaGreenDeviceClient owns all device-domain state and operations,
 keeping the coordinator as a thin Home Assistant adapter.
+
+Responsibilities are split across focused sub-modules:
+- client_connection.py  – connection lifecycle and transport construction
+- client_scanner.py     – scanner orchestration and capability discovery
+- client_registers.py   – register groups, IO helpers, and write support
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Iterable
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
-from pymodbus.client import AsyncModbusTcpClient
-
 from ..const import (
-    CONNECTION_MODE_AUTO,
-    CONNECTION_MODE_TCP,
-    CONNECTION_MODE_TCP_RTU,
-    CONNECTION_TYPE_RTU,
-    CONNECTION_TYPE_TCP,
-    DEFAULT_MAX_BACKOFF,
-    DEFAULT_PARITY,
-    DEFAULT_STOP_BITS,
-    HOLDING_BATCH_BOUNDARIES,
-    SERIAL_PARITY_MAP,
-    SERIAL_STOP_BITS_MAP,
     coil_registers,
     discrete_input_registers,
     holding_registers,
     input_registers,
 )
 from ..coordinator.capabilities import _CoordinatorCapabilitiesMixin
-from ..coordinator.connection import (
-    build_rtu_transport as _build_rtu_transport_impl,
-)
-from ..coordinator.connection import (
-    build_tcp_transport as _build_tcp_transport_impl,
-)
-from ..coordinator.connection import (
-    connect_direct_tcp_client as _connect_direct_tcp_client_impl,
-)
-from ..coordinator.connection import (
-    connect_transport_or_client as _connect_transport_or_client_impl,
-)
-from ..coordinator.connection import (
-    ensure_connected_runtime as _ensure_connected_runtime_impl,
-)
-from ..coordinator.connection import (
-    ensure_transport_selected as _ensure_transport_selected_impl,
-)
-from ..coordinator.connection import (
-    reconnect_client_if_needed as _reconnect_client_if_needed_impl,
-)
-from ..coordinator.connection_lifecycle import (
-    ensure_connected_lifecycle as _ensure_connected_lifecycle_impl,
-)
-from ..coordinator.connection_state import (
-    mark_connection_disconnected as _mark_connection_disconnected_impl,
-)
-from ..coordinator.connection_state import (
-    mark_connection_established as _mark_connection_established_impl,
-)
-from ..coordinator.connection_state import (
-    mark_connection_failure as _mark_connection_failure_impl,
-)
-from ..coordinator.connection_test import run_connection_test as _run_connection_test_impl
-from ..coordinator.disconnect import (
-    close_client_connection as _close_client_connection_impl,
-)
-from ..coordinator.disconnect import (
-    disconnect_locked as _disconnect_locked_impl,
-)
 from ..coordinator.io import _ModbusIOMixin
 from ..coordinator.models import CoordinatorConfig
-from ..coordinator.register_groups import (
-    compute_register_groups as _compute_register_groups_impl,
-)
-from ..coordinator.register_processing import (
-    find_register_name as _find_register_name_impl,
-)
-from ..coordinator.register_processing import (
-    process_register_value as _process_register_value_impl,
-)
-from ..coordinator.runtime_state import (
-    clear_register_failure as _clear_register_failure_impl,
-)
-from ..coordinator.runtime_state import (
-    mark_registers_failed as _mark_registers_failed_impl,
-)
-from ..coordinator.scan import (
-    normalise_available_registers as _normalise_available_registers_impl,
-)
-from ..coordinator.scanner_kwargs import build_scanner_kwargs as _build_scanner_kwargs_impl
-from ..coordinator.transport_select import (
-    select_auto_transport as _select_auto_transport_impl,
-)
-from ..register_defs_cache import get_register_definitions
-from ..registers.read_planner import group_reads
-from ..registers.register_def import RegisterDef
-from ..scanner import (
-    DeviceCapabilities,
-    ThesslaGreenDeviceScanner,
-    is_request_cancelled_error,
-)
+from ..scanner import DeviceCapabilities
 from ..transport.base import BaseModbusTransport
 from ..utils import utcnow as _utcnow
+from .client_connection import _DeviceClientConnectionMixin
+from .client_registers import _DeviceClientRegistersMixin
+from .client_scanner import _DeviceClientScannerMixin
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -113,18 +38,25 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-_ORIGINAL_ASYNC_MODBUS_TCP_CLIENT = AsyncModbusTcpClient
 
-
-def _get_register_definition(name: str) -> RegisterDef:
-    return get_register_definitions()[name]
-
-
-class ThesslaGreenDeviceClient(_ModbusIOMixin, _CoordinatorCapabilitiesMixin):
+class ThesslaGreenDeviceClient(
+    _DeviceClientConnectionMixin,
+    _DeviceClientScannerMixin,
+    _DeviceClientRegistersMixin,
+    _ModbusIOMixin,
+    _CoordinatorCapabilitiesMixin,
+):
     """Device-domain operations client for ThesslaGreen Modbus integration.
 
     Owns all device-domain mutable state and provides device operations.
     The coordinator acts as a thin HA adapter that delegates to this client.
+
+    Method groups are implemented in focused mixins:
+    - Connection lifecycle / transport: _DeviceClientConnectionMixin
+    - Scanner orchestration: _DeviceClientScannerMixin
+    - Register groups / IO helpers / writes: _DeviceClientRegistersMixin
+    - Modbus read protocol: _ModbusIOMixin (from coordinator/)
+    - Derived capability metrics: _CoordinatorCapabilitiesMixin (from coordinator/)
     """
 
     #: Asyncio locks owned by this client (coordinator proxies access these).
@@ -225,293 +157,6 @@ class ThesslaGreenDeviceClient(_ModbusIOMixin, _CoordinatorCapabilitiesMixin):
         # Post-processing state (used by _CoordinatorCapabilitiesMixin).
         self._last_power_timestamp = _utcnow()
         self._total_energy: float = 0.0
-
-    # ------------------------------------------------------------------
-    # Connection lifecycle
-    # ------------------------------------------------------------------
-
-    async def async_ensure_connected(self) -> None:
-        """Ensure Modbus connection is established."""
-        await _ensure_connected_lifecycle_impl(
-            self,
-            ensure_connected_runtime_fn=_ensure_connected_runtime_impl,
-            reconnect_client_if_needed_fn=_reconnect_client_if_needed_impl,
-            ensure_transport_selected_fn_factory=self._build_transport_selector_fn,
-            connect_transport_or_client_fn=_connect_transport_or_client_impl,
-            mark_connection_established_fn=lambda: _mark_connection_established_impl(
-                offline_state_setter=lambda value: setattr(self, "offline_state", value)
-            ),
-            mark_connection_failure_fn=lambda: _mark_connection_failure_impl(
-                statistics=self.statistics,
-                offline_state_setter=lambda value: setattr(self, "offline_state", value),
-            ),
-            logger=_LOGGER,
-        )
-
-    async def async_disconnect(self) -> None:
-        """Disconnect from Modbus device."""
-        async with self._client_lock:
-            await self._disconnect_locked()
-
-    async def async_close(self) -> None:
-        """Close all resources (alias for async_disconnect)."""
-        await self.async_disconnect()
-
-    async def async_test_connection(self) -> None:
-        """Test initial connection to the device."""
-        async with self._write_lock:
-            await _run_connection_test_impl(
-                ensure_connection=self.async_ensure_connected,
-                get_transport=lambda: self._transport,
-                slave_id=self.config.slave_id,
-                test_addresses=list(input_registers().values())[:3],
-                is_cancelled_error=is_request_cancelled_error,
-                logger=_LOGGER,
-            )
-
-    async def _disconnect_locked(self) -> None:
-        """Disconnect without acquiring the client lock."""
-        await _disconnect_locked_impl(
-            transport=self._transport,
-            client=self.client,
-            close_client_connection_fn=_close_client_connection_impl,
-            mark_connection_disconnected_fn=lambda: _mark_connection_disconnected_impl(
-                offline_state_setter=lambda value: setattr(self, "offline_state", value)
-            ),
-            logger=_LOGGER,
-        )
-        self.client = None
-
-    async def _ensure_connection(self) -> None:
-        """Internal alias used by coordinator submodule duck-typing."""
-        await self.async_ensure_connected()
-
-    async def _disconnect(self) -> None:
-        """Internal alias used by coordinator submodule duck-typing."""
-        await self.async_disconnect()
-
-    async def _close_client_connection(self) -> None:
-        """Close client object safely for sync or async close implementations."""
-        await _close_client_connection_impl(client=self.client, logger=_LOGGER)
-
-    # ------------------------------------------------------------------
-    # Transport construction
-    # ------------------------------------------------------------------
-
-    def _build_tcp_transport(self, mode: str) -> BaseModbusTransport:
-        """Build a TCP (or RTU-over-TCP) transport for the given mode."""
-        return _build_tcp_transport_impl(
-            mode=mode,
-            host=self.config.host,
-            port=self.config.port,
-            retry=self.retry,
-            backoff=self.backoff,
-            max_backoff=DEFAULT_MAX_BACKOFF,
-            timeout=self.timeout,
-            offline_state=self.offline_state,
-            connection_type_tcp=CONNECTION_TYPE_TCP,
-            connection_mode_tcp_rtu=CONNECTION_MODE_TCP_RTU,
-        )
-
-    async def _try_direct_client_connect(self, *, allow_parameterless_ctor: bool) -> bool:
-        """Try connecting via AsyncModbusTcpClient and store the connected client.
-
-        Looks up AsyncModbusTcpClient through the coordinator module so that
-        tests can patch ``coordinator.coordinator.AsyncModbusTcpClient`` and
-        have it take effect here.
-        """
-        from custom_components.thessla_green_modbus import coordinator as coordinator_pkg
-
-        # Access the coordinator.py module via the package to pick up any
-        # test patches on coordinator.coordinator.AsyncModbusTcpClient.
-        coord_module = getattr(coordinator_pkg, "coordinator", None)
-        tcp_client_cls = (
-            getattr(coord_module, "AsyncModbusTcpClient", None)
-            if coord_module is not None
-            else None
-        ) or _ORIGINAL_ASYNC_MODBUS_TCP_CLIENT
-
-        direct_client = await _connect_direct_tcp_client_impl(
-            host=self.config.host,
-            port=self.config.port,
-            timeout=self.timeout,
-            tcp_client_cls=tcp_client_cls,
-            allow_parameterless_ctor=allow_parameterless_ctor,
-        )
-        if direct_client is not None:
-            self.client = direct_client
-            self._transport = None
-            return True
-        return False
-
-    def _build_transport_selector_fn(self) -> Any:
-        """Return the transport selector callable for the connection lifecycle."""
-        parity = SERIAL_PARITY_MAP.get(self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
-        stop_bits = SERIAL_STOP_BITS_MAP.get(
-            self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
-        )
-
-        async def _ensure_transport_selected() -> Any:
-            return await _ensure_transport_selected_impl(
-                current_transport=self._transport,
-                connection_type=self.config.connection_type,
-                connection_mode=self.config.connection_mode,
-                host=self.config.host,
-                port=self.config.port,
-                serial_port=self.config.serial_port,
-                baudrate=self.config.baud_rate,
-                parity=parity,
-                stopbits=stop_bits,
-                retry=self.retry,
-                backoff=self.backoff,
-                max_backoff=DEFAULT_MAX_BACKOFF,
-                timeout=self.timeout,
-                offline_state=self.offline_state,
-                connection_type_rtu=CONNECTION_TYPE_RTU,
-                connection_mode_auto=CONNECTION_MODE_AUTO,
-                connection_mode_tcp=CONNECTION_MODE_TCP,
-                build_rtu_transport_fn=_build_rtu_transport_impl,
-                build_tcp_transport_fn=self._build_tcp_transport,
-                select_auto_transport_fn=lambda: _select_auto_transport_impl(
-                    resolved_connection_mode=self._resolved_connection_mode,
-                    build_tcp_transport=self._build_tcp_transport,
-                    try_direct_client_connect=lambda allow_pc: self._try_direct_client_connect(
-                        allow_parameterless_ctor=allow_pc
-                    ),
-                    port=self.config.port,
-                    timeout=self.timeout,
-                    slave_id=self.config.slave_id,
-                    host=self.config.host,
-                    logger=_LOGGER,
-                ),
-            )
-
-        return _ensure_transport_selected
-
-    # ------------------------------------------------------------------
-    # Scanner / device scan
-    # ------------------------------------------------------------------
-
-    def _build_scanner_kwargs(self) -> dict[str, Any]:
-        """Return constructor kwargs for scanner creation."""
-        return _build_scanner_kwargs_impl(
-            self,
-            resolved_connection_mode=self._resolved_connection_mode,
-        )
-
-    async def async_create_scanner(self) -> ThesslaGreenDeviceScanner:
-        """Instantiate a ThesslaGreenDeviceScanner using its create() factory."""
-        return await ThesslaGreenDeviceScanner.create(**self._build_scanner_kwargs())
-
-    async def async_scan_device(self) -> dict[str, Any]:
-        """Run a full device scan and return the raw scan result.
-
-        The caller (coordinator) is responsible for applying the result via
-        ``apply_scan_result`` / ``_apply_scan_result_impl``.
-        """
-        scanner = await self.async_create_scanner()
-        return await scanner.scan_device()
-
-    def _normalise_available_registers(
-        self, available: dict[str, list[str] | set[str]]
-    ) -> dict[str, set[str]]:
-        """Return available register names in canonical form."""
-        return _normalise_available_registers_impl(self, available)
-
-    # ------------------------------------------------------------------
-    # Register groups
-    # ------------------------------------------------------------------
-
-    def compute_register_groups(self) -> None:
-        """Pre-compute register groups for optimized batch reading."""
-        _compute_register_groups_impl(
-            self,
-            get_register_definition=_get_register_definition,
-            group_reads=group_reads,
-            holding_batch_boundaries=HOLDING_BATCH_BOUNDARIES,
-        )
-
-    # ------------------------------------------------------------------
-    # IO mixin required helpers (satisfy _ModbusIOMixin protocol)
-    # ------------------------------------------------------------------
-
-    def _find_register_name(self, register_type: str, address: int) -> str | None:
-        """Find register name by address using pre-built reverse maps."""
-        return _find_register_name_impl(self._reverse_maps, register_type, address)
-
-    def _process_register_value(self, register_name: str, value: int) -> Any:
-        """Decode a raw register value via register-processing helpers."""
-        return _process_register_value_impl(register_name, value)
-
-    def _mark_registers_failed(self, names: Iterable[str | None]) -> None:
-        """Record registers that failed to read."""
-        _mark_registers_failed_impl(self, names)
-
-    def _clear_register_failure(self, name: str) -> None:
-        """Remove register from failed list on successful read."""
-        _clear_register_failure_impl(self, name)
-
-    def _get_client_method(self, name: str) -> Callable[..., Any]:
-        """Return a Modbus method from transport/client or a no-op placeholder."""
-        for obj in (self._transport, self.client):
-            if obj is None:
-                continue
-            method = getattr(obj, name, None)
-            if callable(method):
-                return cast(Callable[..., Any], method)
-
-        async def _missing_method(*_args: Any, **_kwargs: Any) -> Any:
-            return None
-
-        _missing_method.__name__ = name
-        return _missing_method
-
-    # ------------------------------------------------------------------
-    # Write support (minimal, mirrors coordinator write helpers)
-    # ------------------------------------------------------------------
-
-    async def async_write_register(
-        self,
-        register_name: str,
-        value: Any,
-        *,
-        entity_id: str = "",
-        call_description: str = "",
-        offset: int = 0,
-    ) -> bool:
-        """Write a single register by name.
-
-        Delegates to the coordinator's write helpers. Intended for use
-        by external callers (services, tests) once the DeviceClient is
-        the canonical write path.
-        """
-        from ..coordinator.write_path import (
-            SingleWritePlan,
-            encode_write_value,
-            run_single_write_attempts,
-        )
-
-        definition = _get_register_definition(register_name)
-        address = self._register_maps.get("holding_registers", {}).get(register_name)
-        if address is None:
-            _LOGGER.error("Register %s not found in holding registers map", register_name)
-            return False
-
-        encoded_values, scalar_value = encode_write_value(register_name, definition, value, offset)
-        if encoded_values is None and scalar_value is None:
-            return False
-
-        plan = SingleWritePlan(
-            register_name=register_name,
-            address=address,
-            definition=definition,
-            encoded_values=encoded_values,
-            scalar_value=scalar_value,
-            offset=offset,
-            entity_id=entity_id,
-            call_description=call_description,
-        )
-        return await run_single_write_attempts(self, plan)
 
     # ------------------------------------------------------------------
     # Public API

--- a/custom_components/thessla_green_modbus/core/client_connection.py
+++ b/custom_components/thessla_green_modbus/core/client_connection.py
@@ -1,0 +1,252 @@
+"""Connection lifecycle and transport construction mixin for DeviceClient."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+# Reference to the real AsyncModbusTcpClient captured at import time so that
+# tests patching coordinator.coordinator.AsyncModbusTcpClient still take effect
+# (see _try_direct_client_connect).
+from pymodbus.client import AsyncModbusTcpClient as _ORIGINAL_ASYNC_MODBUS_TCP_CLIENT
+
+from ..const import (
+    CONNECTION_MODE_AUTO,
+    CONNECTION_MODE_TCP,
+    CONNECTION_MODE_TCP_RTU,
+    CONNECTION_TYPE_RTU,
+    CONNECTION_TYPE_TCP,
+    DEFAULT_MAX_BACKOFF,
+    DEFAULT_PARITY,
+    DEFAULT_STOP_BITS,
+    SERIAL_PARITY_MAP,
+    SERIAL_STOP_BITS_MAP,
+    input_registers,
+)
+from ..coordinator.connection import (
+    build_rtu_transport as _build_rtu_transport_impl,
+)
+from ..coordinator.connection import (
+    build_tcp_transport as _build_tcp_transport_impl,
+)
+from ..coordinator.connection import (
+    connect_direct_tcp_client as _connect_direct_tcp_client_impl,
+)
+from ..coordinator.connection import (
+    connect_transport_or_client as _connect_transport_or_client_impl,
+)
+from ..coordinator.connection import (
+    ensure_connected_runtime as _ensure_connected_runtime_impl,
+)
+from ..coordinator.connection import (
+    ensure_transport_selected as _ensure_transport_selected_impl,
+)
+from ..coordinator.connection import (
+    reconnect_client_if_needed as _reconnect_client_if_needed_impl,
+)
+from ..coordinator.connection_lifecycle import (
+    ensure_connected_lifecycle as _ensure_connected_lifecycle_impl,
+)
+from ..coordinator.connection_state import (
+    mark_connection_disconnected as _mark_connection_disconnected_impl,
+)
+from ..coordinator.connection_state import (
+    mark_connection_established as _mark_connection_established_impl,
+)
+from ..coordinator.connection_state import (
+    mark_connection_failure as _mark_connection_failure_impl,
+)
+from ..coordinator.connection_test import run_connection_test as _run_connection_test_impl
+from ..coordinator.disconnect import (
+    close_client_connection as _close_client_connection_impl,
+)
+from ..coordinator.disconnect import (
+    disconnect_locked as _disconnect_locked_impl,
+)
+from ..coordinator.transport_select import (
+    select_auto_transport as _select_auto_transport_impl,
+)
+from ..scanner import is_request_cancelled_error
+from ..transport.base import BaseModbusTransport
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _DeviceClientConnectionMixin:
+    """Connection lifecycle and transport construction for ThesslaGreenDeviceClient.
+
+    Extracted from core/client.py to keep client.py focused on composition and
+    public API. All methods require the standard DeviceClient attributes
+    (config, hass, client, _transport, _client_lock, _write_lock, etc.).
+    """
+
+    # Declared here for type-checker; actual values set in ThesslaGreenDeviceClient.__init__.
+    config: Any
+    hass: Any
+    client: Any
+    _transport: Any
+    _client_lock: Any
+    _write_lock: Any
+    offline_state: bool
+    statistics: dict[str, Any]
+    _resolved_connection_mode: str | None
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_ensure_connected(self) -> None:
+        """Ensure Modbus connection is established."""
+        await _ensure_connected_lifecycle_impl(
+            self,
+            ensure_connected_runtime_fn=_ensure_connected_runtime_impl,
+            reconnect_client_if_needed_fn=_reconnect_client_if_needed_impl,
+            ensure_transport_selected_fn_factory=self._build_transport_selector_fn,
+            connect_transport_or_client_fn=_connect_transport_or_client_impl,
+            mark_connection_established_fn=lambda: _mark_connection_established_impl(
+                offline_state_setter=lambda value: setattr(self, "offline_state", value)
+            ),
+            mark_connection_failure_fn=lambda: _mark_connection_failure_impl(
+                statistics=self.statistics,
+                offline_state_setter=lambda value: setattr(self, "offline_state", value),
+            ),
+            logger=_LOGGER,
+        )
+
+    async def async_disconnect(self) -> None:
+        """Disconnect from Modbus device."""
+        async with self._client_lock:
+            await self._disconnect_locked()
+
+    async def async_close(self) -> None:
+        """Close all resources (alias for async_disconnect)."""
+        await self.async_disconnect()
+
+    async def async_test_connection(self) -> None:
+        """Test initial connection to the device."""
+        async with self._write_lock:
+            await _run_connection_test_impl(
+                ensure_connection=self.async_ensure_connected,
+                get_transport=lambda: self._transport,
+                slave_id=self.config.slave_id,
+                test_addresses=list(input_registers().values())[:3],
+                is_cancelled_error=is_request_cancelled_error,
+                logger=_LOGGER,
+            )
+
+    async def _disconnect_locked(self) -> None:
+        """Disconnect without acquiring the client lock."""
+        await _disconnect_locked_impl(
+            transport=self._transport,
+            client=self.client,
+            close_client_connection_fn=_close_client_connection_impl,
+            mark_connection_disconnected_fn=lambda: _mark_connection_disconnected_impl(
+                offline_state_setter=lambda value: setattr(self, "offline_state", value)
+            ),
+            logger=_LOGGER,
+        )
+        self.client = None
+
+    async def _ensure_connection(self) -> None:
+        """Internal alias used by coordinator submodule duck-typing."""
+        await self.async_ensure_connected()
+
+    async def _disconnect(self) -> None:
+        """Internal alias used by coordinator submodule duck-typing."""
+        await self.async_disconnect()
+
+    async def _close_client_connection(self) -> None:
+        """Close client object safely for sync or async close implementations."""
+        await _close_client_connection_impl(client=self.client, logger=_LOGGER)
+
+    # ------------------------------------------------------------------
+    # Transport construction
+    # ------------------------------------------------------------------
+
+    def _build_tcp_transport(self, mode: str) -> BaseModbusTransport:
+        """Build a TCP (or RTU-over-TCP) transport for the given mode."""
+        return _build_tcp_transport_impl(
+            mode=mode,
+            host=self.config.host,
+            port=self.config.port,
+            retry=self.retry,
+            backoff=self.backoff,
+            max_backoff=DEFAULT_MAX_BACKOFF,
+            timeout=self.timeout,
+            offline_state=self.offline_state,
+            connection_type_tcp=CONNECTION_TYPE_TCP,
+            connection_mode_tcp_rtu=CONNECTION_MODE_TCP_RTU,
+        )
+
+    async def _try_direct_client_connect(self, *, allow_parameterless_ctor: bool) -> bool:
+        """Try connecting via AsyncModbusTcpClient and store the connected client.
+
+        Looks up AsyncModbusTcpClient through the coordinator module so that
+        tests can patch ``coordinator.coordinator.AsyncModbusTcpClient`` and
+        have it take effect here.
+        """
+        from custom_components.thessla_green_modbus import coordinator as coordinator_pkg
+
+        coord_module = getattr(coordinator_pkg, "coordinator", None)
+        tcp_client_cls = (
+            getattr(coord_module, "AsyncModbusTcpClient", None)
+            if coord_module is not None
+            else None
+        ) or _ORIGINAL_ASYNC_MODBUS_TCP_CLIENT
+
+        direct_client = await _connect_direct_tcp_client_impl(
+            host=self.config.host,
+            port=self.config.port,
+            timeout=self.timeout,
+            tcp_client_cls=tcp_client_cls,
+            allow_parameterless_ctor=allow_parameterless_ctor,
+        )
+        if direct_client is not None:
+            self.client = direct_client
+            self._transport = None
+            return True
+        return False
+
+    def _build_transport_selector_fn(self) -> Any:
+        """Return the transport selector callable for the connection lifecycle."""
+        parity = SERIAL_PARITY_MAP.get(self.config.parity, SERIAL_PARITY_MAP[DEFAULT_PARITY])
+        stop_bits = SERIAL_STOP_BITS_MAP.get(
+            self.config.stop_bits, SERIAL_STOP_BITS_MAP[DEFAULT_STOP_BITS]
+        )
+
+        async def _ensure_transport_selected() -> Any:
+            return await _ensure_transport_selected_impl(
+                current_transport=self._transport,
+                connection_type=self.config.connection_type,
+                connection_mode=self.config.connection_mode,
+                host=self.config.host,
+                port=self.config.port,
+                serial_port=self.config.serial_port,
+                baudrate=self.config.baud_rate,
+                parity=parity,
+                stopbits=stop_bits,
+                retry=self.retry,
+                backoff=self.backoff,
+                max_backoff=DEFAULT_MAX_BACKOFF,
+                timeout=self.timeout,
+                offline_state=self.offline_state,
+                connection_type_rtu=CONNECTION_TYPE_RTU,
+                connection_mode_auto=CONNECTION_MODE_AUTO,
+                connection_mode_tcp=CONNECTION_MODE_TCP,
+                build_rtu_transport_fn=_build_rtu_transport_impl,
+                build_tcp_transport_fn=self._build_tcp_transport,
+                select_auto_transport_fn=lambda: _select_auto_transport_impl(
+                    resolved_connection_mode=self._resolved_connection_mode,
+                    build_tcp_transport=self._build_tcp_transport,
+                    try_direct_client_connect=lambda allow_pc: self._try_direct_client_connect(
+                        allow_parameterless_ctor=allow_pc
+                    ),
+                    port=self.config.port,
+                    timeout=self.timeout,
+                    slave_id=self.config.slave_id,
+                    host=self.config.host,
+                    logger=_LOGGER,
+                ),
+            )
+
+        return _ensure_transport_selected

--- a/custom_components/thessla_green_modbus/core/client_registers.py
+++ b/custom_components/thessla_green_modbus/core/client_registers.py
@@ -1,0 +1,144 @@
+"""Register operations and IO helpers mixin for DeviceClient."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from typing import Any, cast
+
+from ..const import HOLDING_BATCH_BOUNDARIES
+from ..coordinator.register_groups import (
+    compute_register_groups as _compute_register_groups_impl,
+)
+from ..coordinator.register_processing import (
+    find_register_name as _find_register_name_impl,
+)
+from ..coordinator.register_processing import (
+    process_register_value as _process_register_value_impl,
+)
+from ..coordinator.runtime_state import (
+    clear_register_failure as _clear_register_failure_impl,
+)
+from ..coordinator.runtime_state import (
+    mark_registers_failed as _mark_registers_failed_impl,
+)
+from ..register_defs_cache import get_register_definitions
+from ..registers.read_planner import group_reads
+from ..registers.register_def import RegisterDef
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _get_register_definition(name: str) -> RegisterDef:
+    return get_register_definitions()[name]
+
+
+class _DeviceClientRegistersMixin:
+    """Register operations and IO helpers for ThesslaGreenDeviceClient.
+
+    Extracted from core/client.py to keep client.py focused on composition and
+    public API. All methods require the standard DeviceClient attributes
+    (_register_maps, _reverse_maps, _failed_registers, _register_groups, etc.).
+    """
+
+    _register_maps: dict[str, Any]
+    _reverse_maps: dict[str, Any]
+    _failed_registers: set[str]
+    _register_groups: dict[str, Any]
+    client: Any
+    _transport: Any
+
+    # ------------------------------------------------------------------
+    # Register groups
+    # ------------------------------------------------------------------
+
+    def compute_register_groups(self) -> None:
+        """Pre-compute register groups for optimized batch reading."""
+        _compute_register_groups_impl(
+            self,
+            get_register_definition=_get_register_definition,
+            group_reads=group_reads,
+            holding_batch_boundaries=HOLDING_BATCH_BOUNDARIES,
+        )
+
+    # ------------------------------------------------------------------
+    # IO mixin required helpers (satisfy _ModbusIOMixin protocol)
+    # ------------------------------------------------------------------
+
+    def _find_register_name(self, register_type: str, address: int) -> str | None:
+        """Find register name by address using pre-built reverse maps."""
+        return _find_register_name_impl(self._reverse_maps, register_type, address)
+
+    def _process_register_value(self, register_name: str, value: int) -> Any:
+        """Decode a raw register value via register-processing helpers."""
+        return _process_register_value_impl(register_name, value)
+
+    def _mark_registers_failed(self, names: Iterable[str | None]) -> None:
+        """Record registers that failed to read."""
+        _mark_registers_failed_impl(self, names)
+
+    def _clear_register_failure(self, name: str) -> None:
+        """Remove register from failed list on successful read."""
+        _clear_register_failure_impl(self, name)
+
+    def _get_client_method(self, name: str) -> Callable[..., Any]:
+        """Return a Modbus method from transport/client or a no-op placeholder."""
+        for obj in (self._transport, self.client):
+            if obj is None:
+                continue
+            method = getattr(obj, name, None)
+            if callable(method):
+                return cast(Callable[..., Any], method)
+
+        async def _missing_method(*_args: Any, **_kwargs: Any) -> Any:
+            return None
+
+        _missing_method.__name__ = name
+        return _missing_method
+
+    # ------------------------------------------------------------------
+    # Write support
+    # ------------------------------------------------------------------
+
+    async def async_write_register(
+        self,
+        register_name: str,
+        value: Any,
+        *,
+        entity_id: str = "",
+        call_description: str = "",
+        offset: int = 0,
+    ) -> bool:
+        """Write a single register by name.
+
+        Delegates to the coordinator's write helpers. Intended for use
+        by external callers (services, tests) once the DeviceClient is
+        the canonical write path.
+        """
+        from ..coordinator.write_path import (
+            SingleWritePlan,
+            encode_write_value,
+            run_single_write_attempts,
+        )
+
+        definition = _get_register_definition(register_name)
+        address = self._register_maps.get("holding_registers", {}).get(register_name)
+        if address is None:
+            _LOGGER.error("Register %s not found in holding registers map", register_name)
+            return False
+
+        encoded_values, scalar_value = encode_write_value(register_name, definition, value, offset)
+        if encoded_values is None and scalar_value is None:
+            return False
+
+        plan = SingleWritePlan(
+            register_name=register_name,
+            address=address,
+            definition=definition,
+            encoded_values=encoded_values,
+            scalar_value=scalar_value,
+            offset=offset,
+            entity_id=entity_id,
+            call_description=call_description,
+        )
+        return await run_single_write_attempts(self, plan)

--- a/custom_components/thessla_green_modbus/core/client_scanner.py
+++ b/custom_components/thessla_green_modbus/core/client_scanner.py
@@ -1,0 +1,52 @@
+"""Scanner orchestration mixin for DeviceClient."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..coordinator.scan import (
+    normalise_available_registers as _normalise_available_registers_impl,
+)
+from ..coordinator.scanner_kwargs import build_scanner_kwargs as _build_scanner_kwargs_impl
+from ..scanner import ThesslaGreenDeviceScanner
+
+
+class _DeviceClientScannerMixin:
+    """Scanner orchestration for ThesslaGreenDeviceClient.
+
+    Extracted from core/client.py to keep client.py focused on composition and
+    public API. All methods require the standard DeviceClient attributes
+    (config, _resolved_connection_mode, available_registers, etc.).
+    """
+
+    _resolved_connection_mode: str | None
+
+    # ------------------------------------------------------------------
+    # Scanner / device scan
+    # ------------------------------------------------------------------
+
+    def _build_scanner_kwargs(self) -> dict[str, Any]:
+        """Return constructor kwargs for scanner creation."""
+        return _build_scanner_kwargs_impl(
+            self,
+            resolved_connection_mode=self._resolved_connection_mode,
+        )
+
+    async def async_create_scanner(self) -> ThesslaGreenDeviceScanner:
+        """Instantiate a ThesslaGreenDeviceScanner using its create() factory."""
+        return await ThesslaGreenDeviceScanner.create(**self._build_scanner_kwargs())
+
+    async def async_scan_device(self) -> dict[str, Any]:
+        """Run a full device scan and return the raw scan result.
+
+        The caller (coordinator) is responsible for applying the result via
+        ``apply_scan_result`` / ``_apply_scan_result_impl``.
+        """
+        scanner = await self.async_create_scanner()
+        return await scanner.scan_device()
+
+    def _normalise_available_registers(
+        self, available: dict[str, list[str] | set[str]]
+    ) -> dict[str, set[str]]:
+        """Return available register names in canonical form."""
+        return _normalise_available_registers_impl(self, available)

--- a/docs/coordinator_proxy_cleanup.md
+++ b/docs/coordinator_proxy_cleanup.md
@@ -1,0 +1,123 @@
+# Coordinator Proxy Cleanup
+
+## Summary
+
+All 38 proxy properties in `ThesslaGreenModbusCoordinator` are **retained** because they
+are required by coordinator submodule duck-typing (submodule functions receive the
+coordinator as an untyped owner and access state via `owner.attr`).
+
+What was cleaned up:
+
+- Removed 4 imports that were only used in now-delegated method implementations.
+- Replaced 6 duplicate method implementations with delegation to `_device_client`.
+- Added a block documentation comment explaining the proxy retention rationale.
+- Removed unused `cast` import after delegation.
+
+## Removed Proxies
+
+None removed — all 38 properties retained for reasons documented below.
+
+## Retained Proxies
+
+All proxy properties are retained. Grouped by reason:
+
+### Required by coordinator submodule functions (duck-typing)
+
+Coordinator submodules (`runtime_io`, `read_batches`, `read_bits`, `register_groups`,
+`scan_result`, `state`, `errors`, `update_result`, `scanner_kwargs`, `init_config`, etc.)
+receive the coordinator as an untyped owner parameter and access these attributes:
+
+| Property | Used by submodules |
+|----------|--------------------|
+| `config` | `init_config`, `device_info`, `lifecycle` |
+| `_device_name` | `init_config`, `diagnostics`, `scan_result` |
+| `_resolved_connection_mode` | `init_config`, `connection_lifecycle`, `scan_result` |
+| `timeout` | `runtime_io`, `scanner_kwargs`, `handlers_data` |
+| `retry` | `runtime_io`, `scanner_kwargs`, `read_common`, `retry`, `handlers_data` |
+| `backoff` | `runtime_io`, `scanner_kwargs` |
+| `backoff_jitter` | `runtime_io`, `scanner_kwargs` |
+| `force_full_register_list` | `init_config`, `scanner_kwargs` |
+| `scan_uart_settings` | `init_config`, `scanner_kwargs`, `handlers_data` |
+| `deep_scan` | `init_config`, `scanner_kwargs` |
+| `safe_scan` | `init_config`, `scanner_kwargs`, `register_groups` |
+| `skip_missing_registers` | `init_config`, `scanner_kwargs` |
+| `effective_batch` | `register_groups`, `read_batches`, `read_bits`, `scanner_kwargs`, `handlers_data` |
+| `max_registers_per_request` | `init_config` |
+| `client` | `runtime_io`, `read_batches`, `read_bits`, `schedule`, `update` |
+| `_transport` | `runtime_io`, `read_batches`, `read_bits`, `schedule`, `update`, `retry`, `state` |
+| `_client_lock` | `connection_lifecycle`, `state` |
+| `_write_lock` | `update`, `state` |
+| `_update_in_progress` | `update_state` |
+| `offline_state` | `state`, `update_result`, `errors`, `diagnostics` |
+| `capabilities` | `capabilities_mixin`, `scan`, `scan_result` |
+| `device_info` | `state`, `scan`, `scan_result`, `diagnostics` |
+| `available_registers` | `state`, `scan`, `scan_result`, `read_batches`, `read_bits`, `register_groups` |
+| `_register_maps` | `state`, `scan` |
+| `_reverse_maps` | `state` |
+| `_input_registers_rev` | `state` |
+| `_holding_registers_rev` | `state` |
+| `_coil_registers_rev` | `state` |
+| `_discrete_inputs_rev` | `state` |
+| `_register_groups` | `state`, `register_groups`, `read_batches`, `read_bits` |
+| `_failed_registers` | `state`, `runtime_state`, `read_batches` |
+| `statistics` | `state`, `update_result`, `errors`, `read_batches` |
+| `_consecutive_failures` | `errors`, `update_result`, `state` |
+| `_max_failures` | `errors`, `state` |
+| `device_scan_result` | `scan`, `scan_result` |
+| `unknown_registers` | `state`, `scan_result`, `handlers_data` |
+| `scanned_registers` | `state`, `scan_result`, `handlers_data` |
+| `last_scan` | `state`, `scan_result` |
+| `_last_power_timestamp` | `capabilities_mixin` |
+| `_total_energy` | `capabilities_mixin`, `state` |
+
+### Also required by external callers
+
+The following proxies are also directly accessed by entity platform files and tests:
+
+- `available_registers` — all entity platforms (sensor, switch, fan, number, …)
+- `capabilities` — entity platforms (sensor, switch, climate, …) and tests
+- `device_info` — sensor.py, _setup.py and tests
+- `statistics` — number.py, switch.py, fan.py and tests
+- `device_scan_result` — binary_sensor.py, sensor.py, diagnostics.py
+- `client` — tests (direct attribute access for mock assertions)
+- `_transport` — tests (direct attribute access for mock assertions)
+- `retry` — tests
+- `force_full_register_list` — entity platforms and diagnostics.py
+
+## Duplicate Implementations Removed
+
+Six method implementations in `ThesslaGreenModbusCoordinator` that duplicated DeviceClient
+logic were replaced with delegation calls:
+
+| Method | Before | After |
+|--------|--------|-------|
+| `get_register_map` | `cast(dict[str, int], self._register_maps.get(...))` | `self._device_client.get_register_map(...)` |
+| `_get_client_method` | Full implementation iterating `(self._transport, self.client)` | `self._device_client._get_client_method(name)` |
+| `_find_register_name` | `_find_register_name_impl(self._reverse_maps, ...)` | `self._device_client._find_register_name(...)` |
+| `_process_register_value` | `_process_register_value_impl(...)` | `self._device_client._process_register_value(...)` |
+| `_mark_registers_failed` | `_mark_registers_failed_impl(self, names)` | `self._device_client._mark_registers_failed(names)` |
+| `_clear_register_failure` | `_clear_register_failure_impl(self, name)` | `self._device_client._clear_register_failure(name)` |
+
+## Imports Removed from coordinator.py
+
+- `from .register_processing import find_register_name as _find_register_name_impl`
+- `from .register_processing import process_register_value as _process_register_value_impl`
+- `from .runtime_state import clear_register_failure as _clear_register_failure_impl`
+- `from .runtime_state import mark_registers_failed as _mark_registers_failed_impl`
+- `from typing import cast` (no longer needed after delegation)
+
+## Future Removal Path
+
+Proxy properties can be removed one-by-one as their consuming submodules are
+updated to accept a `DeviceClient` directly instead of the coordinator. Recommended
+approach:
+
+1. Update a coordinator submodule to accept `DeviceClient | ThesslaGreenModbusCoordinator`
+   via a `Protocol` or union type.
+2. Remove the corresponding proxy property from the coordinator.
+3. Update callers of the coordinator method to go through `coordinator._device_client`.
+
+High-value candidates for future removal (internal-only usage):
+- `_update_in_progress` — only accessed by `update_state` module
+- `_last_power_timestamp`, `_total_energy` — only accessed by `capabilities_mixin`
+- `_input_registers_rev`, `_holding_registers_rev`, `_coil_registers_rev`, `_discrete_inputs_rev` — only accessed during initialization in `state.py`

--- a/docs/device_client_cleanup_inventory.md
+++ b/docs/device_client_cleanup_inventory.md
@@ -1,0 +1,79 @@
+# Device Client Cleanup – Architecture Inventory
+
+## Summary
+
+This document inventories the current architecture prior to the device-client cleanup pass.
+
+## Current Proxy Count
+
+The `ThesslaGreenModbusCoordinator` in `coordinator/coordinator.py` exposes **38 proxy property pairs** (getter + setter) that delegate to `self._device_client`:
+
+| Group | Properties |
+|-------|-----------|
+| Config | `config`, `_device_name`, `_resolved_connection_mode` |
+| Settings | `timeout`, `retry`, `backoff`, `backoff_jitter`, `force_full_register_list`, `scan_uart_settings`, `deep_scan`, `safe_scan`, `skip_missing_registers`, `effective_batch`, `max_registers_per_request` |
+| Connection state | `client`, `_transport`, `_client_lock`, `_write_lock`, `_update_in_progress`, `offline_state` |
+| Device info | `capabilities`, `device_info` |
+| Register maps | `available_registers`, `_register_maps`, `_reverse_maps`, `_input_registers_rev`, `_holding_registers_rev`, `_coil_registers_rev`, `_discrete_inputs_rev`, `_register_groups`, `_failed_registers` |
+| Statistics | `statistics`, `_consecutive_failures`, `_max_failures` |
+| Scan state | `device_scan_result`, `unknown_registers`, `scanned_registers`, `last_scan` |
+| Capabilities mixin | `_last_power_timestamp`, `_total_energy` |
+
+## Coordinator-Owned State
+
+All mutable device-domain state lives in `ThesslaGreenDeviceClient`. The coordinator owns:
+- HA-specific lifecycle (`DataUpdateCoordinator` base class)
+- `scan_interval` (HA update interval)
+- `_reauth_scheduled` flag
+- `_stop_listener` callback
+- HA `entry` reference (via base class)
+
+## Major Responsibility Groups in `core/client.py`
+
+| Group | Lines | Methods |
+|-------|-------|---------|
+| Connection lifecycle | ~233–296 | `async_ensure_connected`, `async_disconnect`, `async_close`, `async_test_connection`, `_disconnect_locked`, `_ensure_connection`, `_disconnect`, `_close_client_connection` |
+| Transport construction | ~301–389 | `_build_tcp_transport`, `_try_direct_client_connect`, `_build_transport_selector_fn` |
+| Scanner orchestration | ~394–419 | `async_create_scanner`, `async_scan_device`, `_normalise_available_registers` |
+| Register groups | ~424–432 | `compute_register_groups` |
+| IO mixin helpers | ~437–467 | `_find_register_name`, `_process_register_value`, `_mark_registers_failed`, `_clear_register_failure`, `_get_client_method` |
+| Write support | ~472–514 | `async_write_register` |
+| Public API | ~519–544 | `get_device_info`, `get_capabilities`, `get_register_map`, `is_connected`, `selected_transport` |
+
+## Helper Modules Depending on Coordinator Proxies
+
+All coordinator submodules use duck-typing — they receive the coordinator (or device client)
+as a parameter and access attributes directly. The key submodules are:
+
+- `coordinator/runtime_io.py` — `client`, `_transport`, `timeout`, `retry`, `backoff`, `backoff_jitter`
+- `coordinator/read_batches.py` — `_register_groups`, `available_registers`, `effective_batch`, `client`, `_transport`
+- `coordinator/read_bits.py` — `_register_groups`, `effective_batch`, `client`, `_transport`
+- `coordinator/register_groups.py` — `available_registers`, `_register_groups`, `safe_scan`, `effective_batch`
+- `coordinator/scanner_kwargs.py` — nearly all scan/connection settings
+- `coordinator/state.py` — initializes all device-domain state attributes
+- `coordinator/scan_result.py` — `device_scan_result`, `_resolved_connection_mode`, `capabilities`, `available_registers`, `device_info`, `last_scan`
+- `coordinator/update_result.py` — `statistics`, `_consecutive_failures`, `offline_state`
+- `coordinator/errors.py` — `statistics`, `_consecutive_failures`, `_max_failures`, `offline_state`
+- `services/handlers_data.py` — `timeout`, `retry`, `scan_uart_settings`, `effective_batch`, `unknown_registers`, `scanned_registers`
+
+## External Callers of Coordinator Properties
+
+### Entity Platform Files
+- `available_registers`, `capabilities`, `force_full_register_list`, `device_info`, `statistics`, `device_scan_result`
+
+### Test Files
+- `available_registers`, `client`, `_transport`, `capabilities`, `device_info`, `retry`, `statistics`
+- Tests also patch: `coordinator.coordinator.AsyncModbusTcpClient`
+
+## Recommended Extraction Boundaries
+
+Based on the responsibility groups in `core/client.py`:
+
+1. **`core/client_connection.py`** — Connection lifecycle + transport construction (11 methods)
+2. **`core/client_scanner.py`** — Scanner orchestration (3 methods)
+3. **`core/client_registers.py`** — Register groups + IO helpers + write support (7 methods)
+4. **`core/client.py`** — `__init__` + public API (5 methods/properties) → thin composition root
+
+For coordinator proxies, all 38 properties must be retained to preserve duck-typing used
+by coordinator submodule functions and tests. Duplicate method implementations (where the
+coordinator re-implements logic instead of delegating) are the primary target for removal.

--- a/docs/device_client_cleanup_report.md
+++ b/docs/device_client_cleanup_report.md
@@ -1,0 +1,226 @@
+# Device Client Architecture Cleanup – Final Report
+
+## Summary
+
+This PR completes a controlled extraction/refinement pass on the device-client
+architecture. No Modbus behavior, register semantics, entity IDs, service IDs,
+unique IDs, or translation keys were changed.
+
+---
+
+## Phase 2: core/client.py Split
+
+### Before
+
+`core/client.py` contained a single `ThesslaGreenDeviceClient` class with **544 lines**
+mixing connection lifecycle, transport construction, scanner orchestration, register
+groups, IO helpers, write support, and public API.
+
+### After
+
+| File | Lines | Responsibility |
+|------|-------|---------------|
+| `core/client.py` | 188 | Composition root, `__init__`, public API |
+| `core/client_connection.py` | 252 | Connection lifecycle + transport construction |
+| `core/client_scanner.py` | 52 | Scanner orchestration + register normalization |
+| `core/client_registers.py` | 144 | Register groups, IO helpers, write support |
+
+**`core/client.py` reduced by 356 lines (65%).**
+
+### Extraction Strategy
+
+Each extracted group became a mixin class (`_DeviceClientConnectionMixin`,
+`_DeviceClientScannerMixin`, `_DeviceClientRegistersMixin`). The main class
+`ThesslaGreenDeviceClient` inherits from all three mixins plus the pre-existing
+`_ModbusIOMixin` and `_CoordinatorCapabilitiesMixin` from the coordinator package.
+
+This is consistent with the existing mixin pattern (coordinator also uses
+`_ModbusIOMixin`, `_CoordinatorCapabilitiesMixin`, `_CoordinatorConfigPropertiesMixin`,
+`_CoordinatorScheduleMixin`).
+
+### Public API Preserved
+
+The public API of `ThesslaGreenDeviceClient` is **completely unchanged**:
+- All method signatures are identical.
+- All attributes initialized in `__init__` are identical.
+- The import path `from core.client import ThesslaGreenDeviceClient` is unchanged.
+
+---
+
+## Phase 3: Coordinator Proxy Cleanup
+
+### Duplicate Implementations Removed
+
+6 method implementations in `ThesslaGreenModbusCoordinator` that duplicated DeviceClient
+logic were replaced with clean delegation:
+
+```
+get_register_map        → self._device_client.get_register_map(register_type)
+_get_client_method      → self._device_client._get_client_method(name)
+_find_register_name     → self._device_client._find_register_name(...)
+_process_register_value → self._device_client._process_register_value(...)
+_mark_registers_failed  → self._device_client._mark_registers_failed(names)
+_clear_register_failure → self._device_client._clear_register_failure(name)
+```
+
+### Imports Removed from coordinator.py
+
+5 imports became unused after delegation and were removed:
+- `find_register_name as _find_register_name_impl`
+- `process_register_value as _process_register_value_impl`
+- `clear_register_failure as _clear_register_failure_impl`
+- `mark_registers_failed as _mark_registers_failed_impl`
+- `cast` (from typing)
+
+### Proxy Properties: All 38 Retained
+
+All 38 proxy properties in `ThesslaGreenModbusCoordinator` are retained because:
+- Coordinator submodule functions receive the coordinator via duck-typing and access
+  properties directly (changing their signatures is a separate, larger refactor).
+- Test files directly access coordinator attributes for assertion and mocking.
+- Entity platform files access coordinator properties directly.
+
+A comprehensive retention rationale comment block was added before the proxy property
+section in `coordinator.py`.
+
+For full details see `docs/coordinator_proxy_cleanup.md`.
+
+---
+
+## Phase 4: Dependency Direction
+
+Dependency flow after this PR:
+
+```
+entities / services / scanner
+        ↓
+ThesslaGreenModbusCoordinator (coordinator.coordinator)
+        ↓
+ThesslaGreenDeviceClient (core.client*)
+        ↓
+coordinator submodules (connection, io, scan, register_groups, …)
+        ↓
+transport / registers / modbus
+```
+
+No circular imports exist at module level. The only dynamic import is in
+`_DeviceClientConnectionMixin._try_direct_client_connect` which imports
+`coordinator as coordinator_pkg` inside the method body — this is intentional
+to allow test patching of `coordinator.coordinator.AsyncModbusTcpClient`.
+
+---
+
+## Validation Results
+
+### Compile
+
+```
+python -m compileall -q custom_components/thessla_green_modbus tests tools
+# → no errors
+```
+
+### Ruff Lint
+
+```
+ruff check custom_components tests tools
+# → All checks passed!
+```
+
+### Ruff Import Sort
+
+```
+ruff check --select I custom_components tests tools
+# → All checks passed!
+```
+
+### Ruff Format
+
+```
+ruff format --check custom_components tests tools
+# → 432 files already formatted
+```
+
+### Maintainability Gate
+
+```
+python tools/check_maintainability.py
+# → Maintainability gate passed.
+```
+
+### Translations
+
+```
+python tools/check_translations.py
+# → All translation keys present.
+```
+
+### Register Comparison
+
+```
+python tools/compare_registers_with_reference.py
+# → Same output as baseline (extra entries pre-existed; no regressions).
+```
+
+### pytest
+
+**Environmental note**: The test environment runs Python 3.11 but
+`pytest-homeassistant-custom-component>=0.13.309` requires Python >=3.12.
+Attempting to install this version on Python 3.11 fails with build errors
+on native packages (PyRIC, mock-open). This was the pre-existing baseline
+state — not introduced by this PR.
+
+The code compiles cleanly (`compileall` passes) and all quality tools pass.
+The test suite cannot be executed in this environment due to the Python
+version mismatch, not due to code changes.
+
+---
+
+## Behavioral Confirmation
+
+| Requirement | Status |
+|-------------|--------|
+| Modbus behavior unchanged | ✅ No changes to modbus read/write path |
+| Entity IDs unchanged | ✅ No entity registration code touched |
+| Unique IDs unchanged | ✅ No unique ID generation code touched |
+| Service IDs unchanged | ✅ No service registration code touched |
+| Register names unchanged | ✅ No register map or const.py changes |
+| Register addresses unchanged | ✅ No register map changes |
+| Translation keys unchanged | ✅ No strings.json or translations/ changes |
+| No compatibility shims | ✅ No shim files created |
+| No modbus_helpers.py | ✅ Not reintroduced |
+
+---
+
+## Remaining Architectural Debt
+
+1. **38 coordinator proxy properties** — Required by duck-typing design of all
+   coordinator submodule functions. Reducing them requires updating submodule
+   function signatures to accept `DeviceClient` directly (significant follow-up work).
+
+2. **`_ModbusIOMixin` and `_CoordinatorCapabilitiesMixin` live in `coordinator/`** — Both
+   are imported by `core/client.py`. They could be moved to `core/` in a future pass,
+   making the dependency direction cleaner: `core → coordinator_submodules` would become
+   `core → core_mixins`.
+
+3. **`coordinator.schedule._get_register_definition` dynamic import** — Imports
+   `coordinator_module.get_register_definition` dynamically to allow test patching.
+   If `get_register_definition` were moved to `registers/` this coupling could be removed.
+
+4. **`_try_direct_client_connect` dynamic coordinator import** — Similarly accesses
+   `coordinator.coordinator.AsyncModbusTcpClient` at runtime for test patchability.
+   Could be resolved by making the TCP client class injectable at construction time.
+
+---
+
+## Files Changed
+
+```
+M custom_components/thessla_green_modbus/coordinator/coordinator.py
+M custom_components/thessla_green_modbus/core/client.py
+A custom_components/thessla_green_modbus/core/client_connection.py
+A custom_components/thessla_green_modbus/core/client_scanner.py
+A custom_components/thessla_green_modbus/core/client_registers.py
+A docs/coordinator_proxy_cleanup.md
+A docs/device_client_cleanup_inventory.md
+A docs/device_client_cleanup_report.md
+```


### PR DESCRIPTION
## Summary

Internal architecture cleanup continuing the post-DeviceClient refactor. No Modbus behavior, entity IDs, unique IDs, service IDs, register names, register addresses, or translation keys were changed.

## Extracted core/client.py Responsibilities

`core/client.py` was split from **544 lines** into four focused modules:

| File | Lines | Responsibility |
|------|-------|---------------|
| `core/client.py` | 188 | Composition root, `__init__`, public API only |
| `core/client_connection.py` | 252 | Connection lifecycle + transport construction (11 methods) |
| `core/client_scanner.py` | 52 | Scanner orchestration + register normalization (4 methods) |
| `core/client_registers.py` | 144 | Register groups, IO helpers, write support (7 methods) |

`core/client.py` reduced by **65%**. The public `ThesslaGreenDeviceClient` API is completely unchanged — same import path, same method signatures, same attributes.

Each extracted group is a mixin class (`_DeviceClientConnectionMixin`, `_DeviceClientScannerMixin`, `_DeviceClientRegistersMixin`), consistent with the existing `_ModbusIOMixin` / `_CoordinatorCapabilitiesMixin` pattern.

## Coordinator Proxy Cleanup Summary

**6 duplicate method implementations** in `ThesslaGreenModbusCoordinator` were replaced with clean delegation to `_device_client`:

- `get_register_map` — was reimplementing `cast(dict[str, int], self._register_maps.get(...))`
- `_get_client_method` — was reimplementing full transport/client method lookup loop
- `_find_register_name` — was calling `_find_register_name_impl(self._reverse_maps, ...)`
- `_process_register_value` — was calling `_process_register_value_impl(...)`
- `_mark_registers_failed` — was calling `_mark_registers_failed_impl(self, ...)`
- `_clear_register_failure` — was calling `_clear_register_failure_impl(self, ...)`

**5 imports** removed from `coordinator.py` after delegation made them unused.

**All 38 proxy properties retained** — required by coordinator submodule duck-typing and direct access from test/entity files. A block documentation comment was added explaining the retention rationale and future removal path for each group.

## Dependency Cleanup Summary

Dependency flow verified clean after extraction:

```
entities / services / scanner
        ↓
ThesslaGreenModbusCoordinator  (coordinator.coordinator)
        ↓
ThesslaGreenDeviceClient       (core.client*)
        ↓
coordinator submodules         (connection, io, scan, register_groups, …)
        ↓
transport / registers / modbus
```

No circular imports at module level. The only dynamic import (`coordinator as coordinator_pkg` inside `_try_direct_client_connect`) is intentional for test patchability.

## Validation Results

| Check | Result |
|-------|--------|
| `python -m compileall` | ✅ Clean |
| `ruff check` | ✅ All checks passed |
| `ruff check --select I` (imports) | ✅ All checks passed |
| `ruff format --check` | ✅ 432 files already formatted |
| `tools/check_maintainability.py` | ✅ Maintainability gate passed |
| `tools/check_translations.py` | ✅ All translation keys present |
| `tools/compare_registers_with_reference.py` | ✅ No regressions (extras pre-existed) |
| Merge conflict markers | ✅ None |
| Compatibility shims | ✅ None introduced |

**Note on pytest**: `pytest-homeassistant-custom-component>=0.13.309` requires Python ≥3.12 but the remote execution environment runs Python 3.11. This is a pre-existing environmental constraint; the test collection failure existed before this PR.

## Behavioral Confirmation

- ✅ Modbus behavior did not change — no changes to read/write path or register encoding
- ✅ Entity IDs did not change — no entity registration code touched
- ✅ Unique IDs did not change — no unique ID generation touched
- ✅ Service IDs did not change — no service registration touched
- ✅ Register names did not change — no register map or const.py changes
- ✅ Register addresses did not change — no register map changes
- ✅ Translation keys did not change — no strings.json or translations/ changes

## Remaining Architectural Debt

1. **38 coordinator proxy properties** remain — reducing them requires updating coordinator submodule function signatures to accept `DeviceClient` directly (significant separate effort).
2. `_ModbusIOMixin` and `_CoordinatorCapabilitiesMixin` still live in `coordinator/` — could be moved to `core/` in a future pass.
3. `_try_direct_client_connect` dynamic coordinator import — could be resolved by making the TCP client class injectable at construction time.

See `docs/coordinator_proxy_cleanup.md` and `docs/device_client_cleanup_report.md` for full details.

https://claude.ai/code/session_01RkYqgB555qGxknQxiPSDur

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkYqgB555qGxknQxiPSDur)_