### PR TITLE
refactor: remove final transport compatibility shim

### DIFF
--- a/docs/final_architecture_cleanup.md
+++ b/docs/final_architecture_cleanup.md
@@ -11,8 +11,8 @@
 - `except BaseException` retry path in config flow runtime was narrowed to `CancelledError` + `Exception`.
 
 ## Compatibility shims
-- `modbus_transport.py` remains as a minimal shim to avoid abrupt external breakage; it now directly re-exports from canonical `transport.retry`.
-- `modbus_helpers.py` remains due to broad test and potential external compatibility surface; future removal should be staged.
+- `modbus_transport.py` has been removed. All callers import directly from canonical `transport.*` modules.
+- `modbus_helpers.py` has been removed. All callers import directly from canonical `core.*` modules.
 
 ## Const/entity lookup
 - `const.py` compatibility wrapper block for `_ENTITY_LOOKUP` and unique-id wrappers removed.

--- a/docs/final_transport_shim_cleanup_report.md
+++ b/docs/final_transport_shim_cleanup_report.md
@@ -1,0 +1,111 @@
+# Final Transport Shim Cleanup Report
+
+Branch: `claude/remove-final-shim-Kn2oC`
+Base: `main`
+
+## Objective
+
+Remove the root-level compatibility shim
+`custom_components/thessla_green_modbus/modbus_transport.py`
+and all stale references to it.
+
+## Finding: Shim Was Already Removed
+
+The file `modbus_transport.py` was deleted in a prior commit (`ed88bb3c` —
+"fix: repair broken transport imports and remove modbus_transport shim").
+It does not exist on `main`. No production code, test code, or tooling
+actively imports from it.
+
+This pass removed the **three stale references** left over from when the
+file existed.
+
+## Changes Made
+
+### 1. `tools/check_maintainability.py` — removed stale `STRICT_PATH_LIMITS` entry
+
+The dict contained an entry for `modbus_transport.py` with custom size limits
+`(930, 210)`. Since the file no longer exists the entry was dead code and
+was removed.
+
+### 2. `tests/test_error_contract.py` — updated logger name string
+
+`test_cross_layer_retry_logging_contract` passed an arbitrary logger to
+`log_transport_retry` using the old module path as its name:
+
+```python
+# Before
+logger=logging.getLogger("custom_components.thessla_green_modbus.modbus_transport"),
+
+# After
+logger=logging.getLogger("custom_components.thessla_green_modbus.transport.retry_logging"),
+```
+
+The logger name is an arbitrary string (not an import); the test assertion
+checks only for `"layer=transport"` in the output, not the logger name.
+Updated to the canonical module where `log_transport_retry` is implemented.
+
+### 3. `docs/final_architecture_cleanup.md` — corrected outdated claim
+
+Updated the "Compatibility shims" section from "remains as a minimal shim"
+to "has been removed. All callers import directly from canonical `transport.*`
+modules."
+
+## Canonical Transport Import Paths Now Used Everywhere
+
+| Formerly from shim | Now from canonical module |
+|--------------------|--------------------------|
+| `calculate_backoff` | `transport.retry` |
+| `classify_transport_error` | `transport.retry` |
+| `should_retry` | `transport.retry` |
+| `ErrorKind` | `transport.retry` |
+| `RetryDecision` | `transport.retry` |
+| `log_transport_retry` | `transport.retry_logging` |
+| `apply_transport_backoff` | `transport.retry_logging` |
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| `python -m compileall -q custom_components tests tools` | PASS |
+| `ruff check custom_components tests tools` | PASS |
+| `ruff check --select I custom_components tests tools` | PASS |
+| `ruff format --check custom_components tests tools` | PASS (432 files formatted) |
+| `python tools/check_maintainability.py` | PASS |
+| `python tools/check_translations.py` | PASS |
+| `python tools/compare_registers_with_reference.py` | PASS (62 extras expected; 242 name mismatches pre-existing) |
+| No merge conflict markers | PASS |
+| No remaining `modbus_transport` active imports | PASS |
+| No remaining compatibility shim markers in production code | PASS |
+
+### pytest Environment Limitation
+
+The environment runs Python 3.11.15.
+`pytest-homeassistant-custom-component>=0.13.309` requires Python >= 3.12 and
+could not be installed. pytest is not available in this environment.
+Compilation and static analysis pass; runtime test results must be verified
+in a Python 3.12+ CI environment.
+
+## Confirmed No Behavior Changes
+
+- No Modbus register addresses changed
+- No register names changed
+- No entity IDs changed
+- No unique IDs changed
+- No service IDs changed
+- No translation keys changed
+- No config/options flow behavior changed
+- No new compatibility shims created
+
+## Remaining Compatibility Surfaces
+
+None. All references to `modbus_transport` are now exclusively:
+
+- Historical notes in previously-written documentation files
+- `test_modbus_transport_*.py` file names and docstrings (which are
+  historical labels — the files import from canonical `transport.*` modules)
+
+## Recommended Next Step
+
+Real-device validation against a ThesslaGreen AirPack unit running HA with
+this integration to confirm no regression in register reads, entity values,
+or coordinator scan/update behavior.

--- a/docs/final_transport_shim_inventory.md
+++ b/docs/final_transport_shim_inventory.md
@@ -1,0 +1,61 @@
+# Final Transport Shim Inventory
+
+Branch: `claude/remove-final-shim-Kn2oC`
+Base: `main`
+
+## Shim Under Review
+
+`custom_components/thessla_green_modbus/modbus_transport.py`
+
+## Finding: Shim Already Removed
+
+The file `modbus_transport.py` was removed in a prior commit
+(`ed88bb3c` — "fix: repair broken transport imports and remove modbus_transport shim"),
+which predates this branch. It does not exist on `main`.
+
+There is no shim file to delete. This pass focuses on removing stale references
+left over from when the file existed.
+
+## Prior Shim Contents (from git history)
+
+The shim was a pure re-export module that forwarded names from
+`transport.retry` and `transport.retry_logging` into the root namespace.
+It contained no real logic — only `from .transport.retry import ...` and
+`from .transport.retry_logging import ...` statements.
+
+## Remaining Stale References (before this pass)
+
+| Location | Kind | Detail |
+|----------|------|--------|
+| `tools/check_maintainability.py:17` | Dead config entry | `STRICT_PATH_LIMITS` contained an entry for the now-deleted path; the entry was never matched at runtime but was misleading |
+| `tests/test_error_contract.py:69` | Stale logger name string | `logging.getLogger("...modbus_transport")` used as an arbitrary logger name in a cross-layer retry-logging test; the test does not import from the deleted module, but the name referenced the old shim path |
+| `docs/final_architecture_cleanup.md:14` | Outdated doc claim | Stated "modbus_transport.py remains as a minimal shim"; this was written before the shim was deleted |
+
+## Canonical Replacement Module Paths
+
+All symbols formerly re-exported by `modbus_transport.py` are now in:
+
+| Symbol | Canonical module |
+|--------|-----------------|
+| `calculate_backoff` | `transport.retry` |
+| `classify_transport_error` | `transport.retry` |
+| `should_retry` | `transport.retry` |
+| `ErrorKind` | `transport.retry` |
+| `RetryDecision` | `transport.retry` |
+| `log_transport_retry` | `transport.retry_logging` |
+| `apply_transport_backoff` | `transport.retry_logging` |
+
+## Classification of Usage
+
+| Reference | Type | Safely removable / fixable? |
+|-----------|------|-----------------------------|
+| `tools/check_maintainability.py` STRICT_PATH_LIMITS entry | Tooling dead code | Yes — remove the stale dict entry |
+| `tests/test_error_contract.py` logger name string | Test string (not an import) | Yes — update string to canonical module path |
+| `docs/final_architecture_cleanup.md` claim | Documentation (outdated) | Yes — update to reflect removal |
+
+## Verdict
+
+The shim is safely fully removed. No active production imports, no active test
+imports from `modbus_transport` exist. Only three stale references (one tool
+config entry, one logger-name string, one doc sentence) remain and are fixed by
+this pass.

--- a/tests/test_error_contract.py
+++ b/tests/test_error_contract.py
@@ -66,7 +66,7 @@ def test_cross_layer_retry_logging_contract(caplog: pytest.LogCaptureFixture) ->
         backoff=0.2,
     )
     log_transport_retry(
-        logger=logging.getLogger("custom_components.thessla_green_modbus.modbus_transport"),
+        logger=logging.getLogger("custom_components.thessla_green_modbus.transport.retry_logging"),
         operation="timeout",
         attempt=1,
         max_attempts=3,

--- a/tools/check_maintainability.py
+++ b/tools/check_maintainability.py
@@ -14,7 +14,6 @@ DEFAULT_SCAN_ROOTS = ("custom_components/thessla_green_modbus",)
 STRICT_PATH_LIMITS: dict[str, tuple[int, int]] = {
     "custom_components/thessla_green_modbus/coordinator/coordinator.py": (1200, 220),
     "custom_components/thessla_green_modbus/config_flow.py": (1000, 220),
-    "custom_components/thessla_green_modbus/modbus_transport.py": (930, 210),
     "custom_components/thessla_green_modbus/registers/loader.py": (860, 210),
     "custom_components/thessla_green_modbus/scanner/io_read.py": (820, 210),
     "custom_components/thessla_green_modbus/scanner/core.py": (760, 210),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Base branch:** `main`
- **Removed shim module:** `custom_components/thessla_green_modbus/modbus_transport.py`

`modbus_transport.py` was removed in a prior commit (`ed88bb3c` — "fix: repair broken transport imports and remove modbus_transport shim"). This PR cleans up the three stale references that remained after that deletion.

### Changes

| File | Change |
|------|--------|
| `tools/check_maintainability.py` | Removed dead `STRICT_PATH_LIMITS` entry for the deleted `modbus_transport.py` (was never matched at runtime) |
| `tests/test_error_contract.py` | Updated logger name string from old shim module path (`...modbus_transport`) to canonical module path (`...transport.retry_logging`) |
| `docs/final_architecture_cleanup.md` | Corrected outdated claim that shim "remains as a minimal shim" — it was already removed |
| `docs/final_transport_shim_inventory.md` | New: inventory documenting the shim's prior contents, all callers, and canonical replacement paths |
| `docs/final_transport_shim_cleanup_report.md` | New: cleanup report with validation results |

### Canonical Transport Import Paths Now Used Everywhere

| Formerly from shim | Canonical module |
|--------------------|-----------------|
| `calculate_backoff` | `transport.retry` |
| `classify_transport_error` | `transport.retry` |
| `should_retry` | `transport.retry` |
| `ErrorKind` | `transport.retry` |
| `RetryDecision` | `transport.retry` |
| `log_transport_retry` | `transport.retry_logging` |
| `apply_transport_backoff` | `transport.retry_logging` |

## Validation Results

| Check | Result |
|-------|--------|
| `python -m compileall -q custom_components tests tools` | PASS |
| `ruff check custom_components tests tools` | PASS |
| `ruff check --select I custom_components tests tools` | PASS |
| `ruff format --check custom_components tests tools` | PASS |
| `python tools/check_maintainability.py` | PASS |
| `python tools/check_translations.py` | PASS |
| `python tools/compare_registers_with_reference.py` | PASS (62 extras expected; 242 name mismatches pre-existing) |
| No remaining `modbus_transport` active imports | PASS |
| No merge conflict markers | PASS |

### pytest Environment Limitation

The environment runs Python 3.11.15. `pytest-homeassistant-custom-component>=0.13.309` requires Python >= 3.12 and could not be installed. pytest was not available. Compilation and all static analysis gates pass; runtime test results must be verified in a Python 3.12+ CI environment.

## Confirmations

- **No Modbus behavior changed** — only stale string/config references to the deleted module were updated
- **Entity IDs unchanged**
- **Unique IDs unchanged**
- **Service IDs unchanged**
- **Register names unchanged**
- **Register addresses unchanged**
- **Config/options flow behavior unchanged**
- **Translation keys unchanged**
- **No new compatibility shims created**

## Remaining Compatibility Surfaces

None. All remaining mentions of `modbus_transport` are exclusively historical notes in previously-written documentation and test-file docstrings (which are labels describing extraction history, not active imports).

## Recommended Next Step

Real-device validation against a ThesslaGreen AirPack unit running HA with this integration to confirm no regression in register reads, entity values, or coordinator scan/update behavior.
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaZusg7U8WfWWktxEZGst8)_