### PR TITLE
refactor: complete final shim audit cleanup

### DIFF
--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -7,41 +7,16 @@ from typing import Any
 # ---------------------------------------------------------------------------
 # Entity lookup — implementation lives in entity_lookup.py.
 # ---------------------------------------------------------------------------
-from .entity_lookup import _ENTITY_LOOKUP as _ENTITY_LOOKUP
 from .entity_lookup import _build_entity_lookup as _build_entity_lookup
 
 # ---------------------------------------------------------------------------
-# Options loading — implementation lives in options/__init__.py.
-# Re-exported here for backward compatibility.  Prefer importing from
-# .options in new code.
+# Register map helpers — used internally by migrate_unique_id below.
+# Canonical import path: .registers.maps
 # ---------------------------------------------------------------------------
-from .options import BYPASS_MODES as BYPASS_MODES
-from .options import DAYS_OF_WEEK as DAYS_OF_WEEK
-from .options import FILTER_TYPES as FILTER_TYPES
-from .options import GWC_MODES as GWC_MODES
-from .options import MODBUS_BAUD_RATES as MODBUS_BAUD_RATES
-from .options import MODBUS_PARITY as MODBUS_PARITY
-from .options import MODBUS_PORTS as MODBUS_PORTS
-from .options import MODBUS_STOP_BITS as MODBUS_STOP_BITS
-from .options import OPTIONS_PATH as OPTIONS_PATH
-from .options import PERIODS as PERIODS
-from .options import RESET_TYPES as RESET_TYPES
-from .options import SPECIAL_MODE_OPTIONS as SPECIAL_MODE_OPTIONS
-from .options import _get_options_init_lock as _get_options_init_lock
-from .options import _load_json_option as _load_json_option
-from .options import async_setup_options as async_setup_options
-
-# ---------------------------------------------------------------------------
-# Register map helpers — implementation lives in registers/maps.py.
-# Re-exported here for backward compatibility with callers that import from
-# this module.  Prefer importing from registers.maps in new code.
-# ---------------------------------------------------------------------------
-from .registers.maps import _build_map as _build_map
 from .registers.maps import coil_registers as coil_registers
 from .registers.maps import discrete_input_registers as discrete_input_registers
 from .registers.maps import holding_registers as holding_registers
 from .registers.maps import input_registers as input_registers
-from .registers.maps import multi_register_sizes as multi_register_sizes
 
 # ---------------------------------------------------------------------------
 # Unique-ID helpers — thin façades over unique_id_migration.

--- a/custom_components/thessla_green_modbus/registers/reference.py
+++ b/custom_components/thessla_green_modbus/registers/reference.py
@@ -1,1 +1,0 @@
-"""Reserved module placeholder for future static register references."""

--- a/custom_components/thessla_green_modbus/scanner/register_map_cache.py
+++ b/custom_components/thessla_green_modbus/scanner/register_map_cache.py
@@ -10,7 +10,7 @@ REGISTER_HASH = _register_maps.REGISTER_HASH
 
 
 def sync_register_hash_from_maps() -> str:
-    """Synchronize cached register hash from scanner_register_maps."""
+    """Synchronize cached register hash from scanner.register_maps."""
     global REGISTER_HASH
     REGISTER_HASH = _register_maps.REGISTER_HASH
     return REGISTER_HASH or ""

--- a/custom_components/thessla_green_modbus/transport/crc.py
+++ b/custom_components/thessla_green_modbus/transport/crc.py
@@ -19,8 +19,3 @@ def crc16_bytes(data: bytes) -> bytes:
 
 def append_crc(data: bytes) -> bytes:
     return data + crc16_bytes(data)
-
-
-# Aliases used by tests and compatibility shims
-_crc16 = crc16
-_append_crc = append_crc

--- a/custom_components/thessla_green_modbus/transport/factory.py
+++ b/custom_components/thessla_green_modbus/transport/factory.py
@@ -1,1 +1,0 @@
-"""Reserved module placeholder for future transport factory abstractions."""

--- a/docs/final_architecture_cleanup.md
+++ b/docs/final_architecture_cleanup.md
@@ -15,8 +15,15 @@
 - `modbus_helpers.py` has been removed. All callers import directly from canonical `core.*` modules.
 
 ## Const/entity lookup
-- `const.py` compatibility wrapper block for `_ENTITY_LOOKUP` and unique-id wrappers removed.
-- `entity_lookup.py` is now the cache owner.
+- `const.py` dead re-exports removed: `_ENTITY_LOOKUP`, all 15 options symbols (BYPASS_MODES,
+  DAYS_OF_WEEK, FILTER_TYPES, GWC_MODES, MODBUS_BAUD_RATES, MODBUS_PARITY, MODBUS_PORTS,
+  MODBUS_STOP_BITS, OPTIONS_PATH, PERIODS, RESET_TYPES, SPECIAL_MODE_OPTIONS,
+  _get_options_init_lock, _load_json_option, async_setup_options), `_build_map`,
+  `multi_register_sizes`.
+- `_build_entity_lookup` retained in const.py — used internally by `migrate_unique_id`.
+- Register map functions (`coil_registers`, `discrete_input_registers`, `holding_registers`,
+  `input_registers`) retained in const.py — used internally by `migrate_unique_id`.
+- `entity_lookup.py` is the cache owner. Canonical: `.options`, `.registers.maps`.
 
 ## Risky areas intentionally not changed
 - No coordinator runtime redesign was performed (audit-only).

--- a/docs/final_shim_audit_inventory.md
+++ b/docs/final_shim_audit_inventory.md
@@ -1,0 +1,166 @@
+# Final Shim Audit Inventory
+
+Branch: `refactor/final-shim-audit-cleanup`
+Base: `main`
+Generated during Phase 1 of the final repository-wide shim audit.
+
+---
+
+## Active Shims Found and Removed
+
+### 1. Dead aliases in `transport/crc.py`
+
+**Type:** Dead module-level aliases  
+**File:** `custom_components/thessla_green_modbus/transport/crc.py` (lines 24–26)  
+**Content:**
+```python
+# Aliases used by tests and compatibility shims
+_crc16 = crc16
+_append_crc = append_crc
+```
+**Status:** Active production code  
+**Callers:** None. Tests create their own aliases via `import crc16 as _crc16`; no code imports `_crc16` or `_append_crc` from this module.  
+**Action:** Removed aliases and comment.  
+**Canonical replacement:** `from .crc import crc16`, `from .crc import append_crc`
+
+---
+
+### 2. Empty placeholder `registers/reference.py`
+
+**Type:** Reserved module placeholder (zero code lines)  
+**File:** `custom_components/thessla_green_modbus/registers/reference.py`  
+**Content:** `"""Reserved module placeholder for future static register references."""` (docstring only)  
+**Status:** Active production code (importable but empty)  
+**Callers:** None  
+**Action:** Deleted.
+
+---
+
+### 3. Empty placeholder `transport/factory.py`
+
+**Type:** Reserved module placeholder (zero code lines)  
+**File:** `custom_components/thessla_green_modbus/transport/factory.py`  
+**Content:** `"""Reserved module placeholder for future transport factory abstractions."""` (docstring only)  
+**Status:** Active production code (importable but empty)  
+**Callers:** None  
+**Action:** Deleted.
+
+---
+
+### 4. Dead options re-exports in `const.py`
+
+**Type:** Dead re-export block (backward compatibility shims)  
+**File:** `custom_components/thessla_green_modbus/const.py` (lines 13–32)  
+**Symbols removed:**
+- `BYPASS_MODES`, `DAYS_OF_WEEK`, `FILTER_TYPES`, `GWC_MODES`
+- `MODBUS_BAUD_RATES`, `MODBUS_PARITY`, `MODBUS_PORTS`, `MODBUS_STOP_BITS`
+- `OPTIONS_PATH`, `PERIODS`, `RESET_TYPES`, `SPECIAL_MODE_OPTIONS`
+- `_get_options_init_lock`, `_load_json_option`, `async_setup_options`
+
+**Status:** Active production code (re-exports with no callers)  
+**Callers:** None. All production code imports directly from `.options`. One test file (`test_options_loading.py`) accessed these via `const.*` and was updated to use canonical imports.  
+**Action:** Removed re-export block. Updated `tests/test_options_loading.py`.  
+**Canonical replacement:** `from .options import <symbol>` / `from custom_components.thessla_green_modbus.options import <symbol>`
+
+---
+
+### 5. Dead `_build_map` re-export in `const.py`
+
+**Type:** Dead re-export  
+**File:** `custom_components/thessla_green_modbus/const.py` (line 39)  
+**Status:** Active production code (re-export with no callers)  
+**Callers:** None  
+**Action:** Removed re-export.  
+**Canonical replacement:** `from .registers.maps import _build_map`
+
+---
+
+### 6. Dead `multi_register_sizes` re-export in `const.py`
+
+**Type:** Dead re-export  
+**File:** `custom_components/thessla_green_modbus/const.py` (line 44)  
+**Status:** Active production code (re-export with one test caller)  
+**Callers:** `tests/test_options_loading.py:52` — updated to import from canonical path.  
+**Action:** Removed re-export. Updated `tests/test_options_loading.py`.  
+**Canonical replacement:** `from custom_components.thessla_green_modbus.registers.maps import multi_register_sizes`
+
+---
+
+### 7. Dead `_ENTITY_LOOKUP` re-export in `const.py`
+
+**Type:** Dead re-export  
+**File:** `custom_components/thessla_green_modbus/const.py` (line 10)  
+**Status:** Active production code (re-export with no callers)  
+**Callers:** None (tests patch `entity_lookup._ENTITY_LOOKUP` directly)  
+**Action:** Removed re-export.  
+**Canonical replacement:** `from .entity_lookup import _ENTITY_LOOKUP`
+
+---
+
+### 8. Stale docstring in `scanner/register_map_cache.py`
+
+**Type:** Stale module name in docstring  
+**File:** `custom_components/thessla_green_modbus/scanner/register_map_cache.py:13`  
+**Content:** `"""Synchronize cached register hash from scanner_register_maps."""`  
+**Status:** Stale reference to old flat-file name `scanner_register_maps` (removed long ago)  
+**Action:** Updated to `scanner.register_maps` (canonical package path).
+
+---
+
+## Items Inspected and Retained (Justified)
+
+### `config_flow.py`
+
+**Type:** HA-required entrypoint module  
+**File:** `custom_components/thessla_green_modbus/config_flow.py`  
+**Comment:** "re-exported here so that the canonical import path continues to work"  
+**Justification:** Home Assistant requires a `config_flow.py` file with the `ConfigFlow` class at the integration root. The `_config_flow/` package is the internal implementation. This is a mandatory HA structural requirement, not a compatibility shim.  
+**Action:** Retained as-is.
+
+### Register map functions in `const.py`
+
+**Symbols:** `coil_registers`, `discrete_input_registers`, `holding_registers`, `input_registers`  
+**Justification:** Used internally by `migrate_unique_id` at lines 317–321. Not re-exports for external callers; internal imports needed for function implementation.  
+**Action:** Retained. Updated comment from "backward compatibility" to "used internally."
+
+### `_build_entity_lookup` in `const.py`
+
+**Justification:** Used internally by `migrate_unique_id` at line 316.  
+**Action:** Retained.
+
+### `modbus/__init__.py`
+
+**Type:** Package init (zero code lines, only docstring)  
+**Justification:** Required as a Python package init for the `modbus/` package which contains real modules (`call.py`, `client_close.py`, `frame_logging.py`, `framer.py`).  
+**Action:** Retained.
+
+### `coordinator/__init__.py`
+
+**Type:** Package init (5 code lines)  
+**Justification:** Exports `ThesslaGreenModbusCoordinator` — the integration's primary coordinator class. Legitimate public API.  
+**Action:** Retained.
+
+---
+
+## Stale Documentation Found and Updated
+
+### `docs/final_shim_cleanup_report.md`
+
+**Issue:** "Remaining Architectural Debt" section stated `modbus_transport.py` was still present. That file was deleted in commit `864539f6` (PR #1639) before this audit.  
+**Action:** Updated to reflect removal.
+
+### `docs/final_architecture_cleanup.md`
+
+**Issue:** "Const/entity lookup" section stated `_ENTITY_LOOKUP` had been removed from const.py in a prior PR; in fact it persisted until this audit.  
+**Action:** Updated with accurate record of what was removed in this PR.
+
+---
+
+## No Additional Shims Found
+
+Scanned with:
+- `rg -n "Compatibility shim|re-export|reexport|shim|legacy import|backward compat" custom_components tests tools docs`
+- `rg -n "modbus_helpers|modbus_transport|modbus_exceptions|scanner_helpers|scanner_register_maps|scanner_device_info|config_flow_runtime|config_flow_validation|config_flow_options_form|coordinator\.io|coordinator\.capabilities"` (as import paths)
+- File-shape audit for modules with ≤12 code lines
+
+No additional active shims were identified beyond those listed above.

--- a/docs/final_shim_audit_report.md
+++ b/docs/final_shim_audit_report.md
@@ -1,0 +1,157 @@
+# Final Shim Audit Report
+
+Branch: `refactor/final-shim-audit-cleanup`
+Base: `main`
+
+---
+
+## Summary
+
+A complete repository-wide audit for compatibility shims, re-export wrappers, legacy import
+paths, placeholder modules, and stale cleanup documentation. All active shims identified were
+removed or replaced with canonical imports. No behavior changes were made.
+
+---
+
+## Shims Found
+
+| Item | Location | Type |
+|------|----------|------|
+| Dead `_crc16` / `_append_crc` aliases | `transport/crc.py:24–26` | Dead aliases |
+| Empty placeholder | `registers/reference.py` | Zero-code placeholder |
+| Empty placeholder | `transport/factory.py` | Zero-code placeholder |
+| 15 dead options re-exports | `const.py:13–32` | Dead backward-compat re-exports |
+| Dead `_build_map` re-export | `const.py:39` | Dead re-export |
+| Dead `multi_register_sizes` re-export | `const.py:44` | Dead re-export (1 test caller updated) |
+| Dead `_ENTITY_LOOKUP` re-export | `const.py:10` | Dead re-export |
+| Stale module name in docstring | `scanner/register_map_cache.py:13` | Stale doc reference |
+
+---
+
+## Shims Removed
+
+| Item | Action |
+|------|--------|
+| `transport/crc.py` dead aliases `_crc16`, `_append_crc` and their comment | Deleted |
+| `registers/reference.py` empty placeholder | File deleted |
+| `transport/factory.py` empty placeholder | File deleted |
+| 15 options re-exports from `const.py` | Removed block; callers already used `.options` directly |
+| `_build_map` re-export from `const.py` | Removed (zero callers) |
+| `multi_register_sizes` re-export from `const.py` | Removed; test updated to canonical path |
+| `_ENTITY_LOOKUP` re-export from `const.py` | Removed (zero callers) |
+
+---
+
+## Compatibility Surfaces Intentionally Retained
+
+### `config_flow.py`
+
+Home Assistant requires a `config_flow.py` file at the integration root. This is a mandatory
+HA structural entrypoint, not a compatibility shim. It will always re-export `ConfigFlow` from
+the `_config_flow/` internal package.
+
+### Register map functions in `const.py`
+
+`coil_registers`, `discrete_input_registers`, `holding_registers`, `input_registers` remain
+imported in `const.py` because they are used internally by the `migrate_unique_id` function.
+These are not re-exports for external callers; they are internal imports for function use.
+
+### `_build_entity_lookup` in `const.py`
+
+Used internally by `migrate_unique_id`. Retained.
+
+---
+
+## Import Paths Migrated
+
+| File | Old import | New canonical import |
+|------|-----------|---------------------|
+| `tests/test_options_loading.py:27,39` | `const._load_json_option` | `custom_components.thessla_green_modbus.options._load_json_option` |
+| `tests/test_options_loading.py:52` | `from const import multi_register_sizes` | `from custom_components.thessla_green_modbus.registers.maps import multi_register_sizes` |
+| `tests/test_options_loading.py:80` | `const.async_setup_options` | `custom_components.thessla_green_modbus.options.async_setup_options` |
+| `tests/test_options_loading.py:82` | `const.MODBUS_BAUD_RATES` | `custom_components.thessla_green_modbus.options.MODBUS_BAUD_RATES` |
+
+---
+
+## Stale Docs Cleaned
+
+| Document | Issue | Fix |
+|----------|-------|-----|
+| `docs/final_shim_cleanup_report.md` | "Remaining Architectural Debt" stated `modbus_transport.py` still present; it was deleted in PR #1639 | Updated to reflect removal |
+| `docs/final_architecture_cleanup.md` | "Const/entity lookup" section had inaccurate claims about what had/hadn't been removed from const.py | Updated with accurate record |
+| `scanner/register_map_cache.py:13` | Docstring referenced old `scanner_register_maps` flat-file name | Updated to `scanner.register_maps` |
+
+---
+
+## Dependency Direction Check (Phase 5)
+
+`core/` imports from `coordinator/` (12+ import sites across `client.py`, `client_connection.py`,
+`client_registers.py`, `client_scanner.py`, `io_mixin.py`, `capabilities_mixin.py`).
+This is an architectural layering violation (core/ → coordinator/ creates circular dependency risk),
+but it cannot be fixed safely within the scope of this audit since it would require a major
+restructuring of the `ThesslaGreenDeviceClient` implementation. The violation is documented here.
+
+Expected direction: `coordinator/` → `core/`  
+Actual direction: `core/` ↔ `coordinator/` (bidirectional imports)
+
+This is pre-existing debt from the DeviceClient architecture introduced in PR #1633–#1637 and is
+out of scope for a shim-only audit.
+
+---
+
+## Validation Results
+
+| Gate | Result |
+|------|--------|
+| `python -m compileall -q custom_components tests tools` | PASS |
+| `ruff check custom_components tests tools` | PASS |
+| `ruff check --select I custom_components tests tools` | PASS |
+| `ruff format --check custom_components tests tools` | PASS (430 files formatted) |
+| `python tools/compare_registers_with_reference.py` | PASS (62 extras expected; 242 name mismatches pre-existing) |
+| `python tools/check_maintainability.py` | PASS |
+| `python tools/validate_entity_mappings.py` | PASS (366 entities validated) |
+| `python tools/check_translations.py` | PASS — All translation keys present |
+
+### pytest Environment Limitation
+
+Environment runs Python 3.11.15. `pytest-homeassistant-custom-component>=0.13.309` requires
+Python ≥3.12 and could not be installed. pytest could not collect tests. Compilation and static
+analysis pass. Runtime tests should be run in a Python 3.12+ CI environment (GitHub Actions uses
+Python 3.13 where the full suite passes).
+
+---
+
+## No Active Shim Markers Remain in Production Code
+
+`rg "Compatibility shim|Compatibility re-exports|kept for compatibility|wrapper module|alias module" custom_components/thessla_green_modbus` → no matches.
+
+---
+
+## Behavior Confirmation
+
+- No Modbus register addresses changed
+- No register names changed
+- No entity IDs changed
+- No unique IDs changed
+- No service IDs changed
+- No translation keys changed
+- No config/options flow behavior changed
+- No new compatibility shims created
+- No `modbus_helpers.py` reintroduced
+- No `modbus_transport.py` reintroduced
+
+---
+
+## Remaining Architectural Debt
+
+1. **core/ ↔ coordinator/ circular layering** — `core/` imports from `coordinator/`; this should
+   flow one-way. Fixing requires a structural refactor of `ThesslaGreenDeviceClient`. Out of scope
+   for this audit.
+
+---
+
+## Recommended Next Step
+
+Real-device validation against a ThesslaGreen AirPack unit running Home Assistant with this
+integration to confirm no regression in register reads, entity values, coordinator scan/update
+behavior, and config/options flow.

--- a/docs/final_shim_cleanup_report.md
+++ b/docs/final_shim_cleanup_report.md
@@ -78,9 +78,8 @@ environment and should be run in a Python 3.12+ CI environment.
 
 ## Remaining Architectural Debt
 
-- `modbus_transport.py` root-level shim still present (documented in
-  `docs/final_architecture_cleanup.md` as retained for external compatibility).
-  Removal is out of scope for this PR.
+None. `modbus_transport.py` was removed in commit `864539f6` (PR #1639).
+See `docs/final_transport_shim_cleanup_report.md` for the full removal record.
 
 ## Recommended Next Step
 

--- a/tests/test_options_loading.py
+++ b/tests/test_options_loading.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import custom_components.thessla_green_modbus.const as const
 import pytest
+from custom_components.thessla_green_modbus.options import _load_json_option, async_setup_options
 
 
 def test_deep_scan_defaults():
@@ -24,7 +25,7 @@ def test_missing_options_file(monkeypatch, caplog):
     monkeypatch.setattr(Path, "read_text", missing)
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        options = const._load_json_option("special_modes.json")
+        options = _load_json_option("special_modes.json")
 
     assert options == []  # nosec B101
 
@@ -36,7 +37,7 @@ def test_malformed_options_file(monkeypatch, caplog):
     monkeypatch.setattr(Path, "read_text", malformed)
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        options = const._load_json_option("special_modes.json")
+        options = _load_json_option("special_modes.json")
 
     assert options == []  # nosec B101
 
@@ -48,8 +49,8 @@ def test_scan_uart_defaults_enabled():
 
 
 def test_multi_register_sizes_returns_dict():
-    """multi_register_sizes() is called and returns a dict (const.py line 56)."""
-    from custom_components.thessla_green_modbus.const import multi_register_sizes
+    """multi_register_sizes() is called and returns a dict."""
+    from custom_components.thessla_green_modbus.registers.maps import multi_register_sizes
 
     result = multi_register_sizes()
     assert isinstance(result, dict)
@@ -76,7 +77,9 @@ def test_migrate_unique_id_base_uid_already_has_prefix():
 
 @pytest.mark.asyncio
 async def test_async_setup_options_no_hass_uses_sync_path():
-    """async_setup_options(None) falls back to synchronous loading (const.py line 408)."""
-    await const.async_setup_options(None)
+    """async_setup_options(None) falls back to synchronous loading."""
+    import custom_components.thessla_green_modbus.options as opts_mod
+
+    await async_setup_options(None)
     # After calling with hass=None, globals should still be set (sync path executed)
-    assert const.MODBUS_BAUD_RATES is not None
+    assert opts_mod.MODBUS_BAUD_RATES is not None


### PR DESCRIPTION
## Summary

Base branch: `main`

Complete repository-wide audit and removal of all remaining compatibility shims, re-export wrappers, empty placeholder modules, dead aliases, and stale documentation.

## Shims Found

| Item | Location | Type |
|------|----------|------|
| Dead `_crc16` / `_append_crc` aliases | `transport/crc.py:24–26` | Dead module aliases |
| Empty placeholder | `registers/reference.py` | Zero-code placeholder file |
| Empty placeholder | `transport/factory.py` | Zero-code placeholder file |
| 15 dead options re-exports | `const.py:13–32` | Dead backward-compat re-exports |
| Dead `_build_map` re-export | `const.py:39` | Dead re-export (zero callers) |
| Dead `multi_register_sizes` re-export | `const.py:44` | Dead re-export (1 test caller updated) |
| Dead `_ENTITY_LOOKUP` re-export | `const.py:10` | Dead re-export (zero callers) |
| Stale module name in docstring | `scanner/register_map_cache.py:13` | Stale flat-file reference |

## Shims Removed

- **`transport/crc.py`** — Deleted dead `_crc16 = crc16` and `_append_crc = append_crc` aliases and their misleading comment. Tests create their own aliases via `import crc16 as _crc16`; no code imported these underscore module attributes.
- **`registers/reference.py`** — Deleted. Zero code lines, zero callers.
- **`transport/factory.py`** — Deleted. Zero code lines, zero callers.
- **`const.py` options re-exports** — Removed all 15 symbols (BYPASS_MODES, DAYS_OF_WEEK, FILTER_TYPES, GWC_MODES, MODBUS_BAUD_RATES, MODBUS_PARITY, MODBUS_PORTS, MODBUS_STOP_BITS, OPTIONS_PATH, PERIODS, RESET_TYPES, SPECIAL_MODE_OPTIONS, `_get_options_init_lock`, `_load_json_option`, `async_setup_options`). All production callers already imported directly from `.options`.
- **`const.py` `_build_map`** — Removed dead re-export. Zero callers outside `registers/maps.py` itself.
- **`const.py` `multi_register_sizes`** — Removed re-export; one test updated to canonical `registers.maps` path.
- **`const.py` `_ENTITY_LOOKUP`** — Removed dead re-export. Tests patch `entity_lookup._ENTITY_LOOKUP` directly.

## Compatibility Surfaces Intentionally Retained and Rationale

| Item | Rationale |
|------|-----------|
| `config_flow.py` | Mandatory Home Assistant entrypoint; HA requires `config_flow.py` at integration root with the `ConfigFlow` class. Not a shim. |
| `coil_registers`, `discrete_input_registers`, `holding_registers`, `input_registers` in `const.py` | Used internally by `migrate_unique_id` (lines 317–321). Internal imports, not external re-exports. |
| `_build_entity_lookup` in `const.py` | Used internally by `migrate_unique_id` (line 316). |

## Canonical Import Paths Now Used

| Test file | Old path | New canonical path |
|-----------|----------|-------------------|
| `tests/test_options_loading.py` | `const._load_json_option` | `custom_components.thessla_green_modbus.options._load_json_option` |
| `tests/test_options_loading.py` | `from const import multi_register_sizes` | `from custom_components.thessla_green_modbus.registers.maps import multi_register_sizes` |
| `tests/test_options_loading.py` | `const.async_setup_options` | `custom_components.thessla_green_modbus.options.async_setup_options` |
| `tests/test_options_loading.py` | `const.MODBUS_BAUD_RATES` | `custom_components.thessla_green_modbus.options.MODBUS_BAUD_RATES` |

## Stale Docs Cleaned

- **`docs/final_shim_cleanup_report.md`** — Removed stale "Remaining Architectural Debt" claim that `modbus_transport.py` was still present (it was deleted in PR #1639).
- **`docs/final_architecture_cleanup.md`** — Updated "Const/entity lookup" section with accurate record of what was removed in prior PRs vs. this PR.
- **`scanner/register_map_cache.py:13`** — Updated docstring from stale flat-file name `scanner_register_maps` to canonical `scanner.register_maps`.

## Docs Added

- `docs/final_shim_audit_inventory.md` — Full inventory of every item inspected, classified, and actioned.
- `docs/final_shim_audit_report.md` — Comprehensive audit report covering all phases.

## Dependency Direction Check

`core/` imports from `coordinator/` at 12+ sites (client.py, client_connection.py, client_registers.py, client_scanner.py, io_mixin.py). This bidirectional layering is pre-existing architectural debt from the DeviceClient redesign (PRs #1633–#1637) and cannot be fixed safely within a shim-only audit. Documented in `docs/final_shim_audit_report.md`.

## Validation Results

| Gate | Result |
|------|--------|
| `python -m compileall -q custom_components tests tools` | ✅ PASS |
| `ruff check custom_components tests tools` | ✅ PASS |
| `ruff check --select I custom_components tests tools` | ✅ PASS |
| `ruff format --check custom_components tests tools` | ✅ PASS (430 files) |
| `python tools/compare_registers_with_reference.py` | ✅ PASS (62 extras expected) |
| `python tools/check_maintainability.py` | ✅ PASS |
| `python tools/validate_entity_mappings.py` | ✅ PASS (366 entities) |
| `python tools/check_translations.py` | ✅ PASS |

### pytest Environment Limitation

Environment runs Python 3.11.15. `pytest-homeassistant-custom-component>=0.13.309` requires Python ≥3.12 and could not be installed; pytest could not collect tests. Compilation and all static analysis gates pass. Runtime tests should be verified in the Python 3.12+ CI environment (GitHub Actions uses Python 3.13).

## Behavior Confirmation

- ✅ No Modbus behavior changed
- ✅ No entity IDs changed
- ✅ No unique IDs changed
- ✅ No service IDs changed
- ✅ No register names changed
- ✅ No register addresses changed
- ✅ No translation keys changed
- ✅ No config/options flow behavior changed
- ✅ No new compatibility shims created
- ✅ No removed modules reintroduced

## Recommended Next Step

Real-device validation against a ThesslaGreen AirPack unit running Home Assistant with this integration to confirm no regression in register reads, entity values, coordinator scan/update behavior, and config/options flow.

https://claude.ai/code/session_012cgWe48aHaCAjae771U5VL

---
_Generated by [Claude Code](https://claude.ai/code/session_012cgWe48aHaCAjae771U5VL)_