### PR TITLE
refactor: apply audit cleanup batch

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -37,6 +37,12 @@ from ..core.connection_test import run_connection_test as _run_connection_test_i
 from ..core.io_mixin import _ModbusIOMixin
 from ..core.models import CoordinatorConfig
 from ..core.retry import _PermanentModbusError
+from ..core.scan_helpers import (
+    normalise_available_registers as _normalise_available_registers_impl,
+)
+from ..core.scan_helpers import (
+    normalise_cached_register_name as _normalise_cached_register_name_impl,
+)
 from ..errors import CannotConnect
 from ..register_defs_cache import get_register_definitions
 from ..registers.maps import input_registers
@@ -84,12 +90,6 @@ from .scan import (
 )
 from .scan import (
     load_full_register_list as _load_full_register_list_impl,
-)
-from .scan import (
-    normalise_available_registers as _normalise_available_registers_impl,
-)
-from .scan import (
-    normalise_cached_register_name as _normalise_cached_register_name_impl,
 )
 from .scan import (
     prepare_registers_for_setup as _prepare_registers_for_setup_impl,

--- a/custom_components/thessla_green_modbus/coordinator/scan.py
+++ b/custom_components/thessla_green_modbus/coordinator/scan.py
@@ -6,10 +6,7 @@ import logging
 from typing import Any
 
 from ..const import DEFAULT_NAME, KNOWN_MISSING_REGISTERS, UNKNOWN_MODEL
-from ..core.scan_helpers import (  # noqa: F401 – re-exported for coordinator internal use
-    normalise_available_registers,
-    normalise_cached_register_name,
-)
+from ..core.scan_helpers import normalise_available_registers
 from ..scanner.device_info import DeviceCapabilities
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/thessla_green_modbus/entity_lookup.py
+++ b/custom_components/thessla_green_modbus/entity_lookup.py
@@ -2,22 +2,20 @@
 
 from __future__ import annotations
 
-_ENTITY_LOOKUP: dict[str, tuple[str, str | None, int | None]] | None = None
+import functools
 
 
+@functools.cache
 def _build_entity_lookup() -> dict[str, tuple[str, str | None, int | None]]:
     """Build and cache a mapping of entity keys to register info."""
-    global _ENTITY_LOOKUP
-    if _ENTITY_LOOKUP is None:
-        from .mappings import ENTITY_MAPPINGS as _MAP
+    from .mappings import ENTITY_MAPPINGS as _MAP
 
-        lookup: dict[str, tuple[str, str | None, int | None]] = {}
-        for platform in ("sensor", "binary_sensor", "switch", "select", "number"):
-            for key, cfg in _MAP.get(platform, {}).items():
-                register = cfg.get("register", key)
-                lookup[key] = (register, cfg.get("register_type"), cfg.get("bit"))
-        _ENTITY_LOOKUP = lookup
-    return _ENTITY_LOOKUP
+    lookup: dict[str, tuple[str, str | None, int | None]] = {}
+    for platform in ("sensor", "binary_sensor", "switch", "select", "number"):
+        for key, cfg in _MAP.get(platform, {}).items():
+            register = cfg.get("register", key)
+            lookup[key] = (register, cfg.get("register_type"), cfg.get("bit"))
+    return lookup
 
 
-__all__ = ["_ENTITY_LOOKUP", "_build_entity_lookup"]
+__all__ = ["_build_entity_lookup"]

--- a/custom_components/thessla_green_modbus/mappings/__init__.py
+++ b/custom_components/thessla_green_modbus/mappings/__init__.py
@@ -28,9 +28,9 @@ from ..registers.maps import (
 # Submodule imports — each submodule owns its code; __init__ is the controller
 # ---------------------------------------------------------------------------
 from ._helpers import (
-    _REGISTER_INFO_CACHE,
     _get_register_info,
     _infer_icon,
+    _load_register_info,
     _load_translation_keys,
     _number_translation_keys,
     _parse_states,
@@ -64,13 +64,13 @@ __all__ = [
     "SWITCH_ENTITY_MAPPINGS",
     "TEXT_ENTITY_MAPPINGS",
     "TIME_ENTITY_MAPPINGS",
-    "_REGISTER_INFO_CACHE",
     "_build_entity_mappings",
     "_extend_entity_mappings_from_registers",
     "_get_register_info",
     "_infer_icon",
     "_load_discrete_mappings",
     "_load_number_mappings",
+    "_load_register_info",
     "_load_translation_keys",
     "_number_translation_keys",
     "_parse_states",

--- a/custom_components/thessla_green_modbus/mappings/_helpers.py
+++ b/custom_components/thessla_green_modbus/mappings/_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import sys
@@ -14,7 +15,6 @@ from ..registers.loader import get_all_registers
 from ..utils import _to_snake_case
 
 _LOGGER = logging.getLogger(__name__)
-_REGISTER_INFO_CACHE: dict[str, dict[str, Any]] | None = None
 
 
 def _infer_icon(name: str, unit: str | None) -> str:
@@ -32,46 +32,38 @@ def _infer_icon(name: str, unit: str | None) -> str:
     return "mdi:numeric"
 
 
-def _get_register_info(name: str) -> dict[str, Any] | None:
-    """Return register metadata, handling numeric suffixes.
+@functools.cache
+def _load_register_info() -> dict[str, dict[str, Any]]:
+    """Build and return the full register-info mapping.
 
-    Looks up ``_REGISTER_INFO_CACHE`` through the parent ``mappings`` package
-    module so that test monkeypatching on ``em._REGISTER_INFO_CACHE`` is
-    respected at call time.
+    Reads get_all_registers through the parent mappings module so that
+    test monkeypatching on ``em.get_all_registers`` is respected at call time.
     """
-    global _REGISTER_INFO_CACHE
-
-    # Prefer the cache stored on the parent module so monkeypatch works.
     _parent = sys.modules.get(__package__)
-    cache: dict[str, Any] | None = (
-        getattr(_parent, "_REGISTER_INFO_CACHE", None)
-        if _parent is not None
-        else _REGISTER_INFO_CACHE
-    )
+    fn = (
+        getattr(_parent, "get_all_registers", None) if _parent is not None else None
+    ) or get_all_registers
+    cache: dict[str, dict[str, Any]] = {}
+    for reg in fn():
+        if not reg.name:
+            continue
+        scale = reg.multiplier or 1
+        step = reg.resolution or scale
+        cache[reg.name] = {
+            "access": reg.access,
+            "min": reg.min,
+            "max": reg.max,
+            "unit": reg.unit,
+            "information": reg.information,
+            "scale": scale,
+            "step": step,
+        }
+    return cache
 
-    if cache is None:
-        _fn = (
-            getattr(_parent, "get_all_registers", None) if _parent is not None else None
-        ) or get_all_registers
-        cache = {}
-        for reg in _fn():
-            if not reg.name:
-                continue
-            scale = reg.multiplier or 1
-            step = reg.resolution or scale
-            cache[reg.name] = {
-                "access": reg.access,
-                "min": reg.min,
-                "max": reg.max,
-                "unit": reg.unit,
-                "information": reg.information,
-                "scale": scale,
-                "step": step,
-            }
-        _REGISTER_INFO_CACHE = cache
-        if _parent is not None:
-            _parent._REGISTER_INFO_CACHE = cache  # type: ignore[attr-defined]
 
+def _get_register_info(name: str) -> dict[str, Any] | None:
+    """Return register metadata, handling numeric suffixes."""
+    cache = _load_register_info()
     info = cache.get(name)
     if info is None and (suffix := name.rsplit("_", 1)) and len(suffix) > 1 and suffix[1].isdigit():
         info = cache.get(suffix[0])
@@ -146,9 +138,9 @@ def _load_translation_keys() -> dict[str, set[str]]:
 
 
 __all__ = [
-    "_REGISTER_INFO_CACHE",
     "_get_register_info",
     "_infer_icon",
+    "_load_register_info",
     "_load_translation_keys",
     "_number_translation_keys",
     "_parse_states",

--- a/docs/audit_cleanup_batch_report.md
+++ b/docs/audit_cleanup_batch_report.md
@@ -1,0 +1,208 @@
+# Audit Cleanup Batch Report — 2026-05-17
+
+## Summary
+
+This report documents the cleanup batch applied on branch `refactor/audit-cleanup-batch`
+based on the 2026-05-17 audit plan. The changes are incremental, reversible, and do not
+alter any Modbus behaviour, entity IDs, unique IDs, service IDs, register names, register
+addresses, config/options flow behaviour, or translation keys.
+
+---
+
+## Phase 1 — coordinator/scan.py hidden re-export removed
+
+**Problem:** `coordinator/scan.py` imported `normalise_cached_register_name` from
+`core.scan_helpers` but did not use it locally; it was annotated `# noqa: F401 –
+re-exported for coordinator internal use`. `normalise_available_registers` was imported
+from the same block but IS used internally in `apply_scan_cache`. The `noqa` block
+masked the redundant re-export.
+
+**Changes:**
+- `coordinator/scan.py`: Removed `normalise_cached_register_name` from the import;
+  stripped the `# noqa: F401` comment; retained only `normalise_available_registers`
+  (which is used locally).
+- `coordinator/coordinator.py`: Updated the two `.scan` re-export consumers to import
+  `normalise_available_registers` and `normalise_cached_register_name` directly from
+  `..core.scan_helpers`. Import block re-sorted by ruff.
+
+**Outcome:** No hidden re-exports remain in `coordinator/scan.py`.
+
+---
+
+## Phase 2A — entity_lookup._ENTITY_LOOKUP replaced by functools.cache
+
+**Problem:** `entity_lookup.py` used a module-level `_ENTITY_LOOKUP: ... | None = None`
+sentinel with a `global` statement inside `_build_entity_lookup()`.
+
+**Changes:**
+- `entity_lookup.py`: Removed `_ENTITY_LOOKUP` global. Decorated `_build_entity_lookup`
+  with `@functools.cache`. Updated `__all__` to remove `_ENTITY_LOOKUP`.
+- `tests/test_migrate_unique_id.py`:
+  - Removed `import … entity_lookup as lookup_mod` (no longer needed).
+  - Extended the local `migrate_unique_id` wrapper with an optional `get_entity_lookup`
+    parameter (defaults to the imported `_build_entity_lookup`).
+  - Updated `test_migrate_unique_id_register_to_key_lookup` to pass
+    `get_entity_lookup=lambda: fake_lookup` directly, eliminating all monkeypatch
+    setattr calls on `_ENTITY_LOOKUP`.
+
+**Outcome:** `_ENTITY_LOOKUP` global eliminated. Cache reset available via
+`_build_entity_lookup.cache_clear()`.
+
+---
+
+## Phase 2B — mappings/_helpers._REGISTER_INFO_CACHE replaced by functools.cache
+
+**Problem:** `mappings/_helpers.py` maintained `_REGISTER_INFO_CACHE: ... | None = None`
+with a `global` statement. The cache was populated inside `_get_register_info` using a
+complex parent-module lookup (`sys.modules.get(__package__)`) to support test
+monkeypatching via `em._REGISTER_INFO_CACHE`.
+
+**Changes:**
+- `mappings/_helpers.py`:
+  - Added `import functools`.
+  - Removed `_REGISTER_INFO_CACHE` global.
+  - Added `@functools.cache`-decorated `_load_register_info()` that builds and returns
+    the full register-info dict; retains parent-module lookup for `get_all_registers` so
+    test patching of `em.get_all_registers` still works after `cache_clear()`.
+  - Simplified `_get_register_info(name)` to call `_load_register_info()` directly
+    (plain call, no global state).
+  - Updated `__all__`: removed `_REGISTER_INFO_CACHE`, added `_load_register_info`.
+- `mappings/__init__.py`:
+  - Replaced `_REGISTER_INFO_CACHE` import with `_load_register_info`.
+  - Updated `__all__` accordingly.
+- `tests/test_entity_mappings_base.py`:
+  - `monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", None)` → `em._helpers._load_register_info.cache_clear()`
+  - `monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", {})` → `monkeypatch.setattr(em._helpers, "_load_register_info", lambda: {})`
+- `tests/test_entity_mappings_discrete.py`:
+  - `monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", None)` → `em._helpers._load_register_info.cache_clear()`
+  - `monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", {...})` → `monkeypatch.setattr(em._helpers, "_load_register_info", lambda: {...})`
+  - `monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", {})` → `monkeypatch.setattr(em._helpers, "_load_register_info", lambda: {})`
+
+**Outcome:** `_REGISTER_INFO_CACHE` global eliminated. Cache reset available via
+`_helpers._load_register_info.cache_clear()` (also exposed through `em._helpers`).
+
+---
+
+## Phase 3 — Coordinator proxy migration / client accessor
+
+**Status: Confirmed and deferred.**
+
+`coordinator.device_client` property already exists and returns
+`self._device_client` (a `ThesslaGreenDeviceClient`). This is the public accessor for
+the underlying device client.
+
+`coordinator.client` is already taken as a proxy for the low-level Modbus transport
+connection (`self._device_client.client`). Renaming `coordinator.client` to mean
+`ThesslaGreenDeviceClient` would break ~15 test files that assign `coordinator.client =
+MagicMock(...)` for transport mocking.
+
+No proxy migrations were performed in this PR. The existing proxy boilerplate carries a
+clear retention rationale and a documented future removal path (see coordinator.py
+comment block). Full proxy elimination is deferred — see Remaining Technical Debt.
+
+---
+
+## Phase 4 — Coordinator test fixture consolidation
+
+Four test files contained a private `_make_coordinator()` function identical to
+`tests/helpers_coordinator.make_coordinator`. These duplicates were removed and replaced
+with an import from the shared helper:
+
+| File | Change |
+|---|---|
+| `tests/test_coordinator_lifecycle.py` | Removed private `_make_coordinator`; import from `helpers_coordinator` |
+| `tests/test_coordinator_capabilities.py` | Same |
+| `tests/test_coordinator_update_statistics.py` | Same |
+| `tests/test_coordinator_setup.py` | Same |
+
+Unused imports (`MagicMock`, `ThesslaGreenModbusCoordinator` from direct path) were also
+removed from the affected files as a side effect of the factory removal.
+
+---
+
+## Phase 5 — Large-function decomposition (deferred)
+
+**Targets considered:**
+- `unique_id_migration.py:migrate_unique_id` — 106-line function with two nested
+  helpers. Decomposition was assessed as low-risk but deferred: pytest cannot run in
+  this environment (Python 3.11, requires ≥3.12), and the function is already
+  well-structured with inline helpers `_bit_index` and `_register_address`.
+- `core/read_batches.py:read_input_registers_optimized` — 100-line function with an
+  inline per-register fallback block. The extraction of
+  `_fallback_individual_input_reads` was similarly deferred due to inability to run
+  tests.
+
+**Reason for deferral:** Cannot execute pytest in this environment (Python 3.11 vs
+required ≥3.12). Both decompositions are mechanical and carry negligible semantic risk,
+but they touch hot paths (register reads, unique-ID migration) where silent behavioural
+regressions are unacceptable without test confirmation. Recommend performing these in a
+follow-up PR after real-device validation.
+
+---
+
+## Validation results
+
+| Check | Result |
+|---|---|
+| `python -m compileall` | ✅ clean |
+| `ruff check` | ✅ all checks passed |
+| `ruff check --select I` | ✅ all checks passed |
+| `ruff format --check` | ✅ 433 files already formatted |
+| `tools/check_maintainability.py` | ✅ maintainability gate passed |
+| `tools/validate_entity_mappings.py` | ✅ 366 entities validated |
+| `tools/check_translations.py` | ✅ all translation keys present |
+| `pytest` | ⚠️ cannot run — Python 3.11 environment, requires ≥3.12 |
+
+**pytest limitation:** The integration requires `pytest-homeassistant-custom-component
+>=0.13.309,<0.13.317` which requires Python ≥3.12. The container runs Python 3.11.15.
+All static checks pass. Physical device and pytest validation recommended before merge.
+
+---
+
+## Safety checks
+
+- No hidden re-exports (`# noqa: F401`) remain in coordinator scan path.
+- `_ENTITY_LOOKUP` global removed from `entity_lookup.py`.
+- `_REGISTER_INFO_CACHE` global removed from `mappings/_helpers.py`.
+- `coordinator.device_client` property confirmed present.
+- No merge conflict markers found.
+- `git diff --check` clean.
+- No shims reintroduced.
+
+Pre-existing `global REGISTER_HASH` in `scanner/register_maps.py` is out of scope for
+this PR and remains unchanged.
+
+---
+
+## Coordinator proxies removed
+
+None in this PR. Proxy elimination requires per-proxy caller analysis and test
+confirmation. Deferred to full proxy elimination phase.
+
+## Coordinator proxies retained and why
+
+All existing coordinator proxies (`coordinator.timeout`, `coordinator.retry`,
+`coordinator.effective_batch`, `coordinator.available_registers`, etc.) are retained
+because:
+- Coordinator submodules receive `self` (the coordinator) via duck-typing and access
+  these attributes directly.
+- Test files assign values to these attributes on the coordinator object.
+- Entity platform files read `coordinator.available_registers`, `coordinator.capabilities`,
+  `coordinator.statistics`, etc.
+
+Removal path: when a submodule is refactored to accept `ThesslaGreenDeviceClient`
+directly instead of the coordinator, the corresponding proxy can be removed.
+
+---
+
+## Remaining technical debt
+
+| Item | Notes |
+|---|---|
+| Full coordinator proxy elimination | Requires per-proxy caller migration across submodules and tests; high impact |
+| Options globals / DI | `mutable_global_state_inventory.md` documents remaining globals |
+| Real-device validation | **Recommended before release** — no physical device access available |
+| Remaining test fixture consolidation | Several coordinator test files still use inline `from_params` calls |
+| `migrate_unique_id` decomposition | Deferred — needs pytest green |
+| `read_input_registers_optimized` decomposition | Deferred — needs pytest green |
+| `scanner/register_maps.py:REGISTER_HASH` | Pre-existing mutable global; out of scope here |

--- a/tests/test_coordinator_capabilities.py
+++ b/tests/test_coordinator_capabilities.py
@@ -2,25 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
-
-
-def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
-    hass = MagicMock()
-    hass.async_add_executor_job = None
-    return ThesslaGreenModbusCoordinator.from_params(
-        hass=hass,
-        host="192.168.1.1",
-        port=502,
-        slave_id=1,
-        name="test",
-        scan_interval=30,
-        timeout=3,
-        retry=2,
-        **kwargs,
-    )
+from tests.helpers_coordinator import make_coordinator as _make_coordinator
 
 
 def test_compute_register_groups_safe_scan():

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -5,25 +5,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from custom_components.thessla_green_modbus.const import CONNECTION_TYPE_RTU
 from custom_components.thessla_green_modbus.coordinator import (
-    ThesslaGreenModbusCoordinator,
     lifecycle,
 )
 
-
-def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
-    hass = MagicMock()
-    hass.async_add_executor_job = None
-    return ThesslaGreenModbusCoordinator.from_params(
-        hass=hass,
-        host="192.168.1.1",
-        port=502,
-        slave_id=1,
-        name="test",
-        scan_interval=30,
-        timeout=3,
-        retry=2,
-        **kwargs,
-    )
+from tests.helpers_coordinator import make_coordinator as _make_coordinator
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_setup.py
+++ b/tests/test_coordinator_setup.py
@@ -3,28 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest.mock import MagicMock
 
-from custom_components.thessla_green_modbus.coordinator.coordinator import (
-    ThesslaGreenModbusCoordinator,
-    _utcnow,
-)
+from custom_components.thessla_green_modbus.coordinator.coordinator import _utcnow
 
-
-def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
-    hass = MagicMock()
-    hass.async_add_executor_job = None
-    return ThesslaGreenModbusCoordinator.from_params(
-        hass=hass,
-        host="192.168.1.1",
-        port=502,
-        slave_id=1,
-        name="test",
-        scan_interval=30,
-        timeout=3,
-        retry=2,
-        **kwargs,
-    )
+from tests.helpers_coordinator import make_coordinator as _make_coordinator
 
 
 def test_utcnow_returns_timezone_aware_datetime():

--- a/tests/test_coordinator_update_statistics.py
+++ b/tests/test_coordinator_update_statistics.py
@@ -1,24 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
-
-
-def _make_coordinator(**kwargs) -> ThesslaGreenModbusCoordinator:
-    hass = MagicMock()
-    hass.async_add_executor_job = None
-    return ThesslaGreenModbusCoordinator.from_params(
-        hass=hass,
-        host="192.168.1.1",
-        port=502,
-        slave_id=1,
-        name="test",
-        scan_interval=30,
-        timeout=3,
-        retry=2,
-        **kwargs,
-    )
+from tests.helpers_coordinator import make_coordinator as _make_coordinator
 
 
 def test_clear_register_failure_with_attribute():

--- a/tests/test_entity_mappings_base.py
+++ b/tests/test_entity_mappings_base.py
@@ -9,7 +9,7 @@ def test_get_register_info_skips_nameless_registers(monkeypatch):
     nameless = RegisterDef(function=3, address=100, name="", access="ro")
     named = RegisterDef(function=3, address=101, name="test_valid_reg_p8", access="ro", unit="°C")
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [nameless, named])
-    monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", None)
+    em._helpers._load_register_info.cache_clear()
 
     info = em._get_register_info("test_valid_reg_p8")
     assert info is not None
@@ -22,7 +22,7 @@ def test_get_register_info_numeric_suffix_fallback(monkeypatch):
     """Name ending with _<digit> falls back to base name (line 225)."""
     base_reg = RegisterDef(function=3, address=1, name="pump_speed_p8", access="rw", unit="%")
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [base_reg])
-    monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", None)
+    em._helpers._load_register_info.cache_clear()
 
     base = em._get_register_info("pump_speed_p8")
     assert base is not None
@@ -36,7 +36,7 @@ def test_load_number_mappings_skips_registers_without_info(monkeypatch):
     mystery = RegisterDef(function=3, address=999, name="mystery_reg_p8", access="rw")
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [mystery])
     # Pre-populate cache as empty dict → _get_register_info returns None for all names
-    monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", {})
+    monkeypatch.setattr(em._helpers, "_load_register_info", lambda: {})
 
     result = em._load_number_mappings()
     assert "mystery_reg_p8" not in result
@@ -48,7 +48,7 @@ def test_load_number_mappings_skips_enumerated_unit_registers(monkeypatch):
         function=3, address=1, name="mode_reg_p8", access="rw", unit="0 - off; 1 - on"
     )
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [enum_reg])
-    monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", None)
+    em._helpers._load_register_info.cache_clear()
 
     result = em._load_number_mappings()
     assert "mode_reg_p8" not in result
@@ -60,7 +60,7 @@ def test_load_number_mappings_includes_min_max_when_present(monkeypatch):
         function=3, address=2, name="speed_reg_p8", access="rw", unit="%", min=0, max=100
     )
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [bounded])
-    monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", None)
+    em._helpers._load_register_info.cache_clear()
     # Allow this synthetic register through the translation-key whitelist.
     monkeypatch.setattr(em, "_number_translation_keys", lambda: {"speed_reg_p8"})
 

--- a/tests/test_entity_mappings_discrete.py
+++ b/tests/test_entity_mappings_discrete.py
@@ -34,7 +34,7 @@ def test_load_discrete_mappings_skips_holding_regs_without_info(monkeypatch):
     monkeypatch.setattr(
         em, "holding_registers", lambda: {"unknown_holding_xyz_p8": 0, **original_holding()}
     )
-    monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", None)
+    em._helpers._load_register_info.cache_clear()
 
     binary, switch, select = em._load_discrete_mappings()
     assert "unknown_holding_xyz_p8" not in binary
@@ -127,9 +127,9 @@ def test_load_discrete_creates_switch_for_writable_2state_in_switch_keys(monkeyp
     monkeypatch.setattr(em, "discrete_input_registers", lambda: {})
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [])
     monkeypatch.setattr(
-        em,
-        "_REGISTER_INFO_CACHE",
-        {
+        em._helpers,
+        "_load_register_info",
+        lambda: {
             "sw_reg_p9": {
                 "access": "RW",
                 "unit": "0 - off; 1 - on",
@@ -162,9 +162,9 @@ def test_load_discrete_creates_binary_for_writable_2state_not_in_switch_keys(mon
     monkeypatch.setattr(em, "discrete_input_registers", lambda: {})
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [])
     monkeypatch.setattr(
-        em,
-        "_REGISTER_INFO_CACHE",
-        {
+        em._helpers,
+        "_load_register_info",
+        lambda: {
             "bin_reg_p9": {
                 "access": "RW",
                 "unit": "0 - off; 1 - on",
@@ -196,9 +196,9 @@ def test_load_discrete_creates_select_for_multistate_register(monkeypatch):
     monkeypatch.setattr(em, "discrete_input_registers", lambda: {})
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [])
     monkeypatch.setattr(
-        em,
-        "_REGISTER_INFO_CACHE",
-        {
+        em._helpers,
+        "_load_register_info",
+        lambda: {
             "sel_reg_p9": {
                 "access": "RW",
                 "unit": "0 - auto; 1 - manual; 2 - off",
@@ -236,7 +236,7 @@ def test_load_discrete_skips_diag_register_not_in_holding_on_second_check(monkey
     monkeypatch.setattr(em, "coil_registers", lambda: {})
     monkeypatch.setattr(em, "discrete_input_registers", lambda: {})
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [])
-    monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", {})
+    monkeypatch.setattr(em._helpers, "_load_register_info", lambda: {})
     monkeypatch.setattr(
         em,
         "_load_translation_keys",
@@ -256,7 +256,7 @@ def test_load_discrete_skips_diag_register_not_in_binary_keys(monkeypatch):
     monkeypatch.setattr(em, "coil_registers", lambda: {})
     monkeypatch.setattr(em, "discrete_input_registers", lambda: {})
     monkeypatch.setattr(em, "get_all_registers", lambda *a, **kw: [])
-    monkeypatch.setattr(em, "_REGISTER_INFO_CACHE", {})
+    monkeypatch.setattr(em._helpers, "_load_register_info", lambda: {})
     monkeypatch.setattr(
         em,
         "_load_translation_keys",

--- a/tests/test_migrate_unique_id.py
+++ b/tests/test_migrate_unique_id.py
@@ -1,4 +1,3 @@
-import custom_components.thessla_green_modbus.entity_lookup as lookup_mod
 from custom_components.thessla_green_modbus.const import (
     AIRFLOW_UNIT_M3H,
     AIRFLOW_UNIT_PERCENTAGE,
@@ -19,7 +18,9 @@ from custom_components.thessla_green_modbus.unique_id_migration import (
 )
 
 
-def migrate_unique_id(unique_id, *, serial_number, host, port, slave_id):
+def migrate_unique_id(
+    unique_id, *, serial_number, host, port, slave_id, get_entity_lookup=_build_entity_lookup
+):
     return _migrate_unique_id_raw(
         unique_id,
         serial_number=serial_number,
@@ -28,7 +29,7 @@ def migrate_unique_id(unique_id, *, serial_number, host, port, slave_id):
         slave_id=slave_id,
         domain=DOMAIN,
         airflow_units=(AIRFLOW_UNIT_M3H, AIRFLOW_UNIT_PERCENTAGE),
-        get_entity_lookup=_build_entity_lookup,
+        get_entity_lookup=get_entity_lookup,
         holding_registers=holding_registers,
         input_registers=input_registers,
         coil_registers=coil_registers,
@@ -152,7 +153,7 @@ def test_migrate_unique_id_address_based_lookup():
     assert str(REGISTER_ADDRESS) in result  # nosec B101
 
 
-def test_migrate_unique_id_register_to_key_lookup(monkeypatch):
+def test_migrate_unique_id_register_to_key_lookup():
     """register_to_key path: remainder is register_name but not entity key (lines 330-333)."""
 
     # Inject lookup: entity key "flow_entity" uses register "supply_flow_rate"
@@ -160,19 +161,22 @@ def test_migrate_unique_id_register_to_key_lookup(monkeypatch):
     fake_lookup = {
         "flow_entity": ("supply_flow_rate", "input_registers", None),
     }
-    monkeypatch.setattr(lookup_mod, "_ENTITY_LOOKUP", fake_lookup)
 
     # remainder = "supply_flow_rate" → not in lookup → elif register_to_key path
     uid = f"{DOMAIN}_{HOST}_{PORT}_{SLAVE}_supply_flow_rate"
-    result = migrate_unique_id(uid, serial_number=None, host=HOST, port=PORT, slave_id=SLAVE)
+    result = migrate_unique_id(
+        uid,
+        serial_number=None,
+        host=HOST,
+        port=PORT,
+        slave_id=SLAVE,
+        get_entity_lookup=lambda: fake_lookup,
+    )
 
     # "supply_flow_rate" → register_to_key["supply_flow_rate"] = "flow_entity"
     # address 274 → base_uid = "10_flow_entity_274"
     assert "flow_entity" in result  # nosec B101
     assert str(REGISTER_ADDRESS) in result  # nosec B101
-
-    # Restore cache so subsequent tests see real lookup
-    monkeypatch.setattr(lookup_mod, "_ENTITY_LOOKUP", None)
 
 
 def test_migrate_unique_id_fan_remainder():


### PR DESCRIPTION
## Base branch: main

## Completed audit items

### Phase 1 — coordinator/scan.py hidden re-export removed
- Removed `normalise_cached_register_name` re-export (`noqa: F401`) from `coordinator/scan.py`
- Updated `coordinator/coordinator.py` to import both `normalise_available_registers` and `normalise_cached_register_name` directly from `core.scan_helpers`
- No hidden re-exports remain in the coordinator scan path

### Phase 2A — entity_lookup._ENTITY_LOOKUP replaced by functools.cache
- Removed `_ENTITY_LOOKUP` module-level sentinel and `global` statement from `entity_lookup.py`
- Decorated `_build_entity_lookup` with `@functools.cache`
- Updated `test_migrate_unique_id.py`: test wrapper accepts optional `get_entity_lookup` parameter; the test that previously monkeypatched `_ENTITY_LOOKUP` now passes `get_entity_lookup=lambda: fake_lookup` directly

### Phase 2B — mappings/_REGISTER_INFO_CACHE replaced by functools.cache
- Removed `_REGISTER_INFO_CACHE` global from `mappings/_helpers.py`
- Added `@functools.cache`-decorated `_load_register_info()` — retains parent-module `get_all_registers` lookup so `em.get_all_registers` test patching still works after `cache_clear()`
- Simplified `_get_register_info` to call `_load_register_info()` directly
- Updated `mappings/__init__.py` exports
- Updated `test_entity_mappings_base.py` and `test_entity_mappings_discrete.py`: `_REGISTER_INFO_CACHE = None` → `em._helpers._load_register_info.cache_clear()`; injected dicts → `monkeypatch.setattr(em._helpers, "_load_register_info", lambda: {...})`

### Phase 4 — Coordinator test fixture consolidation
Replaced identical private `_make_coordinator()` functions with an import from `tests.helpers_coordinator.make_coordinator` in four test files:
- `tests/test_coordinator_lifecycle.py`
- `tests/test_coordinator_capabilities.py`
- `tests/test_coordinator_update_statistics.py`
- `tests/test_coordinator_setup.py`

## Deferred audit items and why

### Phase 3 — Coordinator proxy migration
`coordinator.device_client` property already exists and returns `ThesslaGreenDeviceClient`. The name `coordinator.client` is already taken as a proxy for the low-level Modbus transport connection, so renaming is blocked without breaking ~15 test files. Full proxy elimination deferred — requires per-proxy caller analysis across submodules and tests.

### Phase 5 — Large-function decomposition
- `unique_id_migration.py:migrate_unique_id` — deferred; function is well-structured with inline helpers; pytest unavailable in Python 3.11 environment.
- `core/read_batches.py:read_input_registers_optimized` — deferred; same reason.

Both are low-risk decompositions but touch hot paths. Recommend performing in a follow-up PR after real-device validation and pytest confirmation.

## Validation results

| Check | Result |
|---|---|
| `python -m compileall` | ✅ clean |
| `ruff check` | ✅ all checks passed |
| `ruff check --select I` | ✅ all checks passed |
| `ruff format --check` | ✅ 433 files already formatted |
| `tools/check_maintainability.py` | ✅ maintainability gate passed |
| `tools/validate_entity_mappings.py` | ✅ 366 entities validated |
| `tools/check_translations.py` | ✅ all translation keys present |
| `pytest` | ⚠️ cannot run — Python 3.11 environment, requires ≥3.12 |

## pytest environment limitation
`pytest-homeassistant-custom-component >=0.13.309,<0.13.317` requires Python ≥3.12. The CI container runs Python 3.11.15. All static checks pass. **Physical device and pytest validation is strongly recommended before merge.**

## Confirmations
- ✅ No Modbus behaviour changed
- ✅ Entity IDs unchanged
- ✅ Unique IDs and migration results unchanged
- ✅ Service IDs unchanged
- ✅ Register names unchanged
- ✅ Register addresses unchanged
- ✅ Config/options flow behaviour unchanged
- ✅ Translation keys unchanged
- ✅ manifest quality_scale unchanged
- ✅ No shims created or reintroduced
- ✅ No compatibility re-exports added

## Recommended next step
Physical real-device validation before release. Run `pytest tests/` on a Python ≥3.12 environment to confirm no regressions in the updated test files (`test_entity_mappings_base`, `test_entity_mappings_discrete`, `test_migrate_unique_id`).

https://claude.ai/code/session_01PZKa5ZyoKND5pLtPBWocBN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZKa5ZyoKND5pLtPBWocBN)_