### PR TITLE
fix: repair stale input register import

### DIFF
--- a/custom_components/thessla_green_modbus/core/client_connection.py
+++ b/custom_components/thessla_green_modbus/core/client_connection.py
@@ -20,8 +20,8 @@ from ..const import (
     DEFAULT_STOP_BITS,
     SERIAL_PARITY_MAP,
     SERIAL_STOP_BITS_MAP,
-    input_registers,
 )
+from ..registers.maps import input_registers
 from ..scanner import is_request_cancelled_error
 from ..transport.base import BaseModbusTransport
 from .connection import (


### PR DESCRIPTION
Move input_registers import from const.py to its canonical location
in registers.maps, resolving the CI ImportError on collection.

https://claude.ai/code/session_01A4xC4ZX5MsvJRzuYx5NwpJ