### PR TITLE
fix: repair stale register-map imports in coordinator and entities test

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/__init__.py
+++ b/custom_components/thessla_green_modbus/coordinator/__init__.py
@@ -1,8 +1,10 @@
 """Coordinator package public API."""
 
+from ..core import disconnect
 from .coordinator import CoordinatorConfig, ThesslaGreenModbusCoordinator
 
 __all__ = [
     "CoordinatorConfig",
     "ThesslaGreenModbusCoordinator",
+    "disconnect",
 ]

--- a/tests/test_optimized_integration_entities.py
+++ b/tests/test_optimized_integration_entities.py
@@ -4,7 +4,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
-from custom_components.thessla_green_modbus.const import (
+from custom_components.thessla_green_modbus.registers.maps import (
     coil_registers,
     discrete_input_registers,
     holding_registers,


### PR DESCRIPTION
Expose core.disconnect module from coordinator package so test_coordinator_disconnect.py can import it at the expected path.

Redirect coil_registers, discrete_input_registers, holding_registers, input_registers imports in test_optimized_integration_entities.py from const to their canonical location in registers.maps.

https://claude.ai/code/session_01A4xC4ZX5MsvJRzuYx5NwpJ

## Summary
- [ ] Explain what changed and why.

## Maintainability checklist (required for large refactors)
- [ ] I checked whether changed methods/files exceed maintainability thresholds.
- [ ] For large methods/files, I provided extraction rationale.
- [ ] I documented behavior compatibility / facade/re-export compatibility where applicable.
- [ ] I listed test impact (new/updated tests, including contract tests when retry/error semantics changed).
- [ ] I included a short rollback plan for risky refactors.

## Validation
- [ ] `ruff check ...`
- [ ] `pytest ...`
- [ ] `python tools/check_maintainability.py`

## Notes
- Additional context / migration notes / known limitations.
