### PR TITLE
fix: redirect stale register-map imports in conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def enable_event_loop_debug():
 @pytest.fixture
 def mock_coordinator():
     """Return a mock coordinator using MagicMock(spec=ThesslaGreenModbusCoordinator)."""
-    from custom_components.thessla_green_modbus.const import (
+    from custom_components.thessla_green_modbus.registers.maps import (
         coil_registers,
         discrete_input_registers,
         holding_registers,


### PR DESCRIPTION
Update mock_coordinator fixture to import coil_registers,
discrete_input_registers, holding_registers, and input_registers
from registers.maps instead of const, which no longer exports them.

This resolves the ImportError that causes pytest collection to fail
in CI (run 25997515657 / job 76414579389).

https://claude.ai/code/session_01PfczRVkaxR1VM6TjYYpiri