### PR TITLE
fix: redirect stale register_processing imports from coordinator to core

### DIFF
--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -45,7 +45,7 @@ def test_process_register_value_sensor_unavailable_non_temperature():
 
 def test_process_register_value_decoded_equals_sensor_unavailable():
     from custom_components.thessla_green_modbus.const import SENSOR_UNAVAILABLE
-    from custom_components.thessla_green_modbus.coordinator import register_processing as rp
+    from custom_components.thessla_green_modbus.core import register_processing as rp
 
     c = _make_coordinator()
     d = MagicMock()

--- a/tests/test_coordinator_schedule.py
+++ b/tests/test_coordinator_schedule.py
@@ -72,7 +72,7 @@ async def test_async_write_temporary_temperature_missing_register():
 
 def test_process_register_value_schedule_hh_mm():
     """schedule_ register with HH:MM decoded → stored as HH:MM string (not minutes)."""
-    from custom_components.thessla_green_modbus.coordinator import register_processing as rp
+    from custom_components.thessla_green_modbus.core import register_processing as rp
 
     coord = _make_coordinator()
     mock_def = MagicMock()
@@ -91,7 +91,7 @@ def test_process_register_value_schedule_hh_mm():
 
 def test_process_register_value_schedule_hh_mm_invalid():
     """schedule_ register with bad HH:MM → ValueError caught, decoded unchanged (lines 1850-1851)."""
-    from custom_components.thessla_green_modbus.coordinator import register_processing as rp
+    from custom_components.thessla_green_modbus.core import register_processing as rp
 
     coord = _make_coordinator()
     mock_def = MagicMock()


### PR DESCRIPTION
Update three test functions that imported register_processing from the coordinator package, where it does not live. The module resides in core/, not coordinator/.

Affected tests:
- test_coordinator_availability.py::test_process_register_value_decoded_equals_sensor_unavailable
- test_coordinator_schedule.py::test_process_register_value_schedule_hh_mm
- test_coordinator_schedule.py::test_process_register_value_schedule_hh_mm_invalid

https://claude.ai/code/session_01PfczRVkaxR1VM6TjYYpiri

## Summary
- [ ] Explain what changed and why.

## Maintainability checklist (required for large refactors)
- [ ] I checked whether changed methods/files exceed maintainability thresholds.
- [ ] For large methods/files, I provided extraction rationale.
- [ ] I documented behavior compatibility / facade/re-export compatibility where applicable.
- [ ] I listed test impact (new/updated tests, including contract tests when retry/error semantics changed).
- [ ] I included a short rollback plan for risky refactors.

## Validation
- [ ] `ruff check ...`
- [ ] `pytest ...`
- [ ] `python tools/check_maintainability.py`

## Notes
- Additional context / migration notes / known limitations.
