### PR TITLE
fix: remove disconnect from coordinator public API; add CoordinatorConfig.from_entry

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/__init__.py
+++ b/custom_components/thessla_green_modbus/coordinator/__init__.py
@@ -1,10 +1,8 @@
 """Coordinator package public API."""
 
-from ..core import disconnect
 from .coordinator import CoordinatorConfig, ThesslaGreenModbusCoordinator
 
 __all__ = [
     "CoordinatorConfig",
     "ThesslaGreenModbusCoordinator",
-    "disconnect",
 ]

--- a/custom_components/thessla_green_modbus/core/models.py
+++ b/custom_components/thessla_green_modbus/core/models.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
 
 from ..const import (
     DEFAULT_BACKOFF,
@@ -45,3 +49,10 @@ class CoordinatorConfig:
     baud_rate: int = DEFAULT_BAUD_RATE
     parity: str = DEFAULT_PARITY
     stop_bits: int = DEFAULT_STOP_BITS
+
+    @classmethod
+    def from_entry(cls, entry: ConfigEntry | Any) -> CoordinatorConfig:
+        """Build a CoordinatorConfig from a Home Assistant config entry."""
+        from ..coordinator.config_normalization import coordinator_config_from_entry
+
+        return coordinator_config_from_entry(entry, cls)


### PR DESCRIPTION
- Drop `disconnect` from coordinator/__init__.py __all__ and import,
  so the coordinator package exposes only CoordinatorConfig and
  ThesslaGreenModbusCoordinator (fixes test_coordinator_package_public_api_is_minimal).
- Add CoordinatorConfig.from_entry classmethod that delegates to the
  existing coordinator_config_from_entry helper, restoring the entry-
  parsing path expected by test_coordinator_config_from_entry.

https://claude.ai/code/session_01ReLbwybBaas36QEuEkGd7f