### PR TITLE
fix: keep disconnect importable from coordinator without adding to __…

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/__init__.py
+++ b/custom_components/thessla_green_modbus/coordinator/__init__.py
@@ -1,5 +1,6 @@
 """Coordinator package public API."""
 
+from ..core import disconnect as disconnect
 from .coordinator import CoordinatorConfig, ThesslaGreenModbusCoordinator
 
 __all__ = [


### PR DESCRIPTION
…all__

test_coordinator_disconnect.py imports `disconnect` directly from the coordinator package namespace. Keep it accessible via a redundant-alias import (idiomatic re-export that ruff accepts) while keeping it out of __all__ so test_coordinator_package_public_api_is_minimal still passes.

https://claude.ai/code/session_01ReLbwybBaas36QEuEkGd7f

## Summary
- [ ] Explain what changed and why.

## Maintainability checklist (required for large refactors)
- [ ] I checked whether changed methods/files exceed maintainability thresholds.
- [ ] For large methods/files, I provided extraction rationale.
- [ ] I documented behavior compatibility / facade/re-export compatibility where applicable.
- [ ] I listed test impact (new/updated tests, including contract tests when retry/error semantics changed).
- [ ] I included a short rollback plan for risky refactors.

## Validation
- [ ] `ruff check ...`
- [ ] `pytest ...`
- [ ] `python tools/check_maintainability.py`

## Notes
- Additional context / migration notes / known limitations.
