### PR TITLE
Refactor: Move config entry parsing to CoordinatorConfig model

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/config_normalization.py
+++ b/custom_components/thessla_green_modbus/coordinator/config_normalization.py
@@ -3,87 +3,20 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
-from ..const import (
-    CONF_BACKOFF,
-    CONF_BACKOFF_JITTER,
-    CONF_BAUD_RATE,
-    CONF_CONNECTION_MODE,
-    CONF_CONNECTION_TYPE,
-    CONF_DEEP_SCAN,
-    CONF_FORCE_FULL_REGISTER_LIST,
-    CONF_MAX_REGISTERS_PER_REQUEST,
-    CONF_PARITY,
-    CONF_RETRY,
-    CONF_SAFE_SCAN,
-    CONF_SCAN_INTERVAL,
-    CONF_SCAN_UART_SETTINGS,
-    CONF_SERIAL_PORT,
-    CONF_SKIP_MISSING_REGISTERS,
-    CONF_SLAVE_ID,
-    CONF_STOP_BITS,
-    CONF_TIMEOUT,
-    DEFAULT_BACKOFF,
-    DEFAULT_BACKOFF_JITTER,
-    DEFAULT_BAUD_RATE,
-    DEFAULT_CONNECTION_TYPE,
-    DEFAULT_DEEP_SCAN,
-    DEFAULT_MAX_REGISTERS_PER_REQUEST,
-    DEFAULT_NAME,
-    DEFAULT_PARITY,
-    DEFAULT_PORT,
-    DEFAULT_RETRY,
-    DEFAULT_SAFE_SCAN,
-    DEFAULT_SCAN_INTERVAL,
-    DEFAULT_SCAN_UART_SETTINGS,
-    DEFAULT_SERIAL_PORT,
-    DEFAULT_SKIP_MISSING_REGISTERS,
-    DEFAULT_SLAVE_ID,
-    DEFAULT_STOP_BITS,
-    DEFAULT_TIMEOUT,
-    MIN_SCAN_INTERVAL,
-)
+from ..const import MIN_SCAN_INTERVAL
+from ..core.models import CoordinatorConfig
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
-
-    from ..core.models import CoordinatorConfig
 
 
 def coordinator_config_from_entry(
     entry: ConfigEntry, cls: type[CoordinatorConfig]
 ) -> CoordinatorConfig:
     """Build coordinator config from a Home Assistant config entry."""
-    data = entry.data
-    options = entry.options
-    return cls(
-        host=str(data.get("host", "")),
-        port=int(data.get("port", DEFAULT_PORT)),
-        slave_id=int(data.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID)),
-        name=str(data.get("name", DEFAULT_NAME)),
-        scan_interval=int(options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)),
-        timeout=int(options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)),
-        retry=int(options.get(CONF_RETRY, DEFAULT_RETRY)),
-        backoff=float(options.get(CONF_BACKOFF, DEFAULT_BACKOFF)),
-        backoff_jitter=options.get(CONF_BACKOFF_JITTER, DEFAULT_BACKOFF_JITTER),
-        force_full_register_list=bool(options.get(CONF_FORCE_FULL_REGISTER_LIST, False)),
-        scan_uart_settings=bool(options.get(CONF_SCAN_UART_SETTINGS, DEFAULT_SCAN_UART_SETTINGS)),
-        deep_scan=bool(options.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN)),
-        safe_scan=bool(options.get(CONF_SAFE_SCAN, DEFAULT_SAFE_SCAN)),
-        max_registers_per_request=int(
-            options.get(CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST)
-        ),
-        skip_missing_registers=bool(
-            options.get(CONF_SKIP_MISSING_REGISTERS, DEFAULT_SKIP_MISSING_REGISTERS)
-        ),
-        connection_type=str(data.get(CONF_CONNECTION_TYPE, DEFAULT_CONNECTION_TYPE)),
-        connection_mode=cast(str | None, data.get(CONF_CONNECTION_MODE)),
-        serial_port=str(data.get(CONF_SERIAL_PORT, DEFAULT_SERIAL_PORT)),
-        baud_rate=int(data.get(CONF_BAUD_RATE, DEFAULT_BAUD_RATE)),
-        parity=str(data.get(CONF_PARITY, DEFAULT_PARITY)),
-        stop_bits=int(data.get(CONF_STOP_BITS, DEFAULT_STOP_BITS)),
-    )
+    return CoordinatorConfig.from_entry(entry)
 
 
 def normalize_scan_interval(scan_interval: timedelta | int) -> int:

--- a/custom_components/thessla_green_modbus/core/models.py
+++ b/custom_components/thessla_green_modbus/core/models.py
@@ -4,23 +4,48 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
 from ..const import (
+    CONF_BACKOFF,
+    CONF_BACKOFF_JITTER,
+    CONF_BAUD_RATE,
+    CONF_CONNECTION_MODE,
+    CONF_CONNECTION_TYPE,
+    CONF_DEEP_SCAN,
+    CONF_FORCE_FULL_REGISTER_LIST,
+    CONF_MAX_REGISTERS_PER_REQUEST,
+    CONF_PARITY,
+    CONF_RETRY,
+    CONF_SAFE_SCAN,
+    CONF_SCAN_INTERVAL,
+    CONF_SCAN_UART_SETTINGS,
+    CONF_SERIAL_PORT,
+    CONF_SKIP_MISSING_REGISTERS,
+    CONF_SLAVE_ID,
+    CONF_STOP_BITS,
+    CONF_TIMEOUT,
     DEFAULT_BACKOFF,
     DEFAULT_BACKOFF_JITTER,
     DEFAULT_BAUD_RATE,
     DEFAULT_CONNECTION_TYPE,
+    DEFAULT_DEEP_SCAN,
     DEFAULT_MAX_REGISTERS_PER_REQUEST,
     DEFAULT_NAME,
     DEFAULT_PARITY,
+    DEFAULT_PORT,
+    DEFAULT_RETRY,
+    DEFAULT_SAFE_SCAN,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SCAN_UART_SETTINGS,
     DEFAULT_SERIAL_PORT,
+    DEFAULT_SKIP_MISSING_REGISTERS,
+    DEFAULT_SLAVE_ID,
     DEFAULT_STOP_BITS,
+    DEFAULT_TIMEOUT,
 )
 
 
@@ -53,6 +78,32 @@ class CoordinatorConfig:
     @classmethod
     def from_entry(cls, entry: ConfigEntry | Any) -> CoordinatorConfig:
         """Build a CoordinatorConfig from a Home Assistant config entry."""
-        from ..coordinator.config_normalization import coordinator_config_from_entry
-
-        return coordinator_config_from_entry(entry, cls)
+        data = entry.data
+        options = entry.options
+        return cls(
+            host=str(data.get("host", "")),
+            port=int(data.get("port", DEFAULT_PORT)),
+            slave_id=int(data.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID)),
+            name=str(data.get("name", DEFAULT_NAME)),
+            scan_interval=int(options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)),
+            timeout=int(options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)),
+            retry=int(options.get(CONF_RETRY, DEFAULT_RETRY)),
+            backoff=float(options.get(CONF_BACKOFF, DEFAULT_BACKOFF)),
+            backoff_jitter=options.get(CONF_BACKOFF_JITTER, DEFAULT_BACKOFF_JITTER),
+            force_full_register_list=bool(options.get(CONF_FORCE_FULL_REGISTER_LIST, False)),
+            scan_uart_settings=bool(options.get(CONF_SCAN_UART_SETTINGS, DEFAULT_SCAN_UART_SETTINGS)),
+            deep_scan=bool(options.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN)),
+            safe_scan=bool(options.get(CONF_SAFE_SCAN, DEFAULT_SAFE_SCAN)),
+            max_registers_per_request=int(
+                options.get(CONF_MAX_REGISTERS_PER_REQUEST, DEFAULT_MAX_REGISTERS_PER_REQUEST)
+            ),
+            skip_missing_registers=bool(
+                options.get(CONF_SKIP_MISSING_REGISTERS, DEFAULT_SKIP_MISSING_REGISTERS)
+            ),
+            connection_type=str(data.get(CONF_CONNECTION_TYPE, DEFAULT_CONNECTION_TYPE)),
+            connection_mode=cast(str | None, data.get(CONF_CONNECTION_MODE)),
+            serial_port=str(data.get(CONF_SERIAL_PORT, DEFAULT_SERIAL_PORT)),
+            baud_rate=int(data.get(CONF_BAUD_RATE, DEFAULT_BAUD_RATE)),
+            parity=str(data.get(CONF_PARITY, DEFAULT_PARITY)),
+            stop_bits=int(data.get(CONF_STOP_BITS, DEFAULT_STOP_BITS)),
+        )


### PR DESCRIPTION
## Summary
- [x] Explain what changed and why.

This refactor moves the configuration entry parsing logic from `coordinator_config_from_entry()` in `config_normalization.py` to a new `from_entry()` class method in the `CoordinatorConfig` model class. This improves code organization by keeping configuration parsing logic with the data model it populates, reducing circular dependencies and improving maintainability.

**Changes:**
- Moved all configuration parsing logic from `coordinator/config_normalization.py` to `core/models.py`
- Implemented `CoordinatorConfig.from_entry()` class method with the full parsing implementation
- Simplified `coordinator_config_from_entry()` to delegate to the new class method
- Consolidated all required constant imports into `models.py`
- Removed unused `cast` import from `config_normalization.py`

## Maintainability checklist
- [x] I checked whether changed methods/files exceed maintainability thresholds.
  - The `from_entry()` method is 24 lines, well within acceptable limits
  - Consolidates related logic in one place (model class)
- [x] For large methods/files, I provided extraction rationale.
  - N/A - no large methods created
- [x] I documented behavior compatibility / facade/re-export compatibility where applicable.
  - `coordinator_config_from_entry()` remains a public facade that delegates to the model method
  - No breaking changes to public API
- [x] I listed test impact (new/updated tests, including contract tests when retry/error semantics changed).
  - No test changes needed - existing tests for `coordinator_config_from_entry()` will continue to pass
  - The refactoring is internal; behavior is identical
- [x] I included a short rollback plan for risky refactors.
  - Low risk: Simple delegation pattern. If issues arise, revert the move and restore original implementation.

## Validation
- [x] `ruff check ...` - No linting issues introduced
- [x] `pytest ...` - Existing tests pass (behavior unchanged)
- [x] Code organization improved - configuration parsing now co-located with its data model

## Notes
This is a pure refactoring with no functional changes. The public API (`coordinator_config_from_entry()`) remains unchanged and continues to work identically. The change improves code organization by placing configuration parsing logic in the model class where it logically belongs.

https://claude.ai/code/session_01DFc7RDPdY3YHvnDKJK1c6q