### PR TITLE
Format scan_uart_settings configuration line for readability

### DIFF
--- a/custom_components/thessla_green_modbus/core/models.py
+++ b/custom_components/thessla_green_modbus/core/models.py
@@ -91,7 +91,9 @@ class CoordinatorConfig:
             backoff=float(options.get(CONF_BACKOFF, DEFAULT_BACKOFF)),
             backoff_jitter=options.get(CONF_BACKOFF_JITTER, DEFAULT_BACKOFF_JITTER),
             force_full_register_list=bool(options.get(CONF_FORCE_FULL_REGISTER_LIST, False)),
-            scan_uart_settings=bool(options.get(CONF_SCAN_UART_SETTINGS, DEFAULT_SCAN_UART_SETTINGS)),
+            scan_uart_settings=bool(
+                options.get(CONF_SCAN_UART_SETTINGS, DEFAULT_SCAN_UART_SETTINGS)
+            ),
             deep_scan=bool(options.get(CONF_DEEP_SCAN, DEFAULT_DEEP_SCAN)),
             safe_scan=bool(options.get(CONF_SAFE_SCAN, DEFAULT_SAFE_SCAN)),
             max_registers_per_request=int(


### PR DESCRIPTION
## Summary
- [x] Explain what changed and why.

This is a code formatting change that improves readability by breaking a long line in the `CoordinatorConfig.from_entry()` method. The `scan_uart_settings` configuration line exceeded the line length limit and has been reformatted to span multiple lines while maintaining identical functionality.

**Why:** Adheres to code style guidelines and improves maintainability by keeping lines within the project's length threshold.

## Maintainability checklist
- [x] I checked whether changed methods/files exceed maintainability thresholds.
  - This is a formatting-only change; no logic or complexity was altered.
- [x] I documented behavior compatibility / facade/re-export compatibility where applicable.
  - No behavior changes; the configuration value is computed identically.
- [x] I listed test impact (new/updated tests, including contract tests when retry/error semantics changed).
  - No testing needed; this is a formatting change with no functional impact.

## Validation
- [x] Code style: Line length formatting applied
- [x] No functional changes: Configuration logic remains identical
- [x] Existing tests pass: No test modifications required

## Notes
This is a pure formatting change with zero functional impact. The `bool(options.get(...))` expression is evaluated identically before and after the reformatting.

https://claude.ai/code/session_01HvVqxkrUzEfX6kAMoU1K8d