### PR TITLE
fix: avoid blocking translation file I/O during setup

### DIFF
--- a/custom_components/thessla_green_modbus/mappings/__init__.py
+++ b/custom_components/thessla_green_modbus/mappings/__init__.py
@@ -105,12 +105,18 @@ def _run_build_entity_mappings() -> None:
 
 
 async def async_setup_entity_mappings(hass: HomeAssistant | None = None) -> None:
-    """Asynchronously build entity mappings."""
+    """Asynchronously build entity mappings.
 
+    When *hass* is provided the entire build — including translation file reads
+    via :func:`_number_translation_keys` and :func:`_load_translation_keys` —
+    runs in a thread-pool executor so that no blocking I/O occurs on the event
+    loop.  Both translation helpers cache their results after the first call, so
+    subsequent invocations pay no I/O cost regardless of how they are called.
+
+    When *hass* is ``None`` (tools and tests) the build runs synchronously in
+    the calling thread, which is safe because no event loop is active.
+    """
     if hass is not None:
         await hass.async_add_executor_job(_run_build_entity_mappings)
     else:
         _run_build_entity_mappings()
-
-
-_run_build_entity_mappings()

--- a/custom_components/thessla_green_modbus/mappings/_helpers.py
+++ b/custom_components/thessla_green_modbus/mappings/_helpers.py
@@ -88,12 +88,17 @@ def _parse_states(value: str | None) -> dict[str, int] | None:
     return states or None
 
 
+@functools.cache
 def _number_translation_keys() -> set[str]:
     """Return register names that have a Number translation entry in en.json.
 
     Used as a whitelist: only registers present here will produce a Number
     entity, preventing unnamed "Rekuperator" fallback entries for reserved or
     undocumented registers (e.g. ``reserved_8145``–``reserved_8151``).
+
+    Result is cached after the first call so the file is read at most once per
+    process.  Call ``_number_translation_keys.cache_clear()`` in tests that need
+    a fresh read.
     """
     try:
         _translations_dir = Path(__file__).resolve().parents[1] / "translations"
@@ -112,9 +117,14 @@ def _number_translation_keys() -> set[str]:
         return set()
 
 
+@functools.cache
 def _load_translation_keys() -> dict[str, set[str]]:
-    """Return available translation keys for supported entity types."""
+    """Return available translation keys for supported entity types.
 
+    Result is cached after the first call so the file is read at most once per
+    process.  Call ``_load_translation_keys.cache_clear()`` in tests that need
+    a fresh read.
+    """
     try:
         _translations_dir = Path(__file__).resolve().parents[1] / "translations"
         with (_translations_dir / "en.json").open(encoding="utf-8") as f:

--- a/custom_components/thessla_green_modbus/scanner/firmware.py
+++ b/custom_components/thessla_green_modbus/scanner/firmware.py
@@ -94,7 +94,13 @@ async def scan_firmware_info(scanner: Any, info_regs: list[int], device: Scanner
         msg = "Failed to read firmware version registers"
         if details:
             msg += ": " + "; ".join(details)
-        _LOGGER.warning(msg)
+        # version_patch (input register 4) is absent on some older firmware —
+        # that is expected.  Only escalate to WARNING when major or minor is
+        # also missing, which indicates a real communication problem.
+        if patch is None and major is not None and minor is not None:
+            _LOGGER.debug(msg)
+        else:
+            _LOGGER.warning(msg)
         device.firmware_available = False
 
 

--- a/custom_components/thessla_green_modbus/scanner/io_read.py
+++ b/custom_components/thessla_green_modbus/scanner/io_read.py
@@ -125,13 +125,15 @@ def _handle_register_error_response(
 
     Returns (done, payload) — same contract as _process_register_response.
     """
-    _LOGGER.warning(
-        "Exception code %s while reading %s %d-%d",
-        code,
-        register_type.replace("_", " "),
-        start,
-        end,
-    )
+    # Input registers 4-15 (version_patch, compilation timestamps) are absent on
+    # some firmware versions; ILLEGAL DATA ADDRESS (code 2) is the expected response.
+    _rtype = register_type.replace("_", " ")
+    if register_type == "input_registers" and code == 2 and 4 <= start <= 15:
+        _LOGGER.debug(
+            "Expected missing input register (code %s): %s %d-%d", code, _rtype, start, end
+        )
+    else:
+        _LOGGER.warning("Exception code %s while reading %s %d-%d", code, _rtype, start, end)
     if register_type == "input_registers" or code == 2:
         _handle_error_response(
             scanner,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,15 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 # ensure the main-thread loop exists before plugin fixtures request it.
 _ensure_current_event_loop()
 
+# Populate entity mappings before test modules are collected.  Some test-module-
+# level code (e.g. test_translations.py) reads NUMBER_ENTITY_MAPPINGS at import
+# time; without this call those dicts would be empty because the module-level
+# _run_build_entity_mappings() call was removed to eliminate blocking file I/O
+# from the HA event-loop import path.
+import custom_components.thessla_green_modbus.mappings as _thessla_mappings
+
+_thessla_mappings._run_build_entity_mappings()
+
 
 @pytest.fixture
 def mock_config_entry():

--- a/tests/test_no_blocking_io_setup.py
+++ b/tests/test_no_blocking_io_setup.py
@@ -1,0 +1,145 @@
+"""Tests proving that mapping setup does not perform blocking file I/O on the event loop.
+
+Three invariants are verified:
+1. Entity mapping output is identical across independent rebuild calls.
+2. Translation keys are correctly loaded and non-empty.
+3. pathlib.Path.open is never called from within the async event-loop thread
+   when async_setup_entity_mappings(hass) is used.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import custom_components.thessla_green_modbus.mappings as em
+import pytest
+from custom_components.thessla_green_modbus.mappings._helpers import (
+    _load_translation_keys,
+    _number_translation_keys,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Mapping output stability
+# ---------------------------------------------------------------------------
+
+
+def test_entity_mapping_output_is_stable_across_rebuilds() -> None:
+    """Rebuilding mappings twice must produce identical output."""
+    em._run_build_entity_mappings()
+    snapshot_a = copy.deepcopy(em.ENTITY_MAPPINGS)
+
+    em._run_build_entity_mappings()
+    snapshot_b = copy.deepcopy(em.ENTITY_MAPPINGS)
+
+    assert snapshot_a == snapshot_b, "ENTITY_MAPPINGS changed between two consecutive builds"
+
+
+def test_number_entity_mappings_non_empty_after_build() -> None:
+    """NUMBER_ENTITY_MAPPINGS must be populated after a build."""
+    em._run_build_entity_mappings()
+    assert em.NUMBER_ENTITY_MAPPINGS, "NUMBER_ENTITY_MAPPINGS is empty after build"
+
+
+def test_entity_mappings_contains_expected_domains() -> None:
+    """ENTITY_MAPPINGS must contain all expected platform keys after build."""
+    em._run_build_entity_mappings()
+    expected = {"number", "sensor", "binary_sensor", "switch", "select", "text", "time"}
+    missing = expected - set(em.ENTITY_MAPPINGS)
+    assert not missing, f"ENTITY_MAPPINGS missing domains: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Translation key loading
+# ---------------------------------------------------------------------------
+
+
+def test_number_translation_keys_non_empty() -> None:
+    """_number_translation_keys() must return a non-empty set."""
+    keys = _number_translation_keys()
+    assert isinstance(keys, set)
+    assert len(keys) > 0, "_number_translation_keys() returned an empty set"
+
+
+def test_load_translation_keys_non_empty() -> None:
+    """_load_translation_keys() must return non-empty sets for known entity types."""
+    keys = _load_translation_keys()
+    assert isinstance(keys, dict)
+    for domain in ("binary_sensor", "switch", "select"):
+        assert domain in keys, f"Missing domain '{domain}' in translation keys"
+        assert len(keys[domain]) > 0, f"Empty translation key set for domain '{domain}'"
+
+
+def test_translation_keys_match_entity_mappings() -> None:
+    """Every translation_key value in ENTITY_MAPPINGS must appear in en.json."""
+    em._run_build_entity_mappings()
+    trans = _load_translation_keys()
+    num_keys = _number_translation_keys()
+
+    domain_trans: dict[str, set[str]] = {
+        "binary_sensor": trans["binary_sensor"],
+        "switch": trans["switch"],
+        "select": trans["select"],
+        "number": num_keys,
+    }
+
+    for domain, entries in em.ENTITY_MAPPINGS.items():
+        if domain not in domain_trans:
+            continue
+        known = domain_trans[domain]
+        for key, defn in entries.items():
+            tk = defn.get("translation_key", key)
+            assert tk in known, f"translation_key '{tk}' for {domain}.{key} not found in en.json"
+
+
+# ---------------------------------------------------------------------------
+# 3. No blocking Path.open from event-loop thread
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entity_mappings_no_path_open_in_event_loop() -> None:
+    """Path.open must never be called from the event-loop thread during setup.
+
+    The fix ensures that all file I/O (translation JSON loading) happens inside
+    async_add_executor_job, i.e. in a worker thread rather than the event loop.
+    """
+    # Clear the translation-key caches so that actual file reads happen during
+    # this test run (verifying the executor path, not the cached path).
+    _number_translation_keys.cache_clear()
+    _load_translation_keys.cache_clear()
+
+    event_loop_thread = threading.current_thread()
+    open_calls_on_loop_thread: list[str] = []
+
+    original_open = Path.open
+
+    def _tracking_open(self: Path, *args: object, **kwargs: object):  # type: ignore[override]
+        if threading.current_thread() is event_loop_thread:
+            open_calls_on_loop_thread.append(str(self))
+        return original_open(self, *args, **kwargs)
+
+    mock_hass = MagicMock()
+
+    async def _executor_job(fn, *args):
+        """Simulate async_add_executor_job using a real thread-pool executor."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, fn, *args)
+
+    mock_hass.async_add_executor_job = _executor_job
+
+    with patch.object(Path, "open", _tracking_open):
+        await em.async_setup_entity_mappings(hass=mock_hass)
+
+    assert not open_calls_on_loop_thread, (
+        "Path.open was called from the event-loop thread during mapping setup: "
+        + ", ".join(open_calls_on_loop_thread)
+    )
+
+    # Restore caches for subsequent tests
+    _number_translation_keys.cache_clear()
+    _load_translation_keys.cache_clear()
+    em._run_build_entity_mappings()

--- a/tools/validate_entity_mappings.py
+++ b/tools/validate_entity_mappings.py
@@ -175,6 +175,10 @@ def _ensure_homeassistant_importable() -> None:
 def _load_validation_inputs() -> tuple[object, dict[str, Any], dict[str, Any], set[str]]:
     from custom_components.thessla_green_modbus import mappings as mappings_mod
 
+    # The module-level auto-build was removed to prevent blocking I/O on the HA
+    # event loop; tools must trigger it explicitly.
+    mappings_mod._run_build_entity_mappings()
+
     en = _load_json(CC_ROOT / "translations" / "en.json")
     pl = _load_json(CC_ROOT / "translations" / "pl.json")
     _load_json(CC_ROOT / "strings.json")


### PR DESCRIPTION
## Root cause

Home Assistant reported a blocking call to `open()` inside the event loop:

```
custom_components/thessla_green_modbus/mappings/_helpers.py
with (_translations_dir / "en.json").open(encoding="utf-8") as f
```

**Call chain:** `__init__.py` → `_setup.py` → `mappings` (import) → `_build_entity_mappings` → `_load_number_mappings` / `_load_discrete_mappings` → `mappings/_helpers.py`

The problem was a module-level `_run_build_entity_mappings()` call at the bottom of `mappings/__init__.py`. When `_setup.py` is first imported inside `async_setup_entry` (while the HA event loop is running), Python executes that module-level call synchronously. That call reached `_number_translation_keys()` and `_load_translation_keys()` in `_helpers.py`, both of which used `pathlib.Path.open()` — a blocking syscall detected and warned about by HA.

The `async_setup_entity_mappings(hass)` call that follows already ran the same build via `hass.async_add_executor_job` (a thread-pool worker), so the module-level eager call was redundant and solely responsible for the blocking I/O warning.

## Files changed

| File | Change |
|------|--------|
| `mappings/_helpers.py` | Added `@functools.cache` to `_number_translation_keys` and `_load_translation_keys` |
| `mappings/__init__.py` | Removed module-level `_run_build_entity_mappings()` call; improved docstring |
| `scanner/io_read.py` | Downgraded exception-code-2 WARNING → DEBUG for input registers 4–15 |
| `scanner/firmware.py` | Downgraded "failed firmware registers" WARNING → DEBUG when only `version_patch` is missing |
| `tests/conftest.py` | Explicit `_run_build_entity_mappings()` call before test collection |
| `tools/validate_entity_mappings.py` | Explicit `_run_build_entity_mappings()` call inside `_load_validation_inputs()` |
| `tests/test_no_blocking_io_setup.py` | **New** — three test groups described below |

## How blocking `open()` was removed

1. **`@functools.cache` on both translation helpers** — the JSON file is read at most once per process; all subsequent calls are pure in-memory lookups with no I/O.

2. **Remove the module-level `_run_build_entity_mappings()` call** — importing `mappings/__init__.py` now performs no file I/O at all. The module simply defines functions and imports static dicts.

3. **`async_setup_entity_mappings(hass)` already handles the async path correctly** — it calls `hass.async_add_executor_job(_run_build_entity_mappings)`, which runs the entire build (including translation JSON reads) in a thread-pool worker. The `@functools.cache` ensures the second and subsequent builds pay no I/O cost.

4. **Callers that need the build at non-async time** (test collection, CLI tools) call `_run_build_entity_mappings()` explicitly and synchronously from the calling thread — safe because no event loop is active in those contexts.

## Modbus exception logging

- `scanner/io_read.py` `_handle_register_error_response`: exception code 2 (ILLEGAL DATA ADDRESS) on **input registers 4–15** (covers `version_patch` at address 4, and `compilation_days`/`compilation_seconds` at 14–15) is now logged at **DEBUG** level. These registers are legitimately absent on some older firmware versions. All other register types and all other exception codes remain at **WARNING**.

- `scanner/firmware.py` `scan_firmware_info`: when `version_major` and `version_minor` are successfully read but `version_patch` is `None`, the summary message is now **DEBUG** instead of **WARNING**, since that specific combination is expected for devices that don't expose register 4. Real failures (major or minor unreadable) remain at WARNING.

## New tests (`tests/test_no_blocking_io_setup.py`)

**Group 1 — mapping output stability:**
- `test_entity_mapping_output_is_stable_across_rebuilds` — two consecutive builds produce identical `ENTITY_MAPPINGS`
- `test_number_entity_mappings_non_empty_after_build` — `NUMBER_ENTITY_MAPPINGS` is non-empty after build
- `test_entity_mappings_contains_expected_domains` — all platform keys present

**Group 2 — translation key resolution:**
- `test_number_translation_keys_non_empty` — `_number_translation_keys()` returns a non-empty set
- `test_load_translation_keys_non_empty` — `_load_translation_keys()` returns non-empty sets for `binary_sensor`, `switch`, `select`
- `test_translation_keys_match_entity_mappings` — every `translation_key` in `ENTITY_MAPPINGS` exists in `en.json`

**Group 3 — no blocking I/O from event loop:**
- `test_async_setup_entity_mappings_no_path_open_in_event_loop` — clears the translation caches, calls `async_setup_entity_mappings(hass)` with a mock `hass` whose `async_add_executor_job` uses a real `loop.run_in_executor`, patches `Path.open` to record which thread calls it, and asserts **zero calls occurred on the event-loop thread**

## Validation results

```
python -m compileall -q custom_components/thessla_green_modbus tests tools  →  OK (no errors)
ruff check custom_components tests tools                                      →  All checks passed!
ruff check --select I custom_components tests tools                           →  All checks passed!
ruff format --check custom_components tests tools                             →  434 files already formatted
python tools/validate_entity_mappings.py                                     →  OK: 366 entities validated
python tools/check_translations.py                                           →  All translation keys present.
python tools/check_maintainability.py                                        →  Maintainability gate passed.
```

## Invariants confirmed unchanged

| Invariant | Status |
|-----------|--------|
| Entity IDs | ✅ unchanged |
| Translation keys | ✅ unchanged |
| Service IDs | ✅ unchanged |
| Register names | ✅ unchanged |
| Register addresses | ✅ unchanged |
| Modbus behavior | ✅ unchanged (logging level only) |

https://claude.ai/code/session_012wEn1U3uhFSPPYXnEJZWWM

---
_Generated by [Claude Code](https://claude.ai/code/session_012wEn1U3uhFSPPYXnEJZWWM)_