### PR TITLE
Migrate coordinator device-state proxies to `device_client` and remove first proxy slice

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -428,14 +428,6 @@ class ThesslaGreenModbusCoordinator(
     def _register_groups(self, value: dict[str, Any]) -> None:
         self._device_client._register_groups = value
 
-    @property
-    def _failed_registers(self) -> set[str]:
-        return self._device_client._failed_registers
-
-    @_failed_registers.setter
-    def _failed_registers(self, value: set[str]) -> None:
-        self._device_client._failed_registers = value
-
     # -- Statistics and failure tracking --
 
     @property
@@ -445,22 +437,6 @@ class ThesslaGreenModbusCoordinator(
     @statistics.setter
     def statistics(self, value: dict[str, Any]) -> None:
         self._device_client.statistics = value
-
-    @property
-    def _consecutive_failures(self) -> int:
-        return self._device_client._consecutive_failures
-
-    @_consecutive_failures.setter
-    def _consecutive_failures(self, value: int) -> None:
-        self._device_client._consecutive_failures = value
-
-    @property
-    def _max_failures(self) -> int:
-        return self._device_client._max_failures
-
-    @_max_failures.setter
-    def _max_failures(self, value: int) -> None:
-        self._device_client._max_failures = value
 
     # -- Scan state --
 
@@ -497,22 +473,6 @@ class ThesslaGreenModbusCoordinator(
         self._device_client.last_scan = value
 
     # -- Post-processing state (capabilities mixin) --
-
-    @property
-    def _last_power_timestamp(self) -> Any:
-        return self._device_client._last_power_timestamp
-
-    @_last_power_timestamp.setter
-    def _last_power_timestamp(self, value: Any) -> None:
-        self._device_client._last_power_timestamp = value
-
-    @property
-    def _total_energy(self) -> float:
-        return self._device_client._total_energy
-
-    @_total_energy.setter
-    def _total_energy(self, value: float) -> None:
-        self._device_client._total_energy = value
 
     def __init__(
         self,

--- a/custom_components/thessla_green_modbus/coordinator/errors.py
+++ b/custom_components/thessla_green_modbus/coordinator/errors.py
@@ -21,7 +21,7 @@ def apply_update_failure_state(
     if timeout_error:
         coordinator.statistics["timeout_errors"] += 1
     coordinator.statistics["last_error"] = str(exc)
-    coordinator._consecutive_failures += 1
+    coordinator.device_client._consecutive_failures += 1
     coordinator.offline_state = True
 
 
@@ -42,7 +42,7 @@ async def handle_update_error(
     apply_update_failure_state(coordinator, exc, timeout_error=timeout_error)
     await coordinator._disconnect()
 
-    if coordinator._consecutive_failures >= coordinator._max_failures:
+    if coordinator.device_client._consecutive_failures >= coordinator.device_client._max_failures:
         _LOGGER.error("Too many consecutive failures, disconnecting")
         coordinator._trigger_reauth(reauth_reason)
 

--- a/custom_components/thessla_green_modbus/coordinator/state.py
+++ b/custom_components/thessla_green_modbus/coordinator/state.py
@@ -120,8 +120,8 @@ def initialize_runtime_state(coordinator: Any, *, entry: ConfigEntry | None) -> 
     coordinator._discrete_inputs_rev = coordinator._reverse_maps["discrete_inputs"]
 
     coordinator._register_groups = {}
-    coordinator._consecutive_failures = 0
-    coordinator._max_failures = 5
+    coordinator.device_client._consecutive_failures = 0
+    coordinator.device_client._max_failures = 5
 
     coordinator.device_scan_result = None
     coordinator.unknown_registers = {}
@@ -141,5 +141,5 @@ def initialize_runtime_state(coordinator: Any, *, entry: ConfigEntry | None) -> 
     coordinator.last_scan = None
     from ..utils import utcnow
 
-    coordinator._last_power_timestamp = utcnow()
-    coordinator._total_energy = 0.0
+    coordinator.device_client._last_power_timestamp = utcnow()
+    coordinator.device_client._total_energy = 0.0

--- a/custom_components/thessla_green_modbus/coordinator/update_result.py
+++ b/custom_components/thessla_green_modbus/coordinator/update_result.py
@@ -23,7 +23,7 @@ def apply_success_result(
     """Apply successful update-cycle side effects and return payload."""
     coordinator.statistics["successful_reads"] += 1
     coordinator.statistics["last_successful_update"] = _utcnow()
-    coordinator._consecutive_failures = 0
+    coordinator.device_client._consecutive_failures = 0
     coordinator.offline_state = False
 
     response_time = (_utcnow() - start_time).total_seconds()

--- a/custom_components/thessla_green_modbus/coordinator/update_state.py
+++ b/custom_components/thessla_green_modbus/coordinator/update_state.py
@@ -18,7 +18,7 @@ def begin_update_cycle(coordinator: ThesslaGreenModbusCoordinator) -> dict[str, 
         return coordinator.data or {}
 
     coordinator._update_in_progress = True
-    coordinator._failed_registers = set()
+    coordinator.device_client._failed_registers = set()
     return None
 
 

--- a/custom_components/thessla_green_modbus/core/capabilities_mixin.py
+++ b/custom_components/thessla_green_modbus/core/capabilities_mixin.py
@@ -245,7 +245,8 @@ class _CoordinatorCapabilitiesMixin:
         data["estimated_power"] = power
         data["electrical_power"] = power
         now = _utcnow()
-        last_ts = self._last_power_timestamp
+        device_client = self.device_client
+        last_ts = device_client._last_power_timestamp
         if not isinstance(last_ts, datetime):
             elapsed = 0.0
         else:
@@ -260,9 +261,9 @@ class _CoordinatorCapabilitiesMixin:
             ):
                 now = now.replace(tzinfo=UTC)
             elapsed = (now - last_ts).total_seconds()
-        self._total_energy += power * elapsed / 3600000.0
-        data["total_energy"] = self._total_energy
-        self._last_power_timestamp = now
+        device_client._total_energy += power * elapsed / 3600000.0
+        data["total_energy"] = device_client._total_energy
+        device_client._last_power_timestamp = now
 
     def _apply_device_clock(self, data: dict[str, Any]) -> None:
         """Decode and store device clock when valid."""

--- a/docs/coordinator_proxy_remaining_plan.md
+++ b/docs/coordinator_proxy_remaining_plan.md
@@ -114,3 +114,12 @@ See also:
 - `docs/coordinator_proxy_cleanup.md` — prior inventory of proxy properties
 - `docs/coordinator_proxy_migration_inventory.md` — migration inventory from previous PR
 - `docs/device_client_redesign.md` — design rationale for `ThesslaGreenDeviceClient`
+
+## 2026-05-18 update
+
+Consumer code has been migrated to prefer `coordinator.device_client` for device-domain state. Remaining proxy removals are deferred until direct proxy mutations in tests are fully migrated.
+
+
+## 2026-05-18 slice-1 removal
+
+Removed first internal proxy slice from `coordinator.py`: `_last_power_timestamp`, `_total_energy`, `_consecutive_failures`, `_max_failures`, `_failed_registers` (40 -> 35). These were safe because all runtime/test callers now use `coordinator.device_client.*`.

--- a/docs/coordinator_proxy_removal_inventory.md
+++ b/docs/coordinator_proxy_removal_inventory.md
@@ -1,0 +1,47 @@
+# Coordinator Proxy Removal Inventory
+
+- Device-domain state must be accessed via `coordinator.device_client`.
+- Internal `coordinator.<state>` proxy access is deprecated; do not add new proxy usages.
+
+| Proxy | Migrate now | Canonical replacement |
+|---|---|---|
+| `config` | yes | `coordinator.device_client.config` |
+| `_device_name` | yes | `coordinator.device_client._device_name` |
+| `_resolved_connection_mode` | yes | `coordinator.device_client._resolved_connection_mode` |
+| `timeout` | yes | `coordinator.device_client.timeout` |
+| `retry` | yes | `coordinator.device_client.retry` |
+| `backoff` | yes | `coordinator.device_client.backoff` |
+| `backoff_jitter` | yes | `coordinator.device_client.backoff_jitter` |
+| `force_full_register_list` | yes | `coordinator.device_client.force_full_register_list` |
+| `scan_uart_settings` | yes | `coordinator.device_client.scan_uart_settings` |
+| `deep_scan` | yes | `coordinator.device_client.deep_scan` |
+| `safe_scan` | yes | `coordinator.device_client.safe_scan` |
+| `skip_missing_registers` | yes | `coordinator.device_client.skip_missing_registers` |
+| `effective_batch` | yes | `coordinator.device_client.effective_batch` |
+| `max_registers_per_request` | yes | `coordinator.device_client.max_registers_per_request` |
+| `client` | yes | `coordinator.client (raw pymodbus)` |
+| `_transport` | yes | `coordinator.device_client._transport` |
+| `_client_lock` | yes | `coordinator.device_client._client_lock` |
+| `_write_lock` | yes | `coordinator.device_client._write_lock` |
+| `_update_in_progress` | yes | `coordinator.device_client._update_in_progress` |
+| `offline_state` | yes | `coordinator.device_client.offline_state` |
+| `capabilities` | yes | `coordinator.device_client.capabilities` |
+| `device_info` | yes | `coordinator.device_client.device_info` |
+| `available_registers` | yes | `coordinator.device_client.available_registers` |
+| `_register_maps` | yes | `coordinator.device_client._register_maps` |
+| `_reverse_maps` | yes | `coordinator.device_client._reverse_maps` |
+| `_input_registers_rev` | yes | `coordinator.device_client._input_registers_rev` |
+| `_holding_registers_rev` | yes | `coordinator.device_client._holding_registers_rev` |
+| `_coil_registers_rev` | yes | `coordinator.device_client._coil_registers_rev` |
+| `_discrete_inputs_rev` | yes | `coordinator.device_client._discrete_inputs_rev` |
+| `_register_groups` | yes | `coordinator.device_client._register_groups` |
+| `_failed_registers` | yes | `coordinator.device_client._failed_registers` |
+| `statistics` | yes | `coordinator.device_client.statistics` |
+| `_consecutive_failures` | yes | `coordinator.device_client._consecutive_failures` |
+| `_max_failures` | yes | `coordinator.device_client._max_failures` |
+| `device_scan_result` | yes | `coordinator.device_client.device_scan_result` |
+| `unknown_registers` | yes | `coordinator.device_client.unknown_registers` |
+| `scanned_registers` | yes | `coordinator.device_client.scanned_registers` |
+| `last_scan` | yes | `coordinator.device_client.last_scan` |
+| `_last_power_timestamp` | yes | `coordinator.device_client._last_power_timestamp` |
+| `_total_energy` | yes | `coordinator.device_client._total_energy` |

--- a/docs/coordinator_proxy_removal_report.md
+++ b/docs/coordinator_proxy_removal_report.md
@@ -1,0 +1,12 @@
+# Coordinator Proxy Removal Report
+
+- Proxy count before: 40 device-state proxies in `coordinator.py`.
+- Proxy count after: 35 device-state proxies in `coordinator.py`.
+- Removed proxies in this slice:
+  - `_last_power_timestamp`
+  - `_total_energy`
+  - `_consecutive_failures`
+  - `_max_failures`
+  - `_failed_registers`
+- Why safe: these are internal device-runtime fields already owned by `ThesslaGreenDeviceClient`; production and tests were migrated to explicit `coordinator.device_client.*` access before proxy deletion.
+- Remaining proxy count: 35.

--- a/tests/test_coordinator_io.py
+++ b/tests/test_coordinator_io.py
@@ -28,7 +28,7 @@ def coordinator() -> ThesslaGreenModbusCoordinator:
         "discrete_inputs": set(),
     }
     coord._register_groups = {"holding_registers": [(100, 2)]}
-    coord._failed_registers = set()
+    coord.device_client._failed_registers = set()
     coord.effective_batch = 10
     mapping = {100: "mode", 101: "air_flow_rate_manual"}
     coord._find_register_name = lambda rt, addr: mapping.get(addr)

--- a/tests/test_coordinator_offline.py
+++ b/tests/test_coordinator_offline.py
@@ -34,7 +34,7 @@ async def test_coordinator_tracks_offline_and_recovers(monkeypatch) -> None:
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
 
-    assert coordinator._consecutive_failures == 1  # nosec: explicit state check
+    assert coordinator.device_client._consecutive_failures == 1  # nosec: explicit state check
     coordinator._read_input_registers_optimized.reset_mock(side_effect=True)
     coordinator._read_input_registers_optimized.side_effect = None
     coordinator._read_input_registers_optimized.return_value = {"reg": 1}
@@ -42,7 +42,7 @@ async def test_coordinator_tracks_offline_and_recovers(monkeypatch) -> None:
     data = await coordinator._async_update_data()
 
     assert data["reg"] == 1  # nosec: explicit state check
-    assert coordinator._consecutive_failures == 0  # nosec: explicit state check
+    assert coordinator.device_client._consecutive_failures == 0  # nosec: explicit state check
     assert coordinator.statistics["last_successful_update"] is not None  # nosec
 
 
@@ -59,7 +59,7 @@ async def test_coordinator_disconnects_after_retries(monkeypatch) -> None:
         scan_interval=5,
         retry=1,
     )
-    coordinator._max_failures = 1
+    coordinator.device_client._max_failures = 1
     coordinator.client = MagicMock(connected=True)
     coordinator._disconnect = AsyncMock()
     coordinator._ensure_connection = AsyncMock()

--- a/tests/test_coordinator_post_process.py
+++ b/tests/test_coordinator_post_process.py
@@ -17,7 +17,7 @@ def test_post_process_data(coordinator):
         "dac_exhaust": 4.0,
     }
     fake_now = datetime(2024, 1, 1, 12, 0, 0)
-    coordinator._last_power_timestamp = fake_now - timedelta(hours=1)
+    coordinator.device_client._last_power_timestamp = fake_now - timedelta(hours=1)
     with patch(
         "custom_components.thessla_green_modbus.coordinator.coordinator.dt_util.utcnow",
         return_value=fake_now,

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -155,7 +155,7 @@ def test_post_process_data_timezone_aware_timestamp():
     """Timezone-aware last timestamp is handled correctly (lines 1916-1919)."""
     coord = _make_coordinator()
     # Set a timezone-aware last timestamp
-    coord._last_power_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    coord.device_client._last_power_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     data = {"dac_supply": 3.0, "dac_exhaust": 3.0}
     result = coord._post_process_data(data)
     assert "estimated_power" in result
@@ -181,7 +181,7 @@ def test_post_process_data_type_error_in_efficiency():
 def test_post_process_data_non_datetime_last_timestamp():
     """Non-datetime _last_power_timestamp → elapsed=0.0 (line 1914)."""
     coord = _make_coordinator()
-    coord._last_power_timestamp = "not_a_datetime"
+    coord.device_client._last_power_timestamp = "not_a_datetime"
     data = {"dac_supply": 3.0, "dac_exhaust": 3.0}
     result = coord._post_process_data(data)
     assert "estimated_power" in result
@@ -191,7 +191,7 @@ def test_post_process_data_non_datetime_last_timestamp():
 def test_post_process_data_naive_now_aware_last_ts():
     """Naive _utcnow with aware last_ts → adds UTC tz to now (line 1919)."""
     coord = _make_coordinator()
-    coord._last_power_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    coord.device_client._last_power_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     # Patch _utcnow to return naive datetime
     with patch(
         "custom_components.thessla_green_modbus.coordinator.coordinator._utcnow",

--- a/tests/test_coordinator_update_result.py
+++ b/tests/test_coordinator_update_result.py
@@ -18,7 +18,7 @@ def test_apply_success_result_updates_coordinator_state() -> None:
             "last_successful_update": None,
             "average_response_time": 2.0,
         },
-        _consecutive_failures=4,
+        device_client=SimpleNamespace(_consecutive_failures=4),
         offline_state=True,
     )
 
@@ -32,6 +32,6 @@ def test_apply_success_result_updates_coordinator_state() -> None:
     assert result == data
     assert coordinator.statistics["successful_reads"] == 2
     assert coordinator.statistics["last_successful_update"] == now
-    assert coordinator._consecutive_failures == 0
+    assert coordinator.device_client._consecutive_failures == 0
     assert coordinator.offline_state is False
     assert coordinator.statistics["average_response_time"] == 3.5

--- a/tests/test_coordinator_update_state.py
+++ b/tests/test_coordinator_update_state.py
@@ -21,13 +21,13 @@ def test_begin_update_cycle_returns_existing_data_when_already_running() -> None
 def test_begin_update_cycle_initializes_runtime_flags() -> None:
     coordinator = MagicMock()
     coordinator._update_in_progress = False
-    coordinator._failed_registers = {"legacy"}
+    coordinator.device_client._failed_registers = {"legacy"}
 
     result = begin_update_cycle(coordinator)
 
     assert result is None
     assert coordinator._update_in_progress is True
-    assert coordinator._failed_registers == set()
+    assert coordinator.device_client._failed_registers == set()
 
 
 def test_finish_update_cycle_resets_runtime_flag() -> None:

--- a/tests/test_coordinator_update_statistics.py
+++ b/tests/test_coordinator_update_statistics.py
@@ -5,6 +5,9 @@ from tests.helpers_coordinator import make_coordinator as _make_coordinator
 
 def test_clear_register_failure_with_attribute():
     c = _make_coordinator()
-    c._failed_registers = {"outside_temperature", "mode"}
+    c.device_client._failed_registers = {"outside_temperature", "mode"}
     c._clear_register_failure("outside_temperature")
-    assert "outside_temperature" not in c._failed_registers and "mode" in c._failed_registers
+    assert (
+        "outside_temperature" not in c.device_client._failed_registers
+        and "mode" in c.device_client._failed_registers
+    )

--- a/tests/test_device_client.py
+++ b/tests/test_device_client.py
@@ -405,7 +405,7 @@ def test_coordinator_retry_proxy():
 
 def test_coordinator_consecutive_failures_proxy():
     coord = _make_coordinator()
-    coord._consecutive_failures = 3
+    coord.device_client._consecutive_failures = 3
     assert coord.device_client._consecutive_failures == 3
 
 
@@ -424,7 +424,7 @@ def test_coordinator_register_maps_proxy():
 
 def test_coordinator_failed_registers_proxy():
     coord = _make_coordinator()
-    coord._failed_registers.add("fan_speed")
+    coord.device_client._failed_registers.add("fan_speed")
     assert "fan_speed" in coord.device_client._failed_registers
 
 

--- a/tests/test_schedule_summer_regression.py
+++ b/tests/test_schedule_summer_regression.py
@@ -60,7 +60,7 @@ def coordinator() -> ThesslaGreenModbusCoordinator:
         "discrete_inputs": set(),
     }
     coord._register_groups = {"holding_registers": [(SUMMER_BASE_ADDR, len(SUMMER_NAMES))]}
-    coord._failed_registers = set()
+    coord.device_client._failed_registers = set()
     coord.effective_batch = 20
 
     addr_to_name = {SUMMER_BASE_ADDR + i: name for i, name in enumerate(SUMMER_NAMES)}
@@ -68,7 +68,7 @@ def coordinator() -> ThesslaGreenModbusCoordinator:
     coord._process_register_value = lambda _name, value: value
     coord._clear_register_failure = MagicMock()
     coord._mark_registers_failed = MagicMock(
-        side_effect=lambda regs: coord._failed_registers.update(r for r in regs if r)
+        side_effect=lambda regs: coord.device_client._failed_registers.update(r for r in regs if r)
     )
     return coord
 
@@ -113,7 +113,9 @@ async def test_schedule_summer_batch_bug_falls_back_to_individual_reads(
     assert [call.args[1] for call in single_calls] == [SUMMER_BASE_ADDR + i for i in range(4)]
 
     assert data == dict(zip(SUMMER_NAMES, [101, 202, 303, 404], strict=True))
-    assert not any(name.startswith("schedule_summer_") for name in coordinator._failed_registers)
+    assert not any(
+        name.startswith("schedule_summer_") for name in coordinator.device_client._failed_registers
+    )
 
 
 @pytest.mark.asyncio
@@ -146,7 +148,7 @@ async def test_schedule_summer_partial_batch_falls_back_for_tail_only(
     assert len(fallback_call.args[2]) == 2  # tail_names
 
     assert data == dict(zip(SUMMER_NAMES, [101, 202, 303, 404], strict=True))
-    assert not coordinator._failed_registers
+    assert not coordinator.device_client._failed_registers
 
 
 def test_summer_schedule_register_names_exist_in_registry() -> None:


### PR DESCRIPTION
### Motivation

- Consolidate ownership of device-domain runtime state on `ThesslaGreenDeviceClient` to remove redundant proxy properties on the coordinator.
- Reduce coupling and make state mutations explicit via `coordinator.device_client.*` to simplify future proxy removal slices and reduce tracing risk during hardware validation.

### Description

- Removed several internal coordinator proxy properties and direct mutations: `_last_power_timestamp`, `_total_energy`, `_consecutive_failures`, `_max_failures`, and `_failed_registers` in `coordinator.py` and migrated their uses to `coordinator.device_client.*`.
- Updated coordinator helper modules to reference the device client for those fields, including `errors.py`, `state.py`, `update_result.py`, `update_state.py`, and the capabilities mixin in `core/capabilities_mixin.py`.
- Updated automated tests to use the `device_client` attributes instead of the removed coordinator proxies, and adjusted test helpers accordingly.
- Added documentation files describing the proxy removal plan, inventory, and a removal report slice in `docs/` to track progress and rationale.

### Testing

- Ran the coordinator and device-client unit tests touching the changed state accessors, including `tests/test_coordinator_io.py`, `tests/test_coordinator_offline.py`, `tests/test_coordinator_post_process.py`, `tests/test_coordinator_update.py`, `tests/test_coordinator_update_result.py`, `tests/test_coordinator_update_state.py`, `tests/test_coordinator_update_statistics.py`, `tests/test_device_client.py`, and `tests/test_schedule_summer_regression.py`.
- All updated unit tests passed after migrating usages to `coordinator.device_client.*`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4bf1a51c8326898ef0091027fe6e)