### PR TITLE
refactor: remove scan-flag coordinator proxy group; update coordinato…

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -143,11 +143,9 @@ class ThesslaGreenModbusCoordinator(
     """Optimized data coordinator for ThesslaGreen Modbus device.
 
     Acts as the Home Assistant integration boundary.  All device-domain
-    operations are delegated to ``self._device_client`` which is a
-    ``ThesslaGreenDeviceClient`` instance.  The coordinator's device-state
-    attributes (transport, capabilities, register maps, statistics, …) are
-    properties that proxy to the device client, so existing coordinator
-    submodule functions continue to work unchanged via duck-typing.
+    operations are delegated to ``self._device_client``.  Selected
+    device-state attributes are proxied on the coordinator so that
+    submodule functions and entity platforms can access them via duck-typing.
     """
 
     _reauth_scheduled: bool
@@ -157,24 +155,11 @@ class ThesslaGreenModbusCoordinator(
     # Device-state property proxies
     #
     # All mutable device-domain state lives in ``self._device_client``.
-    # The properties below allow coordinator submodule functions (which
-    # receive the coordinator via duck-typing) and tests to continue
-    # accessing coordinator.X and have those accesses transparently
-    # read/write DeviceClient state.
-    #
-    # Retention rationale (applies to every proxy below):
-    #   - Coordinator submodules (runtime_io, read_batches, read_bits,
-    #     register_groups, scan_result, state, etc.) receive ``self``
-    #     (the coordinator) as their duck-typed owner and access these
-    #     attributes directly.
-    #   - Test files access these attributes on the coordinator directly
-    #     (e.g. coordinator.client, coordinator.available_registers).
-    #   - Entity platform files access coordinator.available_registers,
-    #     coordinator.capabilities, coordinator.statistics, etc.
-    #
-    # Future removal path: When a submodule is updated to accept a
-    # DeviceClient instead of the coordinator, the corresponding proxy
-    # can be removed at that point.
+    # These proxies let coordinator submodule functions (which receive
+    # ``self`` as a duck-typed owner) and entity platforms access
+    # coordinator.X transparently.  Scan-flag attributes (deep_scan,
+    # safe_scan, scan_uart_settings, skip_missing_registers) are accessed
+    # directly on ``device_client`` by callers that already hold it.
     # ------------------------------------------------------------------
 
     @property
@@ -369,22 +354,6 @@ class ThesslaGreenModbusCoordinator(
     @_resolved_connection_mode.setter
     def _resolved_connection_mode(self, value: str | None) -> None:
         self._device_client._resolved_connection_mode = value
-
-    @property
-    def scan_uart_settings(self) -> bool:
-        return self._device_client.scan_uart_settings
-
-    @property
-    def skip_missing_registers(self) -> bool:
-        return self._device_client.skip_missing_registers
-
-    @property
-    def deep_scan(self) -> bool:
-        return self._device_client.deep_scan
-
-    @property
-    def safe_scan(self) -> bool:
-        return self._device_client.safe_scan
 
     @property
     def _register_maps(self) -> dict[str, dict[str, int]]:

--- a/custom_components/thessla_green_modbus/coordinator/diagnostics.py
+++ b/custom_components/thessla_green_modbus/coordinator/diagnostics.py
@@ -100,7 +100,7 @@ def get_diagnostic_data(coordinator: Any) -> dict[str, Any]:
         "total_available_registers": total_registers,
         "total_registers_json": total_registers_json,
         "effective_batch": coordinator.effective_batch,
-        "deep_scan": coordinator.deep_scan,
+        "deep_scan": coordinator.device_client.deep_scan,
         "force_full_register_list": coordinator.force_full_register_list,
         "autoscan": not coordinator.force_full_register_list,
         "registers_discovered": registers_discovered,

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -82,7 +82,7 @@ def _coordinator_defaults(coordinator: ThesslaGreenModbusCoordinator) -> dict[st
         "autoscan": not coordinator.force_full_register_list,
         "force_full": coordinator.force_full_register_list,
         "force_full_register_list": coordinator.force_full_register_list,
-        "deep_scan": coordinator.deep_scan,
+        "deep_scan": coordinator.device_client.deep_scan,
         "error_statistics": {
             "connection_errors": coordinator.statistics.get("connection_errors", 0),
             "timeout_errors": coordinator.statistics.get("timeout_errors", 0),

--- a/custom_components/thessla_green_modbus/services/handlers_data.py
+++ b/custom_components/thessla_green_modbus/services/handlers_data.py
@@ -43,7 +43,7 @@ def register_data_services(hass: HomeAssistant, deps: ServiceHandlerDeps) -> Non
                     slave_id=coordinator.slave_id,
                     timeout=int(coordinator.timeout),
                     retry=coordinator.retry,
-                    scan_uart_settings=coordinator.scan_uart_settings,
+                    scan_uart_settings=coordinator.device_client.scan_uart_settings,
                     skip_known_missing=False,
                     full_register_scan=True,
                     max_registers_per_request=coordinator.effective_batch,

--- a/docs/coordinator_proxy_removal_inventory.md
+++ b/docs/coordinator_proxy_removal_inventory.md
@@ -3,45 +3,58 @@
 - Device-domain state must be accessed via `coordinator.device_client`.
 - Internal `coordinator.<state>` proxy access is deprecated; do not add new proxy usages.
 
-| Proxy | Migrate now | Canonical replacement |
+## Completed (2026-05-19)
+
+The scan-flag proxy group was removed.  Callers in `diagnostics.py`,
+`coordinator/diagnostics.py`, and `services/handlers_data.py` were updated to
+use `coordinator.device_client.X` directly.  Note: `register_groups.py` and
+`scanner_kwargs.py` already received a `ThesslaGreenDeviceClient` as their
+duck-typed `coordinator` argument, so those files needed no changes.
+
+| Proxy | Status | Canonical replacement |
 |---|---|---|
-| `config` | yes | `coordinator.device_client.config` |
-| `_device_name` | yes | `coordinator.device_client._device_name` |
-| `_resolved_connection_mode` | yes | `coordinator.device_client._resolved_connection_mode` |
-| `timeout` | yes | `coordinator.device_client.timeout` |
-| `retry` | yes | `coordinator.device_client.retry` |
-| `backoff` | yes | `coordinator.device_client.backoff` |
-| `backoff_jitter` | yes | `coordinator.device_client.backoff_jitter` |
-| `force_full_register_list` | yes | `coordinator.device_client.force_full_register_list` |
-| `scan_uart_settings` | yes | `coordinator.device_client.scan_uart_settings` |
-| `deep_scan` | yes | `coordinator.device_client.deep_scan` |
-| `safe_scan` | yes | `coordinator.device_client.safe_scan` |
-| `skip_missing_registers` | yes | `coordinator.device_client.skip_missing_registers` |
-| `effective_batch` | yes | `coordinator.device_client.effective_batch` |
-| `max_registers_per_request` | yes | `coordinator.device_client.max_registers_per_request` |
-| `client` | yes | `coordinator.client (raw pymodbus)` |
-| `_transport` | yes | `coordinator.device_client._transport` |
-| `_client_lock` | yes | `coordinator.device_client._client_lock` |
-| `_write_lock` | yes | `coordinator.device_client._write_lock` |
-| `_update_in_progress` | yes | `coordinator.device_client._update_in_progress` |
-| `offline_state` | yes | `coordinator.device_client.offline_state` |
-| `capabilities` | yes | `coordinator.device_client.capabilities` |
-| `device_info` | yes | `coordinator.device_client.device_info` |
-| `available_registers` | yes | `coordinator.device_client.available_registers` |
-| `_register_maps` | yes | `coordinator.device_client._register_maps` |
-| `_reverse_maps` | yes | `coordinator.device_client._reverse_maps` |
-| `_input_registers_rev` | yes | `coordinator.device_client._input_registers_rev` |
-| `_holding_registers_rev` | yes | `coordinator.device_client._holding_registers_rev` |
-| `_coil_registers_rev` | yes | `coordinator.device_client._coil_registers_rev` |
-| `_discrete_inputs_rev` | yes | `coordinator.device_client._discrete_inputs_rev` |
-| `_register_groups` | yes | `coordinator.device_client._register_groups` |
-| `_failed_registers` | yes | `coordinator.device_client._failed_registers` |
-| `statistics` | yes | `coordinator.device_client.statistics` |
-| `_consecutive_failures` | yes | `coordinator.device_client._consecutive_failures` |
-| `_max_failures` | yes | `coordinator.device_client._max_failures` |
-| `device_scan_result` | yes | `coordinator.device_client.device_scan_result` |
-| `unknown_registers` | yes | `coordinator.device_client.unknown_registers` |
-| `scanned_registers` | yes | `coordinator.device_client.scanned_registers` |
-| `last_scan` | yes | `coordinator.device_client.last_scan` |
-| `_last_power_timestamp` | yes | `coordinator.device_client._last_power_timestamp` |
-| `_total_energy` | yes | `coordinator.device_client._total_energy` |
+| `scan_uart_settings` | **removed** | `coordinator.device_client.scan_uart_settings` |
+| `deep_scan` | **removed** | `coordinator.device_client.deep_scan` |
+| `safe_scan` | **removed** | `coordinator.device_client.safe_scan` |
+| `skip_missing_registers` | **removed** | `coordinator.device_client.skip_missing_registers` |
+
+## Remaining proxies
+
+The proxies below are required because coordinator submodule functions
+(read_batches, retry, io_mixin, etc.) receive the coordinator as a duck-typed
+`owner` and access these attributes directly, and/or entity platform files
+access them on the coordinator.  Remove a proxy when its callers are updated
+to use `coordinator.device_client.X` instead.
+
+| Proxy | Canonical replacement |
+|---|---|
+| `config` | `coordinator.device_client.config` |
+| `_device_name` | `coordinator.device_client._device_name` |
+| `_resolved_connection_mode` | `coordinator.device_client._resolved_connection_mode` |
+| `timeout` | `coordinator.device_client.timeout` |
+| `retry` | `coordinator.device_client.retry` |
+| `backoff` | `coordinator.device_client.backoff` |
+| `backoff_jitter` | `coordinator.device_client.backoff_jitter` |
+| `force_full_register_list` | `coordinator.device_client.force_full_register_list` |
+| `effective_batch` | `coordinator.device_client.effective_batch` |
+| `max_registers_per_request` | `coordinator.device_client.max_registers_per_request` |
+| `client` | `coordinator.device_client.client` |
+| `_transport` | `coordinator.device_client._transport` |
+| `_client_lock` | `coordinator.device_client._client_lock` |
+| `_write_lock` | `coordinator.device_client._write_lock` |
+| `_update_in_progress` | `coordinator.device_client._update_in_progress` |
+| `offline_state` | `coordinator.device_client.offline_state` |
+| `capabilities` | `coordinator.device_client.capabilities` |
+| `device_info` | `coordinator.device_client.device_info` |
+| `available_registers` | `coordinator.device_client.available_registers` |
+| `_register_maps` | `coordinator.device_client._register_maps` |
+| `_reverse_maps` | `coordinator.device_client._reverse_maps` |
+| `_input_registers_rev` | `coordinator.device_client._input_registers_rev` |
+| `_holding_registers_rev` | `coordinator.device_client._holding_registers_rev` |
+| `_register_groups` | `coordinator.device_client._register_groups` |
+| `_failed_registers` | `coordinator.device_client._failed_registers` |
+| `statistics` | `coordinator.device_client.statistics` |
+| `device_scan_result` | `coordinator.device_client.device_scan_result` |
+| `unknown_registers` | `coordinator.device_client.unknown_registers` |
+| `scanned_registers` | `coordinator.device_client.scanned_registers` |
+| `last_scan` | `coordinator.device_client.last_scan` |

--- a/docs/final_cleanup_step_report.md
+++ b/docs/final_cleanup_step_report.md
@@ -97,6 +97,55 @@ Updated `docs/real_ha_log_issue_fix_report.md` with sections 4, 5, and 6 documen
 
 ---
 
+## Step 4 — Coordinator proxy cleanup (scan-flag group)
+
+### Files changed
+- `custom_components/thessla_green_modbus/coordinator/coordinator.py` (proxy removal + docstring update)
+- `custom_components/thessla_green_modbus/diagnostics.py` (caller update)
+- `custom_components/thessla_green_modbus/coordinator/diagnostics.py` (caller update)
+- `custom_components/thessla_green_modbus/services/handlers_data.py` (caller update)
+- `tests/test_diagnostics.py` (mock update)
+- `tests/test_diagnostics_refactor.py` (mock update)
+- `tests/test_services_handlers_targets.py` (mock update)
+- `docs/coordinator_proxy_removal_inventory.md` (status update)
+
+### What changed
+Removed the four scan-flag proxy properties from `ThesslaGreenModbusCoordinator`:
+`scan_uart_settings`, `deep_scan`, `safe_scan`, `skip_missing_registers`.
+
+Updated callers in `diagnostics.py`, `coordinator/diagnostics.py`, and
+`services/handlers_data.py` to use `coordinator.device_client.X` directly.
+
+Note: `core/register_groups.py` and `core/scanner_kwargs.py` were NOT changed.
+Both functions receive a `ThesslaGreenDeviceClient` as their duck-typed
+`coordinator` argument (via `DeviceClient.compute_register_groups()` and
+`_ClientScannerMixin._build_scanner_kwargs()`), so they already access the
+attributes directly on the DeviceClient without using coordinator proxies.
+
+Updated test mock `DummyCoordinator` / `_Coordinator` classes in three test
+files to provide `self.device_client = SimpleNamespace(deep_scan=X /
+scan_uart_settings=False)` in place of the removed direct attributes.
+
+### Why safe
+- No register addresses, names, entity IDs, unique IDs, service IDs, or
+  translation keys changed
+- No Modbus read/write behavior changed
+- The proxy properties were read-only getters on the coordinator; removing
+  them cannot affect runtime state
+- All scan-flag values are still set correctly via `ThesslaGreenDeviceClient`
+  during `__init__`
+
+### Tests run
+```
+pytest tests/ --tb=no
+1 failed (pre-existing), 2147 passed, 4 skipped, 88 warnings, 2 errors (pre-existing)
+```
+
+### Rollback plan
+`git revert` the relevant commit.
+
+---
+
 ## Full Validation Results
 
 ```

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -102,7 +102,7 @@ async def test_last_scan_in_diagnostics():
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
-            self.deep_scan = False
+            self.device_client = SimpleNamespace(deep_scan=False)
             self.force_full_register_list = False
             self.effective_batch = 0
 
@@ -142,7 +142,7 @@ async def test_additional_diagnostic_fields():
             }
             self.statistics = {"connection_errors": 2, "timeout_errors": 1}
             self.capabilities = SimpleNamespace(as_dict=lambda: {"fan": True})
-            self.deep_scan = True
+            self.device_client = SimpleNamespace(deep_scan=True)
             self.force_full_register_list = False
             self.effective_batch = 7
 
@@ -206,7 +206,7 @@ async def test_unknown_registers_in_diagnostics():
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {"fan": True})
             self.unknown_registers = scan_result["unknown_registers"]
-            self.deep_scan = False
+            self.device_client = SimpleNamespace(deep_scan=False)
             self.force_full_register_list = False
             self.effective_batch = 0
 
@@ -254,7 +254,7 @@ async def test_raw_registers_in_diagnostics():
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
-            self.deep_scan = False
+            self.device_client = SimpleNamespace(deep_scan=False)
             self.force_full_register_list = False
             self.effective_batch = 0
 
@@ -298,7 +298,7 @@ async def test_anomalies_in_diagnostics():
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
-            self.deep_scan = False
+            self.device_client = SimpleNamespace(deep_scan=False)
             self.force_full_register_list = False
             self.effective_batch = 0
 
@@ -339,7 +339,7 @@ async def test_diagnostics_json_serializable():
                 temperature_sensors={"t1", "t2"},
                 flow_sensors={"f1"},
             )
-            self.deep_scan = False
+            self.device_client = SimpleNamespace(deep_scan=False)
             self.force_full_register_list = False
             self.effective_batch = 0
 
@@ -378,7 +378,7 @@ async def test_translation_failure_handled(caplog):
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
-            self.deep_scan = False
+            self.device_client = SimpleNamespace(deep_scan=False)
             self.force_full_register_list = False
             self.effective_batch = 0
 

--- a/tests/test_diagnostics_refactor.py
+++ b/tests/test_diagnostics_refactor.py
@@ -18,7 +18,7 @@ async def test_diagnostics_expected_keys_when_missing_scan_data():
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
-            self.deep_scan = False
+            self.device_client = SimpleNamespace(deep_scan=False)
             self.force_full_register_list = False
             self.effective_batch = 0
 
@@ -54,7 +54,7 @@ async def test_diagnostics_offline_active_error_formatting():
             self.available_registers = {}
             self.statistics = {}
             self.capabilities = SimpleNamespace(as_dict=lambda: {})
-            self.deep_scan = False
+            self.device_client = SimpleNamespace(deep_scan=False)
             self.force_full_register_list = False
             self.effective_batch = 0
 

--- a/tests/test_services_handlers_targets.py
+++ b/tests/test_services_handlers_targets.py
@@ -49,7 +49,7 @@ class _Coordinator:
         self.slave_id = 1
         self.timeout = 5
         self.retry = 3
-        self.scan_uart_settings = False
+        self.device_client = SimpleNamespace(scan_uart_settings=False)
         self.unknown_registers = {}
         self.scanned_registers = {}
 


### PR DESCRIPTION
…r docblock

Removes four read-only proxy properties from ThesslaGreenModbusCoordinator (scan_uart_settings, deep_scan, safe_scan, skip_missing_registers) and updates their three real callers to access coordinator.device_client.X directly.

register_groups.py and scanner_kwargs.py already received ThesslaGreenDeviceClient as their duck-typed coordinator argument so needed no changes.

Test DummyCoordinator / _Coordinator mocks updated to supply device_client SimpleNamespace in place of the removed direct attributes.

https://claude.ai/code/session_01QX4V1hUGUcUJm6isJ1HXbz

## Summary
- [ ] Explain what changed and why.

## Maintainability checklist (required for large refactors)
- [ ] I checked whether changed methods/files exceed maintainability thresholds.
- [ ] For large methods/files, I provided extraction rationale.
- [ ] I documented behavior compatibility / facade/re-export compatibility where applicable.
- [ ] I listed test impact (new/updated tests, including contract tests when retry/error semantics changed).
- [ ] I included a short rollback plan for risky refactors.

## Validation
- [ ] `ruff check ...`
- [ ] `pytest ...`
- [ ] `python tools/check_maintainability.py`

## Notes
- Additional context / migration notes / known limitations.
