### PR TITLE
style: apply ruff format to 27 files after PR #1669

### DIFF
--- a/custom_components/thessla_green_modbus/_setup.py
+++ b/custom_components/thessla_green_modbus/_setup.py
@@ -191,9 +191,15 @@ async def async_migrate_entity_unique_ids(
     except (AttributeError, TypeError, ValueError):
         serial_number = None
 
-    host = getattr(coordinator, "host", None) or getattr(coordinator.device_client.config, "host", "")
-    port = getattr(coordinator, "port", None) or getattr(coordinator.device_client.config, "port", 0)
-    slave_id = getattr(coordinator, "slave_id", None) or getattr(coordinator.device_client.config, "slave_id", 0)
+    host = getattr(coordinator, "host", None) or getattr(
+        coordinator.device_client.config, "host", ""
+    )
+    port = getattr(coordinator, "port", None) or getattr(
+        coordinator.device_client.config, "port", 0
+    )
+    slave_id = getattr(coordinator, "slave_id", None) or getattr(
+        coordinator.device_client.config, "slave_id", 0
+    )
 
     entries = []
     try:

--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -65,7 +65,9 @@ async def async_setup_entry(
 
         register_map = coordinator.get_register_map(register_type)
         available = coordinator.device_client.available_registers.get(register_type, set())
-        force_create = coordinator.device_client.force_full_register_list and register_name in register_map
+        force_create = (
+            coordinator.device_client.force_full_register_list and register_name in register_map
+        )
 
         # Check if this register is available on the device or should be
         # forcibly added from the full register list.

--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -155,7 +155,6 @@ class ThesslaGreenModbusCoordinator(
         """Return the underlying DeviceClient instance."""
         return self._device_client
 
-
     def __init__(
         self,
         hass: HomeAssistant,

--- a/custom_components/thessla_green_modbus/coordinator/diagnostics.py
+++ b/custom_components/thessla_green_modbus/coordinator/diagnostics.py
@@ -77,9 +77,7 @@ def get_diagnostic_data(coordinator: Any) -> dict[str, Any]:
         statistics["last_successful_update"] = statistics["last_successful_update"].isoformat()
     total_registers = sum(len(v) for v in dc.available_registers.values())
     total_registers_json = len(get_all_registers())
-    registers_discovered = {
-        key: len(value) for key, value in dc.available_registers.items()
-    }
+    registers_discovered = {key: len(value) for key, value in dc.available_registers.items()}
     error_stats = {
         "connection_errors": statistics.get("connection_errors", 0),
         "timeout_errors": statistics.get("timeout_errors", 0),
@@ -114,9 +112,7 @@ def get_diagnostic_data(coordinator: Any) -> dict[str, Any]:
     if dc.device_scan_result and "raw_registers" in dc.device_scan_result:
         diagnostics["raw_registers"] = dc.device_scan_result["raw_registers"]
         if "total_addresses_scanned" in dc.device_scan_result:
-            statistics["total_addresses_scanned"] = dc.device_scan_result[
-                "total_addresses_scanned"
-            ]
+            statistics["total_addresses_scanned"] = dc.device_scan_result["total_addresses_scanned"]
 
     return diagnostics
 

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -116,9 +116,13 @@ class _CoordinatorScheduleMixin:
     async def _write_holding_single(self, address: int, value: Any, attempt: int) -> Any:
         """Write a single holding register."""
         if self._device_client._transport is None and self._device_client.client is not None:
-            return await self._device_client.client.write_register(address=address, value=int(value))
+            return await self._device_client.client.write_register(
+                address=address, value=int(value)
+            )
         if self._device_client._transport is not None:
-            return await self._device_client._transport.write_register(self.slave_id, address, value=int(value))
+            return await self._device_client._transport.write_register(
+                self.slave_id, address, value=int(value)
+            )
         return await self._call_modbus(
             self._get_client_method("write_register"),
             address,
@@ -157,7 +161,9 @@ class _CoordinatorScheduleMixin:
         """Build chunk plan for multi-register writes."""
         if require_single_request:
             return [(start_address, values)]
-        return list(chunk_register_values(start_address, values, self._device_client.effective_batch))
+        return list(
+            chunk_register_values(start_address, values, self._device_client.effective_batch)
+        )
 
     def _handle_write_response_failure(
         self,

--- a/custom_components/thessla_green_modbus/core/read_batches.py
+++ b/custom_components/thessla_green_modbus/core/read_batches.py
@@ -38,7 +38,10 @@ def _merge_batch_read_results(
     for i, value in enumerate(response.registers):
         addr = chunk_start + i
         register_name = owner._find_register_name("input_registers", addr)
-        if register_name and register_name in owner.device_client.available_registers["input_registers"]:
+        if (
+            register_name
+            and register_name in owner.device_client.available_registers["input_registers"]
+        ):
             processed_value = owner._process_register_value(register_name, value)
             if processed_value is not None:
                 data[register_name] = processed_value
@@ -245,7 +248,8 @@ async def read_holding_registers_optimized(owner: Any) -> dict[str, Any]:
                     register_name = owner._find_register_name("holding_registers", addr)
                     if (
                         register_name
-                        and register_name in owner.device_client.available_registers["holding_registers"]
+                        and register_name
+                        in owner.device_client.available_registers["holding_registers"]
                     ):
                         processed_value = owner._process_register_value(register_name, value)
                         if processed_value is not None:

--- a/custom_components/thessla_green_modbus/core/read_bits.py
+++ b/custom_components/thessla_green_modbus/core/read_bits.py
@@ -50,7 +50,8 @@ async def read_coil_registers_optimized(owner: Any) -> dict[str, Any]:
                     register_name = owner._find_register_name("coil_registers", addr)
                     if (
                         register_name
-                        and register_name in owner.device_client.available_registers["coil_registers"]
+                        and register_name
+                        in owner.device_client.available_registers["coil_registers"]
                     ):
                         bit = response.bits[i]
                         data[register_name] = bit
@@ -110,7 +111,8 @@ async def read_discrete_inputs_optimized(owner: Any) -> dict[str, Any]:
                     register_name = owner._find_register_name("discrete_inputs", addr)
                     if (
                         register_name
-                        and register_name in owner.device_client.available_registers["discrete_inputs"]
+                        and register_name
+                        in owner.device_client.available_registers["discrete_inputs"]
                     ):
                         bit = response.bits[i]
                         data[register_name] = bit

--- a/custom_components/thessla_green_modbus/diagnostics.py
+++ b/custom_components/thessla_green_modbus/diagnostics.py
@@ -73,12 +73,8 @@ def _coordinator_defaults(coordinator: ThesslaGreenModbusCoordinator) -> dict[st
         "effective_batch": dc.effective_batch,
         "capabilities": dc.capabilities.as_dict(),
         "firmware_version": dc.device_info.get("firmware"),
-        "total_available_registers": sum(
-            len(regs) for regs in dc.available_registers.values()
-        ),
-        "registers_discovered": {
-            key: len(val) for key, val in dc.available_registers.items()
-        },
+        "total_available_registers": sum(len(regs) for regs in dc.available_registers.values()),
+        "registers_discovered": {key: len(val) for key, val in dc.available_registers.items()},
         "status_overview": getattr(coordinator, "status_overview", None),
         "autoscan": not dc.force_full_register_list,
         "force_full": dc.force_full_register_list,
@@ -145,8 +141,13 @@ async def async_get_config_entry_diagnostics(
         },
     )
 
-    if coordinator.device_client.device_scan_result and "raw_registers" in coordinator.device_client.device_scan_result:
-        diagnostics.setdefault("raw_registers", coordinator.device_client.device_scan_result["raw_registers"])
+    if (
+        coordinator.device_client.device_scan_result
+        and "raw_registers" in coordinator.device_client.device_scan_result
+    ):
+        diagnostics.setdefault(
+            "raw_registers", coordinator.device_client.device_scan_result["raw_registers"]
+        )
 
     unknown_regs, failed_addrs = _extract_scan_registers(coordinator)
     diagnostics.setdefault("unknown_registers", unknown_regs)

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -48,7 +48,9 @@ async def async_setup_entry(
     for register in fan_registers:
         if register in coordinator.device_client.available_registers.get(
             "holding_registers", set()
-        ) or register in coordinator.device_client.available_registers.get("input_registers", set()):
+        ) or register in coordinator.device_client.available_registers.get(
+            "input_registers", set()
+        ):
             has_fan_registers = True
             break
 

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -54,7 +54,9 @@ async def async_setup_entry(
     available = coordinator.device_client.available_registers.get("holding_registers", set())
 
     for register_name, entity_config in number_mappings.items():
-        force_create = coordinator.device_client.force_full_register_list and register_name in holding_map
+        force_create = (
+            coordinator.device_client.force_full_register_list and register_name in holding_map
+        )
 
         if reason := capability_block_reason(register_name, coordinator.device_client.capabilities):
             _LOGGER.info("Entity skipped due to capability: %s (%s)", register_name, reason)

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -46,7 +46,9 @@ async def async_setup_entry(
         register_type = select_def["register_type"]
         register_map = coordinator.get_register_map(register_type)
         available = coordinator.device_client.available_registers.get(register_type, set())
-        force_create = coordinator.device_client.force_full_register_list and register_name in register_map
+        force_create = (
+            coordinator.device_client.force_full_register_list and register_name in register_map
+        )
         if reason := capability_block_reason(register_name, coordinator.device_client.capabilities):
             _LOGGER.info("Entity skipped due to capability: %s (%s)", register_name, reason)
             continue

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -107,9 +107,9 @@ async def async_setup_entry(
         # serial_number is always force-created: it reads from device_info (assembled
         # during scan from 6 registers) rather than via per-register polling, so it
         # works even when the device rejects block reads at those addresses.
-        force_create = (coordinator.device_client.force_full_register_list and register_name in register_map) or (
-            register_name == "serial_number" and register_name in register_map
-        )
+        force_create = (
+            coordinator.device_client.force_full_register_list and register_name in register_map
+        ) or (register_name == "serial_number" and register_name in register_map)
 
         # Check if this register is available on the device or should be
         # forcibly added from the full register list.

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -50,14 +50,16 @@ async def async_setup_entry(
         is_available = False
 
         if config["register_type"] == "holding_registers":
-            if register_name in coordinator.device_client.available_registers.get("holding_registers", set()) or (
+            if register_name in coordinator.device_client.available_registers.get(
+                "holding_registers", set()
+            ) or (
                 coordinator.device_client.force_full_register_list and register_name in holding_map
             ):
                 is_available = True
         elif config["register_type"] == "coil_registers":
-            if register_name in coordinator.device_client.available_registers.get("coil_registers", set()) or (
-                coordinator.device_client.force_full_register_list and register_name in coil_map
-            ):
+            if register_name in coordinator.device_client.available_registers.get(
+                "coil_registers", set()
+            ) or (coordinator.device_client.force_full_register_list and register_name in coil_map):
                 is_available = True
 
         if is_available:

--- a/custom_components/thessla_green_modbus/text.py
+++ b/custom_components/thessla_green_modbus/text.py
@@ -41,7 +41,9 @@ async def async_setup_entry(
         register_type = text_def["register_type"]
         register_map = coordinator.get_register_map(register_type)
         available = coordinator.device_client.available_registers.get(register_type, set())
-        force_create = coordinator.device_client.force_full_register_list and register_name in register_map
+        force_create = (
+            coordinator.device_client.force_full_register_list and register_name in register_map
+        )
 
         if reason := capability_block_reason(register_name, coordinator.device_client.capabilities):
             _LOGGER.info("Entity skipped due to capability: %s (%s)", register_name, reason)

--- a/custom_components/thessla_green_modbus/time.py
+++ b/custom_components/thessla_green_modbus/time.py
@@ -42,7 +42,9 @@ async def async_setup_entry(
         register_type = time_def["register_type"]
         register_map = coordinator.get_register_map(register_type)
         available = coordinator.device_client.available_registers.get(register_type, set())
-        force_create = coordinator.device_client.force_full_register_list and register_name in register_map
+        force_create = (
+            coordinator.device_client.force_full_register_list and register_name in register_map
+        )
 
         if reason := capability_block_reason(register_name, coordinator.device_client.capabilities):
             _LOGGER.info("Entity skipped due to capability: %s (%s)", register_name, reason)

--- a/tests/test_all_entity_creation.py
+++ b/tests/test_all_entity_creation.py
@@ -95,7 +95,9 @@ async def test_all_platforms_create_at_least_one_entity(
     mock_coordinator.device_client.force_full_register_list = True
     mock_coordinator.device_client.capabilities = _make_full_capabilities()
 
-    holding = set(mock_coordinator.device_client.available_registers.get("holding_registers", set()))
+    holding = set(
+        mock_coordinator.device_client.available_registers.get("holding_registers", set())
+    )
     holding.add("air_flow_rate_manual")
     mock_coordinator.device_client.available_registers = dict(
         mock_coordinator.device_client.available_registers, holding_registers=holding
@@ -175,7 +177,9 @@ async def test_entity_counts_per_platform(
     mock_coordinator.device_client.force_full_register_list = True
     mock_coordinator.device_client.capabilities = _make_full_capabilities()
 
-    holding = set(mock_coordinator.device_client.available_registers.get("holding_registers", set()))
+    holding = set(
+        mock_coordinator.device_client.available_registers.get("holding_registers", set())
+    )
     holding.add("air_flow_rate_manual")
     mock_coordinator.device_client.available_registers = dict(
         mock_coordinator.device_client.available_registers, holding_registers=holding

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -267,7 +267,10 @@ async def test_read_holding_registers_chunking_and_retries(coordinator):
     data = await coordinator._read_holding_registers_optimized()
 
     assert coordinator.device_client.client.read_holding_registers.await_count == 5
-    counts = [c.kwargs["count"] for c in coordinator.device_client.client.read_holding_registers.await_args_list]
+    counts = [
+        c.kwargs["count"]
+        for c in coordinator.device_client.client.read_holding_registers.await_args_list
+    ]
     assert counts == [MAX_BATCH_REGISTERS, MAX_BATCH_REGISTERS, 4, 4, 1]
     assert data["reg0"] == 1
     assert data[f"reg{MAX_BATCH_REGISTERS}"] == 2

--- a/tests/test_coordinator_io.py
+++ b/tests/test_coordinator_io.py
@@ -159,7 +159,9 @@ async def test_holding_falls_back_to_client_read_method(
 ) -> None:
     coordinator.device_client._transport = None
     client_read = AsyncMock(return_value=SimpleNamespace(registers=[7, 8]))
-    coordinator.device_client.client = SimpleNamespace(connected=True, read_holding_registers=client_read)
+    coordinator.device_client.client = SimpleNamespace(
+        connected=True, read_holding_registers=client_read
+    )
     coordinator._call_modbus = AsyncMock(return_value=SimpleNamespace(registers=[7, 8]))
 
     async def _fake_read_with_retry(read_method, address, count, **_kwargs):

--- a/tests/test_coordinator_statistics.py
+++ b/tests/test_coordinator_statistics.py
@@ -50,5 +50,8 @@ def test_get_diagnostic_data_structure():
 
 def test_get_diagnostic_data_with_raw_registers():
     coord = _make_coordinator()
-    coord.device_client.device_scan_result = {"raw_registers": {"0": 123}, "total_addresses_scanned": 100}
+    coord.device_client.device_scan_result = {
+        "raw_registers": {"0": 123},
+        "total_addresses_scanned": 100,
+    }
     assert "raw_registers" in coord.get_diagnostic_data()

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -144,7 +144,9 @@ def test_fan_turn_off_success(mock_coordinator):
 def test_fan_turn_off_via_airflow_register(mock_coordinator):
     """When on_off_panel_mode unavailable, turn off via air_flow_rate_manual (lines 194-204)."""
     mock_coordinator.data["mode"] = 1  # manual mode
-    mock_coordinator.device_client.available_registers["holding_registers"].discard("on_off_panel_mode")
+    mock_coordinator.device_client.available_registers["holding_registers"].discard(
+        "on_off_panel_mode"
+    )
     mock_coordinator.async_write_register = AsyncMock(return_value=True)
     mock_coordinator.async_request_refresh = AsyncMock()
     fan = ThesslaGreenFan(mock_coordinator)
@@ -196,7 +198,9 @@ def test_fan_set_percentage_auto_mode_uses_temporary_register(mock_coordinator, 
     from custom_components.thessla_green_modbus import fan as fan_module
 
     mock_coordinator.data["mode"] = 0  # auto mode
-    mock_coordinator.device_client.available_registers["holding_registers"].add("air_flow_rate_temporary_2")
+    mock_coordinator.device_client.available_registers["holding_registers"].add(
+        "air_flow_rate_temporary_2"
+    )
     mock_coordinator.async_write_register = AsyncMock(return_value=True)
     mock_coordinator.async_request_refresh = AsyncMock()
 
@@ -234,7 +238,9 @@ def test_fan_write_register_invalid_raises(mock_coordinator):
 
 def test_fan_write_register_not_in_available_skips(mock_coordinator):
     """_write_register skips write when register not in available_registers (lines 281-283)."""
-    mock_coordinator.device_client.available_registers["holding_registers"].discard("air_flow_rate_manual")
+    mock_coordinator.device_client.available_registers["holding_registers"].discard(
+        "air_flow_rate_manual"
+    )
     mock_coordinator.async_write_register = AsyncMock(return_value=True)
     fan = ThesslaGreenFan(mock_coordinator)
     asyncio.run(fan._write_register("air_flow_rate_manual", 50))
@@ -249,6 +255,8 @@ def test_is_writable_holding_register_true(mock_coordinator):
 
 def test_is_writable_holding_register_false_when_missing(mock_coordinator):
     """Helper reports False when register was not discovered on the device."""
-    mock_coordinator.device_client.available_registers["holding_registers"].discard("air_flow_rate_manual")
+    mock_coordinator.device_client.available_registers["holding_registers"].discard(
+        "air_flow_rate_manual"
+    )
     fan = ThesslaGreenFan(mock_coordinator)
     assert fan._is_writable_holding_register("air_flow_rate_manual") is False  # nosec B101

--- a/tests/test_fan_percentage_limits.py
+++ b/tests/test_fan_percentage_limits.py
@@ -40,7 +40,10 @@ def test_fan_percentage_over_100_device_clamps(mock_coordinator):
 async def test_fan_set_percentage_clamps_to_limits():
     hass = SimpleNamespace()
     coordinator = ThesslaGreenModbusCoordinator.from_params(hass, "host", 502, 1, "dev")
-    coordinator.device_client.available_registers["holding_registers"] = {"mode", "air_flow_rate_manual"}
+    coordinator.device_client.available_registers["holding_registers"] = {
+        "mode",
+        "air_flow_rate_manual",
+    }
     coordinator.data = {"min_percentage": 30, "max_percentage": 120, "mode": 1}
     coordinator.async_write_register = AsyncMock(return_value=True)
     coordinator.async_request_refresh = AsyncMock()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -116,9 +116,9 @@ async def test_async_setup_creates_new_numbers(mock_coordinator, mock_config_ent
     hass.data = {DOMAIN: {mock_config_entry.entry_id: mock_coordinator}}
     mock_config_entry.runtime_data = mock_coordinator
 
-    mock_coordinator.device_client.available_registers.setdefault("holding_registers", set()).update(
-        {"max_supply_air_flow_rate", "min_bypass_temperature"}
-    )
+    mock_coordinator.device_client.available_registers.setdefault(
+        "holding_registers", set()
+    ).update({"max_supply_air_flow_rate", "min_bypass_temperature"})
 
     add_entities = MagicMock()
     await async_setup_entry(hass, mock_config_entry, add_entities)

--- a/tests/test_register_cache_invalidation.py
+++ b/tests/test_register_cache_invalidation.py
@@ -83,7 +83,10 @@ def test_apply_scan_cache_keeps_known_missing_for_newer_firmware(
         "device_info": {"firmware": "4.0.1", "serial_number": "Unknown"},
     }
     assert minimal_coordinator._apply_scan_cache(cache) is True
-    assert "compilation_days" in minimal_coordinator.device_client.available_registers["input_registers"]
+    assert (
+        "compilation_days"
+        in minimal_coordinator.device_client.available_registers["input_registers"]
+    )
     assert "uart_0_id" in minimal_coordinator.device_client.available_registers["holding_registers"]
 
 
@@ -101,9 +104,18 @@ def test_apply_scan_cache_strips_known_missing_for_fw311(
         "device_info": {"firmware": "3.11", "serial_number": "Unknown"},
     }
     assert minimal_coordinator._apply_scan_cache(cache) is True
-    assert "compilation_days" not in minimal_coordinator.device_client.available_registers["input_registers"]
-    assert "uart_0_id" not in minimal_coordinator.device_client.available_registers["holding_registers"]
-    assert "outside_temperature" in minimal_coordinator.device_client.available_registers["input_registers"]
+    assert (
+        "compilation_days"
+        not in minimal_coordinator.device_client.available_registers["input_registers"]
+    )
+    assert (
+        "uart_0_id"
+        not in minimal_coordinator.device_client.available_registers["holding_registers"]
+    )
+    assert (
+        "outside_temperature"
+        in minimal_coordinator.device_client.available_registers["input_registers"]
+    )
 
 
 def test_apply_scan_cache_accepts_set_values(
@@ -119,4 +131,7 @@ def test_apply_scan_cache_accepts_set_values(
         "device_info": {"serial_number": "Unknown"},
     }
     assert minimal_coordinator._apply_scan_cache(cache) is True
-    assert "outside_temperature" in minimal_coordinator.device_client.available_registers["input_registers"]
+    assert (
+        "outside_temperature"
+        in minimal_coordinator.device_client.available_registers["input_registers"]
+    )

--- a/tests/test_schedule_summer_regression.py
+++ b/tests/test_schedule_summer_regression.py
@@ -59,7 +59,9 @@ def coordinator() -> ThesslaGreenModbusCoordinator:
         "coil_registers": set(),
         "discrete_inputs": set(),
     }
-    coord.device_client._register_groups = {"holding_registers": [(SUMMER_BASE_ADDR, len(SUMMER_NAMES))]}
+    coord.device_client._register_groups = {
+        "holding_registers": [(SUMMER_BASE_ADDR, len(SUMMER_NAMES))]
+    }
     coord.device_client._failed_registers = set()
     coord.device_client.effective_batch = 20
 

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -94,7 +94,9 @@ def test_error_codes_sensor_translates_active_registers(mock_coordinator, mock_c
         mock_config_entry.runtime_data = mock_coordinator
 
         mock_coordinator.data["s_2"] = 1
-        mock_coordinator.device_client.available_registers.setdefault("holding_registers", set()).add("s_2")
+        mock_coordinator.device_client.available_registers.setdefault(
+            "holding_registers", set()
+        ).add("s_2")
         add_entities = MagicMock()
         with patch(
             "custom_components.thessla_green_modbus.sensor.translation.async_get_translations",

--- a/tests/test_services_handlers_targets.py
+++ b/tests/test_services_handlers_targets.py
@@ -46,7 +46,9 @@ class _Coordinator:
         self.device_client = SimpleNamespace(
             scan_uart_settings=False,
             effective_batch=2,
-            available_registers={"holding_registers": {r.name for r in get_registers_by_function("03")}},
+            available_registers={
+                "holding_registers": {r.name for r in get_registers_by_function("03")}
+            },
             timeout=5,
             retry=3,
             unknown_registers={},

--- a/tests/test_services_scaling.py
+++ b/tests/test_services_scaling.py
@@ -23,6 +23,7 @@ class DummyCoordinator:
         self.writes: list[tuple[int, object, int]] = []
         self.encoded: list[tuple[int, object, int]] = []
         from types import SimpleNamespace
+
         self.device_client = SimpleNamespace(
             available_registers={"holding_registers": set()},
             max_registers_per_request=max_registers_per_request,


### PR DESCRIPTION
Formatting-only cleanup: ruff format found 27 files that diverged from
the project's line-ending / trailing-comma style during the proxy-removal
refactor. No logic, register definitions, entity IDs, or unique IDs changed.

https://claude.ai/code/session_01PaXvUckc41WJsF9KMXawXy