### PR TITLE
Add regression tests for schedule register discovery and time entity creation

### DIFF
--- a/docs/airpack4_vendor_reference_coverage.json
+++ b/docs/airpack4_vendor_reference_coverage.json
@@ -40,7 +40,7 @@
       "address_hex": "0x20fa",
       "integration_name": "e_250",
       "known_intentional": true,
-      "reason": "known prefix 'e_'"
+      "reason": "firmware-observed alarm: filter replacement required (unit without pressure switch); kept as real-device extra"
     },
     {
       "fc": 3,
@@ -49,7 +49,7 @@
       "address_hex": "0x20fc",
       "integration_name": "e_252",
       "known_intentional": true,
-      "reason": "known prefix 'e_'"
+      "reason": "firmware-observed alarm: filter replacement required (unit with pressure switch); kept as real-device extra"
     },
     {
       "fc": 4,

--- a/docs/airpack4_vendor_reference_coverage.md
+++ b/docs/airpack4_vendor_reference_coverage.md
@@ -29,8 +29,8 @@ None — all vendor registers are present in the integration.
 
 | FC | Address (hex) | Address (dec) | Integration name | Known intentional | Reason |
 |-----|--------------|--------------|------------------|-------------------|--------|
-| FC03 | 0x20fa | 8442 | e_250 | yes | known prefix 'e_' |
-| FC03 | 0x20fc | 8444 | e_252 | yes | known prefix 'e_' |
+| FC03 | 0x20fa | 8442 | e_250 | yes | firmware-observed alarm: filter replacement required (unit without pressure switch); kept as real-device extra |
+| FC03 | 0x20fc | 8444 | e_252 | yes | firmware-observed alarm: filter replacement required (unit with pressure switch); kept as real-device extra |
 | FC04 | 0x17 | 23 | heating_temperature | yes | heating_temperature — TH sensor on AirPack4 h/v units |
 | FC04 | 0x12a | 298 | water_removal_active | yes | water_removal_active — HEWR procedure flag, series 4 |
 

--- a/tests/test_available_registers_schedule_time.py
+++ b/tests/test_available_registers_schedule_time.py
@@ -1,0 +1,244 @@
+"""Regression tests for available_registers fallback and time entity creation.
+
+Scenario verified (Phase 2):
+- Batch read for holding registers 16-43 (summer schedule) fails.
+- Individual fallback reads succeed for at least some schedule_summer_* registers.
+- Successful registers are added to available_registers["holding_registers"].
+- Corresponding time entities are created via async_setup_entry.
+
+Also verifies:
+- Failed summer schedule does not block winter schedule discovery.
+- Full register list mode creates both summer and winter schedule time entities.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from custom_components.thessla_green_modbus.scanner.registers import scan_register_batch
+
+# Four Monday summer schedule registers at addresses 16-19 (0x10-0x13)
+_SUMMER_MON_ADDR_TO_NAMES: dict[int, set[str]] = {
+    16: {"schedule_summer_mon_1"},
+    17: {"schedule_summer_mon_2"},
+    18: {"schedule_summer_mon_3"},
+    19: {"schedule_summer_mon_4"},
+}
+_SUMMER_MON_ADDRS = [16, 17, 18, 19]
+
+# Four Monday winter schedule registers at addresses 44-47 (0x2C-0x2F)
+_WINTER_MON_ADDR_TO_NAMES: dict[int, set[str]] = {
+    44: {"schedule_winter_mon_1"},
+    45: {"schedule_winter_mon_2"},
+    46: {"schedule_winter_mon_3"},
+    47: {"schedule_winter_mon_4"},
+}
+_WINTER_MON_ADDRS = [44, 45, 46, 47]
+
+# Minimal time mapping used by entity-creation tests
+_TIME_MAP: dict[str, dict] = {
+    "schedule_summer_mon_1": {
+        "translation_key": "schedule_summer_mon_1",
+        "icon": "mdi:clock-outline",
+        "register_type": "holding_registers",
+    },
+    "schedule_winter_mon_1": {
+        "translation_key": "schedule_winter_mon_1",
+        "icon": "mdi:clock-outline",
+        "register_type": "holding_registers",
+    },
+}
+_REGISTER_MAP = {"schedule_summer_mon_1": 16, "schedule_winter_mon_1": 44}
+
+
+def _make_scanner_stub() -> MagicMock:
+    """Create a minimal scanner stub compatible with scan_register_batch."""
+    scanner = MagicMock()
+    scanner.available_registers = {
+        "holding_registers": set(),
+        "input_registers": set(),
+        "coil_registers": set(),
+        "discrete_inputs": set(),
+    }
+    scanner.failed_addresses = {
+        "modbus_exceptions": {
+            "holding_registers": set(),
+            "input_registers": set(),
+            "coil_registers": set(),
+            "discrete_inputs": set(),
+        },
+        "invalid_values": {
+            "holding_registers": set(),
+            "input_registers": set(),
+            "coil_registers": set(),
+            "discrete_inputs": set(),
+        },
+    }
+    scanner._transport = None
+    scanner._is_valid_register_value = MagicMock(return_value=True)
+    scanner._log_invalid_value = MagicMock()
+    scanner._group_registers_for_batch_read = MagicMock()
+    return scanner
+
+
+@pytest.mark.asyncio
+async def test_summer_batch_fail_individual_success_populates_available_registers() -> None:
+    """Batch read 16-19 fails; individual fallback reads succeed → all four names in available_registers."""
+    scanner = _make_scanner_stub()
+    scanner._group_registers_for_batch_read.return_value = [(16, 4)]
+
+    async def _read(start: int, count: int, *, skip_cache: bool = False):
+        if count > 1:
+            return None  # batch fails
+        return [0x0800]  # individual succeeds with valid BCD time 08:00
+
+    await scan_register_batch(
+        scanner, "holding_registers", _SUMMER_MON_ADDR_TO_NAMES, _SUMMER_MON_ADDRS, _read
+    )
+
+    for name in (
+        "schedule_summer_mon_1",
+        "schedule_summer_mon_2",
+        "schedule_summer_mon_3",
+        "schedule_summer_mon_4",
+    ):
+        assert name in scanner.available_registers["holding_registers"], (
+            f"{name!r} should be in available_registers after successful individual fallback probe"
+        )
+
+
+@pytest.mark.asyncio
+async def test_summer_batch_all_fail_does_not_add_to_available_registers() -> None:
+    """When batch and individual reads both fail, no summer names appear in available_registers."""
+    scanner = _make_scanner_stub()
+    scanner._group_registers_for_batch_read.return_value = [(16, 4)]
+
+    async def _read(start: int, count: int, *, skip_cache: bool = False):
+        return None  # all reads fail
+
+    await scan_register_batch(
+        scanner, "holding_registers", _SUMMER_MON_ADDR_TO_NAMES, _SUMMER_MON_ADDRS, _read
+    )
+
+    for name in (
+        "schedule_summer_mon_1",
+        "schedule_summer_mon_2",
+        "schedule_summer_mon_3",
+        "schedule_summer_mon_4",
+    ):
+        assert name not in scanner.available_registers["holding_registers"], (
+            f"{name!r} must not appear in available_registers when all reads fail"
+        )
+
+
+@pytest.mark.asyncio
+async def test_winter_schedule_independent_of_failed_summer() -> None:
+    """Winter batch succeeds independently even after summer batch and individual reads all fail."""
+    scanner = _make_scanner_stub()
+
+    async def _fail(start: int, count: int, *, skip_cache: bool = False):
+        return None
+
+    async def _succeed(start: int, count: int, *, skip_cache: bool = False):
+        return [0x0800] * count
+
+    # Scan summer (everything fails — no summer names in available_registers)
+    scanner._group_registers_for_batch_read.return_value = [(16, 4)]
+    await scan_register_batch(
+        scanner, "holding_registers", _SUMMER_MON_ADDR_TO_NAMES, _SUMMER_MON_ADDRS, _fail
+    )
+
+    # Scan winter (succeeds — all winter names enter available_registers)
+    scanner._group_registers_for_batch_read.return_value = [(44, 4)]
+    await scan_register_batch(
+        scanner, "holding_registers", _WINTER_MON_ADDR_TO_NAMES, _WINTER_MON_ADDRS, _succeed
+    )
+
+    for name in (
+        "schedule_summer_mon_1",
+        "schedule_summer_mon_2",
+        "schedule_summer_mon_3",
+        "schedule_summer_mon_4",
+    ):
+        assert name not in scanner.available_registers["holding_registers"], (
+            f"Failed summer batch must not leave {name!r} in available_registers"
+        )
+
+    for name in (
+        "schedule_winter_mon_1",
+        "schedule_winter_mon_2",
+        "schedule_winter_mon_3",
+        "schedule_winter_mon_4",
+    ):
+        assert name in scanner.available_registers["holding_registers"], (
+            f"{name!r} should be in available_registers after successful winter batch"
+        )
+
+
+@pytest.mark.asyncio
+async def test_force_full_register_list_creates_schedule_time_entities() -> None:
+    """force_full_register_list creates time entities even when available_registers is empty."""
+    from custom_components.thessla_green_modbus.time import async_setup_entry
+
+    coordinator = MagicMock()
+    coordinator.device_client.available_registers = {"holding_registers": set()}
+    coordinator.device_client.force_full_register_list = True
+    coordinator.device_client.capabilities = MagicMock()
+    coordinator.get_register_map.return_value = _REGISTER_MAP
+
+    config_entry = MagicMock()
+    config_entry.runtime_data = coordinator
+
+    entities_added: list = []
+
+    with patch(
+        "custom_components.thessla_green_modbus.time.ENTITY_MAPPINGS",
+        {"time": _TIME_MAP},
+    ):
+        await async_setup_entry(
+            MagicMock(), config_entry, lambda e, u=True: entities_added.extend(e)
+        )
+
+    names = {e._register_name for e in entities_added}
+    assert "schedule_summer_mon_1" in names, (
+        "force_full_register_list must create summer schedule time entity"
+    )
+    assert "schedule_winter_mon_1" in names, (
+        "force_full_register_list must create winter schedule time entity"
+    )
+
+
+@pytest.mark.asyncio
+async def test_available_registers_creates_schedule_time_entities() -> None:
+    """Time entities are created for register names present in available_registers."""
+    from custom_components.thessla_green_modbus.time import async_setup_entry
+
+    coordinator = MagicMock()
+    coordinator.device_client.available_registers = {
+        "holding_registers": {"schedule_summer_mon_1", "schedule_winter_mon_1"}
+    }
+    coordinator.device_client.force_full_register_list = False
+    coordinator.device_client.capabilities = MagicMock()
+    coordinator.get_register_map.return_value = _REGISTER_MAP
+
+    config_entry = MagicMock()
+    config_entry.runtime_data = coordinator
+
+    entities_added: list = []
+
+    with patch(
+        "custom_components.thessla_green_modbus.time.ENTITY_MAPPINGS",
+        {"time": _TIME_MAP},
+    ):
+        await async_setup_entry(
+            MagicMock(), config_entry, lambda e, u=True: entities_added.extend(e)
+        )
+
+    names = {e._register_name for e in entities_added}
+    assert "schedule_summer_mon_1" in names, (
+        "schedule_summer_mon_1 in available_registers must create a time entity"
+    )
+    assert "schedule_winter_mon_1" in names, (
+        "schedule_winter_mon_1 in available_registers must create a time entity"
+    )

--- a/tests/test_schedule_summer_regression.py
+++ b/tests/test_schedule_summer_regression.py
@@ -40,6 +40,13 @@ SUMMER_NAMES = [
 ]
 SUMMER_BASE_ADDR = 0x10  # 16
 
+# All 28 summer + 28 winter + 14 airing time registers
+_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+_SLOTS = ["1", "2", "3", "4"]
+ALL_SUMMER_NAMES = [f"schedule_summer_{d}_{s}" for d in _DAYS for s in _SLOTS]
+ALL_WINTER_NAMES = [f"schedule_winter_{d}_{s}" for d in _DAYS for s in _SLOTS]
+AIRING_NAMES = [f"airing_summer_{d}" for d in _DAYS] + [f"airing_winter_{d}" for d in _DAYS]
+
 
 @pytest.fixture
 def coordinator() -> ThesslaGreenModbusCoordinator:
@@ -163,3 +170,28 @@ def test_summer_schedule_register_names_exist_in_registry() -> None:
         definition = get_register_definition(name)
         assert definition is not None, f"Register {name!r} missing from registry JSON"
         assert definition.function == 3, f"{name} must be FC03 (holding register)"
+
+
+def test_all_schedule_and_airing_register_names_exist_in_registry() -> None:
+    """Guard against silent renames of all 28 summer + 28 winter + 14 airing registers."""
+    from custom_components.thessla_green_modbus.registers.loader import (
+        get_register_definition,
+    )
+
+    for name in ALL_SUMMER_NAMES + ALL_WINTER_NAMES + AIRING_NAMES:
+        definition = get_register_definition(name)
+        assert definition is not None, f"Register {name!r} missing from registry"
+        assert definition.function == 3, f"{name} must be FC03 (holding register)"
+
+
+def test_entity_mappings_time_contains_all_schedule_entries() -> None:
+    """ENTITY_MAPPINGS['time'] must include all 28 summer + 28 winter + 14 airing entries."""
+    from custom_components.thessla_green_modbus.mappings import ENTITY_MAPPINGS
+
+    time_keys = set(ENTITY_MAPPINGS["time"].keys())
+    for name in ALL_SUMMER_NAMES:
+        assert name in time_keys, f"Missing summer schedule time entity: {name!r}"
+    for name in ALL_WINTER_NAMES:
+        assert name in time_keys, f"Missing winter schedule time entity: {name!r}"
+    for name in AIRING_NAMES:
+        assert name in time_keys, f"Missing airing time entity: {name!r}"

--- a/tools/compare_airpack4_vendor_coverage.py
+++ b/tools/compare_airpack4_vendor_coverage.py
@@ -58,6 +58,8 @@ DANGEROUS_VENDOR_NAMES: set[str] = {
 KNOWN_EXTRA_WHITELIST: dict[tuple[int, int], str] = {
     (4, 0x0017): "heating_temperature — TH sensor on AirPack4 h/v units",
     (4, 0x012A): "water_removal_active — HEWR procedure flag, series 4",
+    (3, 0x20FA): "firmware-observed alarm: filter replacement required (unit without pressure switch); kept as real-device extra",
+    (3, 0x20FC): "firmware-observed alarm: filter replacement required (unit with pressure switch); kept as real-device extra",
 }
 
 KNOWN_EXTRA_PREFIXES = ("alarm", "error", "s_", "e_", "f_")

--- a/tools/compare_airpack4_vendor_coverage.py
+++ b/tools/compare_airpack4_vendor_coverage.py
@@ -58,8 +58,14 @@ DANGEROUS_VENDOR_NAMES: set[str] = {
 KNOWN_EXTRA_WHITELIST: dict[tuple[int, int], str] = {
     (4, 0x0017): "heating_temperature — TH sensor on AirPack4 h/v units",
     (4, 0x012A): "water_removal_active — HEWR procedure flag, series 4",
-    (3, 0x20FA): "firmware-observed alarm: filter replacement required (unit without pressure switch); kept as real-device extra",
-    (3, 0x20FC): "firmware-observed alarm: filter replacement required (unit with pressure switch); kept as real-device extra",
+    (
+        3,
+        0x20FA,
+    ): "firmware-observed alarm: filter replacement required (unit without pressure switch); kept as real-device extra",
+    (
+        3,
+        0x20FC,
+    ): "firmware-observed alarm: filter replacement required (unit with pressure switch); kept as real-device extra",
 }
 
 KNOWN_EXTRA_PREFIXES = ("alarm", "error", "s_", "e_", "f_")


### PR DESCRIPTION
## Summary

This PR adds comprehensive regression tests for the schedule register discovery and time entity creation flow, particularly focusing on the fallback mechanism when batch reads fail. It also updates documentation to clarify the purpose of two firmware-observed alarm registers.

### Changes

**New test file: `tests/test_available_registers_schedule_time.py`**
- Tests the `scan_register_batch` fallback behavior when batch reads fail but individual reads succeed
- Verifies that successful individual reads populate `available_registers`
- Confirms that failed reads do not add entries to `available_registers`
- Tests independence of winter schedule discovery from failed summer schedule reads
- Validates that `force_full_register_list` mode creates time entities even when `available_registers` is empty
- Validates that time entities are created for registers present in `available_registers`

**Updated: `tests/test_schedule_summer_regression.py`**
- Added comprehensive lists of all 28 summer + 28 winter + 14 airing schedule register names
- Added `test_all_schedule_and_airing_register_names_exist_in_registry()` to guard against silent renames
- Added `test_entity_mappings_time_contains_all_schedule_entries()` to ensure all schedule/airing entries are in `ENTITY_MAPPINGS['time']`

**Documentation updates: `docs/airpack4_vendor_reference_coverage.*`**
- Clarified that `e_250` and `e_252` registers are firmware-observed alarms (filter replacement required) rather than generic "known prefix" entries
- Updated both JSON and Markdown coverage documentation consistently

**Tool update: `tools/compare_airpack4_vendor_coverage.py`**
- Added whitelist entries for the two filter replacement alarm registers with proper context

## Maintainability checklist

- [x] Changes are focused and well-scoped (new tests + documentation clarifications)
- [x] Test files follow existing patterns and are self-contained
- [x] Documentation updates improve clarity without introducing complexity
- [x] No refactoring of existing code paths

## Validation

- [x] New tests verify the fallback discovery mechanism and entity creation logic
- [x] Existing tests remain unaffected
- [x] Documentation changes are consistent across JSON and Markdown formats

## Notes

The regression tests specifically target the scenario where:
1. Batch read for holding registers fails
2. Individual fallback reads succeed for some/all registers
3. Successful registers are added to `available_registers`
4. Time entities are created via `async_setup_entry`

This ensures the integration can gracefully handle devices that don't support batch reads while still discovering available schedule registers.

https://claude.ai/code/session_01Vm162McAJKVbtx6Vq5hoB7