### PR TITLE
docs/refactor: plan pymodbus 4 migration and reduce core complexity

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/state.py
+++ b/custom_components/thessla_green_modbus/coordinator/state.py
@@ -71,26 +71,30 @@ def resolve_effective_batch(entry: ConfigEntry | None, max_registers_per_request
     return max(1, effective_batch)
 
 
-def initialize_runtime_state(coordinator: Any, *, entry: ConfigEntry | None) -> None:
-    """Initialize mutable runtime state containers for a coordinator instance."""
+def _initialize_runtime_flags(coordinator: Any, *, entry: ConfigEntry | None) -> None:
+    """Set top-level coordinator flags and online/offline state."""
     coordinator.enable_device_scan = (
         bool(entry.options.get(CONF_ENABLE_DEVICE_SCAN, DEFAULT_ENABLE_DEVICE_SCAN))
         if entry is not None
         else DEFAULT_ENABLE_DEVICE_SCAN
     )
-
     coordinator._reauth_scheduled = False
     coordinator._shutting_down = False
+    coordinator._stop_listener = None
     coordinator.device_client.offline_state = False
 
+
+def _initialize_connection_state(coordinator: Any) -> None:
+    """Reset Modbus client handles and IO locks to initial state."""
     coordinator.device_client.client = None
     coordinator.device_client._transport = None
     coordinator.device_client._client_lock = asyncio.Lock()
     coordinator.device_client._write_lock = asyncio.Lock()
     coordinator.device_client._update_in_progress = False
 
-    coordinator._stop_listener = None
 
+def _initialize_device_state(coordinator: Any, *, entry: ConfigEntry | None) -> None:
+    """Initialize device info, capabilities, available registers, and register maps."""
     coordinator.device_client.device_info = {}
     coordinator.device_client.capabilities = DeviceCapabilities()
     if entry and isinstance(entry.data.get("capabilities"), dict):
@@ -129,11 +133,13 @@ def initialize_runtime_state(coordinator: Any, *, entry: ConfigEntry | None) -> 
     coordinator.device_client._discrete_inputs_rev = coordinator.device_client._reverse_maps[
         "discrete_inputs"
     ]
-
     coordinator.device_client._register_groups = {}
     coordinator.device_client._consecutive_failures = 0
     coordinator.device_client._max_failures = 5
 
+
+def _initialize_scan_state(coordinator: Any) -> None:
+    """Reset scan result containers and update statistics to zero."""
     coordinator.device_client.device_scan_result = None
     coordinator.device_client.unknown_registers = {}
     coordinator.device_client.scanned_registers = {}
@@ -154,3 +160,11 @@ def initialize_runtime_state(coordinator: Any, *, entry: ConfigEntry | None) -> 
 
     coordinator.device_client._last_power_timestamp = utcnow()
     coordinator.device_client._total_energy = 0.0
+
+
+def initialize_runtime_state(coordinator: Any, *, entry: ConfigEntry | None) -> None:
+    """Initialize mutable runtime state containers for a coordinator instance."""
+    _initialize_runtime_flags(coordinator, entry=entry)
+    _initialize_connection_state(coordinator)
+    _initialize_device_state(coordinator, entry=entry)
+    _initialize_scan_state(coordinator)

--- a/custom_components/thessla_green_modbus/register_map.py
+++ b/custom_components/thessla_green_modbus/register_map.py
@@ -44,6 +44,38 @@ class RegisterMapEntry:
     entity_domain: str | None = None
     enum_map: dict[int, Any] = field(default_factory=dict)
 
+    def _validate_bool_value(self, value: Any) -> bool:
+        """Coerce value to bool, resolving enum-decoded strings via enum_map reverse lookup."""
+        if isinstance(value, bool):
+            coerced: bool | int | float = value
+        elif isinstance(value, int | float):
+            coerced = bool(value)
+        elif isinstance(value, str) and self.enum_map:
+            # Value is an enum-decoded string (e.g. "brak"/"jest").
+            # Reverse-lookup the original integer key and coerce that to bool.
+            rev = {v: k for k, v in self.enum_map.items()}
+            raw_key = rev.get(value)
+            return bool(raw_key) if raw_key is not None else bool(value)
+        else:
+            raise ValueError(
+                f"Expected boolean-compatible value for {self.name}, got {type(value)}"
+            )
+        return bool(coerced)
+
+    def _validate_numeric_value(self, value: Any, expected: str) -> float | int:
+        """Validate numeric value against range constraints and return int or float."""
+        if not isinstance(value, int | float):
+            raise ValueError(f"Expected numeric value for {self.name}, got {type(value)}")
+        numeric: float | int = value
+        if self.min_value is not None and numeric < self.min_value:
+            raise ValueError(f"{numeric} below minimum {self.min_value} for {self.name}")
+        if self.max_value is not None and numeric > self.max_value:
+            raise ValueError(f"{numeric} above maximum {self.max_value} for {self.name}")
+        # Preserve integers when no scaling is defined
+        if expected == "int":
+            return int(numeric)
+        return float(numeric)
+
     def validate(self, value: Any) -> Any:
         """Validate and normalise a decoded value.
 
@@ -96,37 +128,9 @@ class RegisterMapEntry:
             return str(value)
 
         if expected == "bool":
-            if isinstance(value, bool):
-                coerced: bool | int | float = value
-            elif isinstance(value, int | float):
-                coerced = bool(value)
-            elif isinstance(value, str) and self.enum_map:
-                # Value is an enum-decoded string (e.g. "brak"/"jest").
-                # Reverse-lookup the original integer key and coerce that to bool.
-                rev = {v: k for k, v in self.enum_map.items()}
-                raw_key = rev.get(value)
-                return bool(raw_key) if raw_key is not None else bool(value)
-            else:
-                raise ValueError(
-                    f"Expected boolean-compatible value for {self.name}, got {type(value)}"
-                )
-            return bool(coerced)
+            return self._validate_bool_value(value)
 
-        numeric: float | int
-        if isinstance(value, int | float):
-            numeric = value
-        else:
-            raise ValueError(f"Expected numeric value for {self.name}, got {type(value)}")
-
-        if self.min_value is not None and numeric < self.min_value:
-            raise ValueError(f"{numeric} below minimum {self.min_value} for {self.name}")
-        if self.max_value is not None and numeric > self.max_value:
-            raise ValueError(f"{numeric} above maximum {self.max_value} for {self.name}")
-
-        # Preserve integers when no scaling is defined
-        if expected == "int":
-            return int(numeric)
-        return float(numeric)
+        return self._validate_numeric_value(value, expected)
 
 
 def _register_type_from_function(function: int) -> str:

--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -292,9 +292,8 @@ async def run_full_scan(
     )
 
 
-async def scan(scanner: Any) -> dict[str, Any]:
-    """Perform the actual register scan using an established connection."""
-    scan_started = time.monotonic()
+def _check_scan_transport_ready(scanner: Any) -> None:
+    """Raise ConnectionException if no usable transport or client is available."""
     transport = scanner._transport
     if transport is None:
         if scanner._client is None:
@@ -302,11 +301,72 @@ async def scan(scanner: Any) -> dict[str, Any]:
     elif scanner._client is None and not transport.is_connected():
         raise ConnectionException("Transport not connected")
 
-    device = ScannerDeviceInfo()
 
+async def _collect_scan_device_info(scanner: Any, device: ScannerDeviceInfo) -> None:
+    """Read firmware and identity registers and populate device info."""
     info_regs = await scanner._read_input_block(0, 30) or []
     await scanner._scan_firmware_info(info_regs, device)
     await scanner._scan_device_identity(info_regs, device)
+
+
+async def _finalize_scan_output(
+    scanner: Any,
+    device: ScannerDeviceInfo,
+    caps: Any,
+    input_registers: Any,
+    holding_registers: Any,
+    coil_registers: Any,
+    discrete_registers: Any,
+    input_max: int,
+    holding_max: int,
+    coil_max: int,
+    discrete_max: int,
+    unknown_registers: dict[str, dict[int, Any]],
+    scanned_registers: dict[str, int],
+    scan_started: float,
+) -> dict[str, Any]:
+    """Compute scan blocks, collect missing registers, and build the result dict."""
+    scan_blocks = scanner._compute_scan_blocks(
+        input_registers,
+        holding_registers,
+        coil_registers,
+        discrete_registers,
+        input_max,
+        holding_max,
+        coil_max,
+        discrete_max,
+    )
+    scanner._log_skipped_ranges()
+
+    raw_registers = await _accumulate_raw_registers(scanner)
+
+    missing_registers = scanner._collect_missing_registers(
+        input_registers, holding_registers, coil_registers, discrete_registers
+    )
+    scan_runtime.log_missing_registers(missing_registers)
+
+    available_registers = {key: set(value) for key, value in scanner.available_registers.items()}
+    return scan_runtime.build_scan_result(
+        scanner,
+        device=device,
+        caps=caps,
+        available_registers=available_registers,
+        unknown_registers=unknown_registers,
+        scanned_registers=scanned_registers,
+        scan_blocks=scan_blocks,
+        missing_registers=missing_registers,
+        scan_started=scan_started,
+        raw_registers=raw_registers,
+    )
+
+
+async def scan(scanner: Any) -> dict[str, Any]:
+    """Perform the actual register scan using an established connection."""
+    scan_started = time.monotonic()
+    _check_scan_transport_ready(scanner)
+
+    device = ScannerDeviceInfo()
+    await _collect_scan_device_info(scanner, device)
 
     (
         input_registers,
@@ -342,7 +402,10 @@ async def scan(scanner: Any) -> dict[str, Any]:
     ]
     _LOGGER.info("Detected %d capabilities", len(device.capabilities))
 
-    scan_blocks = scanner._compute_scan_blocks(
+    return await _finalize_scan_output(
+        scanner,
+        device,
+        caps,
         input_registers,
         holding_registers,
         coil_registers,
@@ -351,29 +414,9 @@ async def scan(scanner: Any) -> dict[str, Any]:
         holding_max,
         coil_max,
         discrete_max,
-    )
-    scanner._log_skipped_ranges()
-
-    raw_registers = await _accumulate_raw_registers(scanner)
-
-    missing_registers = scanner._collect_missing_registers(
-        input_registers, holding_registers, coil_registers, discrete_registers
-    )
-
-    scan_runtime.log_missing_registers(missing_registers)
-
-    available_registers = {key: set(value) for key, value in scanner.available_registers.items()}
-    return scan_runtime.build_scan_result(
-        scanner,
-        device=device,
-        caps=caps,
-        available_registers=available_registers,
-        unknown_registers=unknown_registers,
-        scanned_registers=scanned_registers,
-        scan_blocks=scan_blocks,
-        missing_registers=missing_registers,
-        scan_started=scan_started,
-        raw_registers=raw_registers,
+        unknown_registers,
+        scanned_registers,
+        scan_started,
     )
 
 

--- a/docs/core_consolidation_plan.md
+++ b/docs/core_consolidation_plan.md
@@ -1,0 +1,256 @@
+# Core Package Consolidation Plan
+
+**Status: Planning only — no code merged in this document**
+**Created: 2026-05-29**
+**Related PR: #1685 (docs/refactor: plan pymodbus 4 migration and reduce core complexity)**
+
+---
+
+## 1. Current Layout Inventory
+
+The `core/` package currently has 25 Python files. They are grouped by concern below.
+
+### 1.1 Main client entry point
+
+| File | Concern |
+|---|---|
+| `client.py` | `ThesslaGreenDeviceClient` — assembles all mixins into the main device client |
+
+### 1.2 Connection concern
+
+| File | Concern |
+|---|---|
+| `connection.py` | High-level connection helpers shared by client and scanner |
+| `connection_lifecycle.py` | Async connection open/close logic |
+| `connection_state.py` | Connection state tracking (connected, offline, etc.) |
+| `connection_test.py` | Register-probe helpers for connection validation |
+| `disconnect.py` | Disconnect / teardown helpers |
+| `transport_select.py` | Transport selection logic (TCP vs RTU, mode detection) |
+
+### 1.3 Read path concern
+
+| File | Concern |
+|---|---|
+| `read_batches.py` | Batched multi-register reads |
+| `read_bits.py` | Coil / discrete input reads |
+| `read_common.py` | Shared read infrastructure (retry wrappers, error helpers) |
+| `runtime_io.py` | High-level runtime read/write dispatcher |
+| `io_mixin.py` | `_ModbusIOMixin` — Modbus read protocol mixin used by DeviceClient |
+
+### 1.4 Write path concern
+
+| File | Concern |
+|---|---|
+| `write_path.py` | Write operations (single register, multi-register, coil writes) |
+
+### 1.5 Scanner support
+
+| File | Concern |
+|---|---|
+| `client_scanner.py` | `_DeviceClientScannerMixin` — scanner orchestration methods |
+| `scan_helpers.py` | Scan result processing helpers |
+| `scanner_kwargs.py` | Scanner construction argument assembly |
+
+### 1.6 Capability / model / config helpers
+
+| File | Concern |
+|---|---|
+| `capabilities_mixin.py` | `_CoordinatorCapabilitiesMixin` — derived capability metrics |
+| `models.py` | `CoordinatorConfig` and related data models |
+| `register_groups.py` | Register group grouping and iteration helpers |
+| `register_processing.py` | Register value post-processing (scaling, enum decode, etc.) |
+
+### 1.7 Runtime / config / state helpers
+
+| File | Concern |
+|---|---|
+| `client_connection.py` | `_DeviceClientConnectionMixin` — connection lifecycle mixin |
+| `client_registers.py` | `_DeviceClientRegistersMixin` — register IO helpers mixin |
+| `retry.py` | Retry/backoff utilities |
+| `runtime_state.py` | Runtime state snapshot helpers |
+
+---
+
+## 2. Recommended Target Layout
+
+The long-term target layout reduces the file count while preserving logical separation:
+
+```
+core/
+  __init__.py
+  client.py              # ThesslaGreenDeviceClient (unchanged — assembles mixins)
+  models.py              # CoordinatorConfig, data models (unchanged)
+  connection/            # or connection.py if small enough
+    __init__.py          # re-exports public symbols
+    lifecycle.py         # open/close/teardown (from connection_lifecycle, disconnect)
+    state.py             # connection state (from connection_state)
+    test.py              # connection probe (from connection_test)
+    transport_select.py  # transport selection (from transport_select)
+  read/                  # or read.py if small enough
+    __init__.py
+    batches.py           # from read_batches
+    bits.py              # from read_bits
+    common.py            # from read_common
+    io_mixin.py          # _ModbusIOMixin (from io_mixin)
+    runtime_io.py        # from runtime_io
+  write.py               # from write_path (already focused)
+  register_processing.py # unchanged
+  register_groups.py     # unchanged
+  retry.py               # unchanged
+  scan_helpers.py        # unchanged
+  scanner_kwargs.py      # unchanged
+  capabilities_mixin.py  # unchanged
+  client_connection.py   # unchanged until connection/ package is ready
+  client_scanner.py      # unchanged
+  client_registers.py    # unchanged
+```
+
+### Notes on target layout
+
+- Do not merge `client.py` into a monolith — keep it as the assembler of mixins.
+- The `connection/` sub-package makes sense because there are 6 connection-related files.
+- The `read/` sub-package may be deferred if the file count is manageable.
+- Circular imports are the primary risk; always verify with `python -m compileall` after moves.
+
+---
+
+## 3. Consolidation Rules
+
+These rules apply to every consolidation slice:
+
+1. **Preserve public imports** — if a module is imported by name outside `core/`, keep the old
+   name as a re-export shim for one PR cycle, then remove it in the next.
+   Exception: purely internal helpers with no external import are safe to move immediately.
+
+2. **No behavior changes** — consolidation is file moves only. No logic changes.
+
+3. **Use `git mv`** — preserves history. Never copy-paste.
+
+4. **One concern per PR** — do not mix connection and read consolidation in the same PR.
+
+5. **Run full validation after every slice** — see the validation checklist at the bottom.
+
+6. **Avoid actively-touched files** — if a file was modified in the last 3 PRs or is
+   referenced in a real-device fix, defer its consolidation.
+
+7. **No shims** — per `docs/thesslagreen_guidelines.md`, compatibility shims are forbidden.
+   Update all import sites instead of adding re-export modules.
+
+---
+
+## 4. Suggested Safe Slices
+
+### Slice 0 — Documentation only (this PR)
+
+- Create this document.
+- Identify the safest first move.
+- No code changed.
+
+### Slice 1 — Tiny internal-only helper (optional, this PR)
+
+If a module under `core/` is:
+- fewer than 40 lines,
+- imported only within `core/` itself (no external callers),
+- logically owned by a single larger module,
+
+it may be inlined into its owning module in this PR.
+
+**Candidates assessed:**
+
+| File | Lines | External imports? | Assessment |
+|---|---|---|---|
+| `scanner_kwargs.py` | ~35 | `core/client_scanner.py` only | Potentially safe — see Slice 1 notes |
+| `retry.py` | ~40 | `core/connection.py` only | Potentially safe |
+| `runtime_state.py` | ~30 | `core/client_registers.py` only | Potentially safe |
+
+Assessment is preliminary. Before performing any move:
+- Run `grep -r "from.*core.*<module>" custom_components tests tools` to confirm no external callers.
+- If any external caller is found, defer.
+
+**Deferred from this PR:** No code consolidation was performed in this PR. All three candidates
+above require a grep audit and import-site update that should be done as a standalone slice
+with focused tests. See "Deferred work" in the PR body.
+
+### Slice 2 — Connection helper consolidation
+
+Target: merge `connection_state.py` and `disconnect.py` into `connection_lifecycle.py`
+(or into a `connection/` sub-package).
+
+Prerequisites:
+- Real-device validation after #1684 must be complete.
+- All imports from these modules must be audited.
+- Tests must cover connect/disconnect paths.
+
+Risk: Medium — touches the connection runtime path that was recently changed in #1684.
+
+### Slice 3 — Read helper consolidation
+
+Target: merge `read_common.py` into `read_batches.py` or create a `read/` sub-package.
+
+Prerequisites:
+- Slice 2 must be stable.
+- Read path tests must pass on a real device.
+
+Risk: High — touches the update read cycle. Defer until #1684 real-device validation is done.
+
+### Slice 4 — Mixin review
+
+Target: review whether `capabilities_mixin.py` and `io_mixin.py` should be inlined into
+`client.py` or kept as separate concerns.
+
+Prerequisites:
+- All previous slices must be stable.
+- Only after `check_maintainability.py` reports no violations in `client.py`.
+
+Risk: Low if mechanical, but touches the main client which is central.
+
+---
+
+## 5. Decision Points
+
+Before executing slices, the team must decide:
+
+| Decision | Option A | Option B |
+|---|---|---|
+| Module size preference | Small focused files (current style) | Topic files (fewer, larger) |
+| Sub-package vs single file | `connection/` sub-package | Single `connection.py` |
+| Import compatibility | Update all import sites | Brief re-export shim (one PR) |
+| Timing | After real-device validation | Before real-device validation |
+
+**Current recommendation:** Follow Option A (small files), use sub-packages for groups with
+≥3 files, update import sites directly (no shims), and wait for real-device validation before
+any Slice 2+ work.
+
+---
+
+## 6. Validation Checklist (per slice)
+
+Run these after every consolidation slice:
+
+```bash
+python -m compileall -q custom_components/thessla_green_modbus tests tools
+pytest tests/ -q --tb=long
+ruff check custom_components tests tools
+ruff check --select I custom_components tests tools
+ruff format --check custom_components tests tools
+python tools/compare_airpack4_vendor_coverage.py
+python tools/compare_registers_with_reference.py --show-renames
+python tools/validate_entity_mappings.py
+python tools/check_translations.py
+python tools/check_maintainability.py
+```
+
+All must pass before merging any slice.
+
+---
+
+## 7. Deferred Work
+
+The following are explicitly out of scope until prerequisites are met:
+
+- `read_batches.py` / `read_bits.py` / `read_common.py` consolidation — deferred until
+  Slice 2 (connection) is stable and real-device validation is done.
+- `connection.py` / `connection_lifecycle.py` / `disconnect.py` merge — deferred until
+  real-device validation after #1684 is complete.
+- Any consolidation that touches the Modbus read/write runtime.
+- Any consolidation that changes public import paths without a full import-site audit.

--- a/docs/pymodbus_4_migration_plan.md
+++ b/docs/pymodbus_4_migration_plan.md
@@ -1,0 +1,258 @@
+# pymodbus 4.0 Migration Plan
+
+**Status: Planning only — no code change in this document**
+**Created: 2026-05-29**
+**Related PR: #1685 (docs/refactor: plan pymodbus 4 migration and reduce core complexity)**
+
+---
+
+## 1. Current State
+
+### Manifest requirement
+
+```json
+"requirements": ["pymodbus>=3.6.0,<4.0"]
+```
+
+### Why `<4.0` is intentionally pinned
+
+- The integration targets the stable pymodbus 3.x API surface.
+- pymodbus 4.0 is a new major version and may contain breaking API changes.
+- The `<4.0` pin protects production installs from an unvalidated dependency upgrade.
+- No one has tested the integration against pymodbus 4.x on a real device.
+- Home Assistant currently installs pymodbus from the `requirements` list; if HA itself
+  pins to 3.x, lifting our pin early would be a no-op. If HA lifts its pin before we do,
+  our pin still protects us.
+
+### Integration API surface against pymodbus
+
+All Modbus I/O lives in `transport/` and is isolated from the HA layer. The
+integration uses:
+
+- `AsyncModbusTcpClient` / `AsyncModbusSerialClient` (TCP and RTU modes)
+- `client.connect()` / `client.close()`
+- `client.read_input_registers()` / `client.read_holding_registers()`
+- `client.write_register()` / `client.write_registers()`
+- `client.read_coils()` / `client.read_discrete_inputs()`
+- Response objects: `.registers` / `.bits` attribute access
+- Exception types: `ModbusException`, `ModbusIOException`, `ConnectionException`
+
+---
+
+## 2. Why pymodbus 4.0 Matters
+
+- A major version bump signals that backwards compatibility is not guaranteed.
+- Home Assistant may eventually update its bundled pymodbus or require 4.x.
+- Custom integrations installed via HACS will follow HA's pymodbus version.
+- Delaying migration planning means scrambling under time pressure when the pin
+  eventually needs to be lifted.
+- Proactive planning lets us do the migration on our own schedule with full
+  test coverage.
+
+---
+
+## 3. Known Risk Areas to Verify
+
+The following areas must be tested on pymodbus 4.x before the pin is lifted.
+Each item represents a possible breaking-change surface.
+
+### 3.1 Client construction
+
+| Risk | Area | Notes |
+|---|---|---|
+| Constructor signature change | `AsyncModbusTcpClient` | New kwargs, renamed args, or dropped kwargs |
+| Constructor signature change | `AsyncModbusSerialClient` | Same |
+| `timeout` parameter behavior | Both | May have moved to a separate config object |
+| `retry_on_empty` / retry config | Both | May have changed shape |
+| `source_address` / framer args | Both | Framer API changed between 3.x versions |
+
+### 3.2 Connection lifecycle
+
+| Risk | Area | Notes |
+|---|---|---|
+| `connect()` return value | Both | Some 3.x versions return `bool`, 4.x may differ |
+| `close()` / `transport.close()` | Both | Transport attribute shape may change |
+| `is_socket_open()` or equivalent | Both | Property renamed in some releases |
+| Re-connect after disconnect | Both | Behavior on repeated connect/close |
+
+### 3.3 Register read API
+
+| Risk | Area | Notes |
+|---|---|---|
+| `read_input_registers` signature | Both | `slave` → `device_id` rename in some versions |
+| `read_holding_registers` signature | Both | Same |
+| Response `.registers` attribute | Both | Could change shape or type |
+| `count` vs positional arg | Both | Keyword arg enforcement |
+| `no_response_expected` kwarg | Both | May be renamed or removed |
+
+### 3.4 Coil/discrete read API
+
+| Risk | Area | Notes |
+|---|---|---|
+| `read_coils` signature | Both | slave/device_id, count position |
+| `read_discrete_inputs` signature | Both | Same |
+| Response `.bits` attribute | Both | Could change type (list vs BooleanList) |
+
+### 3.5 Register write API
+
+| Risk | Area | Notes |
+|---|---|---|
+| `write_register` (single) | Both | Signature, slave/device_id |
+| `write_registers` (multi) | Both | Values arg type, slave/device_id |
+
+### 3.6 Exception handling
+
+| Risk | Area | Notes |
+|---|---|---|
+| `ModbusIOException` hierarchy | Both | May move in exception tree |
+| `ExceptionResponse` detection | Both | `isError()` vs `isinstance` |
+| `ConnectionException` location | Both | Module path could change |
+| `transaction_id` mismatch errors | TCP | May be surfaced differently |
+| Timeout exception type | Both | `asyncio.TimeoutError` vs library type |
+
+### 3.7 slave / device_id handling
+
+pymodbus 3.x accepts `slave=<int>` on most calls; 4.x may rename to
+`device_id` or handle it at client construction only. The integration
+passes slave ID on each call in `transport/tcp.py` and `transport/rtu.py`.
+
+### 3.8 RTU-specific
+
+| Risk | Notes |
+|---|---|
+| Serial framer selection | `framer=ModbusRtuFramer` syntax may change |
+| `serial_port` / `port` arg | May be renamed |
+| Parity/stopbits kwargs | Could be wrapped in a SerialConfig object |
+
+---
+
+## 4. Integration-Specific Test Matrix
+
+Before the pin can be lifted, every scenario below must pass on pymodbus 4.x.
+
+| # | Scenario | Test file | Expected result |
+|---|---|---|---|
+| 1 | Setup connection (TCP) | `test_device_scanner_setup.py` | connect completes, no exception |
+| 2 | Setup connection (RTU) | `test_device_scanner_setup.py` | connect completes, no exception |
+| 3 | Normal update read cycle | `test_coordinator_lifecycle.py` | all registers returned correctly |
+| 4 | Input register reads | `test_scanner_io_input.py` | `.registers` values correct |
+| 5 | Holding register reads | `test_scanner_io_holding.py` | `.registers` values correct |
+| 6 | Coil reads | `test_scanner_full_scan_coverage.py` | `.bits` values correct |
+| 7 | Discrete input reads | `test_scanner_full_scan_coverage.py` | `.bits` values correct |
+| 8 | Single register write | `test_coordinator_register_writes.py` | no exception, register updated |
+| 9 | Multi-register write | `test_coordinator_register_writes.py` | same |
+| 10 | Temporary airflow 3-register block write | `test_coordinator_register_writes.py` | atomic write of 3 registers |
+| 11 | RTC clock sync write + readback | `test_coordinator_lifecycle.py` | clock registers written, readback matches |
+| 12 | Scanner fallback (named → full) | `test_scanner_state.py` | fallback path exercised |
+| 13 | `validate_known_registers` service | `test_services_handlers_parameters_registration.py` | no exception, result dict returned |
+| 14 | `scan_all_registers` with throttle | `test_scanner_full_scan_coverage.py` | delay_between_requests respected |
+| 15 | Reconnect after cancelled batch | `test_scanner_cancelled_batch_reconnect.py` | reconnect occurs, next read succeeds |
+| 16 | Device unavailable → reconnect → shutdown | `test_device_scanner_errors.py` | no stale state, shutdown clean |
+
+All tests must pass on pymodbus 4.x before the pin is lifted.
+Mock-based tests must also be updated to reflect any changed API shape.
+
+---
+
+## 5. Migration Strategy
+
+**Step 1 — Create a migration branch**
+
+```bash
+git checkout -b feature/pymodbus-4-migration
+```
+
+Do NOT touch `main` until the migration is complete and validated.
+
+**Step 2 — Relax the pin on the branch only**
+
+In `manifest.json`:
+```json
+"requirements": ["pymodbus>=3.6.0,<5.0"]
+```
+
+Or, to target 4.x explicitly during migration testing:
+```json
+"requirements": ["pymodbus>=4.0,<5.0"]
+```
+
+Do NOT commit this change to `main`.
+
+**Step 3 — Install pymodbus 4.x and run full test suite**
+
+```bash
+pip install "pymodbus>=4.0,<5.0"
+pytest tests/ -q --tb=long
+```
+
+Expect failures. Collect them all before fixing.
+
+**Step 4 — Run focused Modbus transport tests**
+
+```bash
+pytest tests/ -k "scanner or transport or device_scanner or modbus" -q --tb=long
+```
+
+**Step 5 — Fix each failure in isolation**
+
+- Do not change register addresses, entity IDs, or service IDs while fixing.
+- Fix only the transport/client call-site changes needed for 4.x API compatibility.
+- Keep 3.x-specific code paths if HA may still require 3.x.
+
+**Step 6 — Test against real AirPack4 device**
+
+Before merging:
+- Install the migration branch in a real HA instance with an AirPack4 device.
+- Verify all items in `docs/real_device_validation.md` section 3.
+- Capture log evidence and commit it.
+
+**Step 7 — Update manifest and docs**
+
+Only after real-device validation:
+- Update `manifest.json` pin.
+- Update `docs/real_device_validation.md` with evidence.
+- Update this document to reflect the completed migration.
+
+---
+
+## 6. Explicit Non-Goals
+
+The following are explicitly out of scope for the migration:
+
+- No current code migration (the `<4.0` pin remains in `main` until migration is complete).
+- No removal of pymodbus 3.x support until the migration branch is validated.
+- No broad refactoring of transport modules during dependency migration.
+- No entity, register, service, or translation changes during migration.
+- No fan percentage, temperature, or RTC sync behavior changes.
+- No quality_scale upgrade during migration.
+- No removal of mock-based tests — all tests must continue to pass.
+
+---
+
+## 7. Risk Summary
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| API breakage in client construction | High | High | Branch-isolated testing |
+| `slave` → `device_id` rename | Medium | Medium | Grep all call sites in `transport/` |
+| Exception hierarchy change | Medium | High | Run full error-path tests |
+| Response attribute change | Medium | High | Unit tests with real response objects |
+| RTU serial framer change | Medium | Medium | RTU-specific integration test |
+| HA pymodbus version conflict | Low | High | Monitor HA core requirements |
+
+---
+
+## 8. File References
+
+Key files to audit during migration:
+
+```
+transport/tcp.py
+transport/rtu.py
+transport/base.py
+core/connection.py
+core/client_connection.py
+```
+
+These are the only files that import from `pymodbus` directly. The rest of
+the integration is isolated from pymodbus internals.

--- a/docs/real_device_validation.md
+++ b/docs/real_device_validation.md
@@ -16,6 +16,7 @@
 | Overall validation | PARTIAL — user-reported, formal evidence pending |
 | Quality scale gate | Bronze — no upgrade until formal evidence is committed |
 | Fan percentage fix (#1682) | FIXED in code; real-device re-test evidence pending |
+| IO ownership cleanup (#1684) | Coordinator no longer owns low-level IO; post-#1684 HA validation still required |
 | Temperature sensors | User-reported working; no log evidence committed |
 | Vendor coverage | 353/353 registers — verified by tool (`compare_airpack4_vendor_coverage.py`) |
 | Dangerous entities | Present and enabled; `entity_category=config` added (this PR) |


### PR DESCRIPTION
## Summary by task

### Task 0 — Baseline inspection
- Current commit on main: `862381f` (Merge PR #1684)
- Manifest: `pymodbus>=3.6.0,<4.0` (unchanged)
- `quality_scale`: `bronze` (unchanged)
- `core/` layout: 25 files across connection, read, write, scanner, capability, and runtime concerns
- Functions near 80+ lines: `run_full_scan` (86), `scan` (83), `RegisterMapEntry.validate` (83), `initialize_runtime_state` (83)
- Existing architecture docs: `thesslagreen_architecture.md`, `refactor_status.md`, `device_client_redesign.md`
- **#1684 coordinator IO ownership cleanup is already present in main** — this PR does not change IO ownership again and does not change runtime Modbus semantics

### Task 1 — `docs/pymodbus_4_migration_plan.md` (new)
- Documents current state and why `<4.0` pin is intentional
- Lists all known risk areas: client construction, connect/close lifecycle, `read_input_registers`, `read_holding_registers`, `write_register`, `write_registers`, `read_coils`, `read_discrete_inputs`, `slave`/`device_id` argument handling, `no_response_expected`, exception types, timeout/cancellation, RTU vs TCP
- 16-scenario integration test matrix covering all register types, writes, RTC, scanner, and reconnect
- Step-by-step migration strategy (isolated branch → relax pin → full tests → real device → merge)
- Explicit non-goals: no current code change, no 3.x removal, no manifest change

### Task 2 — `docs/core_consolidation_plan.md` (new)
- Full inventory of 25 `core/` files grouped by concern
- Proposed target layout with `connection/` and `read/` sub-packages
- Consolidation rules: no shims, `git mv`, one concern per PR, full validation per slice
- 4 deferred slices with prerequisites and risk levels
- Slice 0 (this PR): documentation only — no code consolidation performed
- Slices 1–4 deferred until real-device validation post-#1684

### Task 3 — Function decompositions
| File | Function | Before | After | Helpers extracted |
|---|---|---|---|---|
| `coordinator/state.py` | `initialize_runtime_state` | 83 lines | 6 lines | `_initialize_runtime_flags`, `_initialize_connection_state`, `_initialize_device_state`, `_initialize_scan_state` |
| `register_map.py` | `RegisterMapEntry.validate` | 83 lines | 55 lines | `_validate_bool_value`, `_validate_numeric_value` |
| `scanner/orchestration.py` | `scan` | 83 lines | 58 lines | `_check_scan_transport_ready`, `_collect_scan_device_info`, `_finalize_scan_output` |
| `scanner/orchestration.py` | `run_full_scan` | 86 lines | 86 lines | Inspected — already maximally decomposed via `_run_word_phase`/`_run_bit_phase`; further extraction would only move logging lines and worsen readability |

### Optional tiny consolidation
None performed. All candidates (`scanner_kwargs.py`, `retry.py`, `runtime_state.py`) require a full import-site grep audit before moving. Deferred to Slice 1 per the consolidation plan.

### Deferred work
- Core consolidation Slices 1–4 (see `docs/core_consolidation_plan.md`)
- pymodbus 4.0 code migration (see `docs/pymodbus_4_migration_plan.md`)
- Real-device validation post-#1684 (see `docs/real_device_validation.md`)

---

## Explicit confirmations

- ✅ pymodbus pin unchanged (`>=3.6.0,<4.0`)
- ✅ No runtime Modbus behavior changed
- ✅ No register addresses changed
- ✅ No register names changed
- ✅ No entity IDs changed
- ✅ No unique IDs changed
- ✅ No service IDs changed
- ✅ No translation keys changed
- ✅ `airpack4_modbus.json` unchanged
- ✅ AirPack4 coverage still `Missing: 0`
- ✅ Fan percentage fix (#1682) preserved — `fan.py` untouched
- ✅ Temperature logic untouched
- ✅ RTC sync untouched
- ✅ Dangerous entities unchanged — `entity_category=config` and default-enabled preserved
- ✅ `quality_scale` remains `bronze`
- ✅ No `entity_registry_enabled_default: False` added
- ✅ `modbus_helpers.py` not reintroduced
- ✅ No compatibility shims added

---

## Validation output

```
$ python -m compileall -q custom_components/thessla_green_modbus tests tools
(no output — all pass)

$ python tools/check_maintainability.py
Maintainability gate passed.

$ ruff check custom_components tests tools
All checks passed!

$ ruff check --select I custom_components tests tools
All checks passed!

$ ruff format --check custom_components tests tools
449 files already formatted

$ python tools/compare_airpack4_vendor_coverage.py
No missing registers.

$ python tools/validate_entity_mappings.py
OK: 367 entities validated

$ python tools/check_translations.py
All translation keys present.

$ python tools/compare_registers_with_reference.py --show-renames
(shows only pre-existing known renames — no new renames)

$ pytest tests/ -q
ENVIRONMENT LIMITATION: requires Python 3.13 + homeassistant stack.
This environment has Python 3.11 — pre-existing limitation confirmed present
on baseline commit 862381f before any changes in this PR.
Full pytest suite must be run in a Python 3.13 HA environment via CI.
```

---

## Risk notes

- **Core consolidation is planned/deferred** — no code was moved; all slices require real-device validation post-#1684 before execution
- **Real-device validation after #1684 is still required** — `docs/real_device_validation.md` remains `PARTIAL`, quality_scale stays `bronze`
- **pymodbus 4.0 is not enabled** — the `<4.0` pin remains; the migration plan is documentation only
- Decomposed helpers are all `_`-prefixed private functions; no public API surface changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01BG5SjEdW5XpNtSUPuKy9an)_