### PR TITLE
ci/docs: require Python 3.13 validation and finalize cleanup follow-up

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,11 +45,23 @@ jobs:
       - name: Ruff
         run: ruff check custom_components tests tools
 
+      - name: Ruff import order
+        run: ruff check --select I custom_components tests tools
+
+      - name: Ruff format
+        run: ruff format --check custom_components tests tools
+
       - name: Compile Python sources
         run: python -m compileall -q custom_components/thessla_green_modbus tests tools
 
       - name: Compare registers with vendor reference
-        run: python tools/compare_registers_with_reference.py
+        run: python tools/compare_registers_with_reference.py --show-renames
+
+      - name: AirPack4 vendor coverage
+        run: python tools/compare_airpack4_vendor_coverage.py
+
+      - name: Check translations
+        run: python tools/check_translations.py
 
       - name: Maintainability gate
         run: python tools/check_maintainability.py
@@ -84,8 +96,11 @@ jobs:
           python -m pip install -e .
           python -m pip install homeassistant==${{ matrix.ha-version }} hacs
 
+      - name: Collect tests
+        run: pytest --collect-only -q
+
       - name: Pytest with coverage
-        run: pytest --cov --cov-report=xml --cov-report=term -q
+        run: pytest tests/ -q --tb=long --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6
@@ -123,42 +138,6 @@ jobs:
 
       - name: Validate entity mappings
         run: python tools/validate_entity_mappings.py
-
-  ruff-adoption-signal:
-    name: Ruff formatting/import-order signal (non-blocking)
-    runs-on: ubuntu-latest
-    needs: lint
-    continue-on-error: true
-    strategy:
-      matrix:
-        python-version: ["3.13"]
-        ha-version: ["2026.2.3"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
-            constraints.txt
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements-dev.txt
-          python -m pip install -e .
-          python -m pip install homeassistant==${{ matrix.ha-version }} hacs
-
-      - name: Ruff import order (informational)
-        run: ruff check --select I custom_components tests tools
-
-      - name: Ruff format drift (informational)
-        run: ruff format --check custom_components tests tools
 
   hassfest:
     name: Hassfest validation

--- a/docs/development_validation.md
+++ b/docs/development_validation.md
@@ -1,0 +1,121 @@
+# Development Validation Guide
+
+This document describes how to reproduce the full CI validation locally.
+
+---
+
+## Required Python version
+
+**Python 3.13 is required.**
+
+Home Assistant's test stack (`pytest-homeassistant-custom-component`) has a hard
+dependency on Python 3.13. Running with Python 3.11 or 3.12 is not sufficient —
+import errors or silent test collection failures will occur.
+
+Python 3.11 or 3.12 sandboxes (including some agent/CI environments) are
+**not authoritative** for full pytest results. If your local environment provides
+only Python 3.11, rely on the GitHub Actions CI job for full pytest results.
+
+---
+
+## Setup
+
+### With uv (recommended)
+
+```bash
+uv venv --python 3.13
+source .venv/bin/activate
+uv pip install -r requirements-dev.txt
+uv pip install -e .
+uv pip install "homeassistant==2026.2.3"
+```
+
+### With standard venv
+
+```bash
+python3.13 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements-dev.txt
+pip install -e .
+pip install "homeassistant==2026.2.3"
+```
+
+---
+
+## Full validation command block
+
+Run these commands in order from the repository root. All must pass before merging.
+
+```bash
+python -m compileall -q custom_components/thessla_green_modbus tests tools
+ruff check custom_components tests tools
+ruff check --select I custom_components tests tools
+ruff format --check custom_components tests tools
+python tools/compare_registers_with_reference.py --show-renames
+python tools/compare_airpack4_vendor_coverage.py
+python tools/validate_entity_mappings.py
+python tools/check_translations.py
+python tools/check_maintainability.py
+pytest --collect-only -q
+pytest tests/ -q --tb=long
+```
+
+---
+
+## Focused test command block
+
+Run these when working on a specific area to get faster feedback:
+
+```bash
+# Core areas from recent PRs
+pytest -q tests/ -k "coordinator or device_client or fan or dangerous or entity_category or register_map or orchestration or maintainability" --tb=long
+
+# Fan percentage
+pytest -q tests/test_fan.py tests/test_fan_percentage_limits.py --tb=long
+
+# Dangerous entities
+pytest -q tests/test_airpack4_dangerous_entity_marking.py tests/test_airpack4_dangerous_register_exposure.py --tb=long
+
+# IO ownership
+pytest -q tests/test_coordinator_io_ownership.py --tb=long
+
+# Cleanup/pin checks
+pytest -q tests/test_cleanup_audit.py --tb=long
+```
+
+---
+
+## CI environment
+
+The GitHub Actions CI (`CI` workflow) mirrors the full validation block above.
+It runs on:
+
+- **Python:** 3.13
+- **Home Assistant:** 2026.2.3
+- **Trigger:** push to `main`, all pull requests, manual `workflow_dispatch`
+
+Jobs:
+
+| Job | What it checks |
+|-----|---------------|
+| `lint` | ruff lint, ruff import-order, ruff format, compileall, register comparison, airpack4 coverage, translations, maintainability |
+| `tests` | pytest collect + full pytest with coverage |
+| `entity-mappings` | entity mapping validation |
+| `hassfest` | HA manifest validation |
+| `hacs` | HACS integration validation |
+
+---
+
+## Notes
+
+- **Python 3.11 is not sufficient.** The `pytest-homeassistant-custom-component`
+  fixture stack imports HA internals that require Python 3.13.
+- **Agent/sandbox environments** that report Python 3.11 cannot confirm full
+  pytest results. State the Python version explicitly in any PR description and
+  note which checks were run locally vs deferred to CI.
+- **pymodbus must remain `>=3.6.0,<4.0`** in both `manifest.json` and
+  `pyproject.toml`. The pymodbus 4.x migration is documented in
+  `docs/pymodbus_4_migration_plan.md` but is not active.
+- **Do not upgrade `quality_scale`** from `bronze` until real-device validation
+  evidence is committed. See `docs/real_device_validation.md`.

--- a/docs/real_device_validation.md
+++ b/docs/real_device_validation.md
@@ -16,10 +16,10 @@
 | Overall validation | PARTIAL — user-reported, formal evidence pending |
 | Quality scale gate | Bronze — no upgrade until formal evidence is committed |
 | Fan percentage fix (#1682) | FIXED in code; real-device re-test evidence pending |
-| IO ownership cleanup (#1684) | Coordinator no longer owns low-level IO; post-#1684 HA validation still required |
+| IO ownership cleanup (#1684) | Coordinator no longer owns low-level IO; post-#1684/#1685 HA validation still required |
 | Temperature sensors | User-reported working; no log evidence committed |
 | Vendor coverage | 353/353 registers — verified by tool (`compare_airpack4_vendor_coverage.py`) |
-| Dangerous entities | Present and enabled; `entity_category=config` added (this PR) |
+| Dangerous entities | Present and enabled; `entity_category=config` added in #1683 |
 
 ---
 
@@ -28,7 +28,7 @@
 | Item | Value |
 |------|-------|
 | Home Assistant Core | Pending user data |
-| Integration version | Current `main` — commit `bea0fdc` (post-PR #1682) |
+| Integration version | Current `main` — commit `6826be4` (post-PR #1685) |
 | Device model | ThesslaGreen AirPack 4 (user-reported) |
 | Firmware version | Pending — device registers may not expose firmware |
 | Connection type | Pending user data (TCP / RTU) |


### PR DESCRIPTION
## Summary by task

### TASK 0 — Baseline inspection
- Latest commit before this PR: `6826be4` (Merge PR #1685)
- CI already used Python 3.13; several required commands were missing or non-blocking
- All local tool checks pass on Python 3.13.12
- pymodbus pin confirmed unchanged: `>=3.6.0,<4.0`
- #1684 IO ownership cleanup confirmed present
- #1685 docs confirmed present (`pymodbus_4_migration_plan.md`, `core_consolidation_plan.md`)
- `core_consolidation_plan.md` matches current `core/` layout (25 files)

### TASK 1 — CI Python 3.13 validation
- Added blocking `ruff check --select I` and `ruff format --check` to lint job (were non-blocking in a separate `ruff-adoption-signal` job)
- Added `--show-renames` flag to `compare_registers_with_reference.py` in lint
- Added `compare_airpack4_vendor_coverage.py` to lint job
- Added `check_translations.py` to lint job
- Added `pytest --collect-only -q` step to tests job
- Changed pytest command to: `pytest tests/ -q --tb=long --cov ...`
- Removed `ruff-adoption-signal` job (its checks are now blocking in lint)

### TASK 2 — Local test environment documentation
- Added `docs/development_validation.md` with:
  - Python 3.13 requirement and why Python 3.11 is insufficient
  - uv and venv setup instructions
  - Full validation command block (identical to CI)
  - Focused test command block
  - CI job summary table
  - Note that agent/sandbox environments on Python 3.11 are not authoritative

### TASK 3 — Maintainability cleanup
- `check_maintainability.py` passes without any code changes
- No functions above threshold after #1685 decompositions
- No further extraction performed — would reduce readability without benefit

### TASK 4 — Core consolidation follow-up (documentation/verification only)
- `docs/core_consolidation_plan.md` verified: exactly matches current `core/` layout (25 Python files)
- No code consolidation performed
- All actual module moves deferred until real-device validation post-#1684

### TASK 5 — pymodbus 4.0 plan preserved without migration
- `manifest.json` still pins `pymodbus>=3.6.0,<4.0`
- `pymodbus_4_migration_plan.md` unchanged; migration is planning-only
- No dependency changes of any kind

### TASK 6 — Real-device validation evidence status
- Updated commit SHA reference from `bea0fdc` to `6826be4` (post-#1685)
- Corrected stale "this PR" reference for `entity_category=config` → #1683
- Updated IO ownership note to reference post-#1684/#1685
- Status remains: **Partial / evidence pending** — no upgrade to quality_scale

### TASK 7 — Regression checks
Existing coverage is comprehensive; no new tests needed:
- `test_cleanup_audit.py` — pymodbus pin (manifest + pyproject consistency)
- `test_airpack4_dangerous_entity_marking.py` — `entity_category=config` for dangerous entities
- `test_coordinator_io_ownership.py` — DeviceClient IO ownership, removed coordinator delegates
- `test_fan.py` / `test_fan_percentage_limits.py` — fan percentage fix

---

## Explicit confirmations

- pymodbus pin unchanged: `>=3.6.0,<4.0`
- pymodbus NOT upgraded
- no runtime Modbus behavior changed
- no register addresses changed
- no register names changed
- no entity IDs changed
- no unique IDs changed
- no service IDs changed
- no translation keys changed
- `airpack4_modbus.json` unchanged
- AirPack4 coverage: Missing 0
- fan percentage fix preserved
- temperature logic untouched
- RTC sync untouched
- dangerous entities unchanged (present, enabled, `entity_category=config`)
- `quality_scale` unchanged (bronze)
- no production compatibility shims added

---

## Validation output

### Local (Python 3.13.12)

```
python -m compileall -q ...        OK
ruff check ...                     All checks passed
ruff check --select I ...          All checks passed
ruff format --check ...            449 files already formatted
compare_registers_with_reference   OK
compare_airpack4_vendor_coverage   Missing: 0, No missing registers
validate_entity_mappings.py        OK: 367 entities validated
check_translations.py              All translation keys present
check_maintainability.py           Maintainability gate passed
pytest --collect-only              Requires homeassistant package — deferred to CI
pytest tests/                      Requires homeassistant package — deferred to CI
```

**Local Python:** 3.13.12  
**CI Python:** 3.13 (GitHub Actions, `ubuntu-latest`)  
**Full pytest result:** deferred to CI job (requires `homeassistant==2026.2.3` package install)

---

## Remaining work

1. **Real-device validation** on AirPack4 post-#1684/#1685 — see `docs/real_device_validation.md` for evidence checklist
2. **Core consolidation slices** (Slice 2+) — only after real-device validation is complete
3. **pymodbus 4 migration** — separate branch/testing, not on `main`, only after pin-lift decision

https://claude.ai/code/session_017jNc3woWfUMYW482N2gFkH

---
_Generated by [Claude Code](https://claude.ai/code/session_017jNc3woWfUMYW482N2gFkH)_