### PR TITLE
refactor: clarify coordinator lifecycle boundary

### DIFF
--- a/custom_components/thessla_green_modbus/coordinator/coordinator.py
+++ b/custom_components/thessla_green_modbus/coordinator/coordinator.py
@@ -376,7 +376,7 @@ class ThesslaGreenModbusCoordinator(
         _store_scan_cache_impl(self)
 
     async def _test_connection(self) -> None:
-        """Test initial connection to the device."""
+        """HA-boundary adapter — called by coordinator/lifecycle.py during HA setup."""
         async with self._device_client._write_lock:
             await _run_connection_test_impl(
                 ensure_connection=self._ensure_connection,
@@ -389,11 +389,11 @@ class ThesslaGreenModbusCoordinator(
             )
 
     async def _async_setup_client(self) -> bool:
-        """Set up the Modbus client if needed.
+        """Intentional test-facing helper — exercises setup-client-with-retry logic.
 
-        Although only invoked in tests within this repository, this helper
-        mirrors the logic executed during Home Assistant start-up. It returns
-        ``True`` on success and ``False`` on failure.
+        Only invoked in tests; it mirrors the connection-establishment path that runs
+        during Home Assistant start-up so that path can be unit-tested without a full
+        HA lifecycle.  Returns ``True`` on success and ``False`` on failure.
         """
         return await _setup_client_with_retry_impl(
             ensure_connection=self._ensure_connection,
@@ -401,17 +401,12 @@ class ThesslaGreenModbusCoordinator(
         )
 
     async def _ensure_connection(self) -> None:
-        """Ensure Modbus connection is established (alias used by coordinator submodules)."""
-        await self._ensure_connected()
+        """HA-boundary adapter — called by coordinator submodules and duck-typed by core.
 
-    async def _try_direct_client_connect(self, *, allow_parameterless_ctor: bool) -> bool:
-        """Try connecting via AsyncModbusTcpClient — delegates to DeviceClient."""
-        return await self._device_client._try_direct_client_connect(
-            allow_parameterless_ctor=allow_parameterless_ctor
-        )
-
-    async def _ensure_connected(self) -> None:
-        """Ensure Modbus connection is established — delegates to DeviceClient."""
+        Submodules (schedule, update, retry, client_registers) receive ``coordinator``
+        and call ``_ensure_connection()`` to establish the Modbus connection.  This is
+        an intentional boundary method; it is *not* proxy debt.
+        """
         await self._device_client.async_ensure_connected()
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -423,15 +418,20 @@ class ThesslaGreenModbusCoordinator(
         return await _async_update_data_impl(self)
 
     async def _disconnect_locked(self) -> None:
-        """Disconnect from Modbus device without acquiring locks — delegates to DeviceClient."""
+        """HA-boundary adapter — passed as a callback to core.connection_lifecycle.
+
+        ``ensure_connected_lifecycle`` receives this as ``disconnect_locked_fn`` so it
+        can disconnect without re-acquiring the already-held client lock.  This is an
+        intentional boundary method; it is *not* proxy debt.
+        """
         await self._device_client._disconnect_locked()
 
-    async def _close_client_connection(self) -> None:
-        """Close client object safely — delegates to DeviceClient."""
-        await self._device_client._close_client_connection()
-
     async def _disconnect(self) -> None:
-        """Disconnect from Modbus device."""
+        """HA-boundary adapter — disconnect called by coordinator submodules.
+
+        Used by errors, schedule, update, write_path, and async_shutdown.  This is an
+        intentional boundary method; it is *not* proxy debt.
+        """
         async with self._device_client._client_lock:
             await self._disconnect_locked()
 

--- a/docs/coordinator_proxy_remaining_plan.md
+++ b/docs/coordinator_proxy_remaining_plan.md
@@ -178,6 +178,45 @@ Previously, `read_batches.py` used `getattr(owner, "_failed_registers", set())` 
 4. Failed-register tracking works via device_client
 5. Fan-percentage and dangerous-entity regressions guarded
 
+## 2026-05-29 slice-4 — lifecycle boundary cleanup (this PR)
+
+Inspected 8 HA lifecycle/connection adapter methods in coordinator:
+`_ensure_connection`, `_ensure_connected`, `_try_direct_client_connect`,
+`_disconnect_locked`, `_close_client_connection`, `_disconnect`, `_async_setup_client`,
+`_test_connection`.
+
+### Kept as intentional HA-boundary adapters (documented in docstrings)
+
+| Method | Why kept |
+|---|---|
+| `_ensure_connection` | Active duck-typing entry point called by schedule, update, retry, client_registers submodules |
+| `_disconnect_locked` | Passed as `disconnect_locked_fn` callback to `core/connection_lifecycle.py:29` |
+| `_disconnect` | Called by errors.py, schedule.py, update.py, write_path.py, and async_shutdown |
+| `_test_connection` | Called in production by `coordinator/lifecycle.py:37` during HA setup |
+| `_async_setup_client` | Intentional test-facing helper (documented); mirrors HA start-up path for unit tests |
+
+### Removed unused coordinator proxies
+
+| Removed | Why |
+|---|---|
+| `_ensure_connected` | One-line forwarder (`await self._device_client.async_ensure_connected()`); sole caller was `_ensure_connection` itself. Inlined. |
+| `_try_direct_client_connect` | Zero callers on coordinator; `DeviceClient._try_direct_client_connect` is called directly via `self` inside `client_connection.py`. |
+| `_close_client_connection` | Zero callers; `_disconnect_locked` in DeviceClient uses the `_close_client_connection_impl` function directly, never going through the coordinator proxy. |
+
+### Why these are not HA-boundary adapters
+
+Unlike `_ensure_connection` / `_disconnect_locked` / `_disconnect` (which satisfy a
+duck-typing protocol consumed by coordinator submodules), the three removed methods were
+never called from outside the class definition itself.  No production code, no tests, and
+no protocol stubs required them on the coordinator.
+
+### New tests
+
+Three assertions added to `tests/test_coordinator_lifecycle.py`:
+- `test_coordinator_no_ensure_connected`
+- `test_coordinator_no_try_direct_client_connect`
+- `test_coordinator_no_close_client_connection`
+
 ## Remaining delegates (none — cleanup complete)
 
 All coordinator delegates backed by `self._device_client.*` have been removed. The

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -61,3 +61,46 @@ async def test_async_setup_orchestration_registers_stop_listener_once():
     coord._test_connection.assert_called_once()
     coord.hass.bus.async_listen_once.assert_called_once()
     assert coord._stop_listener is stop_remove
+
+
+# ---------------------------------------------------------------------------
+# Removed lifecycle proxies — slice-4 (2026-05-29)
+# _ensure_connected, _try_direct_client_connect, _close_client_connection
+# were unused coordinator proxies; confirmed absent after cleanup.
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_no_ensure_connected():
+    """_ensure_connected was a one-line forwarder with zero callers; must be gone."""
+    coord = _make_coordinator()
+    assert not any(
+        "_ensure_connected" in cls.__dict__
+        for cls in type(coord).__mro__
+        if cls.__name__ == "ThesslaGreenModbusCoordinator"
+    ), "_ensure_connected still defined on ThesslaGreenModbusCoordinator"
+    # DeviceClient uses async_ensure_connected (public name); _ensure_connection proxies it.
+    assert callable(coord.device_client.async_ensure_connected)
+
+
+def test_coordinator_no_try_direct_client_connect():
+    """_try_direct_client_connect had zero coordinator-level callers; must be gone."""
+    coord = _make_coordinator()
+    assert not any(
+        "_try_direct_client_connect" in cls.__dict__
+        for cls in type(coord).__mro__
+        if cls.__name__ == "ThesslaGreenModbusCoordinator"
+    ), "_try_direct_client_connect still defined on ThesslaGreenModbusCoordinator"
+    # DeviceClient still owns the implementation.
+    assert callable(coord.device_client._try_direct_client_connect)
+
+
+def test_coordinator_no_close_client_connection():
+    """_close_client_connection had zero coordinator-level callers; must be gone."""
+    coord = _make_coordinator()
+    assert not any(
+        "_close_client_connection" in cls.__dict__
+        for cls in type(coord).__mro__
+        if cls.__name__ == "ThesslaGreenModbusCoordinator"
+    ), "_close_client_connection still defined on ThesslaGreenModbusCoordinator"
+    # DeviceClient still owns the implementation.
+    assert callable(coord.device_client._close_client_connection)


### PR DESCRIPTION
## Summary

Inspected 8 HA lifecycle/connection adapter methods in coordinator and applied minimal safe changes:
removed 3 unused proxies, inlined 1 trivial forwarder, and documented all 5 survivors as intentional HA-boundary adapters.

## Lifecycle adapter classification

### Kept as intentional HA-boundary adapters (docstrings updated)

| Method | Why kept |
|---|---|
| `_ensure_connection` | Duck-typing entry point called by schedule, update, retry, client_registers submodules; declared as abstract stub in `schedule.py` and `io_mixin.py` |
| `_disconnect_locked` | Passed as `disconnect_locked_fn` callback to `core/connection_lifecycle.py:29` — cannot be removed |
| `_disconnect` | Called by errors.py, schedule.py, update.py, write_path.py, and async_shutdown; declared as abstract stub in `schedule.py` |
| `_test_connection` | Called in production by `coordinator/lifecycle.py:37` during HA setup |
| `_async_setup_client` | Intentional test-facing helper — mirrors HA start-up path for unit tests, documented as such |

### Removed unused coordinator proxies

| Removed | Reason |
|---|---|
| `_ensure_connected` | One-line forwarder (`await self._device_client.async_ensure_connected()`); its sole caller was `_ensure_connection` itself. Inlined. |
| `_try_direct_client_connect` | Zero callers on coordinator. `DeviceClient._try_direct_client_connect` is called via `self` inside `client_connection.py`; the coordinator proxy was never reached. |
| `_close_client_connection` | Zero callers on coordinator. `_disconnect_locked` in DeviceClient passes `_close_client_connection_impl` as a function argument directly, never routing through the coordinator proxy. |

## Why these are not old proxy debt

The 5 kept methods satisfy a duck-typing protocol that coordinator submodules consume by receiving `coordinator` as an argument and calling `_ensure_connection()` / `_disconnect()` / `_disconnect_locked()` on it. The 3 removed methods had no such consumers — `grep` confirmed zero production and test call sites on the coordinator class.

## No behaviour changes

- No Modbus runtime changes (read_batches/read_bits/read_common untouched)
- No DeviceClient IO ownership changes
- No register map changes
- No entity/service/translation ID changes
- No scan or RTC sync changes
- `_ensure_connection` still routes to `self._device_client.async_ensure_connected()` (inlined from the removed `_ensure_connected`)

## Validation output

```
python -m compileall -q custom_components/thessla_green_modbus tests tools
→ clean (no output)

ruff check custom_components tests tools
→ All checks passed!

ruff check --select I custom_components tests tools
→ All checks passed!

ruff format --check custom_components tests tools
→ 449 files already formatted

python tools/compare_airpack4_vendor_coverage.py
→ No missing registers.

python tools/check_translations.py
→ All translation keys present.

python tools/check_maintainability.py
→ Maintainability gate passed.
```

Full pytest suite (requires Python 3.13 + HA 2026.2.3) deferred to CI.

## New tests

Three assertions added to `tests/test_coordinator_lifecycle.py`:
- `test_coordinator_no_ensure_connected` — confirms `_ensure_connected` is absent from coordinator MRO
- `test_coordinator_no_try_direct_client_connect` — confirms proxy is gone; DeviceClient still owns it
- `test_coordinator_no_close_client_connection` — confirms proxy is gone; DeviceClient still owns it

## Docs

`docs/coordinator_proxy_remaining_plan.md` updated with slice-4 section documenting the removed/kept classification and rationale.

https://claude.ai/code/session_018BLo3tN1rXmEquw8JwR6y7

---
_Generated by [Claude Code](https://claude.ai/code/session_018BLo3tN1rXmEquw8JwR6y7)_