### PR TITLE
test: remove stale coordinator.get_register_map mock calls

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,6 @@ def mock_coordinator():
         "coil_registers": coil_registers().copy(),
         "discrete_inputs": discrete_input_registers().copy(),
     }
-    coordinator.get_register_map = lambda rt: _register_maps.get(rt, {})
     coordinator.device_client.get_register_map = lambda rt: _register_maps.get(rt, {})
     coordinator.device_client.force_full_register_list = False
     coordinator.device_client.force_full_register_list = False

--- a/tests/helpers_entity_data_correctness.py
+++ b/tests/helpers_entity_data_correctness.py
@@ -32,5 +32,7 @@ def _make_number(coordinator, register_name: str) -> ThesslaGreenNumber:
 
 def _make_select(coordinator, register_name: str) -> ThesslaGreenSelect:
     defn = ENTITY_MAPPINGS["select"][register_name]
-    address = coordinator.device_client.get_register_map(defn["register_type"]).get(register_name, 100)
+    address = coordinator.device_client.get_register_map(defn["register_type"]).get(
+        register_name, 100
+    )
     return ThesslaGreenSelect(coordinator, register_name, address, defn)

--- a/tests/helpers_entity_data_correctness.py
+++ b/tests/helpers_entity_data_correctness.py
@@ -32,5 +32,5 @@ def _make_number(coordinator, register_name: str) -> ThesslaGreenNumber:
 
 def _make_select(coordinator, register_name: str) -> ThesslaGreenSelect:
     defn = ENTITY_MAPPINGS["select"][register_name]
-    address = coordinator.get_register_map(defn["register_type"]).get(register_name, 100)
+    address = coordinator.device_client.get_register_map(defn["register_type"]).get(register_name, 100)
     return ThesslaGreenSelect(coordinator, register_name, address, defn)

--- a/tests/test_available_registers_schedule_time.py
+++ b/tests/test_available_registers_schedule_time.py
@@ -185,7 +185,6 @@ async def test_force_full_register_list_creates_schedule_time_entities() -> None
     coordinator.device_client.available_registers = {"holding_registers": set()}
     coordinator.device_client.force_full_register_list = True
     coordinator.device_client.capabilities = MagicMock()
-    coordinator.get_register_map.return_value = _REGISTER_MAP
     coordinator.device_client.get_register_map.return_value = _REGISTER_MAP
 
     config_entry = MagicMock()
@@ -221,7 +220,6 @@ async def test_available_registers_creates_schedule_time_entities() -> None:
     }
     coordinator.device_client.force_full_register_list = False
     coordinator.device_client.capabilities = MagicMock()
-    coordinator.get_register_map.return_value = _REGISTER_MAP
     coordinator.device_client.get_register_map.return_value = _REGISTER_MAP
 
     config_entry = MagicMock()

--- a/tests/test_entity_data_correctness_number.py
+++ b/tests/test_entity_data_correctness_number.py
@@ -11,7 +11,7 @@ class TestNumberEntity:
 
     def _first_number_register(self, mock_coordinator) -> str:
         """Return first number register that is in holding_registers map."""
-        holding = mock_coordinator.get_register_map("holding_registers")
+        holding = mock_coordinator.device_client.get_register_map("holding_registers")
         for name in ENTITY_MAPPINGS["number"]:
             if name in holding:
                 return name
@@ -47,7 +47,7 @@ class TestNumberEntity:
         assert entity._attr_native_min_value < entity._attr_native_max_value
 
     def test_default_min_is_zero_when_not_configured(self, mock_coordinator):
-        holding = mock_coordinator.get_register_map("holding_registers")
+        holding = mock_coordinator.device_client.get_register_map("holding_registers")
         for name, cfg in ENTITY_MAPPINGS["number"].items():
             if name in holding and "min" not in cfg:
                 entity = _make_number(mock_coordinator, name)
@@ -56,7 +56,7 @@ class TestNumberEntity:
         pytest.skip("All number registers have explicit 'min'")
 
     def test_default_max_is_100_when_not_configured(self, mock_coordinator):
-        holding = mock_coordinator.get_register_map("holding_registers")
+        holding = mock_coordinator.device_client.get_register_map("holding_registers")
         for name, cfg in ENTITY_MAPPINGS["number"].items():
             if name in holding and "max" not in cfg:
                 entity = _make_number(mock_coordinator, name)
@@ -65,7 +65,7 @@ class TestNumberEntity:
         pytest.skip("All number registers have explicit 'max'")
 
     def test_step_defaults_to_one(self, mock_coordinator):
-        holding = mock_coordinator.get_register_map("holding_registers")
+        holding = mock_coordinator.device_client.get_register_map("holding_registers")
         for name, cfg in ENTITY_MAPPINGS["number"].items():
             if name in holding and "step" not in cfg:
                 entity = _make_number(mock_coordinator, name)
@@ -74,7 +74,7 @@ class TestNumberEntity:
         pytest.skip("All number registers have explicit 'step'")
 
     def test_temperature_register_uses_thermometer_icon(self, mock_coordinator):
-        holding = mock_coordinator.get_register_map("holding_registers")
+        holding = mock_coordinator.device_client.get_register_map("holding_registers")
         for name in ENTITY_MAPPINGS["number"]:
             if name in holding and "temperature" in name:
                 entity = _make_number(mock_coordinator, name)
@@ -91,7 +91,7 @@ class TestNumberEntity:
         ][:10],
     )
     def test_explicit_min_max_applied(self, mock_coordinator, register_name, cfg):
-        holding = mock_coordinator.get_register_map("holding_registers")
+        holding = mock_coordinator.device_client.get_register_map("holding_registers")
         if register_name not in holding:
             pytest.skip(f"{register_name} not in holding_registers")
         entity = _make_number(mock_coordinator, register_name)

--- a/tests/test_entity_data_correctness_select.py
+++ b/tests/test_entity_data_correctness_select.py
@@ -72,7 +72,9 @@ class TestSelectEntity:
 
     @pytest.mark.parametrize("select_name,defn", list(ENTITY_MAPPINGS["select"].items()))
     def test_options_are_list_of_strings(self, mock_coordinator, select_name, defn):
-        holding = mock_coordinator.device_client.get_register_map(defn.get("register_type", "holding_registers"))
+        holding = mock_coordinator.device_client.get_register_map(
+            defn.get("register_type", "holding_registers")
+        )
         address = holding.get(select_name, 100)
         entity = ThesslaGreenSelect(mock_coordinator, select_name, address, defn)
         assert isinstance(entity._attr_options, list)

--- a/tests/test_entity_data_correctness_select.py
+++ b/tests/test_entity_data_correctness_select.py
@@ -72,7 +72,7 @@ class TestSelectEntity:
 
     @pytest.mark.parametrize("select_name,defn", list(ENTITY_MAPPINGS["select"].items()))
     def test_options_are_list_of_strings(self, mock_coordinator, select_name, defn):
-        holding = mock_coordinator.get_register_map(defn.get("register_type", "holding_registers"))
+        holding = mock_coordinator.device_client.get_register_map(defn.get("register_type", "holding_registers"))
         address = holding.get(select_name, 100)
         entity = ThesslaGreenSelect(mock_coordinator, select_name, address, defn)
         assert isinstance(entity._attr_options, list)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -218,10 +218,9 @@ async def test_force_full_register_list_adds_missing_number(mock_coordinator, mo
 
 def _make_number(mock_coordinator, register_name):
     """Helper: inject a fake register and return a ThesslaGreenNumber instance."""
-    current_map = dict(mock_coordinator.get_register_map("holding_registers"))
+    current_map = dict(mock_coordinator.device_client.get_register_map("holding_registers"))
     current_map[register_name] = 9990
     _map_fn = lambda register_type: current_map if register_type == "holding_registers" else {}  # noqa: E731
-    mock_coordinator.get_register_map = _map_fn
     mock_coordinator.device_client.get_register_map = _map_fn
     return ThesslaGreenNumber(mock_coordinator, register_name, {})
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes all remaining `coordinator.get_register_map(...)` and `mock_coordinator.get_register_map(...)` calls from test helpers and fixtures
- All test code now uses `coordinator.device_client.get_register_map(...)`, matching the production API after A5/A6 (#1694–#1696)
- No production code changed; no functional change to test logic

## Context

After A5 migrated platform callers to `coordinator.device_client.get_register_map()` and A6 removed the proxy from `coordinator.py`, the conftest fixture was updated to set up both the old and new mock paths in parallel. This PR removes the now-dead old-API side of those dual setups.

## Changed files

| File | Change |
|---|---|
| `tests/conftest.py` | Drop redundant `coordinator.get_register_map = lambda ...` (line 165); `device_client` path is the sole setup |
| `tests/helpers_entity_data_correctness.py` | `_make_select` uses `coordinator.device_client.get_register_map` |
| `tests/test_entity_data_correctness_number.py` | All 6 `mock_coordinator.get_register_map(...)` calls → `device_client` path |
| `tests/test_entity_data_correctness_select.py` | `test_options_are_list_of_strings` → `device_client` path |
| `tests/test_available_registers_schedule_time.py` | Remove duplicate `coordinator.get_register_map.return_value` lines from two tests |
| `tests/test_number.py` | `_make_number` helper reads and overwrites only the `device_client` path; drops dead `mock_coordinator.get_register_map` reassignment |

## Validation

- `ruff check` — pass
- `ruff format --check` — pass
- `python -m compileall` — pass
- Full pytest requires CI (no homeassistant locally)

https://claude.ai/code/session_01PdaaBk4mHy3Q8T3Urj2LLk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdaaBk4mHy3Q8T3Urj2LLk)_