### PR TITLE
Downgrade pydantic to 2.12.2 for CI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ dev = [
     "isort>=5.13.0",
     "ruff>=0.6.0",
     "mypy>=1.10.0",
-    "pydantic==2.13.4",
+    # pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.12.2;
+    # keep in sync with requirements-dev.txt to avoid pip conflicts in CI.
+    "pydantic==2.12.2",
     "pre-commit>=3.7.0",
     "types-PyYAML>=6.0.12",
 ]


### PR DESCRIPTION
## Summary
- [x] Explain what changed and why.

Downgrade pydantic from 2.13.4 to 2.12.2 in the dev dependencies to maintain compatibility with pytest-homeassistant-custom-component versions 0.13.309-0.13.316, which pin pydantic==2.12.2. This prevents pip dependency conflicts in CI environments.

Added a comment documenting the constraint and the need to keep this in sync with requirements-dev.txt.

## Validation
- [x] `ruff check ...` - No linting issues
- [x] `pytest ...` - Existing tests pass
- [x] Dependency resolution verified - Aligns with pytest-homeassistant-custom-component constraints

## Notes
- This change ensures CI pipelines don't encounter pip version conflicts when resolving dependencies
- The version is kept in sync with requirements-dev.txt as noted in the comment

https://claude.ai/code/session_01Qd2mH3GqPySD1TkjrQr4Mm