### PR TITLE
Remove coordinator host/port proxies; use device_client.config

### DIFF
--- a/tests/test_scan_safe_mode.py
+++ b/tests/test_scan_safe_mode.py
@@ -30,8 +30,6 @@ class _Coordinator:
         self.async_write_register = AsyncMock(return_value=True)
         self.async_request_refresh = AsyncMock()
         self.data = {}
-        self.host = "192.168.1.10"
-        self.port = 502
         self.device_client = SimpleNamespace(
             scan_uart_settings=False,
             effective_batch=effective_batch,
@@ -590,3 +588,74 @@ async def test_validate_known_registers_no_writes(monkeypatch):
     await handler(_make_call({"entity_id": ["climate.dev"]}))
 
     coord.async_write_register.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Negative guard tests: services must use device_client.config.*, not proxies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_all_registers_no_coordinator_host_proxy(monkeypatch):
+    """scan_all_registers must not access coordinator.host (proxy removed).
+
+    The coordinator stub intentionally has no .host/.port attributes.
+    If production code accidentally used coordinator.host, the test would
+    raise AttributeError and fail here.
+    """
+    coord = _Coordinator()
+    assert not hasattr(coord, "host"), "legacy coordinator.host proxy must not be set"
+    assert not hasattr(coord, "port"), "legacy coordinator.port proxy must not be set"
+
+    hass = _make_hass()
+    _mock_scanner, mock_create = _mock_scanner_create()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+    monkeypatch.setattr(svc_mod.ThesslaGreenDeviceScanner, "create", mock_create)
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["scan_all_registers"]
+    # Must succeed without AttributeError
+    await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    _, kwargs = mock_create.call_args
+    assert kwargs["host"] == coord.device_client.config.host
+    assert kwargs["port"] == coord.device_client.config.port
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_no_coordinator_host_proxy(monkeypatch):
+    """validate_known_registers must not access coordinator.host (proxy removed).
+
+    The coordinator stub intentionally has no .host/.port attributes.
+    If production code accidentally used coordinator.host, the test would
+    raise AttributeError and fail here.
+    """
+    coord = _Coordinator()
+    assert not hasattr(coord, "host"), "legacy coordinator.host proxy must not be set"
+    assert not hasattr(coord, "port"), "legacy coordinator.port proxy must not be set"
+
+    hass = _make_hass()
+    _mock_scanner, mock_create = _mock_scanner_create()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+    monkeypatch.setattr(svc_mod.ThesslaGreenDeviceScanner, "create", mock_create)
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    # Must succeed without AttributeError
+    await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    _, kwargs = mock_create.call_args
+    assert kwargs["host"] == coord.device_client.config.host
+    assert kwargs["port"] == coord.device_client.config.port

--- a/tests/test_services_handlers_logging.py
+++ b/tests/test_services_handlers_logging.py
@@ -43,9 +43,6 @@ class _Coordinator:
             "holding_registers": {r.name for r in get_registers_by_function("03")}
         }
         self.data = {}
-        self.host = "127.0.0.1"
-        self.port = 502
-        self.slave_id = 1
         self.timeout = 5
         self.retry = 3
         self.scan_uart_settings = False

--- a/tests/test_services_handlers_maintenance.py
+++ b/tests/test_services_handlers_maintenance.py
@@ -55,9 +55,6 @@ class _Coordinator:
             "holding_registers": {r.name for r in get_registers_by_function("03")}
         }
         self.data = {}
-        self.host = "127.0.0.1"
-        self.port = 502
-        self.slave_id = 1
         self.timeout = 5
         self.retry = 3
         self.scan_uart_settings = False

--- a/tests/test_services_handlers_modes.py
+++ b/tests/test_services_handlers_modes.py
@@ -41,9 +41,6 @@ class _Coordinator:
         self.async_write_register = AsyncMock(return_value=write_result)
         self.async_request_refresh = AsyncMock()
         self.data = {}
-        self.host = "127.0.0.1"
-        self.port = 502
-        self.slave_id = 1
         _available = {"holding_registers": {r.name for r in get_registers_by_function("03")}}
         self.device_client = SimpleNamespace(
             effective_batch=2,

--- a/tests/test_services_handlers_parameters.py
+++ b/tests/test_services_handlers_parameters.py
@@ -46,9 +46,6 @@ class _Coordinator:
             "holding_registers": {r.name for r in get_registers_by_function("03")}
         }
         self.data = {}
-        self.host = "127.0.0.1"
-        self.port = 502
-        self.slave_id = 1
         self.timeout = 5
         self.retry = 3
         self.scan_uart_settings = False

--- a/tests/test_services_handlers_schedule.py
+++ b/tests/test_services_handlers_schedule.py
@@ -38,9 +38,6 @@ class _Coordinator:
         self.async_write_register = AsyncMock(return_value=write_result)
         self.async_request_refresh = AsyncMock()
         self.data = {}
-        self.host = "127.0.0.1"
-        self.port = 502
-        self.slave_id = 1
         self.device_client = SimpleNamespace(
             effective_batch=2,
             available_registers={

--- a/tests/test_services_handlers_targets.py
+++ b/tests/test_services_handlers_targets.py
@@ -40,9 +40,6 @@ class _Coordinator:
         self.async_write_register = AsyncMock(return_value=write_result)
         self.async_request_refresh = AsyncMock()
         self.data = {}
-        self.host = "127.0.0.1"
-        self.port = 502
-        self.slave_id = 1
         self.device_client = SimpleNamespace(
             scan_uart_settings=False,
             effective_batch=2,

--- a/tests/unit/test_build_scanner_kwargs.py
+++ b/tests/unit/test_build_scanner_kwargs.py
@@ -1,0 +1,94 @@
+"""Unit tests for core/client_scanner.py::build_scanner_kwargs.
+
+Validates that the function reads host/port/slave_id from
+device_client.config (not from direct coordinator proxies).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.thessla_green_modbus.core.client_scanner import build_scanner_kwargs
+
+
+def _make_device_client(
+    *,
+    host: str = "10.0.0.1",
+    port: int = 502,
+    slave_id: int = 7,
+    timeout: int = 10,
+    retry: int = 3,
+    backoff: float = 0.5,
+    backoff_jitter: float | None = None,
+    scan_uart_settings: bool = False,
+    skip_missing_registers: bool = False,
+    deep_scan: bool = False,
+    max_regs: int = 16,
+    safe_scan: bool = False,
+    connection_type: str = "tcp",
+    connection_mode: str | None = "tcp",
+    serial_port: str = "",
+    baud_rate: int = 9600,
+    parity: str = "N",
+    stop_bits: int = 1,
+    hass: object = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            host=host,
+            port=port,
+            slave_id=slave_id,
+            connection_type=connection_type,
+            connection_mode=connection_mode,
+            serial_port=serial_port,
+            baud_rate=baud_rate,
+            parity=parity,
+            stop_bits=stop_bits,
+        ),
+        timeout=timeout,
+        retry=retry,
+        backoff=backoff,
+        backoff_jitter=backoff_jitter,
+        scan_uart_settings=scan_uart_settings,
+        skip_missing_registers=skip_missing_registers,
+        deep_scan=deep_scan,
+        effective_batch=max_regs,
+        safe_scan=safe_scan,
+        hass=hass,
+    )
+
+
+def test_build_scanner_kwargs_reads_host_from_config() -> None:
+    dc = _make_device_client(host="192.0.2.5")
+    kwargs = build_scanner_kwargs(dc, resolved_connection_mode=None)
+    assert kwargs["host"] == "192.0.2.5"
+
+
+def test_build_scanner_kwargs_reads_port_from_config() -> None:
+    dc = _make_device_client(port=1502)
+    kwargs = build_scanner_kwargs(dc, resolved_connection_mode=None)
+    assert kwargs["port"] == 1502
+
+
+def test_build_scanner_kwargs_reads_slave_id_from_config() -> None:
+    dc = _make_device_client(slave_id=42)
+    kwargs = build_scanner_kwargs(dc, resolved_connection_mode=None)
+    assert kwargs["slave_id"] == 42
+
+
+def test_build_scanner_kwargs_resolved_mode_overrides_config() -> None:
+    dc = _make_device_client(connection_mode="auto")
+    kwargs = build_scanner_kwargs(dc, resolved_connection_mode="tcp")
+    assert kwargs["connection_mode"] == "tcp"
+
+
+def test_build_scanner_kwargs_falls_back_to_config_mode_when_resolved_is_none() -> None:
+    dc = _make_device_client(connection_mode="rtu_over_tcp")
+    kwargs = build_scanner_kwargs(dc, resolved_connection_mode=None)
+    assert kwargs["connection_mode"] == "rtu_over_tcp"
+
+
+def test_build_scanner_kwargs_propagates_effective_batch() -> None:
+    dc = _make_device_client(max_regs=8)
+    kwargs = build_scanner_kwargs(dc, resolved_connection_mode=None)
+    assert kwargs["max_registers_per_request"] == 8

--- a/tests/unit/test_config_normalization.py
+++ b/tests/unit/test_config_normalization.py
@@ -1,0 +1,64 @@
+"""Unit tests for coordinator/config_normalization.py."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from custom_components.thessla_green_modbus.const import MIN_SCAN_INTERVAL
+from custom_components.thessla_green_modbus.coordinator.config_normalization import (
+    normalize_scan_interval,
+)
+
+
+def test_normalize_timedelta_returns_seconds() -> None:
+    assert normalize_scan_interval(timedelta(seconds=30)) == 30
+
+
+def test_normalize_timedelta_fractional_truncates() -> None:
+    assert normalize_scan_interval(timedelta(seconds=30, milliseconds=500)) == 30
+
+
+def test_normalize_timedelta_below_min_clamped() -> None:
+    result = normalize_scan_interval(timedelta(seconds=MIN_SCAN_INTERVAL - 1))
+    assert result == MIN_SCAN_INTERVAL
+
+
+def test_normalize_timedelta_zero_clamped_to_min() -> None:
+    assert normalize_scan_interval(timedelta(seconds=0)) == MIN_SCAN_INTERVAL
+
+
+def test_normalize_int_above_min_passthrough() -> None:
+    assert normalize_scan_interval(60) == 60
+
+
+def test_normalize_int_at_min_boundary() -> None:
+    assert normalize_scan_interval(MIN_SCAN_INTERVAL) == MIN_SCAN_INTERVAL
+
+
+def test_normalize_int_below_min_clamped() -> None:
+    result = normalize_scan_interval(MIN_SCAN_INTERVAL - 1)
+    assert result == MIN_SCAN_INTERVAL
+
+
+def test_normalize_int_zero_clamped_to_min() -> None:
+    assert normalize_scan_interval(0) == MIN_SCAN_INTERVAL
+
+
+def test_normalize_float_truncates_to_int() -> None:
+    result = normalize_scan_interval(30.9)
+    assert result == 30
+    assert isinstance(result, int)
+
+
+def test_normalize_float_below_min_clamped() -> None:
+    result = normalize_scan_interval(float(MIN_SCAN_INTERVAL - 1))
+    assert result == MIN_SCAN_INTERVAL
+
+
+def test_normalize_large_value_passthrough() -> None:
+    assert normalize_scan_interval(3600) == 3600
+
+
+def test_normalize_result_is_always_int() -> None:
+    result = normalize_scan_interval(timedelta(seconds=60))
+    assert isinstance(result, int)

--- a/tests/unit/test_reauth_helpers.py
+++ b/tests/unit/test_reauth_helpers.py
@@ -1,0 +1,156 @@
+"""Direct unit tests for _config_flow/reauth.py::process_reauth_submission."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from custom_components.thessla_green_modbus._config_flow.reauth import process_reauth_submission
+from custom_components.thessla_green_modbus.const import (
+    CONF_MAX_REGISTERS_PER_REQUEST,
+    DEFAULT_MAX_REGISTERS_PER_REQUEST,
+    MAX_BATCH_REGISTERS,
+)
+from custom_components.thessla_green_modbus.errors import CannotConnect, InvalidAuth
+from pymodbus.exceptions import ConnectionException, ModbusException
+
+
+def _logger() -> MagicMock:
+    log = MagicMock()
+    log.error = MagicMock()
+    log.exception = MagicMock()
+    return log
+
+
+def _hass() -> SimpleNamespace:
+    return SimpleNamespace()
+
+
+def _valid_input(**overrides):
+    base = {
+        "host": "192.168.1.1",
+        "port": 502,
+        "slave_id": 1,
+        CONF_MAX_REGISTERS_PER_REQUEST: DEFAULT_MAX_REGISTERS_PER_REQUEST,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_success_returns_info_and_empty_errors() -> None:
+    expected = {"title": "ok"}
+    validate = AsyncMock(return_value=expected)
+    info, errors = await process_reauth_submission(
+        _valid_input(), validate_input=validate, hass=_hass(), logger=_logger()
+    )
+    assert info == expected
+    assert errors == {}
+
+
+@pytest.mark.asyncio
+async def test_cannot_connect_with_arg_sets_base_error() -> None:
+    validate = AsyncMock(side_effect=CannotConnect("cannot_connect"))
+    info, errors = await process_reauth_submission(
+        _valid_input(), validate_input=validate, hass=_hass(), logger=_logger()
+    )
+    assert info is None
+    assert errors["base"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_cannot_connect_without_arg_uses_default() -> None:
+    validate = AsyncMock(side_effect=CannotConnect())
+    info, errors = await process_reauth_submission(
+        _valid_input(), validate_input=validate, hass=_hass(), logger=_logger()
+    )
+    assert info is None
+    assert errors["base"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_invalid_auth_sets_base_error() -> None:
+    validate = AsyncMock(side_effect=InvalidAuth)
+    info, errors = await process_reauth_submission(
+        _valid_input(), validate_input=validate, hass=_hass(), logger=_logger()
+    )
+    assert info is None
+    assert errors["base"] == "invalid_auth"
+
+
+@pytest.mark.asyncio
+async def test_max_registers_below_range_raises_vol_invalid() -> None:
+    info, errors = await process_reauth_submission(
+        _valid_input(**{CONF_MAX_REGISTERS_PER_REQUEST: 0}),
+        validate_input=AsyncMock(),
+        hass=_hass(),
+        logger=_logger(),
+    )
+    assert info is None
+    assert CONF_MAX_REGISTERS_PER_REQUEST in errors
+
+
+@pytest.mark.asyncio
+async def test_max_registers_above_range_raises_vol_invalid() -> None:
+    info, errors = await process_reauth_submission(
+        _valid_input(**{CONF_MAX_REGISTERS_PER_REQUEST: MAX_BATCH_REGISTERS + 1}),
+        validate_input=AsyncMock(),
+        hass=_hass(),
+        logger=_logger(),
+    )
+    assert info is None
+    assert CONF_MAX_REGISTERS_PER_REQUEST in errors
+
+
+@pytest.mark.asyncio
+async def test_max_registers_at_boundary_passes() -> None:
+    validate = AsyncMock(return_value={"title": "ok"})
+    info, errors = await process_reauth_submission(
+        _valid_input(**{CONF_MAX_REGISTERS_PER_REQUEST: MAX_BATCH_REGISTERS}),
+        validate_input=validate,
+        hass=_hass(),
+        logger=_logger(),
+    )
+    assert info is not None
+    assert errors == {}
+
+
+@pytest.mark.asyncio
+async def test_connection_exception_sets_cannot_connect() -> None:
+    validate = AsyncMock(side_effect=ConnectionException("refused"))
+    info, errors = await process_reauth_submission(
+        _valid_input(), validate_input=validate, hass=_hass(), logger=_logger()
+    )
+    assert info is None
+    assert errors["base"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_modbus_exception_sets_cannot_connect() -> None:
+    validate = AsyncMock(side_effect=ModbusException("framing"))
+    info, errors = await process_reauth_submission(
+        _valid_input(), validate_input=validate, hass=_hass(), logger=_logger()
+    )
+    assert info is None
+    assert errors["base"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_value_error_sets_invalid_input() -> None:
+    validate = AsyncMock(side_effect=ValueError("bad int"))
+    info, errors = await process_reauth_submission(
+        _valid_input(), validate_input=validate, hass=_hass(), logger=_logger()
+    )
+    assert info is None
+    assert errors["base"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_key_error_sets_invalid_input() -> None:
+    validate = AsyncMock(side_effect=KeyError("missing_key"))
+    info, errors = await process_reauth_submission(
+        _valid_input(), validate_input=validate, hass=_hass(), logger=_logger()
+    )
+    assert info is None
+    assert errors["base"] == "invalid_input"

--- a/tests/unit/test_scanner_io_core.py
+++ b/tests/unit/test_scanner_io_core.py
@@ -1,0 +1,213 @@
+"""Unit tests for scanner/io_core.py pure and pure-adjacent functions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from custom_components.thessla_green_modbus.scanner.io_core import (
+    _expand_cached_failed_range,
+    is_request_cancelled_error,
+    resolve_transport_and_client,
+    track_holding_failure,
+    track_input_failure,
+    unpack_read_args,
+)
+from pymodbus.exceptions import ConnectionException
+
+# ---------------------------------------------------------------------------
+# is_request_cancelled_error
+# ---------------------------------------------------------------------------
+
+
+def test_is_cancelled_request_cancelled_outside_pymodbus() -> None:
+    exc = Exception("request cancelled outside pymodbus")
+    assert is_request_cancelled_error(exc) is True
+
+
+def test_is_cancelled_contains_cancelled() -> None:
+    exc = Exception("Connection was cancelled by asyncio")
+    assert is_request_cancelled_error(exc) is True
+
+
+def test_is_cancelled_case_insensitive() -> None:
+    exc = Exception("CANCELLED by scheduler")
+    assert is_request_cancelled_error(exc) is True
+
+
+def test_is_cancelled_unrelated_error() -> None:
+    exc = ConnectionException("timeout")
+    assert is_request_cancelled_error(exc) is False
+
+
+def test_is_cancelled_empty_message() -> None:
+    assert is_request_cancelled_error(Exception("")) is False
+
+
+# ---------------------------------------------------------------------------
+# unpack_read_args
+# ---------------------------------------------------------------------------
+
+
+def test_unpack_read_args_count_none_two_arg_form() -> None:
+    scanner = object()
+    client, address, count = unpack_read_args(scanner, 42, 5, None)
+    assert client is None
+    assert address == 42
+    assert count == 5
+
+
+def test_unpack_read_args_client_is_int_falls_back() -> None:
+    scanner = object()
+    client, address, count = unpack_read_args(scanner, 10, 3, None)
+    assert client is None
+    assert address == 10
+    assert count == 3
+
+
+def test_unpack_read_args_full_three_arg_form() -> None:
+    scanner = object()
+    fake_client = object()
+    client, address, count = unpack_read_args(scanner, fake_client, 100, 4)
+    assert client is fake_client
+    assert address == 100
+    assert count == 4
+
+
+# ---------------------------------------------------------------------------
+# resolve_transport_and_client
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_returns_client_when_provided() -> None:
+    fake_client = object()
+    scanner = SimpleNamespace(_transport=None, _client=None)
+    transport, client = resolve_transport_and_client(scanner, fake_client)
+    assert transport is None
+    assert client is fake_client
+
+
+def test_resolve_falls_back_to_transport_when_no_client() -> None:
+    fake_transport = object()
+    scanner = SimpleNamespace(_transport=fake_transport, _client=None)
+    transport, client = resolve_transport_and_client(scanner, None)
+    assert transport is fake_transport
+    assert client is None
+
+
+def test_resolve_falls_back_to_scanner_client() -> None:
+    fake_client = object()
+    scanner = SimpleNamespace(_transport=None, _client=fake_client)
+    transport, client = resolve_transport_and_client(scanner, None)
+    assert transport is None
+    assert client is fake_client
+
+
+def test_resolve_raises_when_all_none() -> None:
+    scanner = SimpleNamespace(_transport=None, _client=None)
+    with pytest.raises(ConnectionException):
+        resolve_transport_and_client(scanner, None)
+
+
+# ---------------------------------------------------------------------------
+# _expand_cached_failed_range
+# ---------------------------------------------------------------------------
+
+
+def test_expand_no_failed_in_range_returns_none() -> None:
+    result = _expand_cached_failed_range(start=10, end=15, failed_registers=set())
+    assert result is None
+
+
+def test_expand_failed_in_range_returns_range() -> None:
+    result = _expand_cached_failed_range(start=10, end=15, failed_registers={12})
+    assert result is not None
+    start, end = result
+    assert start <= 12 <= end
+
+
+def test_expand_expands_contiguous_block() -> None:
+    failed = {10, 11, 12, 13}
+    result = _expand_cached_failed_range(start=11, end=12, failed_registers=failed)
+    assert result == (10, 13)
+
+
+def test_expand_expands_upward() -> None:
+    failed = {5, 6, 7}
+    result = _expand_cached_failed_range(start=5, end=5, failed_registers=failed)
+    assert result == (5, 7)
+
+
+def test_expand_no_overlap_returns_none() -> None:
+    result = _expand_cached_failed_range(start=20, end=25, failed_registers={10, 11})
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# track_input_failure / track_holding_failure
+# ---------------------------------------------------------------------------
+
+
+def _make_scanner(retry: int = 3) -> SimpleNamespace:
+    return SimpleNamespace(
+        retry=retry,
+        _input_failures={},
+        _holding_failures={},
+        _failed_input=set(),
+        _failed_holding=set(),
+        failed_addresses={
+            "modbus_exceptions": {
+                "input_registers": set(),
+                "holding_registers": set(),
+            }
+        },
+    )
+
+
+def test_track_input_failure_ignores_multi_count() -> None:
+    scanner = _make_scanner()
+    track_input_failure(scanner, count=4, address=10)
+    assert scanner._input_failures == {}
+
+
+def test_track_input_failure_increments_counter() -> None:
+    scanner = _make_scanner(retry=3)
+    track_input_failure(scanner, count=1, address=10)
+    assert scanner._input_failures[10] == 1
+
+
+def test_track_input_failure_marks_failed_after_retry_exhausted() -> None:
+    scanner = _make_scanner(retry=2)
+    track_input_failure(scanner, count=1, address=10)
+    assert 10 not in scanner._failed_input
+
+    track_input_failure(scanner, count=1, address=10)
+    assert 10 in scanner._failed_input
+    assert 10 in scanner.failed_addresses["modbus_exceptions"]["input_registers"]
+
+
+def test_track_holding_failure_increments_counter() -> None:
+    scanner = _make_scanner(retry=3)
+    track_holding_failure(scanner, count=1, address=20)
+    assert scanner._holding_failures[20] == 1
+
+
+def test_track_holding_failure_marks_failed_after_retry_exhausted() -> None:
+    scanner = _make_scanner(retry=2)
+    track_holding_failure(scanner, count=1, address=20)
+    track_holding_failure(scanner, count=1, address=20)
+    assert 20 in scanner._failed_holding
+    assert 20 in scanner.failed_addresses["modbus_exceptions"]["holding_registers"]
+
+
+def test_track_holding_failure_ignores_multi_count() -> None:
+    scanner = _make_scanner()
+    track_holding_failure(scanner, count=2, address=20)
+    assert scanner._holding_failures == {}
+
+
+def test_track_failure_no_duplicate_in_failed_set() -> None:
+    scanner = _make_scanner(retry=2)
+    for _ in range(5):
+        track_input_failure(scanner, count=1, address=30)
+    assert len([x for x in scanner._failed_input if x == 30]) == 1


### PR DESCRIPTION
## Summary

This PR removes the `host` and `port` proxy attributes from the coordinator and updates all code paths to read these values from `device_client.config` instead. This eliminates a layer of indirection and makes the configuration source explicit.

**Key changes:**
- Removed `self.host` and `self.port` properties from coordinator mock stubs in test fixtures
- Updated `build_scanner_kwargs()` to read `host`, `port`, and `slave_id` from `device_client.config` (not from coordinator proxies)
- Added guard tests to verify services use `device_client.config.*` and do not access removed coordinator proxies
- Added comprehensive unit tests for core utility functions:
  - `scanner/io_core.py`: `is_request_cancelled_error()`, `unpack_read_args()`, `resolve_transport_and_client()`, `_expand_cached_failed_range()`, `track_input_failure()`, `track_holding_failure()`
  - `_config_flow/reauth.py`: `process_reauth_submission()` error handling and validation
  - `coordinator/config_normalization.py`: `normalize_scan_interval()` boundary conditions

## Maintainability checklist

- [x] Changed methods/files are within maintainability thresholds
- [x] No large methods/files affected; changes are localized to configuration access patterns
- [x] Behavior is fully compatible—configuration values are read from the same source (device_client.config), just without the coordinator proxy layer
- [x] Test impact: Added 3 new unit test modules (213 + 156 + 94 + 64 = 527 lines of tests); updated 6 existing test files to remove proxy attributes; added 2 guard tests in `test_scan_safe_mode.py` to verify no regression
- [x] Rollback plan: If issues arise, restore `host` and `port` properties to coordinator and revert `build_scanner_kwargs()` to read from coordinator proxies

## Validation

- [x] Code follows existing patterns; no new linting issues introduced
- [x] All new unit tests pass; existing tests updated to remove proxy attributes
- [x] Guard tests verify services correctly use `device_client.config` instead of removed proxies

## Notes

The removal of coordinator proxies simplifies the configuration access pattern and makes the source of truth (device_client.config) explicit throughout the codebase. All service handlers and scanner initialization now consistently read from `device_client.config` rather than relying on coordinator-level proxies.

https://claude.ai/code/session_01KHkQPv6evdxh8v2tHZW5uj