### PR TITLE
Fix Codecov upload configuration in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,9 +103,13 @@ jobs:
         run: pytest tests/ -q --tb=long --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage
+        # CODECOV_TOKEN secret is optional; upload failure does not block CI.
+        # Add CODECOV_TOKEN to repository secrets to enable authenticated uploads.
         uses: codecov/codecov-action@v6
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
+          disable_search: true
+          fail_ci_if_error: false
 
   entity-mappings:
     name: Entity mappings validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   addresses, register names, or entity IDs changed.
 
 ### Internal
+- **Fixed Codecov upload configuration** (CI only): corrected `file:` → `files:` input
+  (the old key was silently ignored by `codecov/codecov-action@v6`); added
+  `disable_search: true` so only `coverage.xml` is uploaded and
+  `docs/airpack4_vendor_reference_coverage.json` is no longer auto-discovered;
+  set `fail_ci_if_error: false` — upload is **optional** (no `CODECOV_TOKEN` secret
+  is configured; add one to enable authenticated uploads).
 - **Coordinator proxy cleanup and DeviceClient IO ownership**
   ([#1664](https://github.com/blakinio/thesslagreen/pull/1664)/[#1669](https://github.com/blakinio/thesslagreen/pull/1669)/[#1690](https://github.com/blakinio/thesslagreen/pull/1690)/[#1694](https://github.com/blakinio/thesslagreen/pull/1694)/[#1696](https://github.com/blakinio/thesslagreen/pull/1696)):
   removed coordinator delegate methods and `_ModbusIOMixin`; `DeviceClient` is now the


### PR DESCRIPTION
## Summary
- Fixed Codecov upload configuration in the CI workflow by correcting the deprecated `file:` input parameter to `files:` (the old key was silently ignored by `codecov/codecov-action@v6`)
- Added `disable_search: true` to prevent auto-discovery of unintended coverage files (e.g., `docs/airpack4_vendor_reference_coverage.json`)
- Set `fail_ci_if_error: false` to make coverage uploads optional, since no `CODECOV_TOKEN` secret is currently configured
- Updated CHANGELOG.md to document these CI-only improvements

## Validation
- No code changes; CI workflow configuration only
- Existing tests unaffected
- Changes documented in CHANGELOG.md

## Notes
- The `CODECOV_TOKEN` secret is optional; repositories can add it to their secrets to enable authenticated uploads for better rate limiting and features
- This fix ensures coverage reports are uploaded correctly without blocking CI if the upload fails

https://claude.ai/code/session_013poH3oAB4YKDf4yZJWk9um