### PR TITLE
Refactor validate_known_registers to reuse active connection

### DIFF
--- a/custom_components/thessla_green_modbus/services/handlers_data.py
+++ b/custom_components/thessla_green_modbus/services/handlers_data.py
@@ -2,16 +2,102 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from homeassistant.core import HomeAssistant, ServiceCall
+from pymodbus.exceptions import ConnectionException, ModbusException
 
+from ..registers.read_planner import group_reads
 from .handler_deps import ServiceHandlerDeps
 from .schema import (
     REFRESH_DEVICE_DATA_SCHEMA,
     SCAN_ALL_REGISTERS_SCHEMA,
     VALIDATE_KNOWN_REGISTERS_SCHEMA,
 )
+
+
+def _response_has_data(response: Any) -> bool:
+    """Return True if a Modbus response contains register or coil data."""
+    if response is None:
+        return False
+    registers = getattr(response, "registers", None)
+    if registers:
+        return True
+    return bool(getattr(response, "bits", None))
+
+
+async def _read_batch_via_existing_client(
+    device_client: Any,
+    reg_type: str,
+    start: int,
+    count: int,
+) -> Any:
+    """Read a register batch via device_client's active connection without opening a new one."""
+    method_map = {
+        "input_registers": "read_input_registers",
+        "holding_registers": "read_holding_registers",
+        "coil_registers": "read_coils",
+        "discrete_inputs": "read_discrete_inputs",
+    }
+    fn_name = method_map.get(reg_type)
+    if fn_name is None:
+        raise ValueError(f"Unknown register type: {reg_type}")
+    fn = device_client._get_client_method(fn_name)
+    return await device_client._call_modbus(fn, start, count=count)
+
+
+async def _read_known_registers_safe(
+    coordinator: Any,
+    batch: int,
+    delay_ms: int,
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Read all known register addresses under _write_lock using the active connection.
+
+    Prevents concurrent coordinator polling during validation by holding
+    _write_lock for the entire read loop. No new Modbus transport is opened.
+    Returns (available, missing) name sets per register type.
+    """
+    dc = coordinator.device_client
+    available: dict[str, set[str]] = {}
+    missing: dict[str, set[str]] = {}
+
+    async with dc._write_lock:
+        await coordinator._ensure_connection()
+
+        for reg_type, reg_map in dc._register_maps.items():
+            avail: set[str] = set()
+            miss: set[str] = set()
+
+            if reg_map:
+                addr_to_name: dict[int, str] = {addr: name for name, addr in reg_map.items()}
+                groups = group_reads(sorted(addr_to_name.keys()), max_block_size=batch)
+
+                for start, group_count in groups:
+                    if delay_ms > 0:
+                        await asyncio.sleep(delay_ms / 1000.0)
+
+                    valid_names = {
+                        addr_to_name[start + i]
+                        for i in range(group_count)
+                        if (start + i) in addr_to_name
+                    }
+
+                    try:
+                        resp = await _read_batch_via_existing_client(
+                            dc, reg_type, start, group_count
+                        )
+                        if _response_has_data(resp):
+                            avail.update(valid_names)
+                        else:
+                            miss.update(valid_names)
+                    except (ModbusException, ConnectionException, TimeoutError, OSError):
+                        miss.update(valid_names)
+
+            available[reg_type] = avail
+            missing[reg_type] = miss
+
+    return available, missing
 
 
 def _register_refresh_device_data_service(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
@@ -42,7 +128,12 @@ def _register_refresh_device_data_service(hass: HomeAssistant, deps: ServiceHand
 
 
 def _register_scan_all_registers_service(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
-    """Register the scan_all_registers service."""
+    """Register the scan_all_registers service.
+
+    WARNING: scan_all_registers opens a SEPARATE Modbus connection and will cause
+    transaction_id mismatch errors while the coordinator is actively polling.
+    For safe real-device validation, use validate_known_registers instead.
+    """
 
     async def scan_all_registers(call: ServiceCall) -> dict[str, Any] | None:
         results: dict[str, Any] = {}
@@ -52,9 +143,10 @@ def _register_scan_all_registers_service(hass: HomeAssistant, deps: ServiceHandl
             effective_batch = coordinator.device_client.effective_batch
             batch = call.data.get("max_registers_per_request", effective_batch)
             deps.logger.warning(
-                "scan_all_registers opens a separate Modbus connection to %s:%s for %s; "
-                "this may conflict with the active coordinator refresh. "
-                "Use validate_known_registers for less intrusive register validation.",
+                "scan_all_registers opens a SEPARATE Modbus TCP connection to %s:%s for %s. "
+                "This WILL cause transaction_id mismatch errors while the coordinator is "
+                "actively polling. Stop or disable the integration first, or use "
+                "validate_known_registers which reuses the active connection safely.",
                 coordinator.device_client.config.host,
                 coordinator.device_client.config.port,
                 entity_id,
@@ -115,10 +207,14 @@ def _register_scan_all_registers_service(hass: HomeAssistant, deps: ServiceHandl
 def _register_validate_known_registers_service(
     hass: HomeAssistant, deps: ServiceHandlerDeps
 ) -> None:
-    """Register the validate_known_registers service."""
+    """Register the validate_known_registers service.
+
+    Uses the coordinator's existing Modbus connection under _write_lock.
+    No second connection is opened — safe to call while the integration is active.
+    """
 
     async def validate_known_registers(call: ServiceCall) -> dict[str, Any] | None:
-        """Read only known registers from integration definitions."""
+        """Read only known registers via the active coordinator connection."""
         results: dict[str, Any] = {}
         delay_ms: int = call.data.get("delay_between_requests_ms", 0)
         for entity_id, coordinator in deps.iter_target_coordinators(hass, call):
@@ -130,28 +226,9 @@ def _register_validate_known_registers_service(
                 batch,
                 delay_ms,
             )
-            scanner = None
-            try:
-                scanner = await deps.scanner_create(
-                    host=coordinator.device_client.config.host,
-                    port=coordinator.device_client.config.port,
-                    slave_id=coordinator.device_client.config.slave_id,
-                    timeout=int(coordinator.device_client.timeout),
-                    retry=coordinator.device_client.retry,
-                    scan_uart_settings=False,
-                    skip_known_missing=False,
-                    full_register_scan=False,
-                    max_registers_per_request=batch,
-                    delay_between_requests_ms=delay_ms,
-                    hass=hass,
-                )
-                scan_result = await scanner.scan_device()
-            finally:
-                if scanner is not None:
-                    await scanner.close()
 
-            available = scan_result.get("available_registers", {})
-            missing = scan_result.get("missing_registers", {})
+            available, missing = await _read_known_registers_safe(coordinator, batch, delay_ms)
+
             summary = {
                 "supported_count": sum(len(v) for v in available.values()),
                 "missing_count": sum(len(v) for v in missing.values()),

--- a/tests/test_scan_safe_mode.py
+++ b/tests/test_scan_safe_mode.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -486,53 +487,70 @@ async def test_orchestration_exception_code2_not_fatal():
 
 
 # ---------------------------------------------------------------------------
-# validate_known_registers — uses full_register_scan=False
+# validate_known_registers — test coordinator factory
+# ---------------------------------------------------------------------------
+
+
+def _make_validate_coordinator(effective_batch=4, call_modbus_resp=None):
+    """Create a coordinator stub for validate_known_registers tests.
+
+    The stub includes device_client._write_lock, _register_maps, _call_modbus,
+    and coordinator._ensure_connection — all required by the safe read path.
+    """
+    resp = call_modbus_resp
+    if resp is None:
+        resp = MagicMock()
+        resp.registers = [42]
+        resp.bits = None
+
+    dc = SimpleNamespace(
+        effective_batch=effective_batch,
+        scan_uart_settings=False,
+        timeout=10,
+        retry=3,
+        unknown_registers={},
+        scanned_registers={},
+        device_scan_result=None,
+        slave_id=10,
+        _write_lock=asyncio.Lock(),
+        _transport=None,
+        client=MagicMock(),
+        _register_maps={
+            "input_registers": {"version_major": 0, "version_minor": 1},
+            "holding_registers": {"fan_speed_setpoint": 10},
+            "coil_registers": {},
+            "discrete_inputs": {},
+        },
+        _get_client_method=MagicMock(return_value=AsyncMock()),
+        _call_modbus=AsyncMock(return_value=resp),
+        config=SimpleNamespace(host="192.168.1.10", port=502, slave_id=10),
+    )
+
+    return SimpleNamespace(
+        async_write_register=AsyncMock(return_value=True),
+        async_request_refresh=AsyncMock(),
+        _ensure_connection=AsyncMock(),
+        data={},
+        device_client=dc,
+    )
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — must not call scanner_create (no second connection)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_validate_known_registers_no_full_scan(monkeypatch):
-    """validate_known_registers uses full_register_scan=False (named scan only)."""
-    coord = _Coordinator()
+async def test_validate_known_registers_does_not_call_scanner_create(monkeypatch):
+    """validate_known_registers must not call deps.scanner_create (no second connection)."""
+    coord = _make_validate_coordinator()
     hass = _make_hass()
-    scan_result = {
-        "register_count": 5,
-        "unknown_registers": {},
-        "available_registers": {"input_registers": {"version_major"}},
-        "missing_registers": {},
-        "failed_addresses": {"modbus_exceptions": {"input_registers": set()}},
-    }
-    _mock_scanner, mock_create = _mock_scanner_create(scan_result)
 
     from custom_components.thessla_green_modbus import services as svc_mod
 
     monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
     monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
-    monkeypatch.setattr(svc_mod.ThesslaGreenDeviceScanner, "create", mock_create)
-
-    from custom_components.thessla_green_modbus.services import async_setup_services
-
-    await async_setup_services(hass)
-    handler = hass.services.handlers["validate_known_registers"]
-    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
-
-    _, kwargs = mock_create.call_args
-    assert kwargs["full_register_scan"] is False
-    assert result is not None
-    assert "climate.dev" in result
-
-
-@pytest.mark.asyncio
-async def test_validate_known_registers_slave_id(monkeypatch):
-    """validate_known_registers uses coordinator.device_client.config.slave_id."""
-    coord = _Coordinator(slave_id=10)
-    hass = _make_hass()
-    _mock_scanner, mock_create = _mock_scanner_create()
-
-    from custom_components.thessla_green_modbus import services as svc_mod
-
-    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
-    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+    mock_create = AsyncMock()
     monkeypatch.setattr(svc_mod.ThesslaGreenDeviceScanner, "create", mock_create)
 
     from custom_components.thessla_green_modbus.services import async_setup_services
@@ -541,45 +559,199 @@ async def test_validate_known_registers_slave_id(monkeypatch):
     handler = hass.services.handlers["validate_known_registers"]
     await handler(_make_call({"entity_id": ["climate.dev"]}))
 
-    _, kwargs = mock_create.call_args
-    assert kwargs["slave_id"] == 10
+    mock_create.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — calls _ensure_connection via coordinator (safe path)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_validate_known_registers_delay_passed(monkeypatch):
-    """validate_known_registers passes delay_between_requests_ms."""
-    coord = _Coordinator()
+async def test_validate_known_registers_calls_ensure_connection(monkeypatch):
+    """validate_known_registers calls coordinator._ensure_connection (uses active connection)."""
+    coord = _make_validate_coordinator()
     hass = _make_hass()
-    _mock_scanner, mock_create = _mock_scanner_create()
 
     from custom_components.thessla_green_modbus import services as svc_mod
 
     monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
     monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
-    monkeypatch.setattr(svc_mod.ThesslaGreenDeviceScanner, "create", mock_create)
 
     from custom_components.thessla_green_modbus.services import async_setup_services
 
     await async_setup_services(hass)
     handler = hass.services.handlers["validate_known_registers"]
-    await handler(_make_call({"entity_id": ["climate.dev"], "delay_between_requests_ms": 150}))
+    await handler(_make_call({"entity_id": ["climate.dev"]}))
 
-    _, kwargs = mock_create.call_args
-    assert kwargs["delay_between_requests_ms"] == 150
+    coord._ensure_connection.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — reads via device_client._call_modbus (not a new client)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_validate_known_registers_no_writes(monkeypatch):
-    """validate_known_registers never calls async_write_register."""
-    coord = _Coordinator()
+async def test_validate_known_registers_uses_existing_client(monkeypatch):
+    """validate_known_registers reads registers via device_client._call_modbus."""
+    coord = _make_validate_coordinator()
     hass = _make_hass()
-    _mock_scanner, mock_create = _mock_scanner_create()
 
     from custom_components.thessla_green_modbus import services as svc_mod
 
     monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
     monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
-    monkeypatch.setattr(svc_mod.ThesslaGreenDeviceScanner, "create", mock_create)
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    # _call_modbus is called once per non-empty register batch
+    coord.device_client._call_modbus.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — output shape: available_registers + summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_output_shape(monkeypatch):
+    """validate_known_registers returns available_registers and summary with correct keys."""
+    coord = _make_validate_coordinator()
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    assert result is not None
+    assert "climate.dev" in result
+    entry = result["climate.dev"]
+    assert "available_registers" in entry
+    assert "summary" in entry
+    assert "supported_count" in entry["summary"]
+    assert "missing_count" in entry["summary"]
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — registers marked available when read succeeds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_marks_available_on_success(monkeypatch):
+    """Registers are marked available when _call_modbus returns a non-empty response."""
+    resp = MagicMock()
+    resp.registers = [42]
+    resp.bits = None
+    coord = _make_validate_coordinator(call_modbus_resp=resp)
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    summary = result["climate.dev"]["summary"]
+    assert summary["supported_count"] > 0
+    assert summary["missing_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — registers marked missing when read raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_marks_missing_on_failure(monkeypatch):
+    """Registers are marked missing when _call_modbus raises ConnectionException."""
+    from pymodbus.exceptions import ConnectionException
+
+    coord = _make_validate_coordinator()
+    coord.device_client._call_modbus = AsyncMock(side_effect=ConnectionException("no connection"))
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    summary = result["climate.dev"]["summary"]
+    assert summary["supported_count"] == 0
+    assert summary["missing_count"] > 0
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — respects delay_between_requests_ms via asyncio.sleep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_respects_delay_ms(monkeypatch):
+    """validate_known_registers calls asyncio.sleep for each batch when delay > 0."""
+    coord = _make_validate_coordinator()
+    hass = _make_hass()
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+
+    with patch("asyncio.sleep", side_effect=fake_sleep):
+        await handler(_make_call({"entity_id": ["climate.dev"], "delay_between_requests_ms": 100}))
+
+    assert len(sleep_calls) > 0, "asyncio.sleep must be called when delay > 0"
+    assert all(abs(s - 0.1) < 1e-9 for s in sleep_calls), "sleep duration must be 100ms"
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — never calls async_write_register
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_no_writes(monkeypatch):
+    """validate_known_registers never calls async_write_register."""
+    coord = _make_validate_coordinator()
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
 
     from custom_components.thessla_green_modbus.services import async_setup_services
 
@@ -591,7 +763,70 @@ async def test_validate_known_registers_no_writes(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Negative guard tests: services must use device_client.config.*, not proxies
+# validate_known_registers — regression: no second transport while polling active
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_no_second_transport_while_polling(monkeypatch):
+    """Regression: validate_known_registers must not open a second Modbus connection.
+
+    When the coordinator is actively polling via an existing transport,
+    validate_known_registers must reuse the same connection under _write_lock
+    rather than opening a new TCP transport (which causes transaction_id mismatch).
+    """
+    coord = _make_validate_coordinator()
+    existing_transport = MagicMock()
+    existing_transport.is_connected.return_value = True
+    coord.device_client._transport = existing_transport
+    coord.device_client._call_modbus = AsyncMock(return_value=MagicMock(registers=[1]))
+
+    scanner_create_calls: list = []
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    async def tracking_scanner_create(**kwargs):
+        scanner_create_calls.append(kwargs)
+        mock_s = AsyncMock()
+        mock_s.scan_device = AsyncMock(return_value={})
+        mock_s.close = AsyncMock()
+        return mock_s
+
+    monkeypatch.setattr(svc_mod.ThesslaGreenDeviceScanner, "create", tracking_scanner_create)
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+
+    # Simulate concurrent polling by briefly holding _write_lock, then call validate.
+    polling_started = asyncio.Event()
+
+    async def simulate_polling():
+        async with coord.device_client._write_lock:
+            polling_started.set()
+            await asyncio.sleep(0.01)
+
+    poll_task = asyncio.ensure_future(simulate_polling())
+    await polling_started.wait()
+
+    validate_task = asyncio.ensure_future(handler(_make_call({"entity_id": ["climate.dev"]})))
+    await asyncio.gather(poll_task, validate_task)
+
+    # validate_known_registers must not have opened a new scanner/connection
+    assert scanner_create_calls == [], (
+        "validate_known_registers called scanner_create — this opens a second connection"
+    )
+    # The existing transport must still be the same object (not replaced)
+    assert coord.device_client._transport is existing_transport
+
+
+# ---------------------------------------------------------------------------
+# Negative guard: scan_all_registers must use device_client.config.* not proxies
 # ---------------------------------------------------------------------------
 
 
@@ -628,34 +863,34 @@ async def test_scan_all_registers_no_coordinator_host_proxy(monkeypatch):
     assert kwargs["port"] == coord.device_client.config.port
 
 
+# ---------------------------------------------------------------------------
+# Negative guard: validate_known_registers must not access coordinator.host proxy
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_validate_known_registers_no_coordinator_host_proxy(monkeypatch):
     """validate_known_registers must not access coordinator.host (proxy removed).
 
-    The coordinator stub intentionally has no .host/.port attributes.
-    If production code accidentally used coordinator.host, the test would
-    raise AttributeError and fail here.
+    validate_known_registers no longer uses host/port — it reuses the active
+    connection. This test verifies no AttributeError is raised on a coordinator
+    stub that has no .host/.port attributes.
     """
-    coord = _Coordinator()
+    coord = _make_validate_coordinator()
     assert not hasattr(coord, "host"), "legacy coordinator.host proxy must not be set"
     assert not hasattr(coord, "port"), "legacy coordinator.port proxy must not be set"
 
     hass = _make_hass()
-    _mock_scanner, mock_create = _mock_scanner_create()
 
     from custom_components.thessla_green_modbus import services as svc_mod
 
     monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
     monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
-    monkeypatch.setattr(svc_mod.ThesslaGreenDeviceScanner, "create", mock_create)
 
     from custom_components.thessla_green_modbus.services import async_setup_services
 
     await async_setup_services(hass)
     handler = hass.services.handlers["validate_known_registers"]
-    # Must succeed without AttributeError
-    await handler(_make_call({"entity_id": ["climate.dev"]}))
-
-    _, kwargs = mock_create.call_args
-    assert kwargs["host"] == coord.device_client.config.host
-    assert kwargs["port"] == coord.device_client.config.port
+    # Must succeed without AttributeError — host/port are not accessed
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+    assert result is not None


### PR DESCRIPTION
## Summary

Refactored `validate_known_registers` service to read known registers via the coordinator's existing Modbus connection instead of opening a separate connection. This eliminates transaction_id mismatch errors that occur when validation runs concurrently with active polling.

**Key changes:**
- Replaced `ThesslaGreenDeviceScanner.create()` call with direct `device_client._call_modbus()` reads under `_write_lock`
- Added `_read_known_registers_safe()` helper that holds the write lock for the entire validation loop, preventing concurrent polling interference
- Added `_read_batch_via_existing_client()` to read register batches using the active connection's client methods
- Updated test suite from 3 tests to 10 focused tests covering:
  - No second connection is opened (`scanner_create` not called)
  - Uses `coordinator._ensure_connection()` for safe path
  - Reads via `device_client._call_modbus()` (existing client)
  - Output shape validation (available_registers + summary)
  - Registers marked available/missing based on read success/failure
  - Delay between requests respected via `asyncio.sleep()`
  - No writes performed
  - Regression test: no second transport while polling active
  - Guard test: no coordinator.host proxy access

## Maintainability checklist

- [x] Changed methods/files reviewed for size:
  - `handlers_data.py`: Added 3 new helper functions (~85 lines) + refactored `validate_known_registers` handler (~20 lines). Extraction rationale: `_read_known_registers_safe()` encapsulates the safe read loop with lock management; `_read_batch_via_existing_client()` abstracts register type → method mapping.
  - `test_scan_safe_mode.py`: Replaced 3 old tests with 10 new focused tests. Added `_make_validate_coordinator()` factory (~50 lines) to reduce test boilerplate and ensure consistent stub setup.

- [x] Behavior compatibility:
  - `validate_known_registers` output shape unchanged (available_registers + summary with supported_count/missing_count)
  - Service call signature unchanged
  - No breaking changes to public APIs

- [x] Test impact:
  - Removed 3 old tests that verified `scanner_create` parameters (no longer applicable)
  - Added 10 new tests covering the safe read path, connection reuse, delay handling, and regression scenarios
  - All tests use new `_make_validate_coordinator()` factory for consistency

- [x] Rollback plan (if needed):
  - Revert to calling `deps.scanner_create()` with coordinator config parameters
  - Remove `_read_known_registers_safe()` and `_read_batch_via_existing_client()` helpers
  - Restore old test suite from git history

## Validation

- [x] Tests added/updated: 10 new tests covering safe connection reuse, no second transport, delay handling, and output validation
- [x] Existing tests pass: Old tests removed (no longer applicable); new tests validate the refactored behavior
- [x] Code style: Follows existing patterns (async context managers, exception handling, logging)

## Notes

- The refactoring eliminates a critical bug where `validate_known_registers` would open a second Modbus TCP connection, causing transaction_id mismatch errors during concurrent polling.
- `scan_all_registers` still opens a separate connection (by design, for full register discovery); warning message updated to clarify the difference.
- The `_write_lock` is held for the entire validation loop to prevent the coordinator from polling while validation reads are in progress, ensuring consistent results.

https://claude.ai/code/session_01JrQ4ttyBFxTR2RYKUbe2zP