### PR TITLE
validate_known_registers: add fallback to individual reads on batch failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Detailed v2.8.x release notes: [docs/releases/v2.8.x.md](docs/releases/v2.8.x.md).
 
 ### Fixed
+- **`validate_known_registers` individual-read fallback**: when a batch read fails
+  (e.g. device returns exception code 2 for one unsupported register in a batch),
+  the service now falls back to individual address reads through the same active
+  connection. Only truly unsupported registers are marked missing; valid registers
+  that shared the failed batch are correctly reported as available.
+- **`validate_known_registers` diagnostics**: output now includes
+  `missing_registers` (per register type), `failed_ranges` (batches that triggered
+  fallback), and `summary.missing_by_type` (per-type missing counts). Existing
+  `available_registers` and `summary.{supported,missing}_count` fields are unchanged.
 - **Fan percentage clamped to 0–100**
   ([#1682](https://github.com/blakinio/thesslagreen/pull/1682)):
   `fan.thesslagreen_ventilation` no longer reports `percentage` > 100 to Home Assistant

--- a/custom_components/thessla_green_modbus/services/handlers_data.py
+++ b/custom_components/thessla_green_modbus/services/handlers_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -15,6 +16,10 @@ from .schema import (
     SCAN_ALL_REGISTERS_SCHEMA,
     VALIDATE_KNOWN_REGISTERS_SCHEMA,
 )
+
+_LOGGER = logging.getLogger(__name__)
+
+_CATCH_ERRORS = (ModbusException, ConnectionException, TimeoutError, OSError)
 
 
 def _response_has_data(response: Any) -> bool:
@@ -51,16 +56,22 @@ async def _read_known_registers_safe(
     coordinator: Any,
     batch: int,
     delay_ms: int,
-) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+) -> tuple[dict[str, set[str]], dict[str, set[str]], dict[str, list[dict[str, Any]]]]:
     """Read all known register addresses under _write_lock using the active connection.
 
     Prevents concurrent coordinator polling during validation by holding
     _write_lock for the entire read loop. No new Modbus transport is opened.
-    Returns (available, missing) name sets per register type.
+
+    On batch read failure, falls back to individual address reads within the same
+    lock and connection, so only truly unsupported addresses are marked missing.
+
+    Returns (available, missing, failed_ranges) name sets per register type.
+    failed_ranges contains {start, count, error} for each batch that needed fallback.
     """
     dc = coordinator.device_client
     available: dict[str, set[str]] = {}
     missing: dict[str, set[str]] = {}
+    failed_ranges: dict[str, list[dict[str, Any]]] = {}
 
     async with dc._write_lock:
         await coordinator._ensure_connection()
@@ -68,6 +79,7 @@ async def _read_known_registers_safe(
         for reg_type, reg_map in dc._register_maps.items():
             avail: set[str] = set()
             miss: set[str] = set()
+            faults: list[dict[str, Any]] = []
 
             if reg_map:
                 addr_to_name: dict[int, str] = {addr: name for name, addr in reg_map.items()}
@@ -83,21 +95,47 @@ async def _read_known_registers_safe(
                         if (start + i) in addr_to_name
                     }
 
+                    batch_ok = False
+                    batch_error: str | None = None
                     try:
                         resp = await _read_batch_via_existing_client(
                             dc, reg_type, start, group_count
                         )
                         if _response_has_data(resp):
                             avail.update(valid_names)
+                            batch_ok = True
                         else:
-                            miss.update(valid_names)
-                    except (ModbusException, ConnectionException, TimeoutError, OSError):
-                        miss.update(valid_names)
+                            batch_error = "empty_response"
+                    except _CATCH_ERRORS as exc:
+                        batch_error = type(exc).__name__
+
+                    if not batch_ok:
+                        faults.append({"start": start, "count": group_count, "error": batch_error})
+                        # Fallback: retry each known address individually to isolate failures.
+                        # This ensures only truly unsupported addresses are marked missing.
+                        for i in range(group_count):
+                            addr = start + i
+                            if addr not in addr_to_name:
+                                continue
+                            name = addr_to_name[addr]
+                            if delay_ms > 0:
+                                await asyncio.sleep(delay_ms / 1000.0)
+                            try:
+                                single_resp = await _read_batch_via_existing_client(
+                                    dc, reg_type, addr, 1
+                                )
+                                if _response_has_data(single_resp):
+                                    avail.add(name)
+                                else:
+                                    miss.add(name)
+                            except _CATCH_ERRORS:
+                                miss.add(name)
 
             available[reg_type] = avail
             missing[reg_type] = miss
+            failed_ranges[reg_type] = faults
 
-    return available, missing
+    return available, missing, failed_ranges
 
 
 def _register_refresh_device_data_service(hass: HomeAssistant, deps: ServiceHandlerDeps) -> None:
@@ -221,23 +259,39 @@ def _register_validate_known_registers_service(
             effective_batch = coordinator.device_client.effective_batch
             batch = call.data.get("max_registers_per_request", effective_batch)
             deps.logger.info(
-                "Validate known registers started for %s: batch=%d, delay=%dms",
+                "validate_known_registers started for %s: batch=%d, delay=%dms",
                 entity_id,
                 batch,
                 delay_ms,
             )
 
-            available, missing = await _read_known_registers_safe(coordinator, batch, delay_ms)
+            available, missing, failed_ranges = await _read_known_registers_safe(
+                coordinator, batch, delay_ms
+            )
 
+            missing_by_type = {rt: len(v) for rt, v in missing.items() if v}
             summary = {
                 "supported_count": sum(len(v) for v in available.values()),
                 "missing_count": sum(len(v) for v in missing.values()),
+                "missing_by_type": missing_by_type,
             }
-            results[entity_id] = {"available_registers": available, "summary": summary}
+            results[entity_id] = {
+                "available_registers": available,
+                "missing_registers": missing,
+                "failed_ranges": failed_ranges,
+                "summary": summary,
+            }
             deps.logger.info(
-                "Validate known registers completed for %s: %s",
+                "validate_known_registers completed for %s: supported=%d, missing=%d, by_type=%s",
                 entity_id,
-                summary,
+                summary["supported_count"],
+                summary["missing_count"],
+                missing_by_type,
+            )
+            _LOGGER.debug(
+                "validate_known_registers missing names for %s: %s",
+                entity_id,
+                {rt: sorted(v) for rt, v in missing.items() if v},
             )
         return results or None
 

--- a/tests/test_scan_safe_mode.py
+++ b/tests/test_scan_safe_mode.py
@@ -894,3 +894,244 @@ async def test_validate_known_registers_no_coordinator_host_proxy(monkeypatch):
     # Must succeed without AttributeError — host/port are not accessed
     result = await handler(_make_call({"entity_id": ["climate.dev"]}))
     assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — batch success marks only known names available
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_batch_success_marks_known_names(monkeypatch):
+    """When all batch reads succeed, all known register names are marked available."""
+    resp = MagicMock()
+    resp.registers = [1]
+    resp.bits = None
+    coord = _make_validate_coordinator(call_modbus_resp=resp)
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    summary = result["climate.dev"]["summary"]
+    assert summary["supported_count"] == 3  # version_major, version_minor, fan_speed_setpoint
+    assert summary["missing_count"] == 0
+    # missing_by_type must be empty when nothing is missing
+    assert summary["missing_by_type"] == {}
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — batch failure falls back to individual reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_batch_failure_falls_back_to_individual(monkeypatch):
+    """On batch failure, validate_known_registers retries each address individually.
+
+    The stub register map has two input_registers (addr 0, 1) and one holding
+    register (addr 10). When the first batch read raises, individual reads
+    succeed → supported_count == 3 (not 0).
+    """
+    from pymodbus.exceptions import ModbusException
+
+    good_resp = MagicMock()
+    good_resp.registers = [42]
+    good_resp.bits = None
+
+    call_count = 0
+
+    async def side_effect(fn, addr, *, count):
+        nonlocal call_count
+        call_count += 1
+        # First call is the batch read for input_registers (count=2); make it fail.
+        if call_count == 1:
+            raise ModbusException("simulated batch failure")
+        return good_resp
+
+    coord = _make_validate_coordinator()
+    coord.device_client._call_modbus = side_effect
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    summary = result["climate.dev"]["summary"]
+    # Batch for input_registers failed, but both individual reads succeeded + holding batch ok.
+    assert summary["supported_count"] == 3
+    assert summary["missing_count"] == 0
+    # failed_ranges must record the batch that triggered fallback
+    failed_ranges = result["climate.dev"]["failed_ranges"]
+    assert any(
+        r["start"] == 0 and r["count"] == 2 for r in failed_ranges.get("input_registers", [])
+    ), "failed_ranges must record the failed input_registers batch"
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — individual fallback reduces missing_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_individual_fallback_reduces_missing_count(monkeypatch):
+    """Individual fallback recovers registers that share a batch with a failing one.
+
+    input_registers addr 0 (version_major) succeeds individually; addr 1
+    (version_minor) fails individually. Without fallback both would be missing;
+    with fallback only version_minor is missing.
+    """
+    from pymodbus.exceptions import ConnectionException, ModbusException
+
+    good_resp = MagicMock()
+    good_resp.registers = [99]
+    good_resp.bits = None
+
+    calls: list[tuple[int, int]] = []
+
+    async def side_effect(fn, addr, *, count):
+        calls.append((addr, count))
+        if count > 1:
+            # Batch read → fail to trigger fallback
+            raise ModbusException("batch fail")
+        if addr == 0:
+            return good_resp
+        if addr == 1:
+            raise ConnectionException("addr 1 unsupported")
+        return good_resp
+
+    coord = _make_validate_coordinator()
+    coord.device_client._call_modbus = side_effect
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    summary = result["climate.dev"]["summary"]
+    # version_major recovered individually; version_minor + holding both succeed
+    assert summary["supported_count"] == 2  # version_major + fan_speed_setpoint
+    assert summary["missing_count"] == 1  # version_minor
+    missing = result["climate.dev"]["missing_registers"]
+    assert "version_minor" in missing.get("input_registers", set())
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — unsupported registers remain missing after fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_unsupported_remain_missing(monkeypatch):
+    """Registers that fail both batch and individual reads are marked missing."""
+    from pymodbus.exceptions import ModbusException
+
+    coord = _make_validate_coordinator()
+    coord.device_client._call_modbus = AsyncMock(
+        side_effect=ModbusException("device does not support this register")
+    )
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    summary = result["climate.dev"]["summary"]
+    assert summary["supported_count"] == 0
+    assert summary["missing_count"] == 3  # all three registers missing
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — output includes missing_registers by type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_output_includes_missing_registers(monkeypatch):
+    """Result includes missing_registers and failed_ranges per register type."""
+    coord = _make_validate_coordinator()
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    entry = result["climate.dev"]
+    assert "missing_registers" in entry, "missing_registers must be present in output"
+    assert "failed_ranges" in entry, "failed_ranges must be present in output"
+    assert "missing_by_type" in entry["summary"], "missing_by_type must be in summary"
+    # Backward-compatible fields must still be present
+    assert "available_registers" in entry
+    assert "supported_count" in entry["summary"]
+    assert "missing_count" in entry["summary"]
+
+
+# ---------------------------------------------------------------------------
+# validate_known_registers — missing_by_type counts per register type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_known_registers_missing_by_type_counts(monkeypatch):
+    """missing_by_type in summary reflects per-type missing counts."""
+    from pymodbus.exceptions import ModbusException
+
+    coord = _make_validate_coordinator()
+    coord.device_client._call_modbus = AsyncMock(side_effect=ModbusException("unsupported"))
+    hass = _make_hass()
+
+    from custom_components.thessla_green_modbus import services as svc_mod
+
+    monkeypatch.setattr(svc_mod, "_get_coordinator_from_entity_id", lambda _h, _e: coord)
+    monkeypatch.setattr(svc_mod, "async_extract_entity_ids", lambda c: c.data["entity_id"])
+
+    from custom_components.thessla_green_modbus.services import async_setup_services
+
+    await async_setup_services(hass)
+    handler = hass.services.handlers["validate_known_registers"]
+    result = await handler(_make_call({"entity_id": ["climate.dev"]}))
+
+    by_type = result["climate.dev"]["summary"]["missing_by_type"]
+    # input_registers has version_major (0) and version_minor (1): 2 missing
+    assert by_type.get("input_registers", 0) == 2
+    # holding_registers has fan_speed_setpoint (10): 1 missing
+    assert by_type.get("holding_registers", 0) == 1
+    # empty types must not appear in missing_by_type
+    assert "coil_registers" not in by_type
+    assert "discrete_inputs" not in by_type


### PR DESCRIPTION
## Summary

Enhanced `validate_known_registers` service to gracefully handle batch read failures by falling back to individual address reads through the same active connection. This ensures that only truly unsupported registers are marked missing, rather than marking all registers in a failed batch as unavailable.

**Key changes:**
- When a batch read fails (e.g., device returns exception for one unsupported register), the service now retries each known address individually within the same lock and connection
- Added `failed_ranges` to output: tracks which batches triggered fallback with error details
- Added `missing_by_type` to summary: per-register-type missing counts for better diagnostics
- Added `missing_registers` to output: explicit per-type sets of missing register names
- Improved logging: now logs per-type missing counts and register names at debug level

**Behavior:**
- Batch reads still occur first (no performance regression on healthy devices)
- Fallback only triggers on batch failure; successful batches skip individual reads
- All reads use the existing active connection and `_write_lock` (no new transport opened)
- Backward compatible: existing `available_registers` and `summary.{supported,missing}_count` fields unchanged

## Maintainability checklist

- [x] Changed method `_read_known_registers_safe` signature (return type expanded) and implementation (fallback logic added)
- [x] Fallback logic is localized to `_read_known_registers_safe`; no changes to caller patterns
- [x] Behavior is backward compatible: existing fields preserved, new fields additive
- [x] Test impact: added 6 comprehensive test cases covering batch success, batch failure with fallback, partial recovery, unsupported registers, and output structure

## Validation

- [x] Added 6 new test cases in `test_scan_safe_mode.py`:
  - `test_validate_known_registers_batch_success_marks_known_names`: verifies all known names marked available on batch success
  - `test_validate_known_registers_batch_failure_falls_back_to_individual`: verifies fallback occurs and recovers registers
  - `test_validate_known_registers_individual_fallback_reduces_missing_count`: verifies partial recovery (one register succeeds, one fails)
  - `test_validate_known_registers_unsupported_remain_missing`: verifies truly unsupported registers stay missing
  - `test_validate_known_registers_output_includes_missing_registers`: verifies output structure
  - `test_validate_known_registers_missing_by_type_counts`: verifies per-type missing counts
- [x] All tests pass with mocked Modbus exceptions and responses
- [x] Logging improved with per-type counts and debug-level register names

## Notes

- No breaking changes; existing integrations using `validate_known_registers` will continue to work
- The fallback mechanism is transparent to callers; they receive the same lock guarantees and connection reuse
- Error tracking via `failed_ranges` enables future diagnostics or retry strategies without code changes

https://claude.ai/code/session_01ACL5AtDhjEqPfUT3d1hDcL