### PR TITLE
Isolate deep-scan raw failures from Modbus error summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes since v2.8.0._
+### Fixed
+
+- **Deep scan raw unsupported ranges no longer shown as Modbus errors in confirmation popup**:
+  when `deep_scan=True` (named scan mode), raw input register reads (addresses 0–286) produced
+  Modbus exception responses for unsupported ranges and those addresses were incorrectly stored in
+  `failed_addresses.modbus_exceptions`, causing the confirmation popup to show
+  "Błędy Modbus: input_registers: 269". The fix isolates raw-scan failures in a dedicated
+  `deep_scan_raw_failures` bucket (diagnostic-only) and restores `modbus_exceptions` to its
+  pre-raw-scan state. The popup now shows the same concise diagnostic note as full-scan mode:
+  "deep scan: N unsupported raw ranges (named registers OK)" when named registers are all OK.
+
+### Diagnostics
+
+- `failed_addresses.deep_scan_raw_failures` added to scan result: contains input-register
+  addresses that failed only during the deep-scan raw accumulation pass; excluded from
+  user-facing Modbus error summary.
+- Deep scan UI description updated to clarify offline/diagnostic-only purpose and that it is
+  not required for normal setup or real-device validation.
+
+---
 
 ---
 

--- a/custom_components/thessla_green_modbus/_config_flow/confirm.py
+++ b/custom_components/thessla_green_modbus/_config_flow/confirm.py
@@ -180,15 +180,26 @@ async def build_confirmation_placeholders(
     modbus_failed_summary = _summarize_address_dict(
         failed.get("modbus_exceptions"), exclude=expected_optional
     )
-    # If no named Modbus errors remain but this was a full scan with raw batch failures,
-    # show a brief diagnostic note so the user knows what the deep scan found.
-    if modbus_failed_summary == _N_A and scan_result.get("scan_mode") == "full":
-        batch_failures = failed.get("batch_failures") or {}
-        total_batch = sum(len(v) for v in batch_failures.values() if v)
-        if total_batch > 0:
-            modbus_failed_summary = (
-                f"deep scan: {total_batch} unsupported raw ranges (named registers OK)"
-            )
+    # When no named Modbus errors remain, show a concise diagnostic note if a
+    # deep or full scan found unsupported raw register ranges.
+    if modbus_failed_summary == _N_A:
+        # Full-scan mode (full_register_scan=True): raw failures land in batch_failures.
+        if scan_result.get("scan_mode") == "full":
+            batch_failures = failed.get("batch_failures") or {}
+            total_batch = sum(len(v) for v in batch_failures.values() if v)
+            if total_batch > 0:
+                modbus_failed_summary = (
+                    f"deep scan: {total_batch} unsupported raw ranges (named registers OK)"
+                )
+        # Deep-scan with named mode (deep_scan=True, full_register_scan=False): raw
+        # failures are isolated in deep_scan_raw_failures, not modbus_exceptions.
+        if modbus_failed_summary == _N_A:
+            deep_scan_raw = failed.get("deep_scan_raw_failures") or {}
+            total_raw = sum(len(v) for v in deep_scan_raw.values() if v)
+            if total_raw > 0:
+                modbus_failed_summary = (
+                    f"deep scan: {total_raw} unsupported raw ranges (named registers OK)"
+                )
     invalid_values_summary = _summarize_address_dict(failed.get("invalid_values"))
 
     detected_caps, not_detected_caps = _build_capabilities_lists(

--- a/custom_components/thessla_green_modbus/scanner/orchestration.py
+++ b/custom_components/thessla_green_modbus/scanner/orchestration.py
@@ -53,10 +53,21 @@ def _should_run_full_scan(scanner: Any) -> bool:
 
 
 async def _accumulate_raw_registers(scanner: Any) -> dict[int, int]:
-    """Collect raw input registers for deep scan mode."""
+    """Collect raw input registers for deep scan mode.
+
+    Failures from unsupported raw ranges are stored in
+    failed_addresses["deep_scan_raw_failures"] so they do not pollute the
+    user-facing modbus_exceptions summary in the confirmation popup.
+    """
     raw_registers: dict[int, int] = {}
     if not scanner.deep_scan:
         return raw_registers
+
+    # Snapshot named-scan exceptions so raw-scan additions can be isolated.
+    pre_scan_exceptions: set[int] = set(
+        scanner.failed_addresses["modbus_exceptions"].get("input_registers", set())
+    )
+
     for start, count in scanner._group_registers_for_batch_read(list(range(287))):
         data = (
             await scanner._read_input(scanner._client, start, count)
@@ -67,6 +78,23 @@ async def _accumulate_raw_registers(scanner: Any) -> dict[int, int]:
             continue
         for offset, value in enumerate(data):
             raw_registers[start + offset] = value
+
+    # Move newly added failures to a dedicated diagnostic bucket and
+    # restore modbus_exceptions to the pre-raw-scan state so that
+    # unsupported raw ranges are not presented as named Modbus errors.
+    post_scan_exceptions: set[int] = set(
+        scanner.failed_addresses["modbus_exceptions"].get("input_registers", set())
+    )
+    raw_only_failures = post_scan_exceptions - pre_scan_exceptions
+    if raw_only_failures:
+        if "deep_scan_raw_failures" not in scanner.failed_addresses:
+            scanner.failed_addresses["deep_scan_raw_failures"] = {}
+        existing = scanner.failed_addresses["deep_scan_raw_failures"].get("input_registers", set())
+        scanner.failed_addresses["deep_scan_raw_failures"]["input_registers"] = (
+            existing | raw_only_failures
+        )
+        scanner.failed_addresses["modbus_exceptions"]["input_registers"] = pre_scan_exceptions
+
     return raw_registers
 
 

--- a/custom_components/thessla_green_modbus/scanner/scan_runtime.py
+++ b/custom_components/thessla_green_modbus/scanner/scan_runtime.py
@@ -83,6 +83,11 @@ def build_scan_result(
                 for k, v in scanner.failed_addresses.get("batch_failures", {}).items()
                 if v
             },
+            "deep_scan_raw_failures": {
+                k: sorted(v)
+                for k, v in scanner.failed_addresses.get("deep_scan_raw_failures", {}).items()
+                if v
+            },
         },
         "scan_mode": "full" if getattr(scanner, "full_register_scan", False) else "named",
         "resolved_connection_mode": scanner._resolved_connection_mode,

--- a/custom_components/thessla_green_modbus/scanner/setup.py
+++ b/custom_components/thessla_green_modbus/scanner/setup.py
@@ -187,6 +187,9 @@ def initialize_runtime_collections(scanner: Any, capabilities_cls: Any) -> None:
             "coil_registers": set(),
             "discrete_inputs": set(),
         },
+        "deep_scan_raw_failures": {
+            "input_registers": set(),
+        },
     }
     scanner._sensor_unavailable_checks = {}
 

--- a/custom_components/thessla_green_modbus/translations/en.json
+++ b/custom_components/thessla_green_modbus/translations/en.json
@@ -61,7 +61,7 @@
           "baud_rate": "Baud rate for Modbus RTU communication",
           "parity": "Parity setting for Modbus RTU communication",
           "stop_bits": "Stop bits for Modbus RTU communication",
-          "deep_scan": "Read all registers for diagnostics (may be slow)",
+          "deep_scan": "Advanced offline diagnostic: reads all raw registers 0–286. Not required for normal setup. Produces unsupported-range responses; may conflict with active coordinator polling.",
           "max_registers_per_request": "Maximum registers per Modbus request (1–16)"
         },
         "description": "Set up a connection to a ThesslaGreen AirPack over Modbus TCP or Modbus RTU. The integration automatically detects device functions and registers.",
@@ -1464,7 +1464,7 @@
           "airflow_unit": "Airflow Unit"
         },
         "data_description": {
-          "deep_scan": "Read raw registers 0-300 for diagnostics",
+          "deep_scan": "Advanced offline diagnostic: reads raw registers 0–286. Not required for normal validation. May produce unsupported-range responses and may conflict with active polling.",
           "enable_device_scan": "Enable automatic device scan during setup",
           "force_full_register_list": "Skip scanning and load all registers (may cause errors)",
           "log_level": "Set integration log verbosity",

--- a/custom_components/thessla_green_modbus/translations/pl.json
+++ b/custom_components/thessla_green_modbus/translations/pl.json
@@ -62,7 +62,7 @@
           "baud_rate": "Prędkość transmisji dla Modbus RTU",
           "parity": "Ustawienie parzystości dla Modbus RTU",
           "stop_bits": "Liczba bitów stopu dla Modbus RTU",
-          "deep_scan": "Odczytaj wszystkie rejestry do diagnostyki (może być wolne)",
+          "deep_scan": "Zaawansowana diagnostyka offline: odczytuje surowe rejestry 0–286. Nie jest wymagana do normalnej konfiguracji. Generuje odpowiedzi o nieobsługiwanych zakresach; może powodować konflikty z aktywnym pollowaniem.",
           "max_registers_per_request": "Maksymalna liczba rejestrów w jednym żądaniu Modbus (1–16)"
         },
         "description": "Skonfiguruj połączenie z ThesslaGreen AirPack przez Modbus TCP lub Modbus RTU. Integracja automatycznie wykryje funkcje i rejestry urządzenia."
@@ -1464,7 +1464,7 @@
           "airflow_unit": "Jednostka przepływu powietrza"
         },
         "data_description": {
-          "deep_scan": "Odczyt surowych rejestrów 0-300 do diagnostyki",
+          "deep_scan": "Zaawansowana diagnostyka offline: odczytuje surowe rejestry 0–286. Nie jest wymagana do normalnej walidacji. Może generować odpowiedzi o nieobsługiwanych zakresach i konflikty z aktywnym pollowaniem.",
           "enable_device_scan": "Włącz automatyczne skanowanie urządzenia podczas konfiguracji",
           "force_full_register_list": "Pomiń skanowanie i załaduj wszystkie rejestry (może powodować błędy)",
           "log_level": "Ustaw poziom szczegółowości logów integracji",

--- a/docs/real_device_validation.md
+++ b/docs/real_device_validation.md
@@ -18,6 +18,7 @@
 |------|--------|
 | Overall validation | PARTIAL — HA log evidence committed; HA state/service evidence still pending |
 | Quality scale gate | Bronze — no upgrade until formal evidence is complete |
+| Deep scan | Not required for validation — deep scan is offline/diagnostic-only; normal scan (deep_scan=False) is sufficient for all real-device validation steps |
 | Fan percentage fix (#1682) | FIXED in code; real-device state screenshot/re-test evidence pending |
 | Dangerous entities config category (#1683) | Confirmed by code audit; entity_category=config, remain enabled |
 | IO ownership cleanup (#1684/#1688) | DeviceClient is sole IO owner; HA setup log after cleanup is clean/partial evidence |

--- a/tests/test_config_flow_confirm.py
+++ b/tests/test_config_flow_confirm.py
@@ -534,6 +534,108 @@ async def test_confirm_placeholders_keys_stable():
 
 
 @pytest.mark.asyncio
+async def test_confirm_deep_scan_raw_failures_shown_as_diagnostic_note():
+    """Deep scan raw input failures appear as diagnostic note, not as normal Modbus error count."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+    flow._data = {CONF_HOST: "192.168.1.100", CONF_PORT: 502, "slave_id": 1}
+    flow._device_info = {}
+    # Simulate: deep_scan=True with named scan mode.
+    # Named registers all succeeded (modbus_exceptions empty).
+    # Raw scan produced 269 unsupported ranges, isolated in deep_scan_raw_failures.
+    flow._scan_result = {
+        "register_count": 338,
+        "scan_mode": "named",
+        "raw_registers": {i: i for i in range(22)},  # raw_registers present → deep_scan was True
+        "failed_addresses": {
+            "modbus_exceptions": {},
+            "invalid_values": {},
+            "deep_scan_raw_failures": {
+                "input_registers": list(range(22, 291)),  # 269 raw addresses
+            },
+        },
+    }
+
+    with patch(
+        "homeassistant.helpers.translation.async_get_translations",
+        new=AsyncMock(return_value={}),
+    ):
+        result = await flow.async_step_confirm()
+
+    p = result["description_placeholders"]
+    summary = p["modbus_failed_summary"]
+    # Must NOT show raw addresses as normal Modbus errors
+    assert "input_registers: 269" not in summary
+    # Must show a diagnostic note labelled as deep scan
+    assert "deep scan" in summary
+    assert "unsupported raw ranges" in summary
+    assert "named registers OK" in summary
+
+
+@pytest.mark.asyncio
+async def test_confirm_deep_scan_raw_failures_absent_when_modbus_errors_present():
+    """When named registers genuinely fail during deep scan, the error is still shown."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+    flow._data = {CONF_HOST: "192.168.1.100", CONF_PORT: 502, "slave_id": 1}
+    flow._device_info = {}
+    # Named register at address 50 genuinely failed (not from raw scan),
+    # so modbus_exceptions is non-empty even with deep_scan active.
+    flow._scan_result = {
+        "register_count": 5,
+        "scan_mode": "named",
+        "raw_registers": {},  # deep_scan=True
+        "failed_addresses": {
+            "modbus_exceptions": {"holding_registers": [50]},
+            "invalid_values": {},
+            "deep_scan_raw_failures": {
+                "input_registers": list(range(22, 291)),
+            },
+        },
+    }
+
+    with patch(
+        "homeassistant.helpers.translation.async_get_translations",
+        new=AsyncMock(return_value={}),
+    ):
+        result = await flow.async_step_confirm()
+
+    p = result["description_placeholders"]
+    summary = p["modbus_failed_summary"]
+    # The real named-register failure must still be shown
+    assert "holding_registers: 1" in summary
+
+
+@pytest.mark.asyncio
+async def test_confirm_normal_scan_no_errors_shows_dash():
+    """Normal scan with no failures shows '—' for modbus_failed_summary."""
+    flow = ConfigFlow()
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+
+    flow._data = {CONF_HOST: "192.168.1.100", CONF_PORT: 502, "slave_id": 1}
+    flow._device_info = {}
+    flow._scan_result = {
+        "register_count": 338,
+        "scan_mode": "named",
+        "failed_addresses": {
+            "modbus_exceptions": {},
+            "invalid_values": {},
+        },
+    }
+
+    with patch(
+        "homeassistant.helpers.translation.async_get_translations",
+        new=AsyncMock(return_value={}),
+    ):
+        result = await flow.async_step_confirm()
+
+    p = result["description_placeholders"]
+    assert p["modbus_failed_summary"] == _N_A
+
+
+@pytest.mark.asyncio
 async def test_confirm_step_aborts_on_existing_entry():
     """Ensure confirming a second flow aborts if unique ID already configured."""
 

--- a/tests/test_scanner_scan_runtime.py
+++ b/tests/test_scanner_scan_runtime.py
@@ -49,3 +49,38 @@ def test_build_scan_result_includes_deep_scan_payload() -> None:
     assert result["resolved_connection_mode"] == "tcp"
     assert result["total_addresses_scanned"] == 2
     assert result["raw_registers"] == {0: 1, 1: 2}
+    assert "deep_scan_raw_failures" in result["failed_addresses"]
+
+
+def test_build_scan_result_includes_deep_scan_raw_failures() -> None:
+    """deep_scan_raw_failures from the scanner are included in the result."""
+    scanner = SimpleNamespace(
+        failed_addresses={
+            "modbus_exceptions": {"input_registers": set(), "holding_registers": set()},
+            "invalid_values": {"input_registers": set(), "holding_registers": set()},
+            "deep_scan_raw_failures": {"input_registers": {22, 23, 24}},
+        },
+        _resolved_connection_mode="tcp",
+        deep_scan=True,
+    )
+    device = ScannerDeviceInfo()
+    caps = DeviceCapabilities()
+
+    result = scan_runtime.build_scan_result(
+        scanner,
+        device=device,
+        caps=caps,
+        available_registers={"input_registers": {"a"}, "holding_registers": set()},
+        unknown_registers={},
+        scanned_registers={"input_registers": 5},
+        scan_blocks={"input_registers": [(0, 4)]},
+        missing_registers={},
+        scan_started=0.0,
+        raw_registers={},
+    )
+
+    raw_failures = result["failed_addresses"]["deep_scan_raw_failures"]
+    assert "input_registers" in raw_failures
+    assert sorted(raw_failures["input_registers"]) == [22, 23, 24]
+    # modbus_exceptions must remain clean — not contaminated by raw failures
+    assert result["failed_addresses"]["modbus_exceptions"] == {}


### PR DESCRIPTION
## Summary

When `deep_scan=True` is enabled in named-scan mode, raw input register reads (addresses 0–286) that fail due to unsupported ranges were incorrectly stored in `failed_addresses.modbus_exceptions`, causing the confirmation popup to display them as regular Modbus errors (e.g., "input_registers: 269"). 

This fix isolates raw-scan failures in a dedicated `deep_scan_raw_failures` diagnostic bucket and restores `modbus_exceptions` to its pre-raw-scan state. The confirmation popup now shows the same concise diagnostic note as full-scan mode: "deep scan: N unsupported raw ranges (named registers OK)" when named registers are all OK.

### Changes

- **orchestration.py**: Modified `_accumulate_raw_registers()` to snapshot pre-scan exceptions, isolate newly added failures in `deep_scan_raw_failures`, and restore `modbus_exceptions` to its clean state.
- **scan_runtime.py**: Updated `build_scan_result()` to include `deep_scan_raw_failures` in the result structure.
- **confirm.py**: Enhanced `build_confirmation_placeholders()` to detect and display the diagnostic note for deep-scan raw failures (in addition to existing full-scan batch failures).
- **setup.py**: Initialized `deep_scan_raw_failures` in the scanner's `failed_addresses` structure.
- **Translations**: Updated English and Polish UI descriptions for the `deep_scan` option to clarify it is an advanced offline diagnostic, not required for normal setup.
- **CHANGELOG.md**: Documented the fix and new diagnostic field.
- **docs/real_device_validation.md**: Noted that deep scan is not required for validation.

## Maintainability checklist

- [x] Changes are localized to scanner orchestration, result building, and confirmation UI—no large refactors.
- [x] `_accumulate_raw_registers()` logic is straightforward: snapshot → scan → isolate → restore.
- [x] New `deep_scan_raw_failures` field follows existing `batch_failures` pattern.
- [x] Confirmation logic mirrors full-scan handling; no new complexity.

## Validation

- [x] Three new unit tests added:
  - `test_confirm_deep_scan_raw_failures_shown_as_diagnostic_note`: Verifies diagnostic note appears when only raw failures occur.
  - `test_confirm_deep_scan_raw_failures_absent_when_modbus_errors_present`: Confirms real named-register failures are still shown.
  - `test_confirm_normal_scan_no_errors_shows_dash`: Ensures no false positives when there are no failures.
- [x] Existing test `test_build_scan_result_includes_deep_scan_payload` updated to verify `deep_scan_raw_failures` presence.
- [x] New test `test_build_scan_result_includes_deep_scan_raw_failures` validates the field is correctly populated and isolated from `modbus_exceptions`.

## Notes

- The fix is backward compatible: `deep_scan_raw_failures` is optional in the result structure and defaults to an empty dict.
- No rollback needed; the change is purely additive to the diagnostic data structure and UI presentation.
- Deep scan remains an offline diagnostic feature; this fix only improves how its results are presented to users.

https://claude.ai/code/session_01BWZrZGA8NoesNdjJYM9Zq3