### PR TITLE
Add PARALLEL_UPDATES = 1 to all platform modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **`PARALLEL_UPDATES = 1` declared on all platform modules**: all 10 HA platform
+  modules (`sensor`, `binary_sensor`, `number`, `switch`, `select`, `climate`, `fan`,
+  `time`, `text`, `button`) now set `PARALLEL_UPDATES = 1` at module level. This aligns
+  with HA quality-scale requirements and correctly reflects the serialised single-connection
+  Modbus I/O model used by the integration's DeviceClient.
+
 ### Fixed
 
 - **Normal scan no longer shows recovered batch failures as Modbus errors in confirmation popup**:

--- a/custom_components/thessla_green_modbus/binary_sensor.py
+++ b/custom_components/thessla_green_modbus/binary_sensor.py
@@ -27,6 +27,8 @@ from .mappings import BINARY_SENSOR_ENTITY_MAPPINGS
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 BINARY_SENSOR_DEFINITIONS: dict[str, dict[str, Any]] = BINARY_SENSOR_ENTITY_MAPPINGS
 LEGACY_PROBLEM_KEY_PATTERN = re.compile(r"^problem(?:_\d+)?$")
 

--- a/custom_components/thessla_green_modbus/button.py
+++ b/custom_components/thessla_green_modbus/button.py
@@ -21,6 +21,8 @@ from .entity import ThesslaGreenEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/thessla_green_modbus/climate.py
+++ b/custom_components/thessla_green_modbus/climate.py
@@ -35,6 +35,8 @@ _FEATURE_TURN_OFF = ClimateEntityFeature.TURN_OFF
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 HVAC_MODE_MAP = {0: HVACMode.AUTO, 1: HVACMode.FAN_ONLY, 2: HVACMode.FAN_ONLY}
 HVAC_MODE_REVERSE_MAP = {HVACMode.AUTO: 0, HVACMode.FAN_ONLY: 1}
 

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -23,6 +23,8 @@ from .registers.maps import holding_registers
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/thessla_green_modbus/number.py
+++ b/custom_components/thessla_green_modbus/number.py
@@ -21,6 +21,8 @@ from .mappings import ENTITY_MAPPINGS
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 # Unit mappings
 UNIT_MAPPINGS = {

--- a/custom_components/thessla_green_modbus/select.py
+++ b/custom_components/thessla_green_modbus/select.py
@@ -27,6 +27,8 @@ from .utils import BCD_TIME_PREFIXES
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -36,6 +36,9 @@ from .registers.loader import get_register_definition
 from .utils import TIME_REGISTER_PREFIXES
 
 _LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1
+
 SENSOR_DEFINITIONS: dict[str, dict[str, Any]] = ENTITY_MAPPINGS.get("sensor", {})
 
 

--- a/custom_components/thessla_green_modbus/switch.py
+++ b/custom_components/thessla_green_modbus/switch.py
@@ -21,6 +21,8 @@ from .registers.maps import coil_registers, holding_registers
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/thessla_green_modbus/text.py
+++ b/custom_components/thessla_green_modbus/text.py
@@ -25,6 +25,8 @@ from .mappings import ENTITY_MAPPINGS
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/thessla_green_modbus/time.py
+++ b/custom_components/thessla_green_modbus/time.py
@@ -25,6 +25,8 @@ from .mappings import ENTITY_MAPPINGS
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/docs/ha_quality_scale_audit.md
+++ b/docs/ha_quality_scale_audit.md
@@ -150,6 +150,7 @@ OK homeassistant: installed
 | Entities use appropriate state_class | PASS | `sensor.py` assigns `_attr_state_class` from mapping definitions | — |
 | Entities use appropriate entity_category | PASS | `sensor.py`, `binary_sensor.py` assign `EntityCategory.DIAGNOSTIC` for diagnostic/alarm entities | — |
 | `disabled_by_default` where appropriate | PASS | `sensor.py` and `binary_sensor.py` now set `_attr_entity_registry_enabled_default = False` for all entities with `entity_category == EntityCategory.DIAGNOSTIC`; normal status/control entities remain enabled by default | — |
+| `PARALLEL_UPDATES = 1` on all platform modules | PASS | All 10 platform modules (`sensor`, `binary_sensor`, `number`, `switch`, `select`, `climate`, `fan`, `time`, `text`, `button`) declare `PARALLEL_UPDATES = 1`; enforced by `tests/test_platform_parallel_updates.py` | — |
 | No HA imports in scanner/transport | PASS | Confirmed by `rg` check — zero HA imports in `scanner/`, `transport/`, `core/`, `registers/` | — |
 | CI gates meaningful | PASS | CI: `ruff check`, `compileall`, `compare_registers`, `check_maintainability`, `validate_entity_mappings`, `pytest --cov`, `hassfest`, `hacs/action` | — |
 | HACS validation | FAIL→FIX PENDING | First CI run (PR #1602): FAILED. Root cause: `files` key in `manifest.json` is not a valid HA manifest field; HACS action validates manifest structure. Fix applied: removed `files` from `manifest.json`; `test_manifest_files.py` updated. Awaiting re-run CI result. | Confirm CI passes after this fix |

--- a/tests/test_platform_parallel_updates.py
+++ b/tests/test_platform_parallel_updates.py
@@ -1,0 +1,35 @@
+"""Verify that every HA platform module declares PARALLEL_UPDATES = 1.
+
+Serialised Modbus I/O (one DeviceClient connection) must not allow HA to
+dispatch concurrent entity updates, so each platform module must set
+PARALLEL_UPDATES = 1 at module level.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+PLATFORM_MODULES = [
+    "custom_components.thessla_green_modbus.sensor",
+    "custom_components.thessla_green_modbus.binary_sensor",
+    "custom_components.thessla_green_modbus.number",
+    "custom_components.thessla_green_modbus.switch",
+    "custom_components.thessla_green_modbus.select",
+    "custom_components.thessla_green_modbus.climate",
+    "custom_components.thessla_green_modbus.fan",
+    "custom_components.thessla_green_modbus.time",
+    "custom_components.thessla_green_modbus.text",
+    "custom_components.thessla_green_modbus.button",
+]
+
+
+@pytest.mark.parametrize("module_path", PLATFORM_MODULES)
+def test_parallel_updates_is_one(module_path: str) -> None:
+    """Each platform module must expose PARALLEL_UPDATES == 1."""
+    module = importlib.import_module(module_path)
+    assert hasattr(module, "PARALLEL_UPDATES"), f"{module_path} is missing PARALLEL_UPDATES"
+    assert module.PARALLEL_UPDATES == 1, (
+        f"{module_path}.PARALLEL_UPDATES == {module.PARALLEL_UPDATES!r}, expected 1"
+    )


### PR DESCRIPTION
## Summary
- Added `PARALLEL_UPDATES = 1` declaration to all 10 Home Assistant platform modules (`sensor`, `binary_sensor`, `number`, `switch`, `select`, `climate`, `fan`, `time`, `text`, `button`)
- Added comprehensive test to verify all platform modules declare `PARALLEL_UPDATES = 1`
- Updated quality scale audit documentation to reflect this requirement

This change aligns the integration with Home Assistant quality-scale requirements and correctly reflects the serialised single-connection Modbus I/O model used by the integration's `DeviceClient`. Setting `PARALLEL_UPDATES = 1` prevents Home Assistant from dispatching concurrent entity updates, which would violate the serialised I/O constraint.

## Maintainability checklist
- [x] This is a straightforward addition of a module-level constant to each platform module
- [x] No complex logic or refactoring involved
- [x] Changes are minimal and consistent across all modules
- [x] Added automated test coverage for the new requirement

## Validation
- [x] Added `tests/test_platform_parallel_updates.py` with parametrized test covering all 10 platform modules
- [x] Test verifies both presence and correct value (`== 1`) of `PARALLEL_UPDATES` on each module
- [x] Updated `docs/ha_quality_scale_audit.md` to document this requirement as PASS

## Notes
The test uses `importlib.import_module()` to dynamically verify each platform module at test time, ensuring the requirement is enforced going forward. This prevents accidental removal or incorrect values in future changes.

https://claude.ai/code/session_01AJWkfSuAcfWAiK49uMGq1c