### PR TITLE
Support both pre-2025.10 and current HA async_extract_entity_ids signatures

### DIFF
--- a/custom_components/thessla_green_modbus/services/helpers.py
+++ b/custom_components/thessla_green_modbus/services/helpers.py
@@ -2,33 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, cast
-
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers.service import async_extract_entity_ids
-
-
-def extract_entity_ids(hass: HomeAssistant, call: ServiceCall) -> set[str]:
-    """Return entity IDs from a service call."""
-    if not call.data.get("entity_id"):
-        return set()
-    return cast(set[str], async_extract_entity_ids(call))
-
-
-def iter_target_coordinators(
-    hass: HomeAssistant,
-    call: ServiceCall,
-    get_coordinator_from_entity_id: Callable[[HomeAssistant, str], Any],
-) -> list[tuple[str, Any]]:
-    """Resolve entity IDs to coordinator instances, skipping missing ones."""
-    targets: list[tuple[str, Any]] = []
-    for entity_id in extract_entity_ids(hass, call):
-        coordinator = get_coordinator_from_entity_id(hass, entity_id)
-        if coordinator is None:
-            continue
-        targets.append((entity_id, coordinator))
-    return targets
+from typing import Any
 
 
 def clamp_airflow_rate(coordinator: Any, airflow_rate: int) -> int:

--- a/custom_components/thessla_green_modbus/services/targets.py
+++ b/custom_components/thessla_green_modbus/services/targets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
+from functools import lru_cache
 from typing import Any, cast
 
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -17,6 +18,28 @@ __all__ = [
 ]
 
 
+@lru_cache(maxsize=32)
+def _extractor_needs_hass(extractor: Callable[..., Any]) -> bool:
+    """Detect whether `extractor` needs `hass` as its first argument.
+
+    HA's async_extract_entity_ids dropped the `hass` parameter in HA
+    2025.10; older cores still require `(hass, service_call)`. Inspected
+    once per extractor and cached, since the extractor is typically the
+    same function on every service call.
+    """
+    try:
+        parameters = inspect.signature(extractor).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    required_positional = [
+        p
+        for p in parameters
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        and p.default is inspect.Parameter.empty
+    ]
+    return len(required_positional) >= 2
+
+
 def extract_entity_ids(hass: HomeAssistant, call: ServiceCall) -> set[str]:
     """Return entity IDs from a service call."""
     from homeassistant.helpers.service import async_extract_entity_ids
@@ -28,13 +51,18 @@ def extract_entity_ids_with_extractor(
     hass: HomeAssistant,
     call: ServiceCall,
     *,
-    extractor: Callable[[Any], Any],
+    extractor: Callable[..., Any],
 ) -> set[str]:
-    """Return entity IDs from a service call using injectable extraction backend."""
+    """Return entity IDs from a service call using injectable extraction backend.
+
+    Compatible with both the pre-2025.10 HA signature
+    ``async_extract_entity_ids(hass, service_call)`` and the current
+    ``async_extract_entity_ids(service_call)`` signature.
+    """
     if not call.data.get("entity_id"):
         return set()
 
-    extracted = extractor(call)
+    extracted = extractor(hass, call) if _extractor_needs_hass(extractor) else extractor(call)
     if inspect.isawaitable(extracted):
         extracted.close()
         raw_ids = call.data.get("entity_id")

--- a/tests/test_services_handlers_targets.py
+++ b/tests/test_services_handlers_targets.py
@@ -271,6 +271,75 @@ def test_extract_entity_ids_with_extractor_no_hass_arg():
 
 
 # ---------------------------------------------------------------------------
+# extract_entity_ids_with_extractor — HA version compatibility (both
+# pre-2025.10 two-arg and current one-arg async_extract_entity_ids signatures)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_entity_ids_with_extractor_two_arg_signature():
+    """A legacy two-arg extractor (older HA) is called as extractor(hass, call)."""
+    from types import SimpleNamespace as NS
+
+    from custom_components.thessla_green_modbus.services.targets import (
+        extract_entity_ids_with_extractor,
+    )
+
+    received_args: list = []
+    hass = NS()
+
+    def legacy_extractor(hass_arg, service_call):
+        received_args.extend((hass_arg, service_call))
+        return set(service_call.data["entity_id"])
+
+    call = NS(data={"entity_id": ["sensor.one", "sensor.two"]})
+
+    result = extract_entity_ids_with_extractor(hass, call, extractor=legacy_extractor)
+
+    assert result == {"sensor.one", "sensor.two"}
+    assert received_args == [hass, call]
+
+
+def test_extract_entity_ids_with_extractor_one_arg_signature():
+    """A modern one-arg extractor (current HA) is called as extractor(call)."""
+    from types import SimpleNamespace as NS
+
+    from custom_components.thessla_green_modbus.services.targets import (
+        extract_entity_ids_with_extractor,
+    )
+
+    received_args: list = []
+
+    def modern_extractor(service_call):
+        received_args.append(service_call)
+        return set(service_call.data["entity_id"])
+
+    call = NS(data={"entity_id": ["sensor.three"]})
+
+    result = extract_entity_ids_with_extractor(NS(), call, extractor=modern_extractor)
+
+    assert result == {"sensor.three"}
+    assert received_args == [call]
+
+
+def test_extract_entity_ids_with_extractor_short_circuits_without_entity_id():
+    """Neither signature's extractor is invoked when entity_id is absent."""
+    from types import SimpleNamespace as NS
+
+    from custom_components.thessla_green_modbus.services.targets import (
+        extract_entity_ids_with_extractor,
+    )
+
+    def unreachable_extractor(*args, **kwargs):
+        raise AssertionError("extractor must not be called without entity_id")
+
+    call = NS(data={})
+
+    result = extract_entity_ids_with_extractor(NS(), call, extractor=unreachable_extractor)
+
+    assert result == set()
+
+
+# ---------------------------------------------------------------------------
 # _extract_entity_ids — line 121 (no entity_id key)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Added compatibility layer for Home Assistant's `async_extract_entity_ids` function signature change in HA 2025.10
- Pre-2025.10 versions require `(hass, service_call)` arguments; current versions only require `(service_call)`
- Implemented `_extractor_needs_hass()` helper with signature inspection and LRU caching to detect which signature an extractor uses
- Updated `extract_entity_ids_with_extractor()` to call the extractor with appropriate arguments based on detected signature
- Consolidated duplicate entity ID extraction logic by removing redundant code from `helpers.py` (functions now live in `targets.py`)
- Added comprehensive test coverage for both signatures and edge cases

## Maintainability checklist

- [x] Changed methods are small and focused (`_extractor_needs_hass` is ~20 lines, `extract_entity_ids_with_extractor` updated with 1 conditional)
- [x] Documented behavior compatibility in docstrings explaining both HA versions supported
- [x] Signature inspection is cached via `@lru_cache(maxsize=32)` to avoid repeated introspection per service call
- [x] Consolidated duplicate code by removing `extract_entity_ids()` and `iter_target_coordinators()` from `helpers.py` (they were duplicates of `targets.py` implementations)
- [x] Added 3 new unit tests covering: legacy two-arg signature, modern one-arg signature, and short-circuit behavior when entity_id is absent

## Validation

- Added unit tests: `test_extract_entity_ids_with_extractor_two_arg_signature()`, `test_extract_entity_ids_with_extractor_one_arg_signature()`, `test_extract_entity_ids_with_extractor_short_circuits_without_entity_id()`
- Tests verify correct argument passing for both HA versions and that extractors aren't invoked unnecessarily
- No breaking changes to public API; `extract_entity_ids_with_extractor()` signature unchanged

## Notes

- The `_extractor_needs_hass()` function uses `inspect.signature()` to detect required positional parameters, making it robust to different parameter naming conventions
- LRU caching ensures minimal performance impact; signature inspection happens once per unique extractor function
- Removed duplicate code from `helpers.py` that was already present in `targets.py`, improving maintainability

https://claude.ai/code/session_018SHt3N3EDAd7sYajW93CKo