### PR TITLE
Fix enum register read-back to match polling pipeline representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Targeted read-back now stores enum registers as raw ints, matching the polling
+  pipeline**: after a successful write to an enum-labelled holding register (e.g.
+  `mode`, `season_mode`, `special_mode`, `bypass_off`, `gwc_off`), the targeted
+  read-back applied `RegisterDef.decode()` directly, which stores the enum *label*
+  (e.g. `'manualny'`, `'ZIMA'`) into `coordinator.data`, while the regular polling
+  pipeline (`process_register_value`) stores the raw int for enum registers.  The
+  mismatched representation broke `switch.is_on` (a non-empty label string is truthy,
+  so a switch turned OFF displayed ON) and `select.current_option` (label not found
+  in the reverse option map → "unknown") until the next full poll.  The read-back
+  path now reverts enum-label decodes to the raw register value, exactly like the
+  polling pipeline.
+
 ### Internal
+
+- **Restored `pydantic==2.12.2` dev pin to match
+  `pytest-homeassistant-custom-component 0.13.309–0.13.316`** (all of which pin
+  `pydantic==2.12.2`).  The Dependabot bump to `pydantic==2.13.4` (#1708) made
+  `pip install -r requirements-dev.txt` fail with `ResolutionImpossible`, breaking
+  the CI install step on `main`.  Also corrected the stale comment in
+  `pyproject.toml` that claimed the plugin pins 2.13.4.
 
 - **Targeted read-back after successful single holding-register writes**: after a
   successful write to a safe single holding register, the coordinator now immediately

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -425,6 +425,16 @@ class _CoordinatorScheduleMixin:
         if _raw_readback is not None and _readback_definition is not None:
             try:
                 _decoded = _readback_definition.decode(_raw_readback)
+                if (
+                    getattr(_readback_definition, "enum", None) is not None
+                    and isinstance(_decoded, str)
+                    and isinstance(_raw_readback[0], int)
+                ):
+                    # The polling pipeline (process_register_value) stores raw
+                    # ints for enum registers, not labels; keep the same
+                    # representation so switch.is_on / select.current_option
+                    # don't break until the next full poll.
+                    _decoded = _raw_readback[0]
             except (ValueError, TypeError, KeyError, IndexError, ArithmeticError) as exc:
                 # The write itself already succeeded; a bad read-back decode
                 # must not turn a successful write into a failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,9 @@ dev = [
     "isort>=5.13.0",
     "ruff>=0.6.0",
     "mypy>=1.10.0",
-    # pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.13.4;
+    # pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.12.2;
     # keep in sync with requirements-dev.txt to avoid pip conflicts in CI.
-    "pydantic==2.13.4",
+    "pydantic==2.12.2",
     "pre-commit>=3.7.0",
     "types-PyYAML>=6.0.12",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ PyYAML>=6.0
 types-PyYAML>=6.0.12
 # pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.12.2.
 # Keep this in sync with the plugin's pinned pydantic version to avoid pip conflicts.
-pydantic==2.13.4
+pydantic==2.12.2
 
 # Code quality tools
 black>=24.4.0

--- a/tests/test_write_readback.py
+++ b/tests/test_write_readback.py
@@ -171,6 +171,56 @@ async def test_targeted_readback_uses_decoded_value_not_raw_request(coordinator)
 
 
 @pytest.mark.asyncio
+async def test_targeted_readback_enum_register_matches_poll_representation(coordinator) -> None:
+    """Read-back of an enum register stores the raw int, exactly like the poll cycle.
+
+    ``mode`` decodes to an enum label via RegisterDef.decode ('manualny'), but the
+    polling pipeline (process_register_value) reverts enum labels to the raw int.
+    Targeted read-back must store the same representation, otherwise switch.is_on /
+    select.current_option break until the next full poll.
+    """
+    from custom_components.thessla_green_modbus.core.register_processing import (
+        process_register_value,
+    )
+
+    coordinator._ensure_connection = AsyncMock()
+    client = MagicMock()
+    client.write_register = AsyncMock(return_value=_write_response(error=False))
+    client.read_holding_registers = AsyncMock(return_value=_read_response([1]))
+    coordinator.device_client.client = client
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.data = {"mode": 0}
+
+    result = await coordinator.async_write_register("mode", 1, refresh=True)
+
+    assert result is True
+    coordinator.async_request_refresh.assert_not_called()
+    assert coordinator.data["mode"] == process_register_value("mode", 1)
+    assert coordinator.data["mode"] == 1
+    assert not isinstance(coordinator.data["mode"], str)
+
+
+@pytest.mark.asyncio
+async def test_targeted_readback_special_mode_bitwise_compatible(coordinator) -> None:
+    """Read-back of special_mode stores an int usable in bit comparisons."""
+    coordinator._ensure_connection = AsyncMock()
+    client = MagicMock()
+    client.write_register = AsyncMock(return_value=_write_response(error=False))
+    client.read_holding_registers = AsyncMock(return_value=_read_response([2]))
+    coordinator.device_client.client = client
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.data = {"special_mode": 0}
+
+    result = await coordinator.async_write_register("special_mode", 2, refresh=True)
+
+    assert result is True
+    value = coordinator.data["special_mode"]
+    assert value == 2
+    # switch.is_on for special-mode bit switches compares value == bit
+    assert (value == 2) is True
+
+
+@pytest.mark.asyncio
 async def test_write_failure_returns_false_no_readback(coordinator) -> None:
     """Failed write must return False without attempting read-back."""
     coordinator._ensure_connection = AsyncMock()


### PR DESCRIPTION
## Summary

Fixed targeted read-back after successful writes to enum-labelled holding registers to store raw integers instead of enum labels, matching the representation used by the regular polling pipeline.

**Problem**: After writing to an enum register (e.g., `mode`, `season_mode`, `special_mode`), the targeted read-back applied `RegisterDef.decode()` directly, storing the enum *label* (e.g., `'manualny'`) into `coordinator.data`. However, the polling pipeline (`process_register_value`) stores the raw int for enum registers. This mismatch broke:
- `switch.is_on`: a non-empty label string is truthy, so a switch turned OFF displayed ON
- `select.current_option`: label not found in reverse option map → "unknown"

Both issues persisted until the next full poll cycle.

**Solution**: Modified `async_write_register()` in `coordinator/schedule.py` to detect when a decoded value is an enum label string and revert it to the raw register value, ensuring consistency with the polling pipeline's representation.

## Changes

- **coordinator/schedule.py**: Added logic to detect enum registers and revert label decodes to raw int values during targeted read-back
- **tests/test_write_readback.py**: Added two new test cases:
  - `test_targeted_readback_enum_register_matches_poll_representation`: Verifies enum registers store raw ints, not labels
  - `test_targeted_readback_special_mode_bitwise_compatible`: Verifies special_mode stores an int usable in bit comparisons
- **CHANGELOG.md**: Documented the fix and related dependency pin correction
- **pyproject.toml & requirements-dev.txt**: Corrected pydantic pin from 2.13.4 to 2.12.2 to match pytest-homeassistant-custom-component 0.13.309–0.13.316

## Maintainability checklist

- [x] Change is localized to a single conditional block in `async_write_register()`
- [x] Added comprehensive test coverage for the fix
- [x] Behavior is backward compatible (only affects the internal representation stored in coordinator.data)
- [x] No refactoring or large method changes

## Validation

- [x] New tests added and pass
- [x] Existing tests remain unaffected
- [x] Change is minimal and focused on the specific issue

## Notes

The fix ensures that the targeted read-back path produces the same data representation as the polling pipeline, preventing UI state inconsistencies between successful writes and the next full poll cycle.

https://claude.ai/code/session_01MQy4uhdMQgDxcp8MbgUgBG