### PR TITLE
Fix fan percentage GUI lag with optimistic pending value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fan percentage now updates in the GUI immediately after a successful airflow
+  write**: `fan.percentage` is derived from the status registers `supply_percentage` /
+  `exhaust_percentage`, but fan writes target the setpoint registers `mode`,
+  `air_flow_rate_manual`, and `air_flow_rate_temporary_2` and deliberately keep
+  `targeted_readback=False` (the setpoints are not 1:1 with the displayed status
+  registers).  The GUI therefore lagged one full poll interval behind the physical
+  device even though the write itself succeeded instantly.  The fan entity now keeps a
+  short-lived optimistic `_pending_percentage` (default 10 s TTL) that is set only
+  after a confirmed-successful airflow write and returned by `percentage`/`is_on` until
+  the status registers catch up.  The optimistic value is dropped as soon as a poll
+  reports `supply_percentage` / `exhaust_percentage` within 2 pp of the request, on
+  timeout, or on `turn_off`; it is never set when the write fails.  Targeted read-back
+  stays disabled for the fan write path and no second Modbus client/connection is
+  introduced.
+
 - **Targeted read-back now stores enum registers as raw ints, matching the polling
   pipeline**: after a successful write to an enum-labelled holding register (e.g.
   `mode`, `season_mode`, `special_mode`, `bypass_off`, `gwc_off`), the targeted

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from time import monotonic
 from typing import Any, ClassVar
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pymodbus.exceptions import ConnectionException, ModbusException
 
@@ -24,6 +25,18 @@ from .registers.maps import holding_registers
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
+
+# Transient optimistic display window: after a successful fan airflow write the
+# GUI shows the requested percentage for at most this many seconds, until the
+# supply_percentage / exhaust_percentage status registers catch up on the next
+# full poll.  Fan writes keep targeted_readback=False (the setpoint registers
+# are not 1:1 with the displayed status registers), so without this the GUI
+# would lag one poll interval behind the physical device.
+_PENDING_PERCENTAGE_TTL = 10.0
+# Once the confirmed supply/exhaust status registers land within this many
+# percentage points of the requested value, the optimistic value is dropped in
+# favour of the real device reading.
+_PENDING_PERCENTAGE_MATCH_TOLERANCE = 2
 
 
 async def async_setup_entry(
@@ -91,7 +104,26 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         # Speed range (0-150% as per ThesslaGreen specs)
         self._attr_speed_count = FAN_SPEED_LEVELS
 
+        # Transient optimistic percentage shown immediately after a successful
+        # airflow write, before the supply_percentage / exhaust_percentage
+        # status registers are refreshed by the next full poll.
+        self._pending_percentage: int | None = None
+        self._pending_percentage_ts: float = 0.0
+
         _LOGGER.debug("Initialized fan entity")
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Drop the optimistic pending percentage once real status catches up.
+
+        The coordinator notifies this entity on every poll (and on targeted
+        read-backs of other registers).  As soon as the confirmed
+        supply/exhaust status registers reflect the requested speed the
+        optimistic override is no longer needed, so it is cleared before the
+        normal state write.
+        """
+        self._clear_pending_if_confirmed()
+        super()._handle_coordinator_update()
 
     @property
     def available(self) -> bool:
@@ -109,7 +141,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
             return False
 
         # Check current flow rate
-        flow_rate = self._get_current_flow_rate()
+        flow_rate = self._effective_flow_rate()
         if flow_rate is None:
             return None
 
@@ -123,14 +155,87 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
         when max_percentage = 109).  HA FanEntity.percentage must stay in
         0–100; the raw device value is preserved in extra_state_attributes
         as ``supply_percentage``.
+
+        Immediately after a successful airflow write a short-lived optimistic
+        value is used (see ``_effective_flow_rate``) so the GUI reflects the
+        requested speed without waiting a full poll for the status registers.
         """
-        flow_rate = self._get_current_flow_rate()
+        flow_rate = self._effective_flow_rate()
         if flow_rate is None:
             return None
 
         _min_pct, max_pct = self._percentage_limits()
         raw_clamped = max(0, min(max_pct, int(flow_rate)))
         return min(100, raw_clamped)
+
+    def _effective_flow_rate(self) -> float | None:
+        """Return the optimistic pending percentage if fresh, else real status.
+
+        The pending value is only honoured while it is still within its TTL and
+        has not been superseded by a confirmed status reading; otherwise the
+        normal status/setpoint logic in ``_get_current_flow_rate`` applies.
+        """
+        pending = self._pending_percentage_value()
+        if pending is not None:
+            return float(pending)
+        return self._get_current_flow_rate()
+
+    def _pending_percentage_value(self) -> int | None:
+        """Return the transient pending percentage while it is still fresh.
+
+        The value is set optimistically right after a successful airflow write
+        so the GUI reflects the requested speed immediately.  It self-expires
+        after ``_PENDING_PERCENTAGE_TTL`` seconds; reading it after expiry also
+        clears it so later polls fall back to confirmed device state.
+        """
+        if self._pending_percentage is None:
+            return None
+        if monotonic() - self._pending_percentage_ts > _PENDING_PERCENTAGE_TTL:
+            self._pending_percentage = None
+            return None
+        return self._pending_percentage
+
+    def _confirmed_status_flow_rate(self) -> float | None:
+        """Return the device-reported percentage from status registers only.
+
+        Unlike ``_get_current_flow_rate`` this never falls back to setpoint
+        registers, so the optimistic pending value is only cleared once the
+        actual supply/exhaust status registers reflect the requested speed
+        (setpoint registers update on the very next poll and would otherwise
+        clear the override prematurely, defeating its purpose).
+        """
+        data = self.coordinator.data
+        for register in ("supply_percentage", "exhaust_percentage"):
+            value = data.get(register)
+            if value is not None and isinstance(value, int | float):
+                return float(value)
+        return None
+
+    def _clear_pending_if_confirmed(self) -> None:
+        """Clear the optimistic pending percentage once real status matches it."""
+        if self._pending_percentage is None:
+            return
+        confirmed = self._confirmed_status_flow_rate()
+        if (
+            confirmed is not None
+            and abs(confirmed - self._pending_percentage) <= _PENDING_PERCENTAGE_MATCH_TOLERANCE
+        ):
+            self._pending_percentage = None
+
+    def _set_pending_percentage(self, percentage: int) -> None:
+        """Record an optimistic percentage and push it to the GUI immediately.
+
+        Only called after a confirmed-successful airflow write.  ``percentage``
+        is the raw device value that was written (before the HA 0–100 clamp),
+        matching the units of supply_percentage / exhaust_percentage so the
+        confirmation comparison in ``_clear_pending_if_confirmed`` is valid.
+        """
+        self._pending_percentage = percentage
+        self._pending_percentage_ts = monotonic()
+        # ``hass`` is None in unit tests (entity not added to a platform); the
+        # optimistic state is still stored and returned by ``percentage``.
+        if self.hass is not None:
+            self.async_write_ha_state()
 
     def _get_current_flow_rate(self) -> float | None:
         """Get current percentage-based flow rate from available registers.
@@ -191,6 +296,10 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
+        # Drop any optimistic speed override: turning off must never leave the
+        # GUI showing a stale non-zero percentage.  is_on already reflects the
+        # off state via on_off_panel_mode below.
+        self._pending_percentage = None
         try:
             if self._is_writable_holding_register("on_off_panel_mode"):
                 # If system power control is available, use it to turn off.
@@ -252,6 +361,7 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                     wrote_manual = True
                 if wrote_manual:
                     await self.coordinator.async_request_refresh()
+                    self._set_pending_percentage(actual_percentage)
             else:
                 # Temporary mode - must use 3-register write block
                 if current_mode == "temporary":
@@ -261,9 +371,11 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                     if not success:
                         raise RuntimeError("Failed to write temporary airflow block")
                     await self.coordinator.async_request_refresh()
+                    self._set_pending_percentage(actual_percentage)
                     return
                 if self._is_writable_holding_register("air_flow_rate_temporary_2"):
                     await self._write_register("air_flow_rate_temporary_2", actual_percentage)
+                    self._set_pending_percentage(actual_percentage)
 
             _LOGGER.debug("Set fan speed to %d%%", actual_percentage)
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -389,3 +389,209 @@ def test_fan_turn_off_single_refresh(mock_coordinator):
     fan = ThesslaGreenFan(mock_coordinator)
     asyncio.run(fan.async_turn_off())
     mock_coordinator.async_request_refresh.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Optimistic pending-percentage tests (GUI latency fix)
+#
+# fan.percentage reads status registers (supply_percentage / exhaust_percentage)
+# while writes target setpoint registers (mode / air_flow_rate_manual /
+# air_flow_rate_temporary_2) with targeted_readback=False.  After a successful
+# write the GUI would otherwise lag one full poll interval, so the entity keeps a
+# short-lived optimistic value.  See fan.ThesslaGreenFan._set_pending_percentage.
+# ---------------------------------------------------------------------------
+
+
+def _manual_mode_coordinator(mock_coordinator, *, supply_percentage=50):
+    """Configure the mock coordinator for a manual-mode airflow write."""
+    mock_coordinator.data["mode"] = 1  # manual
+    mock_coordinator.data["supply_percentage"] = supply_percentage
+    mock_coordinator.data["on_off_panel_mode"] = 1
+    mock_coordinator.async_request_refresh = AsyncMock()
+    return mock_coordinator
+
+
+def test_fan_write_success_sets_pending_percentage(mock_coordinator):
+    """A successful airflow write records the requested percentage optimistically."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    mock_coordinator.async_write_register = AsyncMock(return_value=True)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    asyncio.run(fan.async_set_percentage(80))
+
+    assert fan._pending_percentage == 80  # nosec B101
+
+
+def test_fan_percentage_returns_pending_before_refresh(mock_coordinator):
+    """percentage returns the optimistic value even while status still reads stale."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    mock_coordinator.async_write_register = AsyncMock(return_value=True)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    # Before the write the GUI reflects the stale status register.
+    assert fan.percentage == 50  # nosec B101
+
+    asyncio.run(fan.async_set_percentage(80))
+
+    # supply_percentage is still 50 (no poll yet), but the GUI shows 80.
+    assert mock_coordinator.data["supply_percentage"] == 50  # nosec B101
+    assert fan.percentage == 80  # nosec B101
+    assert fan.is_on is True  # nosec B101
+
+
+def test_fan_pending_percentage_expires_after_timeout(mock_coordinator, monkeypatch):
+    """Once the TTL elapses the optimistic value is dropped for confirmed status."""
+    from custom_components.thessla_green_modbus import fan as fan_module
+
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    mock_coordinator.async_write_register = AsyncMock(return_value=True)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(fan_module, "monotonic", lambda: clock["now"])
+
+    fan = ThesslaGreenFan(mock_coordinator)
+    asyncio.run(fan.async_set_percentage(80))
+    assert fan.percentage == 80  # nosec B101
+
+    # Advance the monotonic clock beyond the TTL window.
+    clock["now"] += fan_module._PENDING_PERCENTAGE_TTL + 1
+    assert fan.percentage == 50  # falls back to confirmed status  # nosec B101
+    assert fan._pending_percentage is None  # expiry also clears the value  # nosec B101
+
+
+def test_fan_pending_percentage_not_set_on_write_failure(mock_coordinator):
+    """A failed write must not leave an optimistic value behind."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    mock_coordinator.async_write_register = AsyncMock(return_value=False)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(fan.async_set_percentage(80))
+
+    assert fan._pending_percentage is None  # nosec B101
+    # GUI keeps showing the real device state, never the un-written value.
+    assert fan.percentage == 50  # nosec B101
+
+
+def test_fan_pending_cleared_when_status_confirms(mock_coordinator):
+    """A poll whose status registers reflect the request drops the optimistic value."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    mock_coordinator.async_write_register = AsyncMock(return_value=True)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    asyncio.run(fan.async_set_percentage(80))
+    assert fan.percentage == 80  # nosec B101
+
+    # Next poll lands with status registers reflecting the new speed.
+    mock_coordinator.data["supply_percentage"] = 80
+    fan._clear_pending_if_confirmed()
+    assert fan._pending_percentage is None  # nosec B101
+
+    # From now on the GUI follows confirmed device status again.
+    mock_coordinator.data["supply_percentage"] = 60
+    assert fan.percentage == 60  # nosec B101
+
+
+def test_fan_pending_not_cleared_while_status_still_ramping(mock_coordinator):
+    """A poll whose status has not yet reached the request keeps the optimistic value."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    mock_coordinator.async_write_register = AsyncMock(return_value=True)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    asyncio.run(fan.async_set_percentage(80))
+
+    # Device is still ramping (55 %); the optimistic 80 % must stand.
+    mock_coordinator.data["supply_percentage"] = 55
+    fan._clear_pending_if_confirmed()
+    assert fan._pending_percentage == 80  # nosec B101
+    assert fan.percentage == 80  # nosec B101
+
+
+def test_fan_turn_off_clears_pending_percentage(mock_coordinator):
+    """Turning the fan off drops any optimistic speed override."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    mock_coordinator.async_write_register = AsyncMock(return_value=True)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    asyncio.run(fan.async_set_percentage(80))
+    assert fan._pending_percentage == 80  # nosec B101
+
+    asyncio.run(fan.async_turn_off())
+    assert fan._pending_percentage is None  # nosec B101
+    assert fan.is_on is False  # nosec B101
+
+
+def test_fan_manual_write_keeps_targeted_readback_disabled(mock_coordinator):
+    """mode + air_flow_rate_manual writes must pass targeted_readback=False."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    write_kwargs: list[tuple[str, dict]] = []
+
+    async def _fake_write(register_name, value, **kwargs):
+        write_kwargs.append((register_name, kwargs))
+        return True
+
+    mock_coordinator.async_write_register = AsyncMock(side_effect=_fake_write)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    asyncio.run(fan.async_set_percentage(80))
+
+    assert [name for name, _ in write_kwargs] == ["mode", "air_flow_rate_manual"]  # nosec B101
+    for _name, kwargs in write_kwargs:
+        assert kwargs.get("targeted_readback") is False  # nosec B101
+        assert kwargs.get("refresh") is False  # nosec B101
+
+
+def test_fan_no_setpoint_write_enables_targeted_readback(mock_coordinator, monkeypatch):
+    """No fan setpoint write path may enable generic targeted read-back.
+
+    Covers the auto-mode air_flow_rate_temporary_2 branch in addition to the
+    manual mode + air_flow_rate_manual writes.
+    """
+    from custom_components.thessla_green_modbus import fan as fan_module
+
+    mock_coordinator.data["mode"] = 0  # auto -> temporary_2 branch
+    mock_coordinator.data["supply_percentage"] = 50
+    mock_coordinator.device_client.available_registers["holding_registers"].add(
+        "air_flow_rate_temporary_2"
+    )
+    mock_coordinator.async_request_refresh = AsyncMock()
+
+    write_kwargs: list[dict] = []
+
+    async def _fake_write(register_name, value, **kwargs):
+        write_kwargs.append(kwargs)
+        return True
+
+    mock_coordinator.async_write_register = AsyncMock(side_effect=_fake_write)
+
+    original = fan_module.holding_registers()
+    patched = {**original, "air_flow_rate_temporary_2": 999}
+    monkeypatch.setattr(fan_module, "holding_registers", lambda: patched)
+
+    fan = ThesslaGreenFan(mock_coordinator)
+    asyncio.run(fan.async_set_percentage(70))
+
+    assert write_kwargs, "expected at least one setpoint write"  # nosec B101
+    for kwargs in write_kwargs:
+        assert kwargs.get("targeted_readback") is False  # nosec B101
+
+
+def test_fan_mode_enum_write_does_not_engage_readback(mock_coordinator):
+    """Regression guard for #1730: fan writes to the enum 'mode' register never
+    trigger the coordinator's raw-int targeted read-back path (targeted_readback
+    stays False), so enum raw-int handling remains solely a coordinator concern.
+    """
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    captured: dict[str, dict] = {}
+
+    async def _fake_write(register_name, value, **kwargs):
+        captured[register_name] = kwargs
+        return True
+
+    mock_coordinator.async_write_register = AsyncMock(side_effect=_fake_write)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    asyncio.run(fan.async_set_percentage(80))
+
+    assert "mode" in captured  # nosec B101
+    assert captured["mode"].get("targeted_readback") is False  # nosec B101


### PR DESCRIPTION
## Summary

The fan entity's `percentage` property is derived from status registers (`supply_percentage`/`exhaust_percentage`), but fan writes target setpoint registers (`mode`, `air_flow_rate_manual`, `air_flow_rate_temporary_2`) with `targeted_readback=False` (since setpoints are not 1:1 with displayed status). This caused the GUI to lag one full poll interval behind the physical device even though writes succeeded instantly.

This change introduces a short-lived optimistic `_pending_percentage` value that is set only after a confirmed-successful airflow write and returned by `percentage`/`is_on` until the status registers catch up. The optimistic value:
- Is set immediately after a successful write
- Has a 10-second TTL (configurable via `_PENDING_PERCENTAGE_TTL`)
- Is dropped when status registers report within 2 percentage points of the request
- Is cleared on timeout or `turn_off`
- Is never set when a write fails
- Does not introduce targeted read-back or additional Modbus connections

## Changes

**fan.py**:
- Added `_pending_percentage` and `_pending_percentage_ts` instance variables to track optimistic state
- Added `_handle_coordinator_update()` callback to clear pending value when real status catches up
- Renamed `_get_current_flow_rate()` usage to `_effective_flow_rate()` in `is_on` and `percentage` properties
- Implemented `_effective_flow_rate()` to return pending value if fresh, else real status
- Implemented `_pending_percentage_value()` to handle TTL expiry
- Implemented `_confirmed_status_flow_rate()` to read only status registers (not setpoints)
- Implemented `_clear_pending_if_confirmed()` to drop optimistic value once status matches
- Implemented `_set_pending_percentage()` to record optimistic value and push state to HA
- Updated `async_turn_off()` to clear pending percentage
- Updated `async_set_percentage()` to call `_set_pending_percentage()` after successful writes

**tests/test_fan.py**:
- Added 9 comprehensive unit tests covering:
  - Optimistic value set on successful write
  - Percentage returns pending before refresh
  - Pending value expiry after TTL
  - No pending value on write failure
  - Pending cleared when status confirms
  - Pending retained while status still ramping
  - Pending cleared on turn_off
  - `targeted_readback=False` maintained for all setpoint writes
  - Enum register write handling

**CHANGELOG.md**:
- Documented the fix with implementation details

## Maintainability

- New methods are focused and well-documented
- No changes to existing method signatures or public contracts
- Optimistic state is internal (`_pending_percentage`); no API changes
- All writes continue to use `targeted_readback=False` as before
- Test coverage is comprehensive (9 new tests, 120+ lines)

## Validation

- Added 9 unit tests covering all code paths and edge cases
- Existing tests remain unaffected
- No changes to public API or coordinator interaction patterns
- Optimistic state is transparent to HA (only affects internal `percentage` calculation)

## Notes

The implementation is conservative: the optimistic value is only used for display (`percentage`/`is_on`) and is immediately dropped if any of the following occur:
1. Status registers report within tolerance (device caught up)
2. TTL expires (10 seconds)
3. Fan is turned off
4. Write fails (pending never set)

This ensures the GUI never shows stale data and falls back to confirmed device state gracefully.

https://claude.ai/code/session_0112svgkRzhL7P8mAcL7ggPe