### PR TITLE
Fix fan percentage GUI update ordering: publish optimistic value before refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fan optimistic percentage is now published before the post-write refresh, not
+  after**: `async_set_percentage` set `_pending_percentage` (which writes the HA state)
+  only *after* awaiting `coordinator.async_request_refresh()`, so the optimistic GUI
+  update from the previous fix was delayed until the full refresh completed. The
+  ordering is now inverted for both the manual and temporary write paths — the pending
+  value is recorded and pushed to the GUI immediately after the confirmed-successful
+  airflow write, then the refresh is awaited to reconcile against the real
+  `supply_percentage` / `exhaust_percentage` status registers. Write failures still set
+  no pending value and fire no refresh; targeted read-back stays disabled for fan writes.
+
 - **Fan percentage now updates in the GUI immediately after a successful airflow
   write**: `fan.percentage` is derived from the status registers `supply_percentage` /
   `exhaust_percentage`, but fan writes target the setpoint registers `mode`,

--- a/custom_components/thessla_green_modbus/fan.py
+++ b/custom_components/thessla_green_modbus/fan.py
@@ -360,8 +360,12 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                     )
                     wrote_manual = True
                 if wrote_manual:
-                    await self.coordinator.async_request_refresh()
+                    # Push the optimistic percentage to the GUI *before* the
+                    # full refresh so the displayed speed updates immediately;
+                    # the refresh then reconciles it against the confirmed
+                    # supply/exhaust status registers.
                     self._set_pending_percentage(actual_percentage)
+                    await self.coordinator.async_request_refresh()
             else:
                 # Temporary mode - must use 3-register write block
                 if current_mode == "temporary":
@@ -370,12 +374,18 @@ class ThesslaGreenFan(ThesslaGreenEntity, FanEntity):
                     )
                     if not success:
                         raise RuntimeError("Failed to write temporary airflow block")
-                    await self.coordinator.async_request_refresh()
+                    # Optimistic GUI update before the refresh (see manual branch).
                     self._set_pending_percentage(actual_percentage)
+                    await self.coordinator.async_request_refresh()
                     return
                 if self._is_writable_holding_register("air_flow_rate_temporary_2"):
-                    await self._write_register("air_flow_rate_temporary_2", actual_percentage)
+                    # Skip the per-write refresh so the optimistic percentage is
+                    # published before the (single, caller-controlled) refresh.
+                    await self._write_register(
+                        "air_flow_rate_temporary_2", actual_percentage, refresh=False
+                    )
                     self._set_pending_percentage(actual_percentage)
+                    await self.coordinator.async_request_refresh()
 
             _LOGGER.debug("Set fan speed to %d%%", actual_percentage)
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -595,3 +595,150 @@ def test_fan_mode_enum_write_does_not_engage_readback(mock_coordinator):
 
     assert "mode" in captured  # nosec B101
     assert captured["mode"].get("targeted_readback") is False  # nosec B101
+
+
+# ---------------------------------------------------------------------------
+# Ordering: optimistic percentage must be published *before* the full refresh
+# (regression for the #1731 follow-up GUI-latency fix).  fan.percentage must
+# reflect the requested speed the instant the airflow write confirms, without
+# waiting for coordinator.async_request_refresh() to complete.
+# ---------------------------------------------------------------------------
+
+
+async def test_fan_manual_pending_set_before_refresh(mock_coordinator):
+    """Manual mode records the optimistic value before awaiting the refresh."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    events: list[str] = []
+
+    async def _fake_write(register_name, value, **kwargs):
+        return True
+
+    async def _fake_refresh():
+        # By the time the refresh runs the optimistic value must already be live.
+        events.append(f"refresh:pending={fan._pending_percentage}")
+
+    mock_coordinator.async_write_register = AsyncMock(side_effect=_fake_write)
+    mock_coordinator.async_request_refresh = AsyncMock(side_effect=_fake_refresh)
+
+    fan = ThesslaGreenFan(mock_coordinator)
+    await fan.async_set_percentage(80)
+
+    # The refresh observed the pending value already set: ordering is correct.
+    assert events == ["refresh:pending=80"]  # nosec B101
+
+
+async def test_fan_temporary_pending_set_before_refresh(mock_coordinator):
+    """Temporary mode uses the same set-pending-before-refresh ordering."""
+    mock_coordinator.data["mode"] = 2  # temporary
+    mock_coordinator.data["supply_percentage"] = 50
+    mock_coordinator.data["on_off_panel_mode"] = 1
+    events: list[str] = []
+
+    async def _fake_temp(airflow, **kwargs):
+        events.append("write")
+        return True
+
+    async def _fake_refresh():
+        events.append(f"refresh:pending={fan._pending_percentage}")
+
+    mock_coordinator.async_write_temporary_airflow = AsyncMock(side_effect=_fake_temp)
+    mock_coordinator.async_request_refresh = AsyncMock(side_effect=_fake_refresh)
+
+    fan = ThesslaGreenFan(mock_coordinator)
+    await fan.async_set_percentage(70)
+
+    assert events == ["write", "refresh:pending=70"]  # nosec B101
+
+
+async def test_fan_percentage_is_pending_before_refresh_completes(mock_coordinator):
+    """fan.percentage returns 80 while the refresh is still blocked mid-flight.
+
+    A real ``async_request_refresh`` can take a full poll interval; the GUI must
+    not wait for it.  Here the refresh parks on an ``asyncio.Event`` and we assert
+    the optimistic value is already live before the event is released.
+    """
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    release = asyncio.Event()
+    refresh_started = asyncio.Event()
+
+    async def _blocking_refresh():
+        refresh_started.set()
+        await release.wait()
+
+    mock_coordinator.async_write_register = AsyncMock(return_value=True)
+    mock_coordinator.async_request_refresh = AsyncMock(side_effect=_blocking_refresh)
+
+    fan = ThesslaGreenFan(mock_coordinator)
+    task = asyncio.create_task(fan.async_set_percentage(80))
+
+    # Wait until async_set_percentage is parked inside the (blocked) refresh.
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+
+    # The write has completed but the refresh has NOT: the GUI already shows 80
+    # even though the confirmed status register is still the stale 50.
+    assert mock_coordinator.data["supply_percentage"] == 50  # nosec B101
+    assert fan.percentage == 80  # nosec B101
+    assert fan.is_on is True  # nosec B101
+
+    # Releasing the refresh lets async_set_percentage finish cleanly.
+    release.set()
+    await asyncio.wait_for(task, timeout=1)
+    assert fan.percentage == 80  # nosec B101
+
+
+async def test_fan_temporary_percentage_is_pending_before_refresh_completes(mock_coordinator):
+    """Temporary mode also shows the optimistic value before the refresh returns."""
+    mock_coordinator.data["mode"] = 2  # temporary
+    mock_coordinator.data["supply_percentage"] = 50
+    mock_coordinator.data["on_off_panel_mode"] = 1
+    release = asyncio.Event()
+    refresh_started = asyncio.Event()
+
+    async def _blocking_refresh():
+        refresh_started.set()
+        await release.wait()
+
+    mock_coordinator.async_write_temporary_airflow = AsyncMock(return_value=True)
+    mock_coordinator.async_request_refresh = AsyncMock(side_effect=_blocking_refresh)
+
+    fan = ThesslaGreenFan(mock_coordinator)
+    task = asyncio.create_task(fan.async_set_percentage(70))
+
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+
+    assert mock_coordinator.data["supply_percentage"] == 50  # nosec B101
+    assert fan.percentage == 70  # nosec B101
+
+    release.set()
+    await asyncio.wait_for(task, timeout=1)
+    assert fan.percentage == 70  # nosec B101
+
+
+async def test_fan_manual_write_failure_skips_refresh_and_pending(mock_coordinator):
+    """A failed airflow write sets no optimistic value and never fires a refresh."""
+    _manual_mode_coordinator(mock_coordinator, supply_percentage=50)
+    mock_coordinator.async_write_register = AsyncMock(return_value=False)
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    with pytest.raises(RuntimeError):
+        await fan.async_set_percentage(80)
+
+    assert fan._pending_percentage is None  # nosec B101
+    assert fan.percentage == 50  # stays on confirmed device status  # nosec B101
+    mock_coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_fan_temporary_write_failure_skips_refresh_and_pending(mock_coordinator):
+    """A failed temporary-block write sets no optimistic value and skips refresh."""
+    mock_coordinator.data["mode"] = 2  # temporary
+    mock_coordinator.data["supply_percentage"] = 50
+    mock_coordinator.data["on_off_panel_mode"] = 1
+    mock_coordinator.async_write_temporary_airflow = AsyncMock(return_value=False)
+    mock_coordinator.async_request_refresh = AsyncMock()
+    fan = ThesslaGreenFan(mock_coordinator)
+
+    with pytest.raises(RuntimeError):
+        await fan.async_set_percentage(70)
+
+    assert fan._pending_percentage is None  # nosec B101
+    mock_coordinator.async_request_refresh.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixed a regression where the optimistic fan percentage update was delayed until after the full coordinator refresh completed, defeating the purpose of the previous GUI-latency fix. The ordering is now inverted: `_pending_percentage` is set and published to the GUI immediately after a successful airflow write, then `async_request_refresh()` is awaited to reconcile against the confirmed device status registers.

**Changes:**
- In `async_set_percentage()`, moved `self._set_pending_percentage()` calls to execute *before* `await self.coordinator.async_request_refresh()` for both manual and temporary write paths
- For temporary mode with the `air_flow_rate_temporary_2` register, added `refresh=False` parameter to the per-write call so the optimistic value is published before the single caller-controlled refresh
- Write failures continue to set no pending value and fire no refresh; targeted read-back remains disabled for fan writes

## Maintainability checklist

- [x] Change is localized to fan percentage write logic; no large refactors
- [x] Behavior is backward-compatible; only the timing of state updates changes
- [x] Added comprehensive test coverage for the ordering guarantee

## Validation

- [x] Added 6 new regression tests covering:
  - Manual mode: optimistic value set before refresh starts
  - Temporary mode: optimistic value set before refresh starts
  - Manual mode: percentage reflects pending value while refresh is blocked
  - Temporary mode: percentage reflects pending value while refresh is blocked
  - Manual mode: failed write skips refresh and pending value
  - Temporary mode: failed write skips refresh and pending value
- [x] Tests verify the critical ordering invariant: `fan.percentage` returns the optimistic value before `async_request_refresh()` completes

## Notes

This is a follow-up fix to the previous GUI-latency improvement. The issue was that while the write succeeded immediately, the GUI state wasn't updated until the refresh completed (which can take a full poll interval). Now the optimistic value is published right after the write confirms, giving instant visual feedback while the refresh reconciles against the real device status in the background.

https://claude.ai/code/session_01XdtehWZAXBGUR8mrUFZpPb