### PR TITLE
release: v2.8.1 (manifest version bump + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-07-06
+
+> Enum targeted read-back representation fix and fan percentage GUI responsiveness.
+> No Modbus register addresses, register/entity/unique/service IDs, or translation
+> keys changed. Real-device validation for the fan GUI path is still required.
+
 ### Fixed
 
 - **Fan optimistic percentage is now published before the post-write refresh, not
-  after**: `async_set_percentage` set `_pending_percentage` (which writes the HA state)
+  after** ([#1732](https://github.com/blakinio/thesslagreen/pull/1732)):
+  `async_set_percentage` set `_pending_percentage` (which writes the HA state)
   only *after* awaiting `coordinator.async_request_refresh()`, so the optimistic GUI
   update from the previous fix was delayed until the full refresh completed. The
   ordering is now inverted for both the manual and temporary write paths — the pending
@@ -20,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no pending value and fire no refresh; targeted read-back stays disabled for fan writes.
 
 - **Fan percentage now updates in the GUI immediately after a successful airflow
-  write**: `fan.percentage` is derived from the status registers `supply_percentage` /
+  write** ([#1731](https://github.com/blakinio/thesslagreen/pull/1731)):
+  `fan.percentage` is derived from the status registers `supply_percentage` /
   `exhaust_percentage`, but fan writes target the setpoint registers `mode`,
   `air_flow_rate_manual`, and `air_flow_rate_temporary_2` and deliberately keep
   `targeted_readback=False` (the setpoints are not 1:1 with the displayed status
@@ -35,7 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   introduced.
 
 - **Targeted read-back now stores enum registers as raw ints, matching the polling
-  pipeline**: after a successful write to an enum-labelled holding register (e.g.
+  pipeline** ([#1730](https://github.com/blakinio/thesslagreen/pull/1730)):
+  after a successful write to an enum-labelled holding register (e.g.
   `mode`, `season_mode`, `special_mode`, `bypass_off`, `gwc_off`), the targeted
   read-back applied `RegisterDef.decode()` directly, which stores the enum *label*
   (e.g. `'manualny'`, `'ZIMA'`) into `coordinator.data`, while the regular polling
@@ -45,6 +54,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the reverse option map → "unknown") until the next full poll.  The read-back
   path now reverts enum-label decodes to the raw register value, exactly like the
   polling pipeline.
+
+### Known limitations
+
+- **Fan pending percentage ordering — real-device validation still required**: the
+  optimistic `_pending_percentage` publish/refresh ordering
+  ([#1730](https://github.com/blakinio/thesslagreen/pull/1730),
+  [#1731](https://github.com/blakinio/thesslagreen/pull/1731),
+  [#1732](https://github.com/blakinio/thesslagreen/pull/1732)) has so far only been
+  validated against unit tests and mocked coordinators. On real AirPack4 hardware the
+  post-write `supply_percentage` / `exhaust_percentage` status registers may settle on a
+  different cadence than the mocks assume; if the fan slider still snaps back or lags after
+  a write on a physical device, the pending-value TTL and the ±2 pp reconciliation threshold
+  in `fan.py` may need further tuning. Tracked as a follow-up in
+  `docs/real_device_validation.md`.
 
 ### Internal
 

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -26,7 +26,7 @@
   "requirements": [
     "pymodbus>=3.6.0,<4.0"
   ],
-  "version": "2.8.0",
+  "version": "2.8.1",
   "zeroconf": [
     {
       "type": "_modbus._tcp.local.",


### PR DESCRIPTION
## Summary
- [x] Explain what changed and why.

Home Assistant / HACS was still showing **2.8.0** after PRs #1730, #1731 and #1732 merged, because `manifest.json` was never bumped. HACS/HA only surface a new integration version when the manifest version changes and a matching GitHub tag/release exists.

This release-only PR:
- Bumps `custom_components/thessla_green_modbus/manifest.json` version `2.8.0` → `2.8.1`.
- Dates the accumulated `[Unreleased]` CHANGELOG block as `## [2.8.1] - 2026-07-06` and adds a fresh empty `[Unreleased]` placeholder.
- Adds PR reference links to the three highlighted fixes:
  - #1730 — enum targeted read-back now stores raw int, matching the polling pipeline.
  - #1731 — fan GUI latency fix with optimistic pending percentage.
  - #1732 — fan optimistic percentage published before the post-write refresh.
- Adds a **Known limitations** note: fan pending-percentage ordering still needs real-device validation (tracked in `docs/real_device_validation.md`).

No runtime code changed — this is a version/changelog-only release PR.

## Maintainability checklist (required for large refactors)
- [x] N/A — no code refactor; only `manifest.json` version and `CHANGELOG.md`.

## Validation
- [x] `ruff check custom_components tests tools` — All checks passed
- [x] `ruff check --select I custom_components tests tools` — All checks passed
- [x] `ruff format --check custom_components tests tools` — 450 files already formatted
- [x] `python -m compileall -q custom_components/thessla_green_modbus tests tools` — OK
- [x] `python tools/check_maintainability.py` — Maintainability gate passed
- [x] `python tools/validate_entity_mappings.py` — OK: 367 entities validated
- [x] `python tools/check_translations.py` — All translation keys present
- [ ] `pytest ...` — **not runnable in this sandbox (Python 3.11; test stack requires 3.13).** Needs CI verification on Python 3.13.

## Notes
- After merge, create the GitHub release/tag **`v2.8.1`** on `main` so HACS/HA pick up the new version.
- Rules self-audit: no Modbus register addresses/names, entity IDs, unique IDs, service IDs, or translation keys changed; no config/options flow behavior changed; no unrelated refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTqQrEqgzk3Q2iBHCQu3Ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTqQrEqgzk3Q2iBHCQu3Ak)_