### PR TITLE
docs: add architecture documentation (file inventory, runtime flow, write path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- **Added architecture / file-inventory documentation** under `docs/architecture/`:
+  `file_inventory.md` (per-file ownership, risk level, and do-not-change warnings),
+  `runtime_flow.md` (config-flow scan, DeviceClient ownership, coordinator/entity
+  setup, polling, service registration, unload/reload, real-device validation
+  expectations), and `write_path.md` (HA entity → Modbus write, targeted read-back
+  rules, full-refresh fallback, why fan/climate disable read-back, and optimistic-UI
+  policy). Docs-only; no runtime code, register addresses/names, entity/unique/service
+  IDs, or translation keys changed. Linked from the README documentation list.
+
 ## [2.8.1] - 2026-07-06
 
 > Enum targeted read-back representation fix and fan percentage GUI responsiveness.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ logger:
 ## Dokumentacja dodatkowa
 
 - [Architektura docelowa](docs/thesslagreen_architecture.md)
+- [Inwentarz plików (architektura)](docs/architecture/file_inventory.md)
+- [Przepływ runtime (architektura)](docs/architecture/runtime_flow.md)
+- [Ścieżka zapisu i read-back (architektura)](docs/architecture/write_path.md)
 - [Wytyczne refaktoryzacji](docs/thesslagreen_guidelines.md)
 - [Status refaktoryzacji](docs/refactor_status.md)
 - [Changelog](CHANGELOG.md)

--- a/docs/architecture/file_inventory.md
+++ b/docs/architecture/file_inventory.md
@@ -1,0 +1,113 @@
+# File inventory — thessla_green_modbus
+
+Concise map of what each important file/folder owns and how risky it is to change.
+Read this **before** editing, so a change does not silently break existing user
+installations.
+
+> **Hard invariants (from `CLAUDE.md`).** Never change Modbus register
+> addresses/names, entity IDs, unique IDs, service IDs, or translation keys — they
+> are public contracts. Do not change config/options-flow behaviour, reintroduce
+> `modbus_helpers.py`, or break layer isolation
+> (`transport/ core/ scanner/ registers/ modbus/` must not import Home Assistant
+> outside `TYPE_CHECKING`, nor import from `coordinator/`/platforms). Do not touch
+> the `{16, 8192}` batch boundaries in `const.py`.
+
+Layering (allowed dependency direction, top → bottom):
+
+```text
+HA platforms → coordinator/ → core/ → registers/ + scanner/ → transport/
+```
+
+Risk legend: **🟥 high** (public contract / device I/O / write path),
+**🟧 medium** (behaviour-shaping logic), **🟩 low** (isolated, well-tested, or docs).
+
+## Integration entry point & lifecycle
+
+| Path | Role | Kind | When to change | Risk | Related tests/tools | Notes / do-not-change |
+|---|---|---|---|---|---|---|
+| `__init__.py` | HA `async_setup_entry` / `async_unload_entry` / `async_update_options` / `async_migrate_entry`; wires coordinator, mappings, unique-id migration, platforms, clock sync, services. | Runtime | Only for lifecycle wiring changes. | 🟥 | `tests/test_init*.py`, `test_setup*` | Options update does a **full reload** on purpose. Services registered only for the first entry, unloaded on the last. |
+| `_setup.py` | Setup helpers: build coordinator, start/first-refresh, load mappings/options, migrate unique IDs, forward platform setup. | Runtime | With lifecycle changes. | 🟥 | `tests/test_setup*.py` | Translates connect/auth errors into `ConfigEntryNotReady`/reauth. |
+| `_migrations.py`, `_entry_migrations.py` | Config-entry schema migrations. | Runtime | Only when bumping entry version. | 🟧 | `tests/test_migrations*.py` | Never rewrite historical migration steps. |
+| `manifest.json` | HA integration manifest (domain, version, `quality_scale`, `pymodbus>=3.6,<4.0`, discovery). | Runtime | Version bumps, deps, discovery. | 🟥 | `hassfest` (CI) | Do **not** raise `quality_scale` above `bronze` until real-device validation is PASS. Keep pymodbus pin `<4.0`. |
+| `const.py` | Domain, `PLATFORMS`, config keys/defaults, batch boundaries, maps. | Runtime | New config keys/defaults. | 🟥 | `tests/test_const*.py` | Do **not** change `{16, 8192}` batch boundaries or `DOMAIN`. |
+| `utils.py`, `protocols.py`, `capability_rules.py`, `error_*.py`, `errors.py` | Shared helpers, typing protocols, capability gating, error contracts. | Runtime | Rarely. | 🟧 | related unit tests | Error-classification contracts are relied on by callers; grep call sites first. |
+| `repairs.py` | HA repairs issues. | Runtime | New repair flows. | 🟩 | `tests/test_repairs.py` | — |
+
+## HA platforms (entities)
+
+| Path | Role | Kind | When to change | Risk | Related tests/tools | Notes / do-not-change |
+|---|---|---|---|---|---|---|
+| `entity.py` | `ThesslaGreenEntity` base: `unique_id`, `suggested_object_id`, `available`, `_write_register`. | Runtime | Base entity behaviour. | 🟥 | `tests/test_write_readback.py`, `test_entity*` | `unique_id`/`suggested_object_id` are **public contracts** — do not alter their format. `_write_register` delegates refresh/read-back policy to the coordinator. |
+| `fan.py` | Fan entity; percentage from **status** registers; optimistic pending-percentage; writes `mode`/`air_flow_rate_manual`/`on_off_panel_mode`. | Runtime | Fan UX/write sequencing. | 🟥 | `tests/test_fan.py`, `test_write_readback.py` | Writes pass `targeted_readback=False` and do a **single** trailing refresh. Setpoints ≠ display registers. See `write_path.md`. |
+| `climate.py` | Climate entity; hvac/temperature/fan/preset. | Runtime | Climate UX/write sequencing. | 🟥 | `tests/test_climate*.py` | All write paths pass `refresh=False,targeted_readback=False` + one refresh. See `write_path.md`. |
+| `number.py` | Numeric setpoints (e.g. `air_flow_rate_manual`, temps, `uart_*_id`, `lock_pass`, `rtc_cal`). | Runtime | New number entities. | 🟧 | `tests/test_number*.py` | Writes via base `_write_register` (read-back active for 1:1 setpoints). |
+| `switch.py` | On/off holding/coil registers. | Runtime | New switch entities. | 🟧 | `tests/test_switch*.py` | Reads current state from `coordinator.data`. |
+| `select.py` | Enum/option registers. | Runtime | New select entities. | 🟧 | `tests/test_select*.py` | `schedule_`/`setting_` prefixes excluded from read-back. |
+| `sensor.py` | Read-only measurements (temperatures, airflow, efficiency, power, error/status codes). | Runtime | New sensors. | 🟧 | `tests/test_sensor*.py` | Status-only — must **not** be optimistic. |
+| `binary_sensor.py` | Read-only flags, alarms (`e_*`/`s_*`/`f_*`), diagnostics. | Runtime | New binary sensors. | 🟩 | `tests/test_binary_sensor.py` | Alarm/error state is read-only. |
+| `button.py` | Momentary actions (e.g. resets/tests). | Runtime | New buttons. | 🟧 | `tests/test_button.py` | Triggers may target destructive registers. |
+| `text.py`, `time.py` | Device name (multi-word) / BCD schedule-time slots. | Runtime | New text/time entities. | 🟧 | `tests/test_text*.py`, `test_time*` | Multi-word / `schedule_`/`setting_` writes are excluded from read-back. |
+| `clock_sync.py` | `ClockSyncManager`: optional periodic device-clock sync. | Runtime | Clock-sync behaviour. | 🟧 | `tests/test_clock_sync.py` | Multi-register block write; no single-register read-back. |
+
+## Coordinator (`coordinator/`)
+
+HA-boundary adapter around `DataUpdateCoordinator`. Owns the update cycle, offline
+state, scan cache in the config entry, and the **write path**. Delegates all Modbus
+I/O to `core/` — it must never call raw Modbus itself.
+
+| Path | Role | Risk | Notes / do-not-change |
+|---|---|---|---|
+| `coordinator/coordinator.py` | `ThesslaGreenModbusCoordinator` — mixin assembler; owns `device_client`, setup, shutdown, boundary adapters. | 🟥 | Keep as an assembler; do not merge mixins into a monolith. |
+| `coordinator/schedule.py` | Write mixin: `async_write_register(s)`, `_targeted_readback_safe`, `_NO_READBACK_REGISTERS`, locked read-back. | 🟥 | The single source of the read-back policy. See `write_path.md` before touching. |
+| `coordinator/write_path.py` | Retry loops + `finalize_write_result` for single/multi writes. | 🟥 | Preserve "successful write never fails due to read-back" invariant. |
+| `coordinator/update.py`, `update_state.py`, `update_result.py` | Poll cycle, in-progress guard, success/stats application. | 🟥 | `_read_all_register_data()` is delegated to `core/`. |
+| `coordinator/scan.py`, `scan_result.py`, `schedule_helpers`→`scan.py` | Prepare registers from full-list / cache / device scan; store scan cache in entry options. | 🟧 | Writes to entry options; only place allowed to. |
+| `coordinator/lifecycle.py`, `runtime.py`, `state.py`, `init_config.py`, `config_normalization.py`, `factory.py` | Setup orchestration, runtime state init, config normalisation, `from_params`. | 🟧 | — |
+| `coordinator/device_info.py`, `diagnostics.py`, `errors.py` | Device-info warnings, diagnostic payload, update error handling. | 🟩 | — |
+
+## Core device layer (`core/`)
+
+Home-Assistant-free device domain. `ThesslaGreenDeviceClient` is the **sole owner**
+of the Modbus connection and I/O and is assembled from mixins.
+
+| Path | Role | Risk | Notes / do-not-change |
+|---|---|---|---|
+| `core/client.py` | `ThesslaGreenDeviceClient` mixin assembler (connect/close, read snapshot, scan, write). | 🟥 | **Keep as the mixin assembler** — do not merge into a monolith (CLAUDE.md). |
+| `core/write_path.py` | `SingleWritePlan`, `encode_write_value` (user units → raw). | 🟥 | Encoding correctness = correct device behaviour. |
+| `core/client_connection.py`, `connection*.py`, `disconnect.py`, `transport_select.py`, `retry.py`, `runtime_io.py`, `io_mixin.py` | Connection lifecycle, transport selection, retry/backoff, low-level I/O. | 🟥 | Sole I/O owner; do not add a second Modbus client path. |
+| `core/client_registers.py`, `read_*.py`, `register_*.py` | Batched register reads, decoding to snapshot values. | 🟥 | Respect batch boundaries from `const.py`. |
+| `core/client_scanner.py`, `scan_helpers.py`, `capabilities_mixin.py` | Capability discovery orchestration. | 🟧 | Treat Modbus exception code 2 as unsupported, not fatal. |
+| `core/models.py` | `CoordinatorConfig`, domain models. | 🟧 | — |
+| `modbus/` | Low-level pymodbus call wrappers, framing, frame logging, client close. | 🟥 | Pymodbus-facing; pin `<4.0`. |
+
+## Protocol, scanner, transport
+
+| Path | Role | Kind | Risk | Notes / do-not-change |
+|---|---|---|---|---|
+| `registers/` | Register definitions, JSON loader, cache, codec, read planner, schema, maps. | Runtime | 🟥 | `registers/thessla_green_registers_full.json` is the **single source of truth** for register names/addresses — do not edit names/addresses. No I/O here, no HA imports. |
+| `register_map.py`, `register_defs_cache.py`, `entity_lookup.py`, `unique_id_migration.py` | Register lookups, cached defs, entity lookup, unique-id migration. | Runtime | 🟧 | `unique_id_migration.py` protects existing entity IDs — never weaken. |
+| `scanner/` | Model/firmware/capability detection; safe/normal/deep scan; unsupported-register handling. | Runtime | 🟧 | Never auto-add unknown registers as entities. `scan_all_registers` opens a separate connection and must stay read-only. No HA imports. |
+| `transport/` | Modbus TCP / RTU / RTU-over-TCP, retry, backoff, CRC/framing, error classification. | Runtime | 🟥 | Knows only Modbus — must not know register names, snapshots, or HA. |
+| `mappings/` | Map domain data → HA entity descriptions (sensors, numbers, discrete, special modes). | Runtime | 🟧 | May import HA; must not do Modbus I/O or decode raw registers. Changing a mapping can change entity IDs/categories — verify with `validate_entity_mappings.py`. |
+| `options/` + `options/*.json` | Option lists (bypass/gwc modes, days, baud/parity/stop, special modes). | Runtime | 🟩 | Option values feed selects/services; keep keys stable. |
+
+## Services, config flow, diagnostics, UI text
+
+| Path | Role | Kind | When to change | Risk | Related tests/tools | Notes / do-not-change |
+|---|---|---|---|---|---|---|
+| `services/` | Service registration + handlers (mode, schedule, parameters, maintenance, data, logging). | Runtime | New/changed services. | 🟥 | `tests/test_services*.py` | **Service IDs are a public contract.** All service register writes pass `targeted_readback=False`. `services.yaml` names must match handlers. |
+| `services.yaml` | Service metadata for HA UI. | Runtime | With service changes. | 🟥 | `check_translations.py` | Keep service/field IDs aligned with `services/` and translations. |
+| `config_flow.py` | Thin public HA entrypoint (re-exports `ThesslaGreenConfigFlow`). | Runtime | Never add logic here. | 🟧 | hassfest | Implementation lives in `_config_flow/`. Exists only to satisfy hassfest. |
+| `_config_flow/` | Config & options flow implementation: user/network/schema/validation/device scan/reauth/options. | Runtime | Flow changes only if task requires. | 🟥 | `tests/test_config_flow_*.py` | **Do not change config/options-flow behaviour** unless explicitly required. Scan runs here; result cached into entry options. |
+| `diagnostics.py` | Config-entry diagnostics payload with IP/serial redaction. | Runtime | New diagnostic fields. | 🟧 | `tests/test_diagnostics*.py` | Keep redaction of host/serial/error messages. Diagnostics are status-only. |
+| `strings.json` | Source translation strings (entities, config flow, services, error/status codes). | Runtime | New UI strings. | 🟥 | `check_translations.py`, `generate_strings.py` | **Translation keys are a public contract** — add, do not rename. |
+| `translations/en.json`, `pl.json` | Localised strings generated from `strings.json`. | Runtime | Regenerate after `strings.json`. | 🟧 | `check_translations.py` | Keep keys in sync across locales. |
+| `brand/` | HA brand icon/logo assets. | Runtime | Branding. | 🟩 | — | — |
+
+## Tests, tools, docs
+
+| Path | Role | Kind | When to change | Risk | Related tests/tools | Notes / do-not-change |
+|---|---|---|---|---|---|---|
+| `tests/` | Pytest suite (~250 files): entities, coordinator, write/read-back, services, config flow, dependency direction, register/vendor coverage. | Test | With any behaviour change. | 🟧 | needs **Python 3.13** + HA test stack | `test_dependency_direction.py` enforces layer isolation — may be strengthened, never weakened. Do not edit tests just to collect on older Python. |
+| `tools/` | Standalone validators/utilities: `check_maintainability.py`, `validate_entity_mappings.py`, `check_translations.py`, `compare_registers_with_reference.py`, `compare_airpack4_vendor_coverage.py`, `validate_registers.py`, `generate_strings.py`, `sort_registers_json.py`, `migrate_register_names.py`, `cleanup_old_entities.py`, `clear_airflow_stats.py`, `validate_dashboard_entities.py`, `translate_register_descriptions.py`. | Tool | New checks/generators. | 🟩 | run in CI / manually | Lightweight validators need only `pydantic`/`PyYAML`/`voluptuous`. Generators must not silently change register names/IDs. |
+| `docs/` | Architecture, plans, audits, real-device validation, release docs. | Docs | Documentation updates. | 🟩 | — | `real_device_validation.md` gates the quality scale. Plan docs (`*_plan.md`) are the source of truth for refactors. This inventory + `runtime_flow.md` + `write_path.md` live in `docs/architecture/`. |

--- a/docs/architecture/runtime_flow.md
+++ b/docs/architecture/runtime_flow.md
@@ -1,0 +1,139 @@
+# Runtime flow — thessla_green_modbus
+
+How the integration comes up, polls, serves writes, and tears down at runtime.
+Companion to `file_inventory.md` (what each file owns) and `write_path.md` (how a
+write reaches Modbus). Descriptions are intentionally short.
+
+Layering and ownership:
+
+```text
+HA platforms  ──►  coordinator/  ──►  core/DeviceClient  ──►  registers/ + scanner/  ──►  transport/  ──►  pymodbus
+   (entities)      (HA adapter)       (sole I/O owner)          (defs / discovery)          (Modbus)
+```
+
+`DeviceClient` is the **single owner** of the Modbus connection and all I/O. The
+coordinator is a Home-Assistant adapter and never talks Modbus directly.
+
+## End-to-end lifecycle
+
+```text
+Config flow (user)                         Runtime (per config entry)
+──────────────────                         ──────────────────────────
+user/network form                          async_setup_entry (__init__.py)
+      │                                            │
+      ▼                                            ▼
+device scan (scanner/, own connection)     async_create_coordinator ── builds CoordinatorConfig
+      │  available_registers, caps, model         │                     + DeviceClient (owns IO)
+      ▼                                            ▼
+prepare_entry_payload  ── caches scan       async_start_coordinator
+into entry.options["config_flow_scan_cache"]      │   ├─ coordinator.async_setup()  (scan or reuse cache)
+      │                                            │   └─ async_config_entry_first_refresh()
+      ▼                                            ▼
+config entry created                        entry.runtime_data = coordinator
+                                                   │
+                                                   ├─ async_setup_mappings (options + entity maps)
+                                                   ├─ async_migrate_entity_unique_ids
+                                                   ├─ async_setup_platforms (forward to entity platforms)
+                                                   ├─ ClockSyncManager.attach()
+                                                   └─ async_setup_services (first entry only)
+                                                          │
+                                          ┌────────────────┴───────── every scan_interval ──────────┐
+                                          ▼                                                          │
+                                   _async_update_data ──► DeviceClient._read_all_register_data ──► transport
+                                          │                                                          │
+                                          ▼                                                          │
+                                   entities read coordinator.data ◄──────────────────────────────────┘
+
+unload/reload: async_unload_entry ─► unload platforms ─► coordinator.async_shutdown() ─► disconnect
+options changed: async_update_options ─► full config-entry reload
+```
+
+## 1. Config-flow scan
+
+- `_config_flow/` drives the user/network forms and validation, then runs a device
+  **scan** through `scanner/` to discover `available_registers`, capabilities, model
+  and firmware. The scan opens its own Modbus connection for the probe.
+- Real-device safety: scanning uses the safe/normal path; unsupported registers
+  (Modbus exception code 2) are treated as *not present*, not fatal. Unknown
+  registers are **never** turned into entities automatically.
+- `prepare_entry_payload` (`_config_flow/entry.py`) builds the entry `data` +
+  `options`, and stores a **one-time** `config_flow_scan_cache` in `options` so the
+  first runtime setup can skip a redundant scan.
+
+## 2. DeviceClient ownership
+
+- The coordinator constructor (`coordinator/coordinator.py`) creates the
+  `ThesslaGreenDeviceClient` **first** and holds it as `self._device_client`
+  (exposed read-only via `coordinator.device_client`).
+- `DeviceClient` owns: the transport, connection lifecycle, `_client_lock` /
+  `_write_lock`, retry/backoff, register reads/writes, and capability scanning.
+- The coordinator exposes thin boundary adapters (`_ensure_connection`,
+  `_disconnect`, `_test_connection`) that delegate into `DeviceClient`. These are
+  intentional boundaries, **not** proxy debt — do not remove them.
+
+## 3. Coordinator setup
+
+- `async_create_coordinator` normalises config (connection type/mode, batch, backoff)
+  and instantiates the coordinator.
+- `async_start_coordinator` runs `coordinator.async_setup()` (which either applies
+  the config-flow scan cache, loads the forced full register list, or runs a device
+  scan via `scanner/`) and then `async_config_entry_first_refresh()`.
+- Connection/auth failures are converted to `ConfigEntryNotReady` (retry later) or a
+  reauth flow; they do not crash setup.
+
+## 4. Entity setup
+
+- `async_setup_mappings` loads option lists + entity mappings (`mappings/`,
+  `options/`).
+- `async_migrate_entity_unique_ids` upgrades legacy unique IDs **in place** via
+  `unique_id_migration.py` so existing entities keep their identity.
+- `async_setup_platforms` forwards setup to each platform in `const.PLATFORMS`.
+  Entities subclass `ThesslaGreenEntity`; they only create entities for
+  **available** registers and read their state from `coordinator.data`.
+- `unique_id` and `suggested_object_id` (register-key based) are stable public
+  contracts and must not change format.
+
+## 5. Polling / update path
+
+- `DataUpdateCoordinator` calls `_async_update_data` every `scan_interval`.
+- `run_update_cycle` (`coordinator/update.py`): `_ensure_connection` → verify
+  transport connected → `DeviceClient._read_all_register_data()` (batched reads via
+  `core/` + `registers/read_planner`) → `apply_success_result` publishes a fresh
+  `coordinator.data` dict and updates stats.
+- An in-progress guard (`begin_update_cycle`/`finish_update_cycle`) and the shutdown
+  flag prevent overlapping/stale cycles. Failures go through `handle_update_error`,
+  which manages offline/unavailable state and logs recovery.
+- Entities re-render on the coordinator's listener notification.
+
+## 6. Service registration
+
+- Services are registered once, when the **first** config entry is set up
+  (`async_setup_services`), and removed when the **last** entry is unloaded.
+- Handlers live in `services/` grouped by concern (mode, schedule, parameters,
+  maintenance, data, logging). Service and field IDs match `services.yaml` and the
+  translation keys — all are public contracts.
+- Service register writes go through the shared dispatch with
+  `refresh=False, targeted_readback=False`, and each handler issues its own refresh
+  (see `write_path.md`).
+
+## 7. Unload / reload lifecycle
+
+- `async_unload_entry`: unload platforms → if successful, `coordinator.async_shutdown()`
+  (stops listeners, disconnects transport) → unload services when it was the last
+  entry.
+- `async_update_options` performs a **full config-entry reload** rather than
+  live-patching, because most options affect entity creation and register
+  availability; a reload guarantees a clean, consistent state.
+- `async_migrate_entry` handles config-entry schema version migrations.
+
+## 8. Real-device validation expectations
+
+- `quality_scale` stays `bronze` until `docs/real_device_validation.md` is marked
+  PASS with committed real-device evidence — do not raise it speculatively.
+- For validation on hardware use `validate_known_registers` (reuses the active
+  connection). Avoid `scan_all_registers` as routine validation: it opens a
+  **separate** Modbus connection and only one Modbus tool should talk to the device
+  at a time.
+- Modbus exception code 2 = unsupported register/range, not a device failure.
+- Do not add unknown registers as entities, and do not change register
+  addresses/names or entity/service IDs based on scan output.

--- a/docs/architecture/write_path.md
+++ b/docs/architecture/write_path.md
@@ -1,0 +1,179 @@
+# Write path & targeted read-back — thessla_green_modbus
+
+How a value entered in Home Assistant reaches a Modbus register, how the confirmed
+state comes back, and which entities are allowed to show an optimistic value.
+Grounded in `coordinator/schedule.py`, `coordinator/write_path.py`, `fan.py`,
+`climate.py`, `services/`, and `docs/audits/targeted_readback_write_path_audit.md`.
+
+> **Do not change** register addresses/names, entity/unique/service IDs, or
+> translation keys. Do not broaden the write path reactively. The read-back policy
+> is a deliberate, test-backed design — read the audit before touching it.
+
+## 1. HA entity → Modbus write
+
+```text
+entity.async_set_*()                         (fan/climate/number/switch/select/...)
+      │  value in user units
+      ▼
+ThesslaGreenEntity._write_register  ──►  coordinator.async_write_register(name, value,
+      │                                        refresh=?, targeted_readback=?)
+      ▼
+coordinator/schedule.py: async_write_register
+      │  async with DeviceClient._write_lock:              # serialises all Modbus IO
+      │     _locked_single_register_write
+      │        ├─ _resolve_write_definition(name)          # registers/ definition
+      │        ├─ encode_write_value(...)                  # core/write_path.py: user units → raw
+      │        └─ run_single_write_attempts (write_path.py)# retry/backoff loop
+      │            └─ transport write_register / write_registers
+      ▼
+finalize_write_result ──► optional full refresh
+```
+
+Key points:
+
+- `ThesslaGreenEntity._write_register` (`entity.py`) is the single simple-entity
+  entry; it forwards `refresh` and lets the coordinator own read-back policy. It
+  raises `RuntimeError` if the write returns `False`.
+- All writes run under `DeviceClient._write_lock`, so no scan/poll/other write can
+  interleave on the shared client (prevents pymodbus transaction-ID mismatches).
+- Values are supplied in user-friendly units; `encode_write_value` converts to the
+  raw Modbus representation using the register definition.
+
+## 2. Targeted read-back rules
+
+After a **successful** single-register write, still holding the write lock,
+`async_write_register` may read the register straight back and publish the decoded
+value — avoiding a full poll:
+
+```python
+if targeted_readback and definition is not None and _targeted_readback_safe(name, definition):
+    raw = await self._locked_read_holding_registers(definition.address + offset,
+                                                    count=definition.length)
+```
+
+`_targeted_readback_safe(name, definition)` is eligible **iff**:
+
+- `name` is **not** in `_NO_READBACK_REGISTERS`
+  (`hard_reset_settings`, `hard_reset_schedule`, `filter_change`,
+  `airflow_rate_change_flag`, `temperature_change_flag`, `cfg_mode_1`, `cfg_mode_2`,
+  `pres_check_day_2`, `pres_check_time_2`), **and**
+- `definition.function == 3` (holding register — coils are excluded), **and**
+- `definition.length == 1` (single word — multi-word blocks excluded), **and**
+- `name` does **not** start with `schedule_` or `setting_` (BCD/AATT schedule slots).
+
+Outcomes:
+
+- **Read-back succeeds** → `refresh_after_write = False`; the **decoded device
+  value** (not the requested value) is written into a copy of `coordinator.data` and
+  published via `async_set_updated_data`. No full refresh. For enum registers the raw
+  int is stored (to match the polling pipeline).
+- **Read fails** (`_locked_read_holding_registers` returns `None`) → falls back to a
+  full refresh iff `refresh=True`.
+- **Decode fails after a good read** → caught; `coordinator.data` is left unchanged;
+  full refresh armed iff `refresh=True`.
+
+> **Invariant:** a read-back read/decode failure must **never** turn a successful
+> write into a failure. The read is exception-swallowed to `None`; decode/publish
+> happen **outside** the lock, each try/except-wrapped. Preserve this.
+
+> **Note:** `refresh=False` does **not** disable read-back — only
+> `targeted_readback=False` does. `refresh` only governs the full-refresh fallback.
+
+The current policy is a **deny-list over a permissive default**: any writable
+single-word holding register is eligible unless listed. This is a known, documented
+latent breadth (dangerous config entities like `uart_*`, `lock_*`, `access_level`,
+`configuration_mode` are eligible via their number/select entities). Narrowing it to
+an allow-list is a planned follow-up (see the audit, "Stage 2") — **not** an
+emergency, and out of scope for docs.
+
+## 3. Full-refresh fallback
+
+- When read-back is disabled or ineligible, `refresh_after_write` follows the
+  caller's `refresh` flag; `finalize_write_result` then calls a debounced
+  `async_request_refresh()`.
+- When read-back is eligible but the read/decode fails, the coordinator re-arms a
+  full refresh (if `refresh=True`) so the entity still converges to real device
+  state on the next cycle.
+- Multi-register writes (`async_write_registers`, temporary temp/airflow blocks,
+  clock sync, device name) have **no** read-back path — they always use the full
+  refresh flag.
+
+## 4. Why fan/climate disable targeted read-back in some paths
+
+- **Fan:** the displayed percentage comes from **status** registers
+  (`supply_percentage` / `exhaust_percentage`), while the fan **writes** setpoint
+  registers (`air_flow_rate_manual`, `mode`, `on_off_panel_mode`). A read-back of a
+  setpoint would neither update the display nor be meaningful, so `fan._write_register`
+  passes `targeted_readback=False`. A manual-mode percentage change writes `mode`
+  then `air_flow_rate_manual` **both** with `refresh=False`, then issues a **single**
+  trailing `async_request_refresh()` — no refresh sandwiched between the two writes.
+- **Climate:** every write path (`hvac_mode`, `temperature`, `fan_mode`,
+  `preset_mode`, `turn_on/off`) writes with `refresh=False, targeted_readback=False`
+  and issues exactly one refresh at the end, because operations touch several
+  registers whose relationship to displayed state is not 1:1.
+- **Services:** all service register writes pass `targeted_readback=False` (shared
+  dispatch). They target reset/trigger registers (self-clear to 0), comms params
+  (`uart_*` — a read on a just-reconfigured link is untrustworthy), and multi-word
+  blocks (clock, device name) where a single-word read-back is misleading.
+
+The simple-entity platforms (`number`, `switch`, `select`, `text`, `time`) keep the
+default `targeted_readback=True`; for their 1:1 registers the read-back is correct
+(e.g. the `number` entity for `air_flow_rate_manual` displays that same register).
+
+## 5. Optimistic UI rules
+
+"Optimistic" = showing the requested/last-written value *before* the device confirms
+it. Allowed **only** where the written register is 1:1 with the displayed state and
+the value converges quickly (via targeted read-back or the trailing refresh).
+
+Rules:
+
+- Optimistic state is short-lived and must be **superseded by confirmed device
+  state** as soon as it arrives (e.g. the fan's pending percentage self-expires on a
+  TTL and clears once `supply_percentage`/`exhaust_percentage` match).
+- Never invent optimistic values for measurements or safety/identity state.
+- **Do not add new optimistic behaviour** as part of unrelated work; it is a
+  deliberate, per-entity design decision.
+
+### May use optimistic UI (control state, 1:1 with a write)
+
+| Entity | Optimistic value |
+|---|---|
+| **fan** | `percentage` (pending-percentage after a confirmed airflow write; TTL-bounded, cleared on confirmed status) |
+| **number** | setpoints (target values the user just set) |
+| **switch** | control on/off state |
+| **select** | current selected option |
+| **climate** | `target_temperature`, `hvac_mode`, `fan_mode`, `preset_mode` |
+
+### Must NOT use optimistic UI (status / measured / safety / identity)
+
+These reflect the device's real state and must only ever show confirmed reads:
+
+- `supply_air_flow` / `exhaust_air_flow`
+- `supply_percentage` / `exhaust_percentage` **as status** (the fan's own display source)
+- temperatures
+- efficiency
+- power
+- heat recovery
+- alarms / errors
+- firmware / model / serial
+- `device_clock`
+- diagnostics
+
+Rationale: an optimistic guess on any of these could hide a fault, misreport airflow,
+or show a stale identity/clock value — all of which mislead the user and undermine
+real-device trust.
+
+## 6. Related tests
+
+- `tests/test_write_readback.py` — read-back policy, success/read-fail/decode-fail
+  outcomes, decoded-not-requested value, lock held during read-back,
+  `targeted_readback` × `refresh` matrix, decode-failure never fails the write.
+- `tests/test_fan.py` — no refresh between `mode`/`air_flow_rate_manual`, single
+  refresh, `targeted_readback=False`, optimistic pending-percentage behaviour.
+- `tests/test_climate.py` — every write path passes `targeted_readback=False` with
+  one refresh per operation.
+- `tests/test_services*.py` — service writes assert read-back disabled.
+
+These run on **Python 3.13** with the HA test stack; verify in CI when the local
+sandbox is older.


### PR DESCRIPTION
## Summary

Added three comprehensive architecture documentation files under `docs/architecture/` to guide developers on codebase structure, runtime behavior, and write-path design:

1. **`file_inventory.md`** — Maps every important file/folder to its ownership, risk level (🟥/🟧/🟩), and do-not-change warnings. Includes hard invariants (register addresses, entity/service IDs, translation keys are public contracts) and layer-isolation rules.

2. **`runtime_flow.md`** — Traces the integration lifecycle from config-flow scan through entity setup, polling, service registration, and unload. Documents DeviceClient as the sole Modbus I/O owner and the coordinator as a Home-Assistant adapter boundary.

3. **`write_path.md`** — Details how a user-entered value reaches a Modbus register, how targeted read-back works (with eligibility rules and the `_NO_READBACK_REGISTERS` deny-list), full-refresh fallback, why fan/climate disable read-back in certain paths, and optimistic-UI policy (allowed for control state, forbidden for measurements/safety/identity).

Updated `README.md` to link the new architecture docs and `CHANGELOG.md` to document the addition.

**No runtime code, register addresses/names, entity/unique/service IDs, or translation keys changed.** This is documentation-only.

## Maintainability checklist

- [x] No code changes — documentation only.
- [x] Docs reference existing test files (`tests/test_write_readback.py`, `tests/test_fan.py`, `tests/test_climate.py`, etc.) and audit (`docs/audits/targeted_readback_write_path_audit.md`).
- [x] Hard invariants and do-not-change warnings are explicit in `file_inventory.md` and `write_path.md`.
- [x] Layer isolation rules documented in `file_inventory.md` and `runtime_flow.md`.

## Validation

- [x] No linting or test changes required (docs-only).
- [x] Links in README and CHANGELOG verified to match new file paths.
- [x] Docs cross-reference each other and existing test/audit files.

## Notes

- Docs are grounded in existing code and tests; they do not prescribe new behavior.
- `write_path.md` explicitly notes the current deny-list policy is a known latent breadth and that narrowing to an allow-list is a planned follow-up (Stage 2), not an emergency.
- All three docs emphasize that register addresses, entity/service IDs, and translation keys are public contracts and must not be changed.

https://claude.ai/code/session_017wWZzCYzu7Gj6YsLjSM9WM