### PR TITLE
Add automated GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "custom_components/thessla_green_modbus/manifest.json"
+      - "CHANGELOG.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Read version from manifest
+        id: version
+        run: |
+          version=$(python3 -c "import json; print(json.load(open('custom_components/thessla_green_modbus/manifest.json'))['version'])")
+          if [ -z "$version" ]; then
+            echo "::error::Could not read version from manifest.json"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved version $version (tag v$version)"
+
+      - name: Check whether tag already exists
+        id: check
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists locally; skipping release."
+          elif git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists on origin; skipping release."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG does not exist; a release will be created."
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        if: steps.check.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python3 << 'PYEOF'
+          import os
+          import re
+
+          version = os.environ["VERSION"]
+          try:
+              text = open("CHANGELOG.md", encoding="utf-8").read()
+          except FileNotFoundError:
+              text = ""
+          pattern = r"(?m)^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^## \[|\Z)"
+          match = re.search(pattern, text, re.DOTALL)
+          body = match.group(1).strip() if match else "See CHANGELOG.md for full release notes."
+          with open("release_notes.md", "w", encoding="utf-8") as handle:
+              handle.write(body)
+          PYEOF
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Summary
- [x] Explain what changed and why.

Added a new GitHub Actions workflow (`.github/workflows/release.yml`) that automatically creates GitHub releases when the version in `manifest.json` or `CHANGELOG.md` is updated on the main branch.

**Why:** This automation eliminates manual release creation steps, ensures consistent tagging, and keeps releases synchronized with version updates in the manifest file.

**How it works:**
1. Triggers on pushes to main that modify `manifest.json` or `CHANGELOG.md`
2. Extracts the version from `manifest.json`
3. Checks if a release tag already exists (prevents duplicate releases)
4. Extracts release notes from `CHANGELOG.md` for the corresponding version
5. Creates a GitHub release with the extracted notes

## Maintainability checklist
- [x] This is a configuration change (workflow file), not a code refactor
- [x] No code complexity or maintainability thresholds apply
- [x] No behavior compatibility concerns (new feature, not a modification)
- [x] No test impact (workflow configuration)
- [x] No rollback plan needed (can be disabled by deleting the workflow file)

## Validation
- [x] Workflow syntax is valid YAML
- [x] No code changes to validate with linting/testing tools
- [x] Workflow logic verified against GitHub Actions documentation

## Notes
- The workflow uses `softprops/action-gh-release@v2` for creating releases
- Concurrency is set to prevent simultaneous release attempts
- The workflow can be manually triggered via `workflow_dispatch` for testing
- Release notes are extracted from `CHANGELOG.md` using regex pattern matching for the version header

https://claude.ai/code/session_018nidhRvKUdbepQpLdRjCaJ