### PR TITLE
revert(deps): restore pydantic==2.12.2 dev pin (revert #1741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Restored `pydantic==2.12.2` dev pin (revert of Dependabot #1741; no runtime
+  change).** `pytest-homeassistant-custom-component 0.13.309–0.13.316` (the range
+  pinned in `requirements-dev.txt` / `pyproject.toml`) all depend on
+  `pydantic==2.12.2`, so the Dependabot minor bump to `pydantic==2.13.4`
+  ([#1741](https://github.com/blakinio/thesslagreen/pull/1741)) made
+  `pip install -r requirements-dev.txt` fail with `ResolutionImpossible`, breaking
+  the CI dependency-install step on `main` (commit `0c46629`: the Lint job failed and
+  Tests / Entity-mappings were skipped). Reverted the pin to `2.12.2` in both
+  `requirements-dev.txt` and `pyproject.toml` and restored the accurate
+  `pyproject.toml` comment (Dependabot had rewritten it to claim the plugin pins
+  2.13.4). This is a repeat of the #1708 regression fixed in 2.8.1. No runtime code,
+  Modbus register addresses/names, entity/unique/service IDs, translation keys, or
+  config/options-flow behavior changed.
 - **Repository cleanup follow-up (tooling/docs; no runtime change).** Removed the
   stale `info.md` (its counts/capabilities were outdated and `hacs.json:
   render_readme:true` makes `README.md` canonical) and the unused `.yamllint.yaml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,9 @@ dev = [
     "isort>=5.13.0",
     "ruff>=0.6.0",
     "mypy>=1.10.0",
-    # pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.13.4;
+    # pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.12.2;
     # keep in sync with requirements-dev.txt to avoid pip conflicts in CI.
-    "pydantic==2.13.4",
+    "pydantic==2.12.2",
     "pre-commit>=3.7.0",
     "types-PyYAML>=6.0.12",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ PyYAML>=6.0
 types-PyYAML>=6.0.12
 # pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.12.2.
 # Keep this in sync with the plugin's pinned pydantic version to avoid pip conflicts.
-pydantic==2.13.4
+pydantic==2.12.2
 
 # Code quality tools
 black>=24.4.0


### PR DESCRIPTION
## Summary
- [x] Explain what changed and why.

Reverts the pin change from Dependabot **#1741** (`pydantic 2.12.2 → 2.13.4`), which broke CI on `main`.

`pytest-homeassistant-custom-component 0.13.309–0.13.316` — the range pinned in `requirements-dev.txt` and `pyproject.toml` — **all depend on `pydantic==2.12.2`**. Bumping the direct pin to `2.13.4` made `pip install -r requirements-dev.txt` fail with `ResolutionImpossible`, so the CI dependency-install step could not complete on `main` (commit `0c46629`, run `28885972852`: the **Lint** job failed at *Install dependencies*; **Tests** and **Entity mappings validation** were skipped as a result).

This PR:
- restores `pydantic==2.12.2` in `requirements-dev.txt`
- restores `pydantic==2.12.2` in `pyproject.toml` and fixes the `pyproject.toml` comment that Dependabot had rewritten to wrongly claim the plugin pins `2.13.4`
- adds a CHANGELOG `[Unreleased] → Internal` note

This is a repeat of the **#1708** regression that was fixed in 2.8.1; the version range in the plugin has not moved, so the direct pin must stay at `2.12.2`.

Dev-tooling only. **No runtime code, Modbus register addresses/names, entity/unique/service IDs, translation keys, or config/options-flow behavior changed.**

## Maintainability checklist (required for large refactors)
- [x] N/A — 3-line dependency-pin revert across `requirements-dev.txt` / `pyproject.toml`; no methods or files refactored.

## Validation
Run locally on this sandbox (Python 3.11.15) after the revert:
- [x] `ruff check custom_components tests tools` — All checks passed
- [x] `ruff check --select I custom_components tests tools` — All checks passed
- [x] `ruff format --check custom_components tests tools` — 456 files already formatted
- [x] `python -m compileall -q custom_components/thessla_green_modbus tests tools` — OK
- [x] `python tools/check_maintainability.py` — passed
- [x] `python tools/validate_entity_mappings.py` — 367 entities validated
- [x] `python tools/check_translations.py` — all keys present
- [x] `python tools/validate_registers.py` — OK
- [x] `python tools/compare_registers_with_reference.py --show-renames` — exit 0
- [x] `python tools/compare_airpack4_vendor_coverage.py` — 0 missing
- [ ] `pytest ...` — **not runnable in this sandbox** (Python 3.11; `pytest-homeassistant-custom-component >=0.13.309` requires Python ≥3.13 and `homeassistant` is not installed). Must be verified by CI on Python 3.13, which this revert unblocks by fixing the install step.

## Notes
- Rollback: revert this commit to return to the `2.13.4` pin (not recommended until the HA plugin range is advanced to a version that also moves to `pydantic 2.13.x`).
- Follow-up suggestion (out of scope): add a Dependabot `ignore` for `pydantic` version-updates, or group it with `pytest-homeassistant-custom-component`, to stop this recurring bump/break cycle (#1567 → #1708 → #1741).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01781Sw3CkrzTD9NyrAg3miQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01781Sw3CkrzTD9NyrAg3miQ)_