### PR TITLE
chore(release): prepare v2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.2] - 2026-07-08
+
+> Mostly tooling and documentation cleanup, plus the already-merged safe optimistic
+> UI for controllable/setpoint entities. No Modbus register addresses/names, entity
+> IDs, unique IDs, service IDs, translation keys, or config/options-flow behavior
+> changed.
+
+### Added
+
+- **Comprehensive, safe optimistic UI state for controllable/setpoint entities**
+  ([#1734](https://github.com/blakinio/thesslagreen/pull/1734)).
+  A new shared helper `custom_components/thessla_green_modbus/optimistic.py`
+  (`OptimisticState`) lets control entities reflect a *requested* value in the GUI
+  immediately after a confirmed-successful write, instead of lagging one full
+  coordinator poll behind the physical device. The helper supports
+  `set_pending`/`get_pending`/`clear_pending`/`clear_if_confirmed`, a TTL (default
+  10 s), and an optional float tolerance. It is wired into:
+  - **Number** (`native_value`) — shows the pending setpoint after a successful write.
+  - **Switch** (`is_on`) — stores the pending raw register value so simple, bit, and
+    mutually-exclusive `special_mode` switches evaluate consistently.
+  - **Select** (`current_option`) — shows the pending option; schedule/setting/BCD-time
+    selects are deliberately excluded.
+  - **Climate** — `target_temperature`, `hvac_mode`, `fan_mode`, `preset_mode`, and the
+    visible mode after turn on/off. `current_temperature` and `hvac_action` stay
+    confirmed-only; airflow/temperature extra attributes are never made optimistic.
+
+  Optimistic state is stored only after a confirmed-successful write, never mutates
+  `coordinator.data`, self-expires after the TTL, and is cleared as soon as the
+  coordinator confirms the real value. Failed writes never update the GUI
+  optimistically. The full post-write refresh is preserved everywhere; for the climate
+  multi-register flows the pending value is set before awaiting the refresh so the GUI
+  updates immediately. The fan keeps its existing dedicated optimistic-percentage
+  implementation (unchanged; targeted read-back stays disabled for fan writes). No
+  Modbus register addresses, register/entity/unique/service IDs, or translation keys
+  changed. (Runtime code merged in [#1734]; this entry restores a changelog note that
+  was clobbered by a later merge.)
+
+### Docs
+
+- **Added architecture / file-inventory documentation** under `docs/architecture/`:
+  `file_inventory.md` (per-file ownership, risk level, and do-not-change warnings),
+  `runtime_flow.md` (config-flow scan, DeviceClient ownership, coordinator/entity
+  setup, polling, service registration, unload/reload, real-device validation
+  expectations), and `write_path.md` (HA entity → Modbus write, targeted read-back
+  rules, full-refresh fallback, why fan/climate disable read-back, and optimistic-UI
+  policy). Docs-only; no runtime code, register addresses/names, entity/unique/service
+  IDs, or translation keys changed. Linked from the README documentation list.
+- Added §11 "Optimistic UI validation for controllable entities" to
+  `docs/real_device_validation.md` with a real-device checklist and PASS criteria
+  ([#1734](https://github.com/blakinio/thesslagreen/pull/1734)).
+
 ### Internal
 
 - **Restored `pydantic==2.12.2` dev pin (revert of Dependabot #1741; no runtime
@@ -47,17 +98,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (ruff per-file-ignore path) and `docs/architecture/file_inventory.md`. All moves use
   `git mv` (history preserved). No Modbus register addresses/names, entity/unique/service
   IDs, translation keys, or config/options-flow behavior changed; no runtime module moved.
-
-### Docs
-
-- **Added architecture / file-inventory documentation** under `docs/architecture/`:
-  `file_inventory.md` (per-file ownership, risk level, and do-not-change warnings),
-  `runtime_flow.md` (config-flow scan, DeviceClient ownership, coordinator/entity
-  setup, polling, service registration, unload/reload, real-device validation
-  expectations), and `write_path.md` (HA entity → Modbus write, targeted read-back
-  rules, full-refresh fallback, why fan/climate disable read-back, and optimistic-UI
-  policy). Docs-only; no runtime code, register addresses/names, entity/unique/service
-  IDs, or translation keys changed. Linked from the README documentation list.
 
 ## [2.8.1] - 2026-07-06
 

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -26,7 +26,7 @@
   "requirements": [
     "pymodbus>=3.6.0,<4.0"
   ],
-  "version": "2.8.1",
+  "version": "2.8.2",
   "zeroconf": [
     {
       "type": "_modbus._tcp.local.",


### PR DESCRIPTION
## Summary
- [x] Explain what changed and why.

Release-only PR for **v2.8.2**. Two files change, no runtime/test/requirements changes:

- **`custom_components/thessla_green_modbus/manifest.json`** — `version` bumped `2.8.1` → `2.8.2`.
- **`CHANGELOG.md`** — rolled the `[Unreleased]` block into a dated `## [2.8.2] - 2026-07-08` section and left a fresh empty `## [Unreleased]` on top. The 2.8.2 section:
  - opens with a summary note: mostly tooling/docs cleanup plus the already-merged optimistic UI for controllable/setpoint entities;
  - **restores** the optimistic-UI `Added` entry and the Docs §11 note originally added in #1734 but clobbered by the immediately following #1735 merge (the runtime code — `optimistic.py` plus number/switch/select/climate wiring — already shipped on `main`, only its changelog note was lost);
  - keeps the existing `Docs` (#1735 architecture docs) and `Internal` (#1737 / #1742 / #1743) entries.

This collects the work merged after v2.8.1: #1734 (optimistic UI), #1735 (architecture docs), #1737 (tools/manual reorg), #1739 (duplicate release workflow removal), #1740 (repo file inventory audit), #1742 (cleanup follow-up), #1743 (pydantic dev-pin revert).

Explicitly: **No Modbus register addresses/names, entity IDs, unique IDs, service IDs, translation keys, or config/options-flow behavior changed.** No runtime code, tests, or requirements were touched in this PR.

## Maintainability checklist (required for large refactors)
- N/A — not a refactor. Only `manifest.json` (version) and `CHANGELOG.md` change; no methods/files added or resized.

## Validation
- [x] `ruff check custom_components tests tools` — passed (also `--select I` and `ruff format --check`: all clean).
- [ ] `pytest ...` — could not run here: the sandbox is Python 3.11 and the HA test stack (`pytest-homeassistant-custom-component`) requires Python 3.13; needs CI verification on 3.13.
- [x] `python tools/check_maintainability.py` — passed.
- [x] `python -m compileall` (custom_components/tests/tools) — passed.
- [x] `tools/validate_entity_mappings.py` (367 entities), `tools/validate_registers.py`, `tools/check_translations.py`, `tools/compare_registers_with_reference.py --show-renames`, `tools/compare_airpack4_vendor_coverage.py` (no missing registers), `tools/check_maintainability.py` — all passed.

## Notes
- **Tag/release are automatic.** `.github/workflows/release.yaml` fires on push to `main` for `manifest.json` / `CHANGELOG.md`, reads the manifest version, extracts the `## [2.8.2]` section as release notes, and creates tag **`v2.8.2`** + the GitHub release if the tag doesn't already exist. No manual tag or release was created, per the task.
- Verified the release-notes regex extracts the `## [2.8.2]` section cleanly (stops at `## [2.8.1]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGx55mRUCwSvsX2K7caFXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGx55mRUCwSvsX2K7caFXS)_