### PR TITLE
Replace targeted read-back deny-list with explicit allow-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **Targeted read-back restricted to an explicit safe allow-list.** The post-write
+  targeted read-back policy (`coordinator/schedule.py`) was changed from a permissive
+  deny-list (any single-word holding register was eligible unless enumerated) to an
+  explicit `_READBACK_ALLOW_LIST` of registers known to be 1:1 with a single displayed
+  entity state — airflow / temperature / coefficient / timing setpoints and operational
+  mode controls exposed via the number/select/switch platforms. Dangerous configuration
+  registers written through those same platforms — communication config (`uart_*`),
+  security (`lock_*`, `access_level`), configuration mode (`configuration_mode`,
+  `cfg_mode_*`), device config/clock (`language`, `rtc_cal`), reset/trigger/self-clearing
+  registers, and schedule/setting BCD-AATT slots — are no longer read-back eligible and
+  now converge via the existing debounced full refresh. The `function == 3` /
+  `length == 1` checks are kept as defence-in-depth. Fan, climate, and service write
+  paths already opt out with `targeted_readback=False` and are unchanged; a read-back
+  read/decode failure still never fails a successful write, and enum read-back still
+  stores the raw int. No Modbus register addresses/names, entity IDs, unique IDs, service
+  IDs, translation keys, or config/options-flow behavior changed. See
+  `docs/architecture/write_path.md` and
+  `docs/audits/targeted_readback_write_path_audit.md` ("Stage 2").
+
 ## [2.8.2] - 2026-07-08
 
 > Mostly tooling and documentation cleanup, plus the already-merged safe optimistic

--- a/custom_components/thessla_green_modbus/coordinator/schedule.py
+++ b/custom_components/thessla_green_modbus/coordinator/schedule.py
@@ -23,38 +23,106 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Registers that must never use targeted read-back after a write.
-# Includes reset/trigger registers (values return to 0 after device processes them),
-# block-write helpers (only written as part of multi-register sequences), and
-# destructive/service-only registers where a read-back would be misleading.
-_NO_READBACK_REGISTERS: frozenset[str] = frozenset(
+# Explicit allow-list of registers eligible for targeted read-back after a write.
+#
+# Targeted read-back is restricted to writable holding registers that are 1:1 with a
+# single displayed entity state — setpoints and operational mode controls exposed via
+# the number/select/switch platforms — where reading the just-written register straight
+# back is both safe and useful.  Everything else defaults to a full refresh, including:
+#   * communication config (uart_*),
+#   * security (lock_*, access_level),
+#   * configuration mode (configuration_mode, cfg_mode_*),
+#   * reset/trigger/self-clearing registers (hard_reset_*, filter_change, *_change_flag,
+#     pres_check_*_2),
+#   * schedule/setting BCD-AATT slots (schedule_*, setting_*),
+#   * device identity/clock/calibration (language, rtc_cal, device_name, date_time*),
+#   * and any multi-word block.
+#
+# This replaces the previous permissive deny-list (any single-word holding register was
+# eligible unless enumerated), which left dangerous config entities read-back-eligible.
+# See docs/architecture/write_path.md and docs/audits/targeted_readback_write_path_audit.md.
+_READBACK_ALLOW_LIST: frozenset[str] = frozenset(
     {
-        "hard_reset_settings",
-        "hard_reset_schedule",
-        "filter_change",
-        "airflow_rate_change_flag",
-        "temperature_change_flag",
-        "cfg_mode_1",
-        "cfg_mode_2",
-        "pres_check_day_2",
-        "pres_check_time_2",
+        # Airflow / fan-speed setpoints (%)
+        "air_flow_rate_manual",
+        "air_flow_rate_temporary",
+        "air_flow_rate_temporary_4401",
+        "fan_speed_1_coef",
+        "fan_speed_2_coef",
+        "fan_speed_3_coef",
+        "max_supply_air_flow_rate",
+        "max_exhaust_air_flow_rate",
+        "max_supply_air_flow_rate_gwc",
+        "max_exhaust_air_flow_rate_gwc",
+        "nominal_supply_air_flow",
+        "nominal_exhaust_air_flow",
+        "nominal_supply_air_flow_gwc",
+        "nominal_exhaust_air_flow_gwc",
+        # Special-function intensity setpoints (%)
+        "airing_bathroom_coef",
+        "airing_coef",
+        "airing_switch_coef",
+        "bypass_coef_1",
+        "bypass_coef_2",
+        "contamination_coef",
+        "empty_house_coef",
+        "fireplace_supply_coef",
+        "hood_supply_coef",
+        "hood_exhaust_coef",
+        "open_window_coef",
+        # Special-function / GWC timings
+        "airing_panel_mode_time",
+        "airing_switch_mode_time",
+        "airing_switch_mode_on_delay",
+        "airing_switch_mode_off_delay",
+        "fireplace_mode_time",
+        "gwc_regen_period",
+        # Temperature setpoints (°C)
+        "supply_air_temperature_manual",
+        "supply_air_temperature_temporary",
+        "supply_air_temperature_temporary_4404",
+        "min_bypass_temperature",
+        "min_gwc_air_temperature",
+        "max_gwc_air_temperature",
+        "delta_t_gwc",
+        "air_temperature_summer_free_heating",
+        "air_temperature_summer_free_cooling",
+        # Filter wear thresholds
+        "cfgszf_fn_new",
+        "cfgszf_fw_new",
+        # Operational mode controls (enum select/switch, 1:1 with displayed state)
+        "mode",
+        "season_mode",
+        "special_mode",
+        "on_off_panel_mode",
+        "comfort_mode_panel",
+        "bypass_user_mode",
+        "bypass_off",
+        "gwc_off",
+        "gwc_regen",
+        "cfg_post_heater_mode",
+        "pres_check_day",
+        "pres_check_day_4432",
     }
 )
 
 
 def _targeted_readback_safe(register_name: str, definition: Any) -> bool:
-    """Return True when single-register targeted holding-register read-back is safe.
+    """Return True only for registers on the explicit safe read-back allow-list.
 
-    Only function-3 (holding register) single-word registers that are not in the
-    explicit exclusion list are eligible.  Schedule BCD-time and AATT setting
-    registers are deferred to full_refresh_only for v1 because schedule writes
-    involve pairs of registers and a single-register read-back gives a partial view.
+    A register is eligible for targeted read-back after a write iff it is on
+    ``_READBACK_ALLOW_LIST`` (a curated set of 1:1 writable holding registers) and is
+    still a function-3 single-word register.  The function/length checks are
+    defence-in-depth: only holding single-word registers can ever read back, even if
+    the allow-list were to drift from the register definitions.  Everything not on the
+    allow-list — comms/security/config-mode registers, reset/trigger/self-clearing
+    registers, schedule/setting BCD-AATT slots, device identity/clock, and multi-word
+    blocks — falls back to a full refresh.
     """
     return (
-        register_name not in _NO_READBACK_REGISTERS
+        register_name in _READBACK_ALLOW_LIST
         and definition.function == 3
         and definition.length == 1
-        and not register_name.startswith(("schedule_", "setting_"))
     )
 
 

--- a/docs/architecture/write_path.md
+++ b/docs/architecture/write_path.md
@@ -53,13 +53,16 @@ if targeted_readback and definition is not None and _targeted_readback_safe(name
 
 `_targeted_readback_safe(name, definition)` is eligible **iff**:
 
-- `name` is **not** in `_NO_READBACK_REGISTERS`
-  (`hard_reset_settings`, `hard_reset_schedule`, `filter_change`,
-  `airflow_rate_change_flag`, `temperature_change_flag`, `cfg_mode_1`, `cfg_mode_2`,
-  `pres_check_day_2`, `pres_check_time_2`), **and**
+- `name` is on the explicit **`_READBACK_ALLOW_LIST`** — a curated set (~54 registers)
+  of writable holding registers that are 1:1 with a single displayed entity state:
+  airflow / temperature / coefficient / timing setpoints and operational mode controls
+  (`mode`, `season_mode`, `special_mode`, `on_off_panel_mode`, `bypass_*`, `gwc_*`, …)
+  exposed through the number/select/switch platforms, **and**
 - `definition.function == 3` (holding register — coils are excluded), **and**
-- `definition.length == 1` (single word — multi-word blocks excluded), **and**
-- `name` does **not** start with `schedule_` or `setting_` (BCD/AATT schedule slots).
+- `definition.length == 1` (single word — multi-word blocks excluded).
+
+The `function`/`length` checks are **defence-in-depth**: only a holding single-word
+register can ever read back, even if the allow-list drifts from the register map.
 
 Outcomes:
 
@@ -79,12 +82,21 @@ Outcomes:
 > **Note:** `refresh=False` does **not** disable read-back — only
 > `targeted_readback=False` does. `refresh` only governs the full-refresh fallback.
 
-The current policy is a **deny-list over a permissive default**: any writable
-single-word holding register is eligible unless listed. This is a known, documented
-latent breadth (dangerous config entities like `uart_*`, `lock_*`, `access_level`,
-`configuration_mode` are eligible via their number/select entities). Narrowing it to
-an allow-list is a planned follow-up (see the audit, "Stage 2") — **not** an
-emergency, and out of scope for docs.
+The policy is an **explicit allow-list** (default deny). Only registers *known* to be
+1:1 write=status are eligible; everything else defaults to a full refresh, including:
+communication config (`uart_*`), security (`lock_*`, `access_level`), configuration mode
+(`configuration_mode`, `cfg_mode_*`), reset/trigger/self-clearing registers
+(`hard_reset_*`, `filter_change`, `*_change_flag`, `pres_check_*_2`), schedule/setting
+BCD-AATT slots (`schedule_*`, `setting_*`), device identity/clock/calibration
+(`language`, `rtc_cal`, `device_name`, `date_time*`), and any multi-word block.
+
+This replaced the earlier permissive **deny-list over a default-allow**, under which
+dangerous config entities (`uart_*`, `lock_*`, `access_level`, `configuration_mode`)
+were read-back eligible through their number/select/switch entities — the latent
+breadth documented as "Stage 2" in
+`docs/audits/targeted_readback_write_path_audit.md`. Registers outside the allow-list
+are still written normally; they simply converge via the debounced full refresh instead
+of a targeted read-back.
 
 ## 3. Full-refresh fallback
 
@@ -117,8 +129,12 @@ emergency, and out of scope for docs.
   blocks (clock, device name) where a single-word read-back is misleading.
 
 The simple-entity platforms (`number`, `switch`, `select`, `text`, `time`) keep the
-default `targeted_readback=True`; for their 1:1 registers the read-back is correct
-(e.g. the `number` entity for `air_flow_rate_manual` displays that same register).
+default `targeted_readback=True`, but the read-back only actually fires for registers on
+`_READBACK_ALLOW_LIST`. For their 1:1 registers the read-back is correct (e.g. the
+`number` entity for `air_flow_rate_manual` displays that same register); their dangerous
+config registers (`uart_*`, `lock_*`, `access_level`, `configuration_mode`, `language`,
+`rtc_cal`) are **not** on the allow-list, so those writes fall back to a full refresh
+even though the platform did not opt out.
 
 ## 5. Optimistic UI rules
 

--- a/docs/audits/targeted_readback_write_path_audit.md
+++ b/docs/audits/targeted_readback_write_path_audit.md
@@ -341,7 +341,23 @@ The Stage-1 items are already merged. Before writing more code, reproduce the or
 
 No further Stage-1 work is required. If anything, add regression test **M5** to pin the fan optimistic-update behaviour.
 
-### Stage 2 — read-back policy refactor (the real open work)
+### Stage 2 — read-back policy refactor (the real open work) — **IMPLEMENTED**
+> Implemented as the explicit allow-list `_READBACK_ALLOW_LIST` in
+> `coordinator/schedule.py` (replacing `_NO_READBACK_REGISTERS`). `_targeted_readback_safe`
+> now returns eligible **iff** the register is on the allow-list and is still a
+> function-3 single-word register. The allow-list was derived by enumerating the
+> writable holding-1w registers exposed via the number/select/switch platforms and
+> removing every group with a `risk_category` (`communication_lockout`, `security_lock`,
+> `advanced_configuration`, `destructive_action`), the reset/trigger/config-mode set, the
+> `schedule_`/`setting_` BCD-AATT slots, and the `language`/`rtc_cal` config/clock
+> registers. The policy was kept inline in `schedule.py` (no new module) to keep the diff
+> small; extraction into a dedicated module remains an optional future cleanup. Tests
+> landed in `tests/test_write_readback.py` (allow/deny parametrised predicate tests, an
+> allow-list-composition guard, and a non-allow-listed `uart_0_baud` full-refresh
+> integration test). Fan/climate/service opt-outs and the decode-failure invariant are
+> unchanged.
+
+Original proposal (for reference):
 - Extract the policy into a dedicated helper/module (e.g. `coordinator/readback_policy.py`) so it is independently testable and does not live inside the write mixin.
 - Replace the permissive deny-list with an **allow-list / category** model: eligible only when the register is *known* 1:1 write=status. Drive exclusion of `uart_*`, `lock_*`, `access_level`, `configuration_mode`, `language`, `rtc_cal`, and any `date_time*`/multi-register fragment either by name predicate or (better) by the `risk_category` metadata already present in the entity mappings (`communication_lockout`, `security_lock`, `advanced_configuration`, `destructive_action`).
 - Land tests **M1–M4, M6** alongside the change.

--- a/docs/real_device_validation.md
+++ b/docs/real_device_validation.md
@@ -354,23 +354,35 @@ This section tracks validation of the targeted read-back feature added in [Unrel
 
 ### 9.1 How it works
 
-After a successful write to a safe single holding register (e.g. `mode`,
-`air_flow_rate_manual`, `special_mode`, `comfort_temperature`, `required_temperature`),
-the coordinator immediately reads back only the written register under the same
-`_write_lock`.  The decoded value is applied to `coordinator.data` and HA listeners
-are notified via `async_set_updated_data` — without triggering a full register scan.
-If the read-back fails, the coordinator falls back to a full refresh.
+Targeted read-back is gated by an **explicit allow-list** (`_READBACK_ALLOW_LIST` in
+`coordinator/schedule.py`): only registers *known* to be 1:1 with a single displayed
+entity state are eligible — airflow / temperature / coefficient / timing setpoints and
+operational mode controls (e.g. `mode`, `air_flow_rate_manual`, `special_mode`,
+`season_mode`, `on_off_panel_mode`) exposed via number/select/switch. After a successful
+write to an allow-listed single holding register, the coordinator immediately reads back
+only the written register under the same `_write_lock`. The decoded value is applied to
+`coordinator.data` and HA listeners are notified via `async_set_updated_data` — without
+triggering a full register scan. If the read-back fails, the coordinator falls back to a
+full refresh.
 
 ### 9.2 Excluded registers (full_refresh_only / no_readback)
 
-- Reset/trigger: `hard_reset_settings`, `hard_reset_schedule`, `filter_change`,
-  `airflow_rate_change_flag`, `temperature_change_flag`, `cfg_mode_1`, `cfg_mode_2`,
+Anything **not** on `_READBACK_ALLOW_LIST` falls back to a full refresh, including:
+
+- Communication config: `uart_0_id`, `uart_1_id`, `uart_0_baud/parity/stop`,
+  `uart_1_baud/parity/stop`
+- Security / lock: `lock_pass`, `lock_flag`, `access_level`
+- Configuration mode: `configuration_mode`, `cfg_mode_1`, `cfg_mode_2`
+- Device config / clock calibration: `language`, `rtc_cal`, `device_name`, `date_time*`
+- Reset/trigger/self-clearing: `hard_reset_settings`, `hard_reset_schedule`,
+  `filter_change`, `airflow_rate_change_flag`, `temperature_change_flag`,
   `pres_check_day_2`, `pres_check_time_2`
 - Schedule BCD-time registers: all `schedule_*`
 - AATT schedule-setting registers: all `setting_*`
 - Coil registers (function=1): no holding-register read-back
 - Multi-word registers (e.g. `device_name`): full_refresh_only
-- Fan setpoint registers: full_refresh_only (fan display reads from `supply_percentage`)
+- Fan setpoint registers via the fan entity: full_refresh_only (fan display reads from
+  `supply_percentage`; the fan opts out with `targeted_readback=False`)
 
 ### 9.3 Real-device checklist
 
@@ -386,6 +398,7 @@ If the read-back fails, the coordinator falls back to a full refresh.
 | 8 | Call `reset_filters` or `reset_settings` service | Service succeeds; no targeted read-back attempted (confirm by no DEBUG read-back log line); full refresh follows if needed | — | — |
 | 9 | Confirm fan percentage still updates after fan speed change | Fan entity percentage updates correctly after a speed change (full refresh still happens for fan) | — | — |
 | 10 | Capture HA log lines showing targeted read-back and fallback | Confirm `Targeted read-back for <register> decoded to` and/or `Targeted read-back failed for <register>` lines appear at DEBUG level | — | — |
+| 11 | Change a non-allow-listed config entity (e.g. `select.access_level` or a `uart_*` entity, if exposed) | Write succeeds; **no** targeted read-back attempted for that register (no DEBUG read-back line); value converges on the next full refresh | — | — |
 
 ### 9.4 Sign-off
 

--- a/tests/test_write_readback.py
+++ b/tests/test_write_readback.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from custom_components.thessla_green_modbus.coordinator import ThesslaGreenModbusCoordinator
 from custom_components.thessla_green_modbus.coordinator.schedule import (
-    _NO_READBACK_REGISTERS,
+    _READBACK_ALLOW_LIST,
     _targeted_readback_safe,
 )
 from custom_components.thessla_green_modbus.registers.loader import RegisterDef
@@ -70,37 +70,117 @@ def _reg(function: int = 3, length: int = 1, name: str = "test_reg") -> Register
     return RegisterDef(function=function, address=100, name=name, access="rw", length=length)
 
 
-def test_targeted_readback_safe_holding_single() -> None:
-    """Normal holding single register is eligible for targeted read-back."""
-    assert _targeted_readback_safe("mode", _reg(function=3, length=1, name="mode")) is True
+# A representative sample of allow-listed 1:1 setpoint/mode registers.
+_ALLOW_SAMPLE = [
+    "air_flow_rate_manual",
+    "mode",
+    "special_mode",
+    "season_mode",
+    "on_off_panel_mode",
+    "comfort_mode_panel",
+    "bypass_off",
+    "gwc_off",
+    "bypass_user_mode",
+    "min_bypass_temperature",
+    "supply_air_temperature_manual",
+    "fan_speed_1_coef",
+    "cfgszf_fn_new",
+]
+
+# Registers that must NOT be read-back eligible under the allow-list policy.
+_DENY_SAMPLE = [
+    # communication config
+    "uart_0_id",
+    "uart_1_id",
+    "uart_0_baud",
+    "uart_0_parity",
+    "uart_0_stop",
+    "uart_1_baud",
+    # security / lock
+    "lock_pass",
+    "lock_flag",
+    "access_level",
+    # configuration mode
+    "configuration_mode",
+    "cfg_mode_1",
+    "cfg_mode_2",
+    # device config / clock calibration
+    "language",
+    "rtc_cal",
+    # reset / trigger / self-clearing
+    "hard_reset_settings",
+    "hard_reset_schedule",
+    "filter_change",
+    "airflow_rate_change_flag",
+    "temperature_change_flag",
+    # schedule / setting BCD-AATT slots
+    "schedule_summer_mon_1",
+    "setting_summer_mon_1",
+    # not a known writable entity register at all
+    "some_unmapped_register",
+]
+
+
+@pytest.mark.parametrize("name", _ALLOW_SAMPLE)
+def test_targeted_readback_safe_allow_listed(name: str) -> None:
+    """Allow-listed holding single registers are eligible for targeted read-back."""
+    assert _targeted_readback_safe(name, _reg(function=3, length=1, name=name)) is True
+
+
+@pytest.mark.parametrize("name", _DENY_SAMPLE)
+def test_targeted_readback_safe_not_allow_listed(name: str) -> None:
+    """Non-allow-listed writable holding registers fall back to full refresh.
+
+    Even presented as a function-3 single-word register, anything outside the
+    allow-list (uart_*, lock_*, access_level, configuration_mode, reset/trigger,
+    schedule_/setting_, or unmapped registers) is never read-back eligible.
+    """
+    assert _targeted_readback_safe(name, _reg(function=3, length=1, name=name)) is False
 
 
 def test_targeted_readback_safe_coil_excluded() -> None:
-    """Coil registers (function=1) are never eligible for read-back in v1."""
+    """Coil registers (function=1) are never eligible for read-back."""
     assert _targeted_readback_safe("system_on_off", _reg(function=1, name="system_on_off")) is False
 
 
 def test_targeted_readback_safe_multi_register_excluded() -> None:
-    """Multi-word registers stay on full_refresh_only."""
+    """Multi-word registers stay on full_refresh_only (defence-in-depth length check)."""
+    # Even an allow-listed name is rejected if it is not a single-word register.
+    assert _targeted_readback_safe("mode", _reg(function=3, length=2, name="mode")) is False
     assert _targeted_readback_safe("device_name", _reg(length=8, name="device_name")) is False
 
 
-def test_targeted_readback_safe_no_readback_register() -> None:
-    """Registers in _NO_READBACK_REGISTERS are excluded."""
-    for name in _NO_READBACK_REGISTERS:
-        assert _targeted_readback_safe(name, _reg(name=name)) is False, name
-
-
-def test_targeted_readback_safe_schedule_excluded() -> None:
-    """schedule_ registers stay on full_refresh_only for v1."""
-    reg = _reg(name="schedule_summer_mon_1")
-    assert _targeted_readback_safe("schedule_summer_mon_1", reg) is False
-
-
-def test_targeted_readback_safe_setting_excluded() -> None:
-    """setting_ (AATT) registers stay on full_refresh_only for v1."""
-    reg = _reg(name="setting_summer_mon_1")
-    assert _targeted_readback_safe("setting_summer_mon_1", reg) is False
+def test_readback_allow_list_excludes_dangerous_groups() -> None:
+    """The allow-list must never contain comms/security/config-mode/reset registers."""
+    forbidden = {
+        "uart_0_id",
+        "uart_1_id",
+        "uart_0_baud",
+        "uart_0_parity",
+        "uart_0_stop",
+        "uart_1_baud",
+        "uart_1_parity",
+        "uart_1_stop",
+        "lock_pass",
+        "lock_flag",
+        "access_level",
+        "configuration_mode",
+        "cfg_mode_1",
+        "cfg_mode_2",
+        "language",
+        "rtc_cal",
+        "hard_reset_settings",
+        "hard_reset_schedule",
+        "filter_change",
+        "airflow_rate_change_flag",
+        "temperature_change_flag",
+        "pres_check_day_2",
+        "pres_check_time_2",
+    }
+    overlap = forbidden & _READBACK_ALLOW_LIST
+    assert not overlap, f"Dangerous registers leaked into allow-list: {overlap}"
+    # No schedule_/setting_ BCD-AATT slot may be allow-listed either.
+    assert not any(name.startswith(("schedule_", "setting_")) for name in _READBACK_ALLOW_LIST)
 
 
 # ---------------------------------------------------------------------------
@@ -260,7 +340,7 @@ async def test_hard_reset_settings_no_targeted_readback(coordinator, monkeypatch
     result = await coordinator.async_write_register("hard_reset_settings", 1, refresh=True)
 
     assert result is True
-    # hard_reset_settings is in _NO_READBACK_REGISTERS → no targeted read-back
+    # hard_reset_settings is not on _READBACK_ALLOW_LIST → no targeted read-back
     client.read_holding_registers.assert_not_called()
     # Falls back to full refresh (refresh=True)
     coordinator.async_request_refresh.assert_called_once()
@@ -284,6 +364,32 @@ async def test_hard_reset_schedule_no_targeted_readback(coordinator, monkeypatch
     result = await coordinator.async_write_register("hard_reset_schedule", 1, refresh=True)
 
     assert result is True
+    client.read_holding_registers.assert_not_called()
+    coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_non_allow_listed_holding_register_falls_back_to_refresh(
+    coordinator, monkeypatch
+) -> None:
+    """A writable single-word holding register NOT on the allow-list (e.g. a UART
+    comms-config register) must skip targeted read-back and use a full refresh."""
+    import custom_components.thessla_green_modbus.coordinator.coordinator as coord_mod
+
+    uart_def = RegisterDef(function=3, address=4200, name="uart_0_baud", access="rw")
+    monkeypatch.setattr(coord_mod, "get_register_definition", lambda _n: uart_def)
+
+    coordinator._ensure_connection = AsyncMock()
+    client = MagicMock()
+    client.write_register = AsyncMock(return_value=_write_response(error=False))
+    client.read_holding_registers = AsyncMock(return_value=_read_response([1]))
+    coordinator.device_client.client = client
+    coordinator.async_request_refresh = AsyncMock()
+
+    result = await coordinator.async_write_register("uart_0_baud", 1, refresh=True)
+
+    assert result is True
+    # Not on the allow-list → no targeted read-back, full refresh instead.
     client.read_holding_registers.assert_not_called()
     coordinator.async_request_refresh.assert_called_once()
 
@@ -641,15 +747,16 @@ async def test_fan_write_register_no_refresh_when_refresh_false() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_no_readback_registers_are_documented() -> None:
-    """The exclusion set contains the required safety entries."""
+def test_allow_list_contains_core_setpoints() -> None:
+    """The allow-list must retain the core 1:1 setpoint/mode controls."""
     required = {
-        "hard_reset_settings",
-        "hard_reset_schedule",
-        "filter_change",
-        "airflow_rate_change_flag",
-        "temperature_change_flag",
+        "air_flow_rate_manual",
+        "mode",
+        "special_mode",
+        "season_mode",
+        "on_off_panel_mode",
+        "supply_air_temperature_manual",
     }
-    assert required.issubset(_NO_READBACK_REGISTERS), (
-        f"Missing from _NO_READBACK_REGISTERS: {required - _NO_READBACK_REGISTERS}"
+    assert required.issubset(_READBACK_ALLOW_LIST), (
+        f"Missing from _READBACK_ALLOW_LIST: {required - _READBACK_ALLOW_LIST}"
     )


### PR DESCRIPTION
## Summary

Replaced the permissive deny-list policy for post-write targeted read-back with an explicit `_READBACK_ALLOW_LIST` containing only registers known to be 1:1 with a single displayed entity state.

**What changed:**
- `_NO_READBACK_REGISTERS` (deny-list) → `_READBACK_ALLOW_LIST` in `coordinator/schedule.py`
- Allow-list contains ~54 registers: airflow/temperature/coefficient/timing setpoints and operational mode controls (`mode`, `season_mode`, `special_mode`, `on_off_panel_mode`, `bypass_*`, `gwc_*`, etc.) exposed via number/select/switch platforms
- `_targeted_readback_safe()` now returns eligible **iff** register is on the allow-list AND is a function-3 single-word register
- Removed the `schedule_`/`setting_` prefix checks (now handled by allow-list membership)

**Why:**
The previous deny-list left dangerous configuration registers read-back eligible when written through their number/select/switch entities: communication config (`uart_*`), security (`lock_*`, `access_level`), configuration mode (`configuration_mode`, `cfg_mode_*`), device config/clock (`language`, `rtc_cal`), reset/trigger/self-clearing registers, and schedule/setting BCD-AATT slots. These now fall back to the existing debounced full refresh instead of targeted read-back. This is the "Stage 2" policy refactor from the targeted read-back audit.

**Behavior:**
- Registers on the allow-list: targeted read-back (unchanged)
- Registers not on the allow-list: full refresh fallback (previously targeted read-back)
- Write success is unaffected; only convergence path changes
- Fan/climate/service opt-outs and decode-failure invariant unchanged

## Maintainability checklist

- [x] Changed methods/files are within maintainability thresholds (policy constants and one predicate function)
- [x] Documented behavior compatibility: dangerous registers still write normally, just converge via full refresh instead of targeted read-back
- [x] Test impact: parametrised allow/deny predicate tests, allow-list composition guard, and non-allow-listed `uart_0_baud` integration test added; old deny-list tests removed
- [x] Rollback plan: revert `_READBACK_ALLOW_LIST` to `_NO_READBACK_REGISTERS` and restore `schedule_`/`setting_` prefix checks in `_targeted_readback_safe()`

## Validation

- Existing tests updated to parametrised allow/deny samples
- New guard test ensures dangerous register groups never leak into allow-list
- New integration test confirms non-allow-listed registers fall back to full refresh
- Documentation updated: `docs/architecture/write_path.md`, `docs/real_device_validation.md`, `docs/audits/targeted_readback_write_path_audit.md`
- CHANGELOG entry added

## Notes

- No Modbus register addresses, entity IDs, unique IDs, service IDs, translation keys, or config/options-flow behavior changed
- The `function == 3` / `length == 1` checks are kept as defence-in-depth
- Allow-list was derived by enumerating writable holding-1w registers exposed via number/select/switch platforms and removing every group with a `risk_category` or known dangerous pattern
- Policy remains inline in `schedule.py` (no new module) to keep diff small; extraction is an optional future cleanup

https://claude.ai/code/session_01Qri5sT44tLALsK46dckG3N