### PR TITLE
chore(docs/tooling): align pre-commit docs and prevent invalid pydantic bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      # pytest-homeassistant-custom-component 0.13.309-0.13.316 pins pydantic==2.12.2.
+      # A direct pydantic bump to 2.13.4 broke CI (#1741) and was reverted (#1743).
+      # Keep pydantic locked to the HA test plugin's pin; only move it when the plugin's
+      # supported range moves (it will pull the compatible pydantic along with it).
+      # Ignore direct minor/patch pydantic bumps so this invalid PR stops recurring.
+      - dependency-name: "pydantic"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,8 +134,7 @@ git checkout -b feature/your-feature-name
 We follow these conventions:
 
 **Python Code:**
-- Use [Black](https://black.readthedocs.io/) for formatting (100 char line length)
-- Use [isort](https://pycqa.github.io/isort/) for import sorting
+- Use [Ruff](https://docs.astral.sh/ruff/) for formatting and import sorting (100 char line length)
 - Follow [PEP 8](https://pep8.org/) style guidelines
 - Use type hints where possible
 
@@ -250,43 +249,35 @@ If you have a ThesslaGreen device:
 
 ### Pre-commit Checks
 
-Run `pre-commit install` once to activate these checks. Before committing, the following checks run automatically:
+Run `pre-commit install` once to activate these checks. Before committing, the following hooks run automatically (see `.pre-commit-config.yaml`):
 
-- **Black** - Code formatting
-- **isort** - Import sorting
-- **flake8** - Linting
-- **mypy** - Type checking
-- **bandit** - Security scanning
-- **yamllint** - YAML validation
-- **check-merge-conflict** - Prevents committing unresolved merge conflicts
-- **check-json** - Validates translation files
-- **hassfest** - Validates integration metadata against Home Assistant rules
-- **vulture** - Detects unused code in `custom_components/thessla_green_modbus`
+- **validate-registers** - Validates the register JSON source of truth
+- **ruff** - Linting and import sorting (`--fix`)
+- **ruff-format** - Code formatting
+- **mypy** - Type checking (`custom_components/thessla_green_modbus`)
+- **check-yaml** - YAML validation
+- **check-json** - JSON / translation file validation
+- **end-of-file-fixer** - Ensures files end with a trailing newline
+- **trailing-whitespace** - Strips trailing whitespace
 
 ### Manual Quality Checks
 
 ```bash
-# Format code
-black custom_components/
+# Lint
+ruff check custom_components tests tools
 
-# Sort imports
-isort custom_components/
+# Import order
+ruff check --select I custom_components tests tools
 
-# Lint code
-flake8 custom_components/ --max-line-length=100
+# Format (check only; drop --check to apply)
+ruff format --check custom_components tests tools
 
 # Type checking
 mypy custom_components/thessla_green_modbus/
-
-# Security scan
-bandit -r custom_components/
-
-# Validate integration metadata
-hassfest --config=.
-
-# Dead code detection
-vulture custom_components/thessla_green_modbus --min-confidence=80
 ```
+
+> **Note:** `hassfest` and `HACS` integration validation run automatically in CI via
+> dedicated GitHub Actions; they are not distributed as installable PyPI packages.
 
 ## Submitting Changes
 


### PR DESCRIPTION
## Summary
Documentation/tooling-only cleanup. No runtime code touched.

- **`CONTRIBUTING.md`** — rewrite the pre-commit and manual quality-check sections to match `.pre-commit-config.yaml`. The active hooks are `validate-registers`, `ruff` (lint + import order via `--fix`), `ruff-format`, `mypy`, `check-yaml`, `check-json`, `end-of-file-fixer`, `trailing-whitespace`. Removed stale references to **Black, isort, flake8, yamllint, bandit, vulture** (and hassfest-as-pre-commit), and pointed the Python code-style guidance at Ruff. Manual-check commands now use `ruff check` / `ruff check --select I` / `ruff format --check`; `mypy` kept.
- **`.github/dependabot.yml`** — add an `ignore` rule for direct minor/patch `pydantic` bumps. The dev pin `pydantic==2.12.2` is dictated by `pytest-homeassistant-custom-component` 0.13.309–0.13.316; a direct bump to 2.13.4 broke CI (#1741) and was reverted (#1743). Pydantic should only move when the HA test plugin's supported range moves (which pulls the compatible pydantic along with it). This stops the recurring invalid Dependabot PR.

## Maintainability checklist (required for large refactors)
- [x] N/A — documentation/tooling only; no methods/files changed, no maintainability impact.
- [x] Behavior compatibility: no runtime, entity, register, service, or config/options-flow behavior changed.
- [x] Test impact: none — no code or tests changed.
- [x] Rollback plan: `git revert` this single commit; both files are docs/config only, zero runtime effect.

## Validation
- [x] `ruff check custom_components tests tools` — passed
- [x] `ruff check --select I custom_components tests tools` — passed
- [x] `ruff format --check custom_components tests tools` — passed
- [x] `python -m compileall -q custom_components/thessla_green_modbus tests tools` — passed
- [x] `python tools/check_maintainability.py` — passed
- [x] `python tools/validate_entity_mappings.py` — passed (367 entities)
- [x] `python tools/check_translations.py` — passed
- [x] `python tools/validate_registers.py` — passed
- [x] `.github/dependabot.yml` parses as valid YAML with the pydantic ignore rule present
- [ ] `pytest` — not run locally (sandbox is Python 3.11; HA test stack requires 3.13). No code/tests changed, so no new behavior for pytest to cover; CI verifies on 3.13.

## Notes
- No changelog: docs/tooling-only (no runtime/entity/register/service changes).
- No Modbus register addresses/names, entity IDs, unique IDs, service IDs, or translation keys changed.
- Rebased onto current `main` (post-#1745/#1746); diff is exactly the two files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qri5sT44tLALsK46dckG3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qri5sT44tLALsK46dckG3N)_