### PR TITLE
Final polish: docs audit, dead-code removal, test helper consolidation

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,0 @@
-[bandit]
-exclude = tests,tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- **Documentation consistency audit (final polish).** Aligned stale docs with the
+  current repository: `CONTRIBUTING.md` no longer instructs contributors to branch
+  off / rebase onto a `dev`/`develop` branch (it now targets `main`, matching the
+  no-`dev` rule); `docs/thesslagreen_architecture.md` file lists corrected
+  (`services.py` → `services/` package, and the phantom `core/runtime_state.py`
+  replaced with the real `core/io_mixin.py`); and `README_en.md` dropped the stale
+  `get_diagnostic_info` service bullet (no such service exists — diagnostics are
+  obtained via HA's "Download diagnostics"). No runtime, register, entity/service
+  ID, or translation changes.
+
 ### Internal
 
 - **Dead-code audit (final polish).** Removed proven-unused internal code left after the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Repository hygiene audit (final polish).** Removed the orphaned `.bandit` config:
+  bandit is not installed (`requirements-dev.txt`), not wired into CI, pre-commit, or
+  `pyproject.toml`, and its only documented reference (a `CONTRIBUTING.md` dev step) was
+  already removed — leaving a config for a tool nothing runs. No automated pipeline
+  consumed it, so removal cannot affect CI. (Restore a 2-line `[bandit]` `exclude =
+  tests,tools` file if bandit is ever wired in.)
 - **Dead-code audit (final polish).** Removed proven-unused internal code left after the
   refactor series: two private no-caller static-method wrappers on `_ModbusIOMixin`
   (`_is_illegal_data_address_response`, `_is_transient_error_response` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Dead-code audit (final polish).** Removed proven-unused internal code left after the
+  refactor series: two private no-caller static-method wrappers on `_ModbusIOMixin`
+  (`_is_illegal_data_address_response`, `_is_transient_error_response` in
+  `core/io_mixin.py`) plus their now-orphaned `read_batches` imports — the live read path
+  calls the `read_batches` module functions directly; and three unreferenced module-level
+  constants in `const.py` (`MODEL`, `DEFAULT_CONNECTION_MODE`, `LOG_LEVEL_OPTIONS`). All
+  removals were verified to have zero references across `custom_components/`, `tests/`, and
+  `tools/` and no dynamic lookups. The protected batch-boundary constants
+  (`MAX_REGISTERS_PER_REQUEST = 16`, `HOLDING_BATCH_BOUNDARIES = {16, 8192}`) and all
+  documented public API (DeviceClient `async_close`/`async_test_connection`/
+  `async_scan_device`/`get_capabilities`, `error_contract.is_transient`, the `errors.py`
+  exception hierarchy) were retained. No Modbus register addresses/names, entity IDs,
+  unique IDs, service IDs, translation keys, or config/options-flow behavior changed.
 - **Consolidated the shared read helpers (core consolidation Slice 4, narrow).** The
   `core/read_common.py` module (shared low-level read retry/error helpers:
   `is_illegal_data_address_response`, `is_transient_error_response`, `execute_read_call`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,16 +116,17 @@ The test suite ensures the JSON definitions remain valid.
 
 ### Branch Strategy
 
-- `main` - stable releases
-- `dev` - development branch
-- `feature/your-feature-name` - feature branches
-- `bugfix/issue-description` - bug fix branches
+- `main` - the single long-lived branch; all work targets `main`.
+- `feature/your-feature-name` - feature branches, created from `main`.
+- `bugfix/issue-description` - bug fix branches, created from `main`.
+
+> There is no `dev`/`develop` branch. Do not create or reintroduce one.
 
 ### Creating a Feature Branch
 
 ```bash
-git checkout develop
-git pull origin develop
+git checkout main
+git pull origin main
 git checkout -b feature/your-feature-name
 ```
 
@@ -285,10 +286,10 @@ mypy custom_components/thessla_green_modbus/
 
 1. **Update your branch:**
    ```bash
-   git checkout develop
-   git pull origin develop
+   git checkout main
+   git pull origin main
    git checkout your-feature-branch
-   git rebase develop
+   git rebase main
    ```
 
 2. **Run all checks:**

--- a/README_en.md
+++ b/README_en.md
@@ -212,8 +212,7 @@ Logs are visible in **Settings → System → Logs** and the `home-assistant.log
 
 ### View last read and error counters
 - **Entity attributes:** in **Developer Tools → States** open any integration entity; the `last_updated` attribute marks the last successful poll.
-- **Device diagnostics:** **Settings → Devices & Services → ThesslaGreen Modbus → ⋮ → Download diagnostics** to see `last_successful_update`, `successful_reads`/`failed_reads`, `last_error` and response-time statistics.
-- **`get_diagnostic_info` service:** call `thessla_green_modbus.get_diagnostic_info` from **Developer Tools → Services** to retrieve full diagnostics (device identity, available registers, error history).
+- **Device diagnostics:** **Settings → Devices & Services → ThesslaGreen Modbus → ⋮ → Download diagnostics** to see `last_successful_update`, `successful_reads`/`failed_reads`, `last_error` and response-time statistics (device identity, available registers and error history are included in the same download).
 
 ## ❔ FAQ
 

--- a/custom_components/thessla_green_modbus/const.py
+++ b/custom_components/thessla_green_modbus/const.py
@@ -48,7 +48,6 @@ HOLDING_BATCH_BOUNDARIES: frozenset[int] = frozenset({16, 8192})
 # Integration constants
 DOMAIN = "thessla_green_modbus"
 MANUFACTURER = "ThesslaGreen"
-MODEL = "AirPack Home Series 4"
 # Fallback model name used when the unit does not report one
 UNKNOWN_MODEL = "Unknown"
 
@@ -89,7 +88,6 @@ DEFAULT_CONNECTION_TYPE = CONNECTION_TYPE_TCP
 CONNECTION_MODE_TCP = "tcp"
 CONNECTION_MODE_TCP_RTU = "tcp_rtu"
 CONNECTION_MODE_AUTO = "auto"
-DEFAULT_CONNECTION_MODE = CONNECTION_MODE_AUTO
 
 # Default serial settings per ProtokolModbusRTU_AirPack4 specification: "9600 bps 8/N/1"
 DEFAULT_SERIAL_PORT = ""
@@ -176,7 +174,6 @@ DEFAULT_DEEP_SCAN = False
 DEFAULT_MAX_REGISTERS_PER_REQUEST = MAX_BATCH_REGISTERS
 DEFAULT_SAFE_SCAN = False
 DEFAULT_LOG_LEVEL = "info"
-LOG_LEVEL_OPTIONS = ["debug", "info", "warning", "error"]
 
 # Registers that are known to be unavailable on some devices
 KNOWN_MISSING_REGISTERS = {

--- a/custom_components/thessla_green_modbus/core/io_mixin.py
+++ b/custom_components/thessla_green_modbus/core/io_mixin.py
@@ -15,12 +15,6 @@ from .read_batches import (
     execute_read_call as _execute_read_call_impl,
 )
 from .read_batches import (
-    is_illegal_data_address_response as _is_illegal_data_address_response_impl,
-)
-from .read_batches import (
-    is_transient_error_response as _is_transient_error_response_impl,
-)
-from .read_batches import (
     log_read_retry as _log_read_retry_impl,
 )
 from .read_batches import (
@@ -111,14 +105,6 @@ class _ModbusIOMixin:
 
     async def _read_all_register_data(self) -> dict[str, Any]:
         return await _read_all_register_data_impl(self)
-
-    @staticmethod
-    def _is_illegal_data_address_response(response: Any) -> bool:
-        return bool(_is_illegal_data_address_response_impl(response))
-
-    @staticmethod
-    def _is_transient_error_response(response: Any) -> bool:
-        return bool(_is_transient_error_response_impl(response))
 
     async def _execute_read_call(
         self,

--- a/docs/coordinator_proxy_remaining_plan.md
+++ b/docs/coordinator_proxy_remaining_plan.md
@@ -471,3 +471,46 @@ delegates were removed.
 
 Both methods had zero callers after A5. Confirmed by `grep -r` on `custom_components` and
 `tests` before removal.
+
+---
+
+## 2026-07-08 final verification — no trivial device_client proxies remain
+
+Re-audited `coordinator/coordinator.py` against the whole codebase to confirm the
+cleanup is complete. **No trivial `coordinator → device_client` forwarders remain**
+that can be removed without changing runtime behavior or public contracts.
+
+### Correction to earlier entries
+
+Earlier entries (slice-5, A4) recorded `host`, `port`, and `slave_id` as **RETAINED**
+config property proxies. Those proxies **were subsequently removed** in commit
+`3b02b07` ("Remove coordinator.host/port proxy — all callers use device_client.config
+directly"). `_CoordinatorConfigPropertiesMixin` no longer exists. All callers now use
+`coordinator.device_client.config.host/port/slave_id` (and `device_client.slave_id`),
+including `entity.py` `unique_id` — so **no entity unique ID changed**.
+
+### Current `@property` surface on the coordinator (3 total)
+
+| Property | Classification | Why kept |
+|---|---|---|
+| `device_client` | intentional accessor | Core abstraction — the single entry point to device-domain state (220+ usages). |
+| `status_overview` | diagnostics adapter | Combines `device_client.statistics` with coordinator-level `scan_interval`; consumed by `diagnostics.py`. Not a device_client forwarder. |
+| `performance_stats` | diagnostics adapter | Aggregates `device_client.statistics`; consumed by `diagnostics.py`. Not a device_client forwarder. |
+
+### Remaining intentional (non-removable) delegating methods
+
+| Method | Classification | Why kept |
+|---|---|---|
+| `_ensure_connection` | HA-boundary adapter | Duck-typed entry point called by schedule/update/retry/client_registers submodules. |
+| `_disconnect_locked` | HA-boundary callback | Passed as `disconnect_locked_fn` to `core/connection_lifecycle.py`. |
+| `_disconnect` | HA-boundary adapter | Acquires `_client_lock`, then delegates; called by errors/schedule/update/write_path/shutdown. |
+| `_test_connection`, `_async_setup_client` | HA-boundary / test helper | Mirror HA start-up connection path; hold `_write_lock`, compose test addresses. |
+| `get_diagnostic_data`, `get_device_info` | diagnostics adapter | Combine `device_client` state with coordinator `entry`/`data`; behavior differs from `device_client`'s own methods. |
+| `_parse_backoff_jitter` (staticmethod) | test-facing helper | Forwards to `runtime.parse_backoff_jitter` (NOT device_client); asserted directly by unit tests. |
+| `_apply_scan_result`, `_run_device_scan`, `_warn_missing_device_info`, `_prepare_registers_for_setup`, `_get_scan_cache_from_entry`, `_consume_config_flow_scan_cache`, `_load_full_register_list`, `_normalise_available_registers`, `_apply_scan_cache`, `_store_scan_cache` | deferred `_impl` delegates | Forward to `coordinator/scan*.py` / `device_info.py` submodules (which need the coordinator's `entry`/`hass`), not to `device_client`. Removal requires the submodule-calling-convention refactor described in "Future Removal Path" and is gated on real-device validation. |
+
+### Conclusion
+
+The coordinator/device_client proxy reduction is **complete** for the scope achievable
+without the deferred submodule-signature refactor (which is gated on real-device
+validation). No further trivial device_client proxies exist to remove.

--- a/docs/thesslagreen_architecture.md
+++ b/docs/thesslagreen_architecture.md
@@ -85,7 +85,7 @@ Pliki i moduły:
 ```text
 __init__.py
 config_flow.py
-services.py
+services/
 diagnostics.py
 repairs.py
 entity.py
@@ -183,7 +183,7 @@ core/write_path.py          — SingleWritePlan, encode_write_value
 core/capabilities_mixin.py  — mixin capabilities
 core/models.py              — modele domenowe
 core/connection.py          — connection state
-core/runtime_state.py       — runtime state
+core/io_mixin.py            — read-path Modbus IO
 ```
 
 Odpowiedzialność:

--- a/tests/helpers_scanner.py
+++ b/tests/helpers_scanner.py
@@ -12,6 +12,13 @@ def _make_ok_response(registers):
     return resp
 
 
+def _make_bit_response(bits):
+    resp = MagicMock()
+    resp.isError.return_value = False
+    resp.bits = list(bits)
+    return resp
+
+
 async def _make_scanner(**kwargs):
     return await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 1, **kwargs)
 

--- a/tests/test_device_scanner_registers.py
+++ b/tests/test_device_scanner_registers.py
@@ -5,16 +5,11 @@ from custom_components.thessla_green_modbus.const import CONNECTION_TYPE_RTU
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 from pymodbus.exceptions import ConnectionException
 
+from .helpers_scanner import _make_ok_response
+
 
 async def _make_scanner(**kwargs):
     return await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 1, **kwargs)
-
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
 
 
 def _make_transport():

--- a/tests/test_device_scanner_selection.py
+++ b/tests/test_device_scanner_selection.py
@@ -7,16 +7,11 @@ from pymodbus.exceptions import (
     ModbusIOException,
 )
 
+from .helpers_scanner import _make_ok_response
+
 
 async def _make_scanner(**kwargs):
     return await ThesslaGreenDeviceScanner.create("192.168.1.1", 502, 1, **kwargs)
-
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
 
 
 def _make_transport(*, input_response=None, holding_response=None):

--- a/tests/test_scanner_error_paths.py
+++ b/tests/test_scanner_error_paths.py
@@ -11,12 +11,7 @@ from pymodbus.exceptions import (
     ModbusIOException,
 )
 
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
+from .helpers_scanner import _make_ok_response
 
 
 async def _make_scanner(**kwargs):

--- a/tests/test_scanner_io_coils.py
+++ b/tests/test_scanner_io_coils.py
@@ -11,19 +11,7 @@ from pymodbus.exceptions import (
     ModbusException,
 )
 
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
-
-
-def _make_bit_response(bits):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.bits = list(bits)
-    return resp
+from .helpers_scanner import _make_bit_response, _make_ok_response
 
 
 async def _make_scanner(**kwargs):

--- a/tests/test_scanner_io_discrete.py
+++ b/tests/test_scanner_io_discrete.py
@@ -11,19 +11,7 @@ from pymodbus.exceptions import (
     ModbusException,
 )
 
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
-
-
-def _make_bit_response(bits):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.bits = list(bits)
-    return resp
+from .helpers_scanner import _make_bit_response, _make_ok_response
 
 
 async def _make_scanner(**kwargs):

--- a/tests/test_scanner_io_holding.py
+++ b/tests/test_scanner_io_holding.py
@@ -7,19 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
-
-
-def _make_bit_response(bits):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.bits = list(bits)
-    return resp
+from .helpers_scanner import _make_ok_response
 
 
 async def _make_scanner(**kwargs):

--- a/tests/test_scanner_io_input.py
+++ b/tests/test_scanner_io_input.py
@@ -8,19 +8,7 @@ from pymodbus.exceptions import (
     ModbusIOException,
 )
 
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
-
-
-def _make_bit_response(bits):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.bits = list(bits)
-    return resp
+from .helpers_scanner import _make_ok_response
 
 
 async def _make_scanner(**kwargs):

--- a/tests/test_scanner_retry_contracts.py
+++ b/tests/test_scanner_retry_contracts.py
@@ -6,19 +6,7 @@ import pytest
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
 from pymodbus.exceptions import ModbusException
 
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
-
-
-def _make_bit_response(bits):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.bits = list(bits)
-    return resp
+from .helpers_scanner import _make_bit_response, _make_ok_response
 
 
 async def _make_scanner(**kwargs):

--- a/tests/test_scanner_setup_coverage.py
+++ b/tests/test_scanner_setup_coverage.py
@@ -7,12 +7,7 @@ import pytest
 from custom_components.thessla_green_modbus.const import CONNECTION_MODE_TCP, CONNECTION_TYPE_RTU
 from pymodbus.exceptions import ConnectionException
 
-
-def _make_ok_response(registers):
-    resp = MagicMock()
-    resp.isError.return_value = False
-    resp.registers = list(registers)
-    return resp
+from .helpers_scanner import _make_ok_response
 
 
 async def _make_scanner(**kwargs):


### PR DESCRIPTION
## Summary

This PR completes three final hygiene audits across documentation, dead code, and test infrastructure:

1. **Documentation consistency audit** — aligned stale docs with current repository state:
   - `CONTRIBUTING.md`: removed references to non-existent `dev`/`develop` branch; all work now targets `main` only.
   - `docs/thesslagreen_architecture.md`: corrected file/module listings (`services.py` → `services/` package; phantom `core/runtime_state.py` → real `core/io_mixin.py`).
   - `README_en.md`: removed stale `get_diagnostic_info` service bullet (diagnostics obtained via HA's "Download diagnostics" only).
   - `docs/coordinator_proxy_remaining_plan.md`: added final verification entry confirming no trivial `coordinator → device_client` proxies remain.

2. **Dead-code audit** — removed proven-unused internal code:
   - `core/io_mixin.py`: removed two private no-caller static-method wrappers (`_is_illegal_data_address_response`, `_is_transient_error_response`) and their orphaned `read_batches` imports. The live read path calls `read_batches` module functions directly.
   - `const.py`: removed three unreferenced module-level constants (`MODEL`, `DEFAULT_CONNECTION_MODE`, `LOG_LEVEL_OPTIONS`). All removals verified to have zero references across `custom_components/`, `tests/`, and `tools/`.
   - `.bandit`: removed orphaned config file. Bandit is not installed, not wired into CI/pre-commit/`pyproject.toml`, and its only documented reference was already removed.

3. **Test helper consolidation** — deduplicated `_make_ok_response` and `_make_bit_response` helpers:
   - Moved shared test helpers from individual test files into `tests/helpers_scanner.py`.
   - Updated 8 test files to import from the shared module instead of defining locally.

**No runtime behavior, register addresses, entity IDs, unique IDs, service IDs, translation keys, or config/options-flow behavior changed.** Protected batch-boundary constants and all documented public API retained.

## Maintainability checklist

- [x] Dead-code removals verified to have zero references across codebase.
- [x] Documentation changes are non-breaking (clarifications and corrections only).
- [x] Test helper consolidation reduces duplication without changing test semantics.
- [x] No changes to public API surface or entity/service contracts.

## Validation

- [x] `ruff check` — no linting issues.
- [x] `pytest` — all existing tests pass (no test logic changed, only imports updated).
- [x] Manual verification: grep confirmed zero references to removed constants and methods.

## Notes

- The `.bandit` removal can be safely reverted if bandit is wired into CI in the future (restore a 2-line `[bandit]` `exclude = tests,tools` file).
- All removals are low-risk: dead code with zero callers, stale documentation, and test helper deduplication.

https://claude.ai/code/session_019dnHnYwLyp9rWiwxThmj53