### PR TITLE
chore(release): prepare v2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.3] - 2026-07-09
+
+> Wrap-up of the post-refactor cleanup series. Ships the targeted read-back safe
+> allow-list, the connection-helper and narrow read-helper `core/` consolidations,
+> and real-device validation, dead-code, test-helper, and documentation polish.
+> **No Modbus register addresses/names, entity IDs, unique IDs, service IDs,
+> translation keys, or config/options-flow behavior changed.** `quality_scale`
+> stays `bronze` — real-device validation is still PARTIAL pending the manual
+> UI/service evidence enumerated in the release gate.
+
 ### Docs
 
+- **Real-device validation evidence + plan refresh.** Recorded the 2026-07-08 real
+  device HA-log evidence in `docs/real_device_validation.md` (clean post-refactor
+  setup, config-flow scan-cache startup, service registration, basic read path, and
+  successful `air_flow_rate_manual` writes; no `transaction_id mismatch` or false
+  transport disconnect observed), and refreshed `docs/core_consolidation_plan.md` to
+  the current repository state after the completed slices (19 `core/` files; broad
+  Slice 4 / Slice 5 / mixin-into-`client.py` marked DEFERRED / NOT RECOMMENDED NOW).
+  Validation remains PARTIAL and `quality_scale` stays `bronze`. Docs-only.
 - **Documentation consistency audit (final polish).** Aligned stale docs with the
   current repository: `CONTRIBUTING.md` no longer instructs contributors to branch
   off / rebase onto a `dev`/`develop` branch (it now targets `main`, matching the
@@ -51,8 +69,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cycle is untouched, and `read_bits.py`/`runtime_io.py`/`io_mixin.py` were not moved. No
   Modbus register addresses/names, entity IDs, unique IDs, service IDs, or translation keys
   changed. See `docs/core_consolidation_plan.md`.
+- **Consolidated the scanner test helpers (final polish).** Duplicated response-mock
+  factories across the scanner test modules were consolidated into
+  `tests/helpers_scanner.py` so the tests share one source of truth. Test-only change;
+  no runtime, register, entity/service ID, or translation changes.
 - **Consolidated the connection helper modules (core consolidation Slice 3).** The
-  tiny `core/connection_state.py` and `core/disconnect.py` helper modules were inlined
   tiny `core/connection_state.py` and `core/disconnect.py` helper modules were inlined
   into their sole caller-adjacent module `core/connection_lifecycle.py` (byte-identical
   function bodies), reducing the `core/` file count from 23 to 21. `core/client_connection.py`

--- a/custom_components/thessla_green_modbus/manifest.json
+++ b/custom_components/thessla_green_modbus/manifest.json
@@ -26,7 +26,7 @@
   "requirements": [
     "pymodbus>=3.6.0,<4.0"
   ],
-  "version": "2.8.2",
+  "version": "2.8.3",
   "zeroconf": [
     {
       "type": "_modbus._tcp.local.",


### PR DESCRIPTION
## Summary
- [x] Explain what changed and why.

Release prep for **v2.8.3**, wrapping up the post-refactor cleanup series. Release-only — no runtime code changes.

- **`manifest.json`** — `version` `2.8.2` → `2.8.3` (`quality_scale` stays `bronze`; real-device validation is still PARTIAL).
- **`CHANGELOG.md`** — opened a fresh empty `[Unreleased]` and moved the accumulated entries into `## [2.8.3] - 2026-07-09`, with a summary covering:
  - targeted read-back safe allow-list (#1745)
  - connection-helper `core/` consolidation (#1748)
  - narrow read-helper `core/` consolidation (#1750)
  - real-device validation docs update (#1751) + core consolidation plan refresh (#1753)
  - docs / dead-code / test-helper polish (#1752)
  - Also added the previously un-itemised real-device validation + core-plan docs refresh and scanner test-helper consolidation entries, and fixed a duplicated line in the connection-helper entry.

The release workflow (`.github/workflows/release.yaml`) creates the `v2.8.3` tag and GitHub release automatically after this merges to `main` (it triggers on `manifest.json` / `CHANGELOG.md` pushes and extracts notes from the `## [2.8.3]` section). No tag or release is created manually.

## Maintainability checklist (required for large refactors)
- [x] N/A — release-only (version bump + changelog), no methods/files changed.
- [x] N/A — no code moved.
- [x] Behavior compatibility: no behavior change.
- [x] N/A — no test impact.
- [x] Rollback plan: `git revert` the release commit (restores `2.8.2` + prior `[Unreleased]`); no tag is created until merge.

## Validation
- [x] `python -m compileall -q custom_components/thessla_green_modbus tests tools` — OK.
- [x] `ruff check` / `ruff check --select I` / `ruff format --check custom_components tests tools` — all pass (453 files formatted).
- [x] `python tools/compare_registers_with_reference.py --show-renames` — exit 0.
- [x] `python tools/compare_airpack4_vendor_coverage.py` — exit 0, 0 missing vendor registers, no tracked-file diff.
- [x] `python tools/check_maintainability.py` — gate passed.
- [x] `python tools/validate_entity_mappings.py` — OK, 367 entities.
- [x] `python tools/check_translations.py` — all keys present.
- [x] `python tools/validate_registers.py` — exit 0.
- [ ] `pytest` — not run locally (sandbox is Python 3.11; the test stack requires 3.13). Needs CI verification on Python 3.13. No runtime code changed, so no test behavior is affected.

## Notes
- **Rules self-audit:** no Modbus register addresses/names, entity IDs, unique IDs, service IDs, translation keys, or config/options-flow behavior changed. No runtime code touched. Not a `dev` branch. No shims introduced. `quality_scale` kept at `bronze`.
- Preconditions confirmed before opening: PR #1753 merged, `main` CI green on `ad10bef`, no other open PRs, no validation regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxJAvxoNT1yabpZTab2vig

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxJAvxoNT1yabpZTab2vig)_