### PR TITLE
feat(agents): add portable checkpoint resume workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,13 @@
 - Treat chat history as disposable. Keep durable task or handoff state compact and leave exactly one concrete next action when handing work off.
 - When the next action is safe and autonomous, continue without waiting for acknowledgement.
 
+## Durable continuation
+
+- For substantial work, use the checkpoint contract in `docs/agents/CONTEXT_HANDOFF.md`.
+- Validate the active task checkpoint with `python tools/agents/checkpoint.py <task-path> --require-checkpoint`.
+- Generate a compact next-agent prompt with `python tools/agents/resume.py --task <task-path>`.
+- A continuation agent must resume from Git, the task checkpoint and live PR/CI state, not from the previous chat transcript.
+
 ## Scope and precedence
 
 - Repository-local and nearest nested `AGENTS.md` instructions remain authoritative for repository-specific safety, branching, ownership, validation, deployment, and merge rules.

--- a/docs/agents/CONTEXT_HANDOFF.md
+++ b/docs/agents/CONTEXT_HANDOFF.md
@@ -1,0 +1,11 @@
+# Agent Context Handoff
+
+Chat history is disposable. Git state, the active task checkpoint, the live PR and deterministic validation evidence are durable state.
+
+For every substantial task: keep one compact `## Context checkpoint`, update it after material changes, validate with `python tools/agents/checkpoint.py <task-path> --require-checkpoint`, then generate the next-agent prompt with `python tools/agents/resume.py --task <task-path>`.
+
+The next agent verifies only live state that can invalidate `next_action`, then continues from that action. Never pass the previous chat transcript as the handoff.
+
+Checkpoint v1 carries branch/head/PR/status, `PROVEN`, `DERIVED`, `UNKNOWN`, `CONFLICT`, first failure, changed paths, validation, blockers, and exactly one concrete `next_action`.
+
+Do not repeat a full preflight when checkpoint and live state agree. Do not store full logs, diffs, source files, old chat, repeated CI history or whole-repository inventories. `tools/agents/checkpoint.py` enforces compactness ceilings.

--- a/docs/agents/GOVERNANCE_CONTRACT.json
+++ b/docs/agents/GOVERNANCE_CONTRACT.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "contract_name": "portable-agent-checkpoint-handoff",
+  "shared_checkpoint_contract": {
+    "version": 1,
+    "required_fields": ["checkpoint_version", "updated_at", "head", "branch", "pr", "status", "context_routes", "owned_paths", "proven", "derived", "unknown", "conflicts", "first_failure", "rejected_hypotheses", "changed_paths", "validation", "blockers", "next_action"],
+    "allowed_statuses": ["investigating", "implementing", "validating", "blocked", "ready"],
+    "allowed_validation_results": ["PASS", "FAIL", "BLOCKED", "NOT_RUN"],
+    "evidence_state_fields": {"PROVEN": "proven", "DERIVED": "derived", "UNKNOWN": "unknown", "CONFLICT": "conflicts"},
+    "compactness_limits": {"context_routes": 8, "owned_paths": 64, "proven": 16, "derived": 12, "unknown": 12, "conflicts": 8, "rejected_hypotheses": 16, "changed_paths": 32, "validation": 12, "blockers": 8}
+  }
+}

--- a/docs/agents/tasks/TASK_TEMPLATE.md
+++ b/docs/agents/tasks/TASK_TEMPLATE.md
@@ -1,0 +1,44 @@
+---
+task_id: TASK-YYYYMMDD-short-slug
+status: implementing
+branch: <task-branch>
+base_branch: main
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+related_pr: ""
+owned_paths:
+  - <path/glob>
+---
+
+# <Task title>
+
+## Context checkpoint
+
+```yaml
+checkpoint_version: 1
+updated_at: YYYY-MM-DDTHH:MM:SSZ
+head: UNKNOWN
+branch: <task-branch>
+pr: none
+status: investigating
+context_routes:
+  - none
+owned_paths:
+  - <path/glob>
+proven:
+  - <current verified fact>
+derived: []
+unknown: []
+conflicts: []
+first_failure:
+  marker: none
+  evidence: none
+rejected_hypotheses: []
+changed_paths: []
+validation:
+  - command: not-run
+    result: NOT_RUN
+    evidence: none
+blockers: []
+next_action: <exactly one concrete next step>
+```

--- a/tools/agents/checkpoint.py
+++ b/tools/agents/checkpoint.py
@@ -57,9 +57,7 @@ def parse_checkpoint(path: Path) -> dict[str, object] | None:
     if not matches:
         return None
     if len(matches) != 1:
-        raise ValueError(
-            f"{path}: expected exactly one {CHECKPOINT_HEADING} section"
-        )
+        raise ValueError(f"{path}: expected exactly one {CHECKPOINT_HEADING} section")
 
     remainder = text[matches[0].end() :]
     next_heading = re.search(r"(?m)^##\s+", remainder)
@@ -76,9 +74,7 @@ def parse_checkpoint(path: Path) -> dict[str, object] | None:
     current_key: str | None = None
     current_validation: dict[str, str] | None = None
 
-    for line_number, raw in enumerate(
-        section[fence.end() : block_end].splitlines(), start=1
-    ):
+    for line_number, raw in enumerate(section[fence.end() : block_end].splitlines(), start=1):
         if not raw.strip() or raw.lstrip().startswith("#"):
             continue
 
@@ -87,9 +83,7 @@ def parse_checkpoint(path: Path) -> dict[str, object] | None:
 
         if indent == 0:
             if ":" not in line:
-                raise ValueError(
-                    f"{path}:{line_number}: invalid checkpoint line"
-                )
+                raise ValueError(f"{path}:{line_number}: invalid checkpoint line")
             key, value = line.split(":", 1)
             key = key.strip()
             value = value.strip()
@@ -100,15 +94,11 @@ def parse_checkpoint(path: Path) -> dict[str, object] | None:
             current_validation = None
             if key in LIST_KEYS or key == "validation":
                 if value not in {"", "[]"}:
-                    raise ValueError(
-                        f"{path}:{line_number}: {key} must be a YAML list"
-                    )
+                    raise ValueError(f"{path}:{line_number}: {key} must be a YAML list")
                 data[key] = []
             elif key == "first_failure":
                 if value:
-                    raise ValueError(
-                        f"{path}:{line_number}: first_failure must be a mapping"
-                    )
+                    raise ValueError(f"{path}:{line_number}: first_failure must be a mapping")
                 data[key] = {}
             else:
                 data[key] = scalar(value)
@@ -116,9 +106,7 @@ def parse_checkpoint(path: Path) -> dict[str, object] | None:
 
         if current_key in LIST_KEYS:
             if indent != 2 or not line.startswith("- "):
-                raise ValueError(
-                    f"{path}:{line_number}: invalid list item under {current_key}"
-                )
+                raise ValueError(f"{path}:{line_number}: invalid list item under {current_key}")
             values = data[current_key]
             assert isinstance(values, list)
             values.append(scalar(line[2:]))
@@ -126,9 +114,7 @@ def parse_checkpoint(path: Path) -> dict[str, object] | None:
 
         if current_key == "first_failure":
             if indent != 2 or ":" not in line:
-                raise ValueError(
-                    f"{path}:{line_number}: invalid first_failure item"
-                )
+                raise ValueError(f"{path}:{line_number}: invalid first_failure item")
             key, value = line.split(":", 1)
             mapping = data[current_key]
             assert isinstance(mapping, dict)
@@ -141,9 +127,7 @@ def parse_checkpoint(path: Path) -> dict[str, object] | None:
             if indent == 2 and line.startswith("- "):
                 item = line[2:].strip()
                 if ":" not in item:
-                    raise ValueError(
-                        f"{path}:{line_number}: invalid validation item"
-                    )
+                    raise ValueError(f"{path}:{line_number}: invalid validation item")
                 key, value = item.split(":", 1)
                 current_validation = {key.strip(): scalar(value)}
                 items.append(current_validation)
@@ -154,9 +138,7 @@ def parse_checkpoint(path: Path) -> dict[str, object] | None:
                 continue
             raise ValueError(f"{path}:{line_number}: invalid validation item")
 
-        raise ValueError(
-            f"{path}:{line_number}: scalar field cannot have nested values"
-        )
+        raise ValueError(f"{path}:{line_number}: scalar field cannot have nested values")
 
     return data
 
@@ -172,9 +154,7 @@ def validate_checkpoint(data: dict[str, object], path: Path) -> list[str]:
     required_fields = contract.get("required_fields", [])
     assert isinstance(required_fields, list)
     errors.extend(
-        f"{path}: missing checkpoint field {key}"
-        for key in required_fields
-        if key not in data
+        f"{path}: missing checkpoint field {key}" for key in required_fields if key not in data
     )
 
     if str(data.get("checkpoint_version", "")) != str(contract.get("version")):
@@ -191,8 +171,7 @@ def validate_checkpoint(data: dict[str, object], path: Path) -> list[str]:
 
     first_failure = data.get("first_failure")
     if not isinstance(first_failure, dict) or not all(
-        str(first_failure.get(key, "")).strip()
-        for key in ("marker", "evidence")
+        str(first_failure.get(key, "")).strip() for key in ("marker", "evidence")
     ):
         errors.append(f"{path}: invalid first_failure")
 
@@ -204,8 +183,7 @@ def validate_checkpoint(data: dict[str, object], path: Path) -> list[str]:
     else:
         for index, item in enumerate(validation, start=1):
             if not isinstance(item, dict) or not all(
-                str(item.get(key, "")).strip()
-                for key in ("command", "result", "evidence")
+                str(item.get(key, "")).strip() for key in ("command", "result", "evidence")
             ):
                 errors.append(f"{path}: invalid validation item {index}")
                 continue
@@ -219,28 +197,20 @@ def validate_checkpoint(data: dict[str, object], path: Path) -> list[str]:
         if not isinstance(value, list):
             errors.append(f"{path}: {key} must be a list")
         elif len(value) > int(limit):
-            errors.append(
-                f"{path}: {key} has {len(value)} items; "
-                f"compactness limit is {limit}"
-            )
+            errors.append(f"{path}: {key} has {len(value)} items; compactness limit is {limit}")
 
     evidence_map = contract.get("evidence_state_fields", {})
     assert isinstance(evidence_map, dict)
     evidence_fields = list(evidence_map.values())
     evidence_sets = {
-        key: {
-            normalized_fact(str(item))
-            for item in data.get(key, [])
-            if str(item).strip()
-        }
+        key: {normalized_fact(str(item)) for item in data.get(key, []) if str(item).strip()}
         for key in evidence_fields
     }
     for index, left in enumerate(evidence_fields):
         for right in evidence_fields[index + 1 :]:
             overlap = evidence_sets[left] & evidence_sets[right]
             errors.extend(
-                f"{path}: evidence fact appears in both "
-                f"{left} and {right}: {fact}"
+                f"{path}: evidence fact appears in both {left} and {right}: {fact}"
                 for fact in sorted(overlap)
             )
 
@@ -248,9 +218,7 @@ def validate_checkpoint(data: dict[str, object], path: Path) -> list[str]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Validate compact agent task checkpoints"
-    )
+    parser = argparse.ArgumentParser(description="Validate compact agent task checkpoints")
     parser.add_argument("task", nargs="?", type=Path)
     parser.add_argument("--tasks", type=Path)
     parser.add_argument("--require-checkpoint", action="store_true")

--- a/tools/agents/checkpoint.py
+++ b/tools/agents/checkpoint.py
@@ -171,9 +171,11 @@ def validate_checkpoint(data: dict[str, object], path: Path) -> list[str]:
 
     required_fields = contract.get("required_fields", [])
     assert isinstance(required_fields, list)
-    for key in required_fields:
-        if key not in data:
-            errors.append(f"{path}: missing checkpoint field {key}")
+    errors.extend(
+        f"{path}: missing checkpoint field {key}"
+        for key in required_fields
+        if key not in data
+    )
 
     if str(data.get("checkpoint_version", "")) != str(contract.get("version")):
         errors.append(f"{path}: wrong checkpoint_version")
@@ -236,11 +238,11 @@ def validate_checkpoint(data: dict[str, object], path: Path) -> list[str]:
     for index, left in enumerate(evidence_fields):
         for right in evidence_fields[index + 1 :]:
             overlap = evidence_sets[left] & evidence_sets[right]
-            for fact in sorted(overlap):
-                errors.append(
-                    f"{path}: evidence fact appears in both "
-                    f"{left} and {right}: {fact}"
-                )
+            errors.extend(
+                f"{path}: evidence fact appears in both "
+                f"{left} and {right}: {fact}"
+                for fact in sorted(overlap)
+            )
 
     return errors
 

--- a/tools/agents/checkpoint.py
+++ b/tools/agents/checkpoint.py
@@ -1,68 +1,284 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse,json,re,sys
+
+import argparse
+import json
+import re
+import sys
 from pathlib import Path
-H="## Context checkpoint";L={"context_routes","owned_paths","proven","derived","unknown","conflicts","rejected_hypotheses","changed_paths","blockers"};P={"","none","unknown","pending","n/a","tbd","todo","later"}
-def cfg():return json.loads((Path(__file__).resolve().parents[2]/"docs/agents/GOVERNANCE_CONTRACT.json").read_text())["shared_checkpoint_contract"]
-def s(v):
- v=v.strip();return v[1:-1] if len(v)>=2 and v[0]==v[-1] and v[0] in {'\"',"'"} else v
-def parse(p):
- t=p.read_text();m=list(re.finditer(r"(?m)^## Context checkpoint\s*$",t))
- if not m:return None
- if len(m)!=1:raise ValueError(f"{p}: expected one {H}")
- r=t[m[0].end():];n=re.search(r"(?m)^##\s+",r);q=r[:n.start()] if n else r;f=re.search(r"```(?:yaml|yml)\s*\n",q,re.I)
- if not f:raise ValueError(f"{p}: checkpoint has no YAML fence")
- e=q.find("```",f.end());d={};cur=None;cv=None
- if e<0:raise ValueError(f"{p}: checkpoint fence not closed")
- for no,raw in enumerate(q[f.end():e].splitlines(),1):
-  if not raw.strip() or raw.lstrip().startswith("#"):continue
-  ind=len(raw)-len(raw.lstrip());line=raw.strip()
-  if ind==0:
-   if ":" not in line:raise ValueError(f"{p}:{no}: invalid line")
-   k,v=line.split(":",1);k=k.strip();v=v.strip();cur=k;cv=None
-   if k in d:raise ValueError(f"{p}:{no}: duplicate {k}")
-   if k in L or k=="validation":d[k]=[] if v in {"","[]"} else (_ for _ in ()).throw(ValueError(f"{p}:{no}: {k} must be list"))
-   elif k=="first_failure":d[k]={}
-   else:d[k]=s(v)
-  elif cur in L:d[cur].append(s(line[2:])) if ind==2 and line.startswith("- ") else (_ for _ in ()).throw(ValueError(f"{p}:{no}: invalid list"))
-  elif cur=="first_failure":k,v=line.split(":",1);d[cur][k.strip()]=s(v)
-  elif cur=="validation":
-   if ind==2 and line.startswith("- "):k,v=line[2:].split(":",1);cv={k.strip():s(v)};d[cur].append(cv)
-   elif ind==4 and cv is not None:k,v=line.split(":",1);cv[k.strip()]=s(v)
-   else:raise ValueError(f"{p}:{no}: invalid validation")
- return d
-def validate(d,p):
- c=cfg();e=[]
- for k in c["required_fields"]:
-  if k not in d:e.append(f"{p}: missing {k}")
- if str(d.get("checkpoint_version",""))!=str(c["version"]):e.append(f"{p}: wrong checkpoint_version")
- if d.get("status") not in c["allowed_statuses"]:e.append(f"{p}: unsupported status")
- if str(d.get("next_action","")).strip().casefold() in P:e.append(f"{p}: next_action must be concrete")
- ff=d.get("first_failure")
- if not isinstance(ff,dict) or not all(str(ff.get(k,"")).strip() for k in ("marker","evidence")):e.append(f"{p}: invalid first_failure")
- for k,limit in c.get("compactness_limits",{}).items():
-  v=d.get(k,[])
-  if not isinstance(v,list):e.append(f"{p}: {k} must be list")
-  elif len(v)>limit:e.append(f"{p}: {k} compactness limit {limit} exceeded")
- val=d.get("validation",[])
- for i,x in enumerate(val,1):
-  if not isinstance(x,dict) or not all(str(x.get(k,"")).strip() for k in ("command","result","evidence")):e.append(f"{p}: invalid validation {i}")
-  elif x["result"] not in c["allowed_validation_results"]:e.append(f"{p}: unsupported validation result")
- fields=list(c["evidence_state_fields"].values());sets={k:{" ".join(str(x).casefold().split()) for x in d.get(k,[]) if str(x).strip()} for k in fields}
- for i,a in enumerate(fields):
-  for b in fields[i+1:]:
-   if sets[a]&sets[b]:e.append(f"{p}: evidence overlaps {a}/{b}")
- return e
-def main():
- a=argparse.ArgumentParser();a.add_argument("task",nargs="?",type=Path);a.add_argument("--tasks",type=Path);a.add_argument("--require-checkpoint",action="store_true");x=a.parse_args()
- if bool(x.task)==bool(x.tasks):a.error("provide one task or --tasks")
- ps=[x.task] if x.task else sorted(x.tasks.glob("*.md"));err=[]
- for p in ps:
-  try:d=parse(p)
-  except Exception as z:err.append(str(z));continue
-  if d is None:
-   if x.require_checkpoint:err.append(f"{p}: missing {H}")
-  else:err+=validate(d,p)
- for z in err:print("ERROR:",z,file=sys.stderr)
- return 1 if err else (print(f"Validated {len(ps)} checkpoint task(s).") or 0)
-if __name__=="__main__":raise SystemExit(main())
+
+CHECKPOINT_HEADING = "## Context checkpoint"
+LIST_KEYS = {
+    "context_routes",
+    "owned_paths",
+    "proven",
+    "derived",
+    "unknown",
+    "conflicts",
+    "rejected_hypotheses",
+    "changed_paths",
+    "blockers",
+}
+PLACEHOLDER_NEXT_ACTIONS = {
+    "",
+    "none",
+    "unknown",
+    "pending",
+    "n/a",
+    "tbd",
+    "todo",
+    "later",
+}
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def load_contract() -> dict[str, object]:
+    path = repository_root() / "docs/agents/GOVERNANCE_CONTRACT.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    contract = raw["shared_checkpoint_contract"]
+    if not isinstance(contract, dict):
+        raise ValueError(f"{path}: invalid shared checkpoint contract")
+    return contract
+
+
+def scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def parse_checkpoint(path: Path) -> dict[str, object] | None:
+    text = path.read_text(encoding="utf-8")
+    matches = list(re.finditer(r"(?m)^## Context checkpoint\s*$", text))
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError(
+            f"{path}: expected exactly one {CHECKPOINT_HEADING} section"
+        )
+
+    remainder = text[matches[0].end() :]
+    next_heading = re.search(r"(?m)^##\s+", remainder)
+    section = remainder[: next_heading.start()] if next_heading else remainder
+    fence = re.search(r"```(?:yaml|yml)\s*\n", section, re.IGNORECASE)
+    if not fence:
+        raise ValueError(f"{path}: checkpoint has no fenced YAML block")
+
+    block_end = section.find("```", fence.end())
+    if block_end < 0:
+        raise ValueError(f"{path}: checkpoint fence is not closed")
+
+    data: dict[str, object] = {}
+    current_key: str | None = None
+    current_validation: dict[str, str] | None = None
+
+    for line_number, raw in enumerate(
+        section[fence.end() : block_end].splitlines(), start=1
+    ):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+
+        indent = len(raw) - len(raw.lstrip(" "))
+        line = raw.strip()
+
+        if indent == 0:
+            if ":" not in line:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid checkpoint line"
+                )
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            if key in data:
+                raise ValueError(f"{path}:{line_number}: duplicate key {key}")
+
+            current_key = key
+            current_validation = None
+            if key in LIST_KEYS or key == "validation":
+                if value not in {"", "[]"}:
+                    raise ValueError(
+                        f"{path}:{line_number}: {key} must be a YAML list"
+                    )
+                data[key] = []
+            elif key == "first_failure":
+                if value:
+                    raise ValueError(
+                        f"{path}:{line_number}: first_failure must be a mapping"
+                    )
+                data[key] = {}
+            else:
+                data[key] = scalar(value)
+            continue
+
+        if current_key in LIST_KEYS:
+            if indent != 2 or not line.startswith("- "):
+                raise ValueError(
+                    f"{path}:{line_number}: invalid list item under {current_key}"
+                )
+            values = data[current_key]
+            assert isinstance(values, list)
+            values.append(scalar(line[2:]))
+            continue
+
+        if current_key == "first_failure":
+            if indent != 2 or ":" not in line:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid first_failure item"
+                )
+            key, value = line.split(":", 1)
+            mapping = data[current_key]
+            assert isinstance(mapping, dict)
+            mapping[key.strip()] = scalar(value)
+            continue
+
+        if current_key == "validation":
+            items = data[current_key]
+            assert isinstance(items, list)
+            if indent == 2 and line.startswith("- "):
+                item = line[2:].strip()
+                if ":" not in item:
+                    raise ValueError(
+                        f"{path}:{line_number}: invalid validation item"
+                    )
+                key, value = item.split(":", 1)
+                current_validation = {key.strip(): scalar(value)}
+                items.append(current_validation)
+                continue
+            if indent == 4 and current_validation is not None and ":" in line:
+                key, value = line.split(":", 1)
+                current_validation[key.strip()] = scalar(value)
+                continue
+            raise ValueError(f"{path}:{line_number}: invalid validation item")
+
+        raise ValueError(
+            f"{path}:{line_number}: scalar field cannot have nested values"
+        )
+
+    return data
+
+
+def normalized_fact(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def validate_checkpoint(data: dict[str, object], path: Path) -> list[str]:
+    contract = load_contract()
+    errors: list[str] = []
+
+    required_fields = contract.get("required_fields", [])
+    assert isinstance(required_fields, list)
+    for key in required_fields:
+        if key not in data:
+            errors.append(f"{path}: missing checkpoint field {key}")
+
+    if str(data.get("checkpoint_version", "")) != str(contract.get("version")):
+        errors.append(f"{path}: wrong checkpoint_version")
+
+    statuses = contract.get("allowed_statuses", [])
+    assert isinstance(statuses, list)
+    if data.get("status") not in statuses:
+        errors.append(f"{path}: unsupported status")
+
+    next_action = str(data.get("next_action", "")).strip().casefold()
+    if next_action in PLACEHOLDER_NEXT_ACTIONS:
+        errors.append(f"{path}: next_action must be concrete")
+
+    first_failure = data.get("first_failure")
+    if not isinstance(first_failure, dict) or not all(
+        str(first_failure.get(key, "")).strip()
+        for key in ("marker", "evidence")
+    ):
+        errors.append(f"{path}: invalid first_failure")
+
+    validation = data.get("validation")
+    allowed_results = contract.get("allowed_validation_results", [])
+    assert isinstance(allowed_results, list)
+    if not isinstance(validation, list):
+        errors.append(f"{path}: validation must be a list")
+    else:
+        for index, item in enumerate(validation, start=1):
+            if not isinstance(item, dict) or not all(
+                str(item.get(key, "")).strip()
+                for key in ("command", "result", "evidence")
+            ):
+                errors.append(f"{path}: invalid validation item {index}")
+                continue
+            if item["result"] not in allowed_results:
+                errors.append(f"{path}: unsupported validation result")
+
+    limits = contract.get("compactness_limits", {})
+    assert isinstance(limits, dict)
+    for key, limit in limits.items():
+        value = data.get(key, [])
+        if not isinstance(value, list):
+            errors.append(f"{path}: {key} must be a list")
+        elif len(value) > int(limit):
+            errors.append(
+                f"{path}: {key} has {len(value)} items; "
+                f"compactness limit is {limit}"
+            )
+
+    evidence_map = contract.get("evidence_state_fields", {})
+    assert isinstance(evidence_map, dict)
+    evidence_fields = list(evidence_map.values())
+    evidence_sets = {
+        key: {
+            normalized_fact(str(item))
+            for item in data.get(key, [])
+            if str(item).strip()
+        }
+        for key in evidence_fields
+    }
+    for index, left in enumerate(evidence_fields):
+        for right in evidence_fields[index + 1 :]:
+            overlap = evidence_sets[left] & evidence_sets[right]
+            for fact in sorted(overlap):
+                errors.append(
+                    f"{path}: evidence fact appears in both "
+                    f"{left} and {right}: {fact}"
+                )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate compact agent task checkpoints"
+    )
+    parser.add_argument("task", nargs="?", type=Path)
+    parser.add_argument("--tasks", type=Path)
+    parser.add_argument("--require-checkpoint", action="store_true")
+    args = parser.parse_args()
+
+    if bool(args.task) == bool(args.tasks):
+        parser.error("provide exactly one task or --tasks directory")
+
+    paths = [args.task] if args.task else sorted(args.tasks.glob("*.md"))
+    errors: list[str] = []
+    for path in paths:
+        try:
+            data = parse_checkpoint(path)
+        except (OSError, ValueError) as exc:
+            errors.append(str(exc))
+            continue
+        if data is None:
+            if args.require_checkpoint:
+                errors.append(f"{path}: missing {CHECKPOINT_HEADING}")
+        else:
+            errors.extend(validate_checkpoint(data, path))
+
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    if errors:
+        return 1
+
+    print(f"Validated {len(paths)} checkpoint task(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agents/checkpoint.py
+++ b/tools/agents/checkpoint.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse,json,re,sys
+from pathlib import Path
+H="## Context checkpoint";L={"context_routes","owned_paths","proven","derived","unknown","conflicts","rejected_hypotheses","changed_paths","blockers"};P={"","none","unknown","pending","n/a","tbd","todo","later"}
+def cfg():return json.loads((Path(__file__).resolve().parents[2]/"docs/agents/GOVERNANCE_CONTRACT.json").read_text())["shared_checkpoint_contract"]
+def s(v):
+ v=v.strip();return v[1:-1] if len(v)>=2 and v[0]==v[-1] and v[0] in {'\"',"'"} else v
+def parse(p):
+ t=p.read_text();m=list(re.finditer(r"(?m)^## Context checkpoint\s*$",t))
+ if not m:return None
+ if len(m)!=1:raise ValueError(f"{p}: expected one {H}")
+ r=t[m[0].end():];n=re.search(r"(?m)^##\s+",r);q=r[:n.start()] if n else r;f=re.search(r"```(?:yaml|yml)\s*\n",q,re.I)
+ if not f:raise ValueError(f"{p}: checkpoint has no YAML fence")
+ e=q.find("```",f.end());d={};cur=None;cv=None
+ if e<0:raise ValueError(f"{p}: checkpoint fence not closed")
+ for no,raw in enumerate(q[f.end():e].splitlines(),1):
+  if not raw.strip() or raw.lstrip().startswith("#"):continue
+  ind=len(raw)-len(raw.lstrip());line=raw.strip()
+  if ind==0:
+   if ":" not in line:raise ValueError(f"{p}:{no}: invalid line")
+   k,v=line.split(":",1);k=k.strip();v=v.strip();cur=k;cv=None
+   if k in d:raise ValueError(f"{p}:{no}: duplicate {k}")
+   if k in L or k=="validation":d[k]=[] if v in {"","[]"} else (_ for _ in ()).throw(ValueError(f"{p}:{no}: {k} must be list"))
+   elif k=="first_failure":d[k]={}
+   else:d[k]=s(v)
+  elif cur in L:d[cur].append(s(line[2:])) if ind==2 and line.startswith("- ") else (_ for _ in ()).throw(ValueError(f"{p}:{no}: invalid list"))
+  elif cur=="first_failure":k,v=line.split(":",1);d[cur][k.strip()]=s(v)
+  elif cur=="validation":
+   if ind==2 and line.startswith("- "):k,v=line[2:].split(":",1);cv={k.strip():s(v)};d[cur].append(cv)
+   elif ind==4 and cv is not None:k,v=line.split(":",1);cv[k.strip()]=s(v)
+   else:raise ValueError(f"{p}:{no}: invalid validation")
+ return d
+def validate(d,p):
+ c=cfg();e=[]
+ for k in c["required_fields"]:
+  if k not in d:e.append(f"{p}: missing {k}")
+ if str(d.get("checkpoint_version",""))!=str(c["version"]):e.append(f"{p}: wrong checkpoint_version")
+ if d.get("status") not in c["allowed_statuses"]:e.append(f"{p}: unsupported status")
+ if str(d.get("next_action","")).strip().casefold() in P:e.append(f"{p}: next_action must be concrete")
+ ff=d.get("first_failure")
+ if not isinstance(ff,dict) or not all(str(ff.get(k,"")).strip() for k in ("marker","evidence")):e.append(f"{p}: invalid first_failure")
+ for k,limit in c.get("compactness_limits",{}).items():
+  v=d.get(k,[])
+  if not isinstance(v,list):e.append(f"{p}: {k} must be list")
+  elif len(v)>limit:e.append(f"{p}: {k} compactness limit {limit} exceeded")
+ val=d.get("validation",[])
+ for i,x in enumerate(val,1):
+  if not isinstance(x,dict) or not all(str(x.get(k,"")).strip() for k in ("command","result","evidence")):e.append(f"{p}: invalid validation {i}")
+  elif x["result"] not in c["allowed_validation_results"]:e.append(f"{p}: unsupported validation result")
+ fields=list(c["evidence_state_fields"].values());sets={k:{" ".join(str(x).casefold().split()) for x in d.get(k,[]) if str(x).strip()} for k in fields}
+ for i,a in enumerate(fields):
+  for b in fields[i+1:]:
+   if sets[a]&sets[b]:e.append(f"{p}: evidence overlaps {a}/{b}")
+ return e
+def main():
+ a=argparse.ArgumentParser();a.add_argument("task",nargs="?",type=Path);a.add_argument("--tasks",type=Path);a.add_argument("--require-checkpoint",action="store_true");x=a.parse_args()
+ if bool(x.task)==bool(x.tasks):a.error("provide one task or --tasks")
+ ps=[x.task] if x.task else sorted(x.tasks.glob("*.md"));err=[]
+ for p in ps:
+  try:d=parse(p)
+  except Exception as z:err.append(str(z));continue
+  if d is None:
+   if x.require_checkpoint:err.append(f"{p}: missing {H}")
+  else:err+=validate(d,p)
+ for z in err:print("ERROR:",z,file=sys.stderr)
+ return 1 if err else (print(f"Validated {len(ps)} checkpoint task(s).") or 0)
+if __name__=="__main__":raise SystemExit(main())

--- a/tools/agents/resume.py
+++ b/tools/agents/resume.py
@@ -95,10 +95,8 @@ def render_prompt(data: dict[str, object]) -> str:
     if isinstance(first_failure, dict):
         lines.extend(
             [
-                "FIRST_FAILURE_MARKER: "
-                f"{first_failure.get('marker', 'none')}",
-                "FIRST_FAILURE_EVIDENCE: "
-                f"{first_failure.get('evidence', 'none')}",
+                f"FIRST_FAILURE_MARKER: {first_failure.get('marker', 'none')}",
+                f"FIRST_FAILURE_EVIDENCE: {first_failure.get('evidence', 'none')}",
             ]
         )
 

--- a/tools/agents/resume.py
+++ b/tools/agents/resume.py
@@ -1,30 +1,145 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse,json,re
+
+import argparse
+import json
+import re
 from pathlib import Path
+
 import checkpoint
-def tid(p):
- m=re.search(r"(?m)^task_id:\s*[\"']?([^\"'\n]+)",p.read_text());return m.group(1).strip() if m else p.stem
-def bundle(p):
- d=checkpoint.parse(p)
- if d is None:return {"task_id":tid(p),"checkpoint":str(p),"warning":"CHECKPOINT_MISSING","next_action":"Reconstruct and write a valid Context checkpoint from current Git, PR, CI and task evidence before substantive implementation."}
- e=checkpoint.validate(d,p)
- if e:raise ValueError("; ".join(e))
- keys=("head","branch","pr","status","proven","derived","unknown","conflicts","first_failure","changed_paths","validation","blockers","next_action")
- return {"task_id":tid(p),"checkpoint":str(p),**{k:d.get(k) for k in keys}}
-def render(d):
- lines=[f"Continue task {d['task_id']} from repository state.","Do not rely on previous chat history.",f"CHECKPOINT: {d['checkpoint']}"]
- if d.get("warning"):return "\n".join(lines+[f"WARNING: {d['warning']}",f"NEXT_ACTION: {d['next_action']}","Verify live repository state before substantive implementation."])
- lines += [f"HEAD: {d.get('head','UNKNOWN')}",f"BRANCH: {d.get('branch','UNKNOWN')}",f"PR: {d.get('pr','none')}",f"STATUS: {d.get('status','UNKNOWN')}"]
- for label,key in (("PROVEN","proven"),("DERIVED","derived"),("UNKNOWN","unknown"),("CONFLICTS","conflicts"),("CHANGED_PATHS","changed_paths"),("BLOCKERS","blockers")):
-  lines.append(label+":");lines += [f"- {x}" for x in d.get(key,[])]
- ff=d.get("first_failure",{})
- if isinstance(ff,dict):lines += [f"FIRST_FAILURE_MARKER: {ff.get('marker','none')}",f"FIRST_FAILURE_EVIDENCE: {ff.get('evidence','none')}"]
- lines.append("VALIDATION:")
- for x in d.get("validation",[]):
-  if isinstance(x,dict):lines.append(f"- {x.get('command','')}: {x.get('result','')}; evidence={x.get('evidence','')}")
- lines += [f"NEXT_ACTION: {d.get('next_action','UNKNOWN')}","","OPERATING_RULES:","- Treat Git, checkpoint and live PR/CI as source of truth.","- Verify only live state that can invalidate NEXT_ACTION.","- Do not repeat the full preflight when checkpoint and live state agree.","- Do not rediscover PROVEN facts unless live evidence changed.","- Preserve UNKNOWN and CONFLICT; never guess.","- Do not paste full logs, diffs or old chat history.","- Execute NEXT_ACTION autonomously when safe.","- Update the checkpoint and leave exactly one next_action before handing off."]
- return "\n".join(lines)
-def main():
- a=argparse.ArgumentParser();a.add_argument("--task",type=Path,required=True);a.add_argument("--json",action="store_true");x=a.parse_args();d=bundle(x.task.resolve());print(json.dumps(d,indent=2) if x.json else render(d));return 0
-if __name__=="__main__":raise SystemExit(main())
+
+
+def task_id(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"(?m)^task_id:\s*[\"']?([^\"'\n]+)", text)
+    return match.group(1).strip() if match else path.stem
+
+
+def build_bundle(path: Path) -> dict[str, object]:
+    data = checkpoint.parse_checkpoint(path)
+    if data is None:
+        return {
+            "task_id": task_id(path),
+            "checkpoint": str(path),
+            "warning": "CHECKPOINT_MISSING",
+            "next_action": (
+                "Reconstruct and write a valid Context checkpoint from current "
+                "Git, PR, CI and task evidence before substantive implementation."
+            ),
+        }
+
+    errors = checkpoint.validate_checkpoint(data, path)
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    keys = (
+        "head",
+        "branch",
+        "pr",
+        "status",
+        "proven",
+        "derived",
+        "unknown",
+        "conflicts",
+        "first_failure",
+        "changed_paths",
+        "validation",
+        "blockers",
+        "next_action",
+    )
+    return {
+        "task_id": task_id(path),
+        "checkpoint": str(path),
+        **{key: data.get(key) for key in keys},
+    }
+
+
+def render_prompt(data: dict[str, object]) -> str:
+    lines = [
+        f"Continue task {data['task_id']} from repository state.",
+        "Do not rely on previous chat history.",
+        f"CHECKPOINT: {data['checkpoint']}",
+    ]
+
+    if data.get("warning"):
+        lines.extend(
+            [
+                f"WARNING: {data['warning']}",
+                f"NEXT_ACTION: {data['next_action']}",
+                "Verify live repository state before substantive implementation.",
+            ]
+        )
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            f"HEAD: {data.get('head', 'UNKNOWN')}",
+            f"BRANCH: {data.get('branch', 'UNKNOWN')}",
+            f"PR: {data.get('pr', 'none')}",
+            f"STATUS: {data.get('status', 'UNKNOWN')}",
+        ]
+    )
+
+    for label, key in (
+        ("PROVEN", "proven"),
+        ("DERIVED", "derived"),
+        ("UNKNOWN", "unknown"),
+        ("CONFLICTS", "conflicts"),
+        ("CHANGED_PATHS", "changed_paths"),
+        ("BLOCKERS", "blockers"),
+    ):
+        lines.append(f"{label}:")
+        lines.extend(f"- {item}" for item in data.get(key, []))
+
+    first_failure = data.get("first_failure", {})
+    if isinstance(first_failure, dict):
+        lines.extend(
+            [
+                "FIRST_FAILURE_MARKER: "
+                f"{first_failure.get('marker', 'none')}",
+                "FIRST_FAILURE_EVIDENCE: "
+                f"{first_failure.get('evidence', 'none')}",
+            ]
+        )
+
+    lines.append("VALIDATION:")
+    for item in data.get("validation", []):
+        if isinstance(item, dict):
+            lines.append(
+                f"- {item.get('command', '')}: {item.get('result', '')}; "
+                f"evidence={item.get('evidence', '')}"
+            )
+
+    lines.extend(
+        [
+            f"NEXT_ACTION: {data.get('next_action', 'UNKNOWN')}",
+            "",
+            "OPERATING_RULES:",
+            "- Treat Git, checkpoint and live PR/CI as source of truth.",
+            "- Verify only live state that can invalidate NEXT_ACTION.",
+            "- Do not repeat the full preflight when checkpoint and live state agree.",
+            "- Do not rediscover PROVEN facts unless live evidence changed.",
+            "- Preserve UNKNOWN and CONFLICT; never guess.",
+            "- Do not paste full logs, diffs or old chat history.",
+            "- Execute NEXT_ACTION autonomously when safe.",
+            "- Update the checkpoint and leave exactly one next_action before handing off.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a compact continuation prompt from a task checkpoint"
+    )
+    parser.add_argument("--task", type=Path, required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    data = build_bundle(args.task.resolve())
+    print(json.dumps(data, indent=2) if args.json else render_prompt(data))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agents/resume.py
+++ b/tools/agents/resume.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse,json,re
+from pathlib import Path
+import checkpoint
+def tid(p):
+ m=re.search(r"(?m)^task_id:\s*[\"']?([^\"'\n]+)",p.read_text());return m.group(1).strip() if m else p.stem
+def bundle(p):
+ d=checkpoint.parse(p)
+ if d is None:return {"task_id":tid(p),"checkpoint":str(p),"warning":"CHECKPOINT_MISSING","next_action":"Reconstruct and write a valid Context checkpoint from current Git, PR, CI and task evidence before substantive implementation."}
+ e=checkpoint.validate(d,p)
+ if e:raise ValueError("; ".join(e))
+ keys=("head","branch","pr","status","proven","derived","unknown","conflicts","first_failure","changed_paths","validation","blockers","next_action")
+ return {"task_id":tid(p),"checkpoint":str(p),**{k:d.get(k) for k in keys}}
+def render(d):
+ lines=[f"Continue task {d['task_id']} from repository state.","Do not rely on previous chat history.",f"CHECKPOINT: {d['checkpoint']}"]
+ if d.get("warning"):return "\n".join(lines+[f"WARNING: {d['warning']}",f"NEXT_ACTION: {d['next_action']}","Verify live repository state before substantive implementation."])
+ lines += [f"HEAD: {d.get('head','UNKNOWN')}",f"BRANCH: {d.get('branch','UNKNOWN')}",f"PR: {d.get('pr','none')}",f"STATUS: {d.get('status','UNKNOWN')}"]
+ for label,key in (("PROVEN","proven"),("DERIVED","derived"),("UNKNOWN","unknown"),("CONFLICTS","conflicts"),("CHANGED_PATHS","changed_paths"),("BLOCKERS","blockers")):
+  lines.append(label+":");lines += [f"- {x}" for x in d.get(key,[])]
+ ff=d.get("first_failure",{})
+ if isinstance(ff,dict):lines += [f"FIRST_FAILURE_MARKER: {ff.get('marker','none')}",f"FIRST_FAILURE_EVIDENCE: {ff.get('evidence','none')}"]
+ lines.append("VALIDATION:")
+ for x in d.get("validation",[]):
+  if isinstance(x,dict):lines.append(f"- {x.get('command','')}: {x.get('result','')}; evidence={x.get('evidence','')}")
+ lines += [f"NEXT_ACTION: {d.get('next_action','UNKNOWN')}","","OPERATING_RULES:","- Treat Git, checkpoint and live PR/CI as source of truth.","- Verify only live state that can invalidate NEXT_ACTION.","- Do not repeat the full preflight when checkpoint and live state agree.","- Do not rediscover PROVEN facts unless live evidence changed.","- Preserve UNKNOWN and CONFLICT; never guess.","- Do not paste full logs, diffs or old chat history.","- Execute NEXT_ACTION autonomously when safe.","- Update the checkpoint and leave exactly one next_action before handing off."]
+ return "\n".join(lines)
+def main():
+ a=argparse.ArgumentParser();a.add_argument("--task",type=Path,required=True);a.add_argument("--json",action="store_true");x=a.parse_args();d=bundle(x.task.resolve());print(json.dumps(d,indent=2) if x.json else render(d));return 0
+if __name__=="__main__":raise SystemExit(main())

--- a/tools/agents/resume.py
+++ b/tools/agents/resume.py
@@ -103,12 +103,12 @@ def render_prompt(data: dict[str, object]) -> str:
         )
 
     lines.append("VALIDATION:")
-    for item in data.get("validation", []):
-        if isinstance(item, dict):
-            lines.append(
-                f"- {item.get('command', '')}: {item.get('result', '')}; "
-                f"evidence={item.get('evidence', '')}"
-            )
+    lines.extend(
+        f"- {item.get('command', '')}: {item.get('result', '')}; "
+        f"evidence={item.get('evidence', '')}"
+        for item in data.get("validation", [])
+        if isinstance(item, dict)
+    )
 
     lines.extend(
         [


### PR DESCRIPTION
## Scope

Add a portable checkpoint/resume handoff workflow so continuation agents can resume without previous chat history.

- checkpoint contract v1 with compactness limits;
- deterministic checkpoint validator;
- compact `resume.py` generator;
- task template and handoff documentation;
- root AGENTS integration.

No application/runtime behavior changes.