### PR TITLE
Audit cleanup: remove false-green Codecov step and sync quality status

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,9 +97,6 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     needs: lint
-    permissions:
-      contents: read
-      id-token: write
     strategy:
       matrix:
         python-version: ["3.13"]
@@ -107,8 +104,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -131,16 +126,7 @@ jobs:
         run: pytest --collect-only -q
 
       - name: Pytest with coverage
-        run: pytest tests/ -q --tb=long --cov --cov-report=xml --cov-report=term
-
-      - name: Upload coverage
-        # Authenticate with GitHub OIDC so no long-lived Codecov secret is required.
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        with:
-          files: ./coverage.xml
-          disable_search: true
-          use_oidc: true
-          fail_ci_if_error: false
+        run: pytest tests/ -q --tb=long --cov --cov-report=term
 
   minimum-ha:
     name: Minimum HA API contracts (2026.1.0)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,9 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         python-version: ["3.13"]
@@ -104,6 +107,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -129,12 +134,12 @@ jobs:
         run: pytest tests/ -q --tb=long --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage
-        # CODECOV_TOKEN secret is optional; upload failure does not block CI.
-        # Add CODECOV_TOKEN to repository secrets to enable authenticated uploads.
+        # Authenticate with GitHub OIDC so no long-lived Codecov secret is required.
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./coverage.xml
           disable_search: true
+          use_oidc: true
           fail_ci_if_error: false
 
   minimum-ha:

--- a/docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
+++ b/docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
@@ -1,0 +1,73 @@
+---
+task_id: TASK-20260811-deep-audit-cleanup
+status: implementing
+branch: codex/audit-cleanup-20260811
+base_branch: main
+created: 2026-08-11
+updated: 2026-08-11
+related_pr: ""
+owned_paths:
+  - .github/workflows/ci.yaml
+  - docs/quality/STATUS.md
+  - docs/release_readiness.md
+  - docs/ha_quality_scale_audit.md
+  - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
+required_reads:
+  - AGENTS.md
+  - docs/agents/CONTEXT_HANDOFF.md
+  - docs/agents/tasks/TASK-20260810-ha-integration-10of10-followup.md
+search_first:
+  - follow-up
+  - CODECOV_TOKEN
+optional_reads:
+  - docs/real_device_validation.md
+---
+
+# Deep audit cleanup after HA hardening
+
+## Context checkpoint
+
+```yaml
+checkpoint_version: 1
+updated_at: 2026-08-11T12:45:00Z
+head: 62e3cb10894767671c7aeb33a5e62b24c82c07ff
+branch: codex/audit-cleanup-20260811
+pr: none
+status: implementing
+context_routes:
+  - GitHub connector
+owned_paths:
+  - .github/workflows/ci.yaml
+  - docs/quality/STATUS.md
+  - docs/release_readiness.md
+  - docs/ha_quality_scale_audit.md
+  - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
+proven:
+  - main has no open pull requests or issues and no non-main branches before this task
+  - TASK-20260810-ha-integration-10of10-followup.md is status done and PR #1763 is merged
+  - main@62e3cb1 has nine successful GitHub Actions checks
+  - the Tests job reports total coverage 90.78 percent
+  - the Codecov upload in the successful Tests job is rejected because no valid tokenless authentication is available
+  - current quality/release docs still describe the already-green follow-up CI as pending
+  - manifest.json and pyproject.toml require pymodbus>=3.6.1,<4.0
+  - physical AirPack post-hardening validation remains an external acceptance gate
+derived:
+  - use Codecov OIDC rather than introducing a long-lived repository upload secret
+unknown:
+  - post-hardening behavior on a physical AirPack during reconnect and 24-72 hour soak
+conflicts: []
+first_failure:
+  marker: Codecov upload
+  evidence: Tests job 93778480635 reports 'Token required - not valid tokenless upload'
+rejected_hypotheses:
+  - an unfinished implementation branch exists
+  - an open PR or issue is waiting to be completed
+changed_paths:
+  - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
+validation:
+  - command: main GitHub Actions check-runs inspection
+    result: PASS_WITH_NONBLOCKING_CODECOV_UPLOAD_FAILURE
+    evidence: main@62e3cb1, Tests job 93778480635
+blockers: []
+next_action: enable Codecov OIDC in the Tests job and synchronize current quality/release documentation
+```

--- a/docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
+++ b/docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
@@ -1,6 +1,6 @@
 ---
 task_id: TASK-20260811-deep-audit-cleanup
-status: verifying
+status: done
 branch: codex/audit-cleanup-20260811
 base_branch: main
 created: 2026-08-11
@@ -30,11 +30,11 @@ optional_reads:
 
 ```yaml
 checkpoint_version: 1
-updated_at: 2026-08-11T12:30:00Z
-head: a625380f81599dd07fc2600cbd689d087c661d4e
+updated_at: 2026-08-11T13:15:00Z
+verified_head: daa9f814f472f6b51074c88692425b1d5d96cdf9
 branch: codex/audit-cleanup-20260811
 pr: 1765
-status: verifying
+status: done
 context_routes:
   - GitHub connector
   - Home Assistant connector (read-only audit)
@@ -48,12 +48,15 @@ owned_paths:
 proven:
   - main had no open pull requests or issues and no non-main branches before this task
   - TASK-20260810-ha-integration-10of10-followup.md is status done and PR #1763 is merged
-  - main@62e3cb1 has nine successful GitHub Actions checks
+  - main@62e3cb1 had nine successful GitHub Actions checks before this audit
   - baseline Tests job 93778480635 reports total coverage 90.78 percent
   - baseline Codecov upload failed with 'Token required - not valid tokenless upload' while the Tests job remained green
   - PR #1765 Tests job 93786147158 successfully obtained a GitHub OIDC token but Codecov then failed with 'Repository not found'
   - Codecov upload is therefore not a functioning CI/release signal for this repository today
-  - current quality/release docs previously described already-green follow-up CI as pending and had stale dependency/version context
+  - the non-blocking Codecov upload was removed while the blocking local pytest coverage gate was retained
+  - PR #1765 run 31494460377 on verified_head daa9f814 passed Lint, Hassfest, HACS, full Tests, minimum HA 2026.1.0 contracts, current HA 2026.8.1 contracts, pymodbus 3.6.1, pymodbus 3.14.0, and entity mappings validation
+  - PR #1765 Tests job 93789362227 confirms 90.78 percent total coverage and contains no Codecov upload step
+  - current quality/release docs now record merged follow-up PR #1763 and current dependency/version context
   - manifest.json and pyproject.toml on current main require pymodbus>=3.6.1,<4.0 while tag v2.8.3 requires pymodbus>=3.6.0,<4.0
   - physical AirPack post-hardening validation remains an external acceptance gate
   - read-only live HA diagnostics show the installed v2.8.3 integration connected with 337 successful and 0 failed sampled reads, 336 available registers, about 14.258 seconds average update-cycle duration, about 22.555 seconds scan duration, and about 53.134 seconds config-entry setup duration
@@ -86,6 +89,9 @@ validation:
   - command: PR #1765 first Tests job inspection
     result: PASS_WITH_EXTERNAL_CODECOV_REPOSITORY_NOT_FOUND
     evidence: Tests job 93786147158
+  - command: PR #1765 full GitHub Actions matrix after Codecov removal
+    result: PASS
+    evidence: run 31494460377 on daa9f814, Tests job 93789362227
 blockers: []
-next_action: verify the latest PR #1765 head with the full GitHub Actions matrix after removal of the Codecov upload, then mark this checkpoint done
+next_action: merge PR #1765 after the final documentation-only synchronization check; post-hardening physical AirPack acceptance remains external
 ```

--- a/docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
+++ b/docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
@@ -1,13 +1,14 @@
 ---
 task_id: TASK-20260811-deep-audit-cleanup
-status: implementing
+status: verifying
 branch: codex/audit-cleanup-20260811
 base_branch: main
 created: 2026-08-11
 updated: 2026-08-11
-related_pr: ""
+related_pr: "#1765"
 owned_paths:
   - .github/workflows/ci.yaml
+  - docs/audits/deep_audit_2026-08-11.md
   - docs/quality/STATUS.md
   - docs/release_readiness.md
   - docs/ha_quality_scale_audit.md
@@ -29,45 +30,62 @@ optional_reads:
 
 ```yaml
 checkpoint_version: 1
-updated_at: 2026-08-11T12:45:00Z
-head: 62e3cb10894767671c7aeb33a5e62b24c82c07ff
+updated_at: 2026-08-11T12:30:00Z
+head: a625380f81599dd07fc2600cbd689d087c661d4e
 branch: codex/audit-cleanup-20260811
-pr: none
-status: implementing
+pr: 1765
+status: verifying
 context_routes:
   - GitHub connector
+  - Home Assistant connector (read-only audit)
 owned_paths:
   - .github/workflows/ci.yaml
+  - docs/audits/deep_audit_2026-08-11.md
   - docs/quality/STATUS.md
   - docs/release_readiness.md
   - docs/ha_quality_scale_audit.md
   - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
 proven:
-  - main has no open pull requests or issues and no non-main branches before this task
+  - main had no open pull requests or issues and no non-main branches before this task
   - TASK-20260810-ha-integration-10of10-followup.md is status done and PR #1763 is merged
   - main@62e3cb1 has nine successful GitHub Actions checks
-  - the Tests job reports total coverage 90.78 percent
-  - the Codecov upload in the successful Tests job is rejected because no valid tokenless authentication is available
-  - current quality/release docs still describe the already-green follow-up CI as pending
-  - manifest.json and pyproject.toml require pymodbus>=3.6.1,<4.0
+  - baseline Tests job 93778480635 reports total coverage 90.78 percent
+  - baseline Codecov upload failed with 'Token required - not valid tokenless upload' while the Tests job remained green
+  - PR #1765 Tests job 93786147158 successfully obtained a GitHub OIDC token but Codecov then failed with 'Repository not found'
+  - Codecov upload is therefore not a functioning CI/release signal for this repository today
+  - current quality/release docs previously described already-green follow-up CI as pending and had stale dependency/version context
+  - manifest.json and pyproject.toml on current main require pymodbus>=3.6.1,<4.0 while tag v2.8.3 requires pymodbus>=3.6.0,<4.0
   - physical AirPack post-hardening validation remains an external acceptance gate
+  - read-only live HA diagnostics show the installed v2.8.3 integration connected with 337 successful and 0 failed sampled reads, 336 available registers, about 14.258 seconds average update-cycle duration, about 22.555 seconds scan duration, and about 53.134 seconds config-entry setup duration
+  - live runtime is the published v2.8.3 build and is not evidence for post-release main behavior
 derived:
-  - use Codecov OIDC rather than introducing a long-lived repository upload secret
+  - remove the non-blocking Codecov upload rather than retain a false-green external signal
+  - prioritize measured polling/startup optimization over broad speculative refactoring
 unknown:
   - post-hardening behavior on a physical AirPack during reconnect and 24-72 hour soak
+  - whether removing redundant sensor translation loading alone removes the live >10 second sensor-platform setup warning
 conflicts: []
 first_failure:
-  marker: Codecov upload
-  evidence: Tests job 93778480635 reports 'Token required - not valid tokenless upload'
+  marker: external Codecov repository availability
+  evidence: PR #1765 Tests job 93786147158 obtains OIDC token then receives 'Repository not found'
 rejected_hypotheses:
-  - an unfinished implementation branch exists
-  - an open PR or issue is waiting to be completed
+  - an unfinished implementation branch existed before this audit
+  - an open PR or issue was waiting to be completed before this audit
+  - GitHub OIDC token issuance was the remaining Codecov blocker
 changed_paths:
+  - .github/workflows/ci.yaml
+  - docs/audits/deep_audit_2026-08-11.md
+  - docs/quality/STATUS.md
+  - docs/release_readiness.md
+  - docs/ha_quality_scale_audit.md
   - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
 validation:
-  - command: main GitHub Actions check-runs inspection
-    result: PASS_WITH_NONBLOCKING_CODECOV_UPLOAD_FAILURE
+  - command: baseline main GitHub Actions inspection
+    result: PASS_WITH_NONBLOCKING_CODECOV_FAILURE
     evidence: main@62e3cb1, Tests job 93778480635
+  - command: PR #1765 first Tests job inspection
+    result: PASS_WITH_EXTERNAL_CODECOV_REPOSITORY_NOT_FOUND
+    evidence: Tests job 93786147158
 blockers: []
-next_action: enable Codecov OIDC in the Tests job and synchronize current quality/release documentation
+next_action: verify the latest PR #1765 head with the full GitHub Actions matrix after removal of the Codecov upload, then mark this checkpoint done
 ```

--- a/docs/audits/deep_audit_2026-08-11.md
+++ b/docs/audits/deep_audit_2026-08-11.md
@@ -1,0 +1,134 @@
+# Deep integration audit — 2026-08-11
+
+## Scope
+
+This audit covers the current repository state, CI/release governance, the main Home Assistant integration runtime paths, and read-only evidence from the owner's running Home Assistant instance.
+
+Repository baseline: `main@62e3cb10894767671c7aeb33a5e62b24c82c07ff` before this audit cleanup.
+
+Important evidence boundary: the running Home Assistant instance is using published integration version `2.8.3` with `pymodbus>=3.6.0,<4.0`. Current repository `main` is still versioned `2.8.3` but contains post-release hardening and requires `pymodbus>=3.6.1,<4.0`. Runtime observations from the installed release therefore do **not** prove post-hardening `main` behavior on physical hardware.
+
+## Executive assessment
+
+The integration is architecturally mature for a HACS custom integration. Its strongest areas are write safety, transport compatibility, config-entry lifecycle, explicit error propagation, Repairs integration, diagnostics, and CI breadth. The main opportunities are no longer broad structural rewrites; they are measured I/O efficiency, startup latency, real-device acceptance of the post-hardening candidate, and raising per-module test coverage.
+
+No unfinished implementation branch, open pull request, or open issue existed at the start of this audit. The previously active hardening follow-up (`TASK-20260810-ha-integration-10of10-followup.md`, PR #1763) was already complete. Its remaining hardware validation items are external acceptance gates, not abandoned code tasks.
+
+## Verified strengths
+
+### Runtime architecture
+
+- `custom_components/thessla_green_modbus/__init__.py` uses config-entry lifecycle and integration-wide service registration.
+- `custom_components/thessla_green_modbus/coordinator/coordinator.py` centralizes update ownership through `DataUpdateCoordinator`.
+- `custom_components/thessla_green_modbus/coordinator/update.py` serializes polling against writes through the shared I/O lock and converts transport failures into coordinator failures instead of silently publishing stale success.
+- `custom_components/thessla_green_modbus/core/read_batches.py` implements bounded grouped/chunked reads with fallback behavior.
+- `custom_components/thessla_green_modbus/coordinator/schedule.py` and the write-path helpers use retry/reconnect handling, explicit success/failure semantics, conservative targeted read-back, and Repairs lifecycle support.
+
+### Compatibility and CI
+
+Baseline `main@62e3cb1` had nine successful GitHub Actions checks. The suite covers lint/format/type checking, full tests, minimum and current Home Assistant API contracts, `pymodbus` `3.6.1` and `3.14.0`, entity mapping validation, Hassfest, HACS, and layering/package checks.
+
+The baseline Tests job (`93778480635`) reported total coverage of **90.78%**. This passes the repository's 80% coverage gate but does not meet the current Home Assistant Silver test-coverage requirement because multiple integration modules remain below 95%.
+
+### Live stability sample
+
+Read-only diagnostics from the running Home Assistant instance showed:
+
+- Home Assistant `2026.8.1`, Python `3.14.6`;
+- integration loaded and connected over TCP;
+- `337` successful reads, `0` failed reads, `0` connection errors, `0` timeout errors;
+- reported success rate `100%` for the sampled statistics;
+- `336` available registers;
+- `113232` total registers read;
+- average successful update-cycle duration about `14.258 s`;
+- configured scan interval `30 s`;
+- device scan duration about `22.555 s`;
+- config-entry setup duration about `53.134 s`.
+
+`113232 / 337 = 336`, so the sampled runtime statistics are consistent with every successful polling cycle reading the complete set of 336 available registers.
+
+## Findings
+
+### A1 — High polling cost
+
+**FACT:** `core/runtime_io.py` reads input registers, holding registers, coils, and discrete inputs during each normal update. The live installed release reports an average successful cycle of about 14.258 s at a 30 s interval, with all 336 available registers accounted for on every successful cycle.
+
+**INFERENCE:** A large fraction of current Modbus traffic is spent repeatedly fetching data classes that normally change far less often than temperatures, fan states, alarms, or instantaneous operating values.
+
+**RECOMMENDATION:** design a measured fast/slow/on-demand polling model. Keep safety-critical/live telemetry in the fast path; move schedules, configuration, and other low-volatility data to a slower refresh or explicit refresh path. Validate request count, cycle time, entity freshness, reconnect behavior, and write/read-back behavior on the physical AirPack before rollout.
+
+### A2 — Startup latency and full device scan on restart
+
+**FACT:** `coordinator/scan.py::prepare_registers_for_setup` consumes the config-flow scan cache once, but when `enable_device_scan` remains enabled it performs a fresh full device scan on later setups. The code explicitly removes the one-time cache so subsequent Home Assistant restarts scan again. The live installed release reports a scan duration around 22.555 s and total config-entry setup around 53.134 s.
+
+**RECOMMENDATION:** replace the unconditional restart-time full scan with a versioned/TTL cache plus explicit invalidation/revalidation rules. Preserve a manual force-rescan path. Treat this as hardware-sensitive work and benchmark before/after on the real device.
+
+### A3 — Sensor platform startup warning and redundant translation loads
+
+**FACT:** the running Home Assistant log contains `Setup of sensor platform thessla_green_modbus is taking over 10 seconds.`
+
+**FACT:** `sensor.py::async_setup_entry` loads translations once. `ThesslaGreenActiveErrorsSensor.async_added_to_hass` loads translations again, while the inspected entity logic uses `_error_status_description` for its state/attributes. The stored `_translations` values in `ThesslaGreenErrorCodesSensor` / `ThesslaGreenActiveErrorsSensor` are not used by the inspected class logic.
+
+**INFERENCE:** removing the redundant translation calls is a safe cleanup candidate and may reduce platform setup overhead, but it cannot by itself explain or guarantee elimination of the full >10 s warning because device I/O/startup work is also expensive.
+
+**RECOMMENDATION:** remove the unused translation fetch/storage under a focused test, then remeasure platform setup time. Do not claim the warning fixed until the real HA log confirms it.
+
+### A4 — Device identity remains incomplete
+
+**FACT:** live diagnostics report `model: Unknown`, `firmware: Unknown`, and `firmware_available: false`, while capabilities and 336 registers are successfully detected.
+
+**FACT:** `scanner/firmware.py` only publishes a formatted firmware version when major, minor, and patch are all present. The live register scan shows the patch register absent while major/minor registers are available.
+
+**RECOMMENDATION:** decide and test a partial-version policy (for example major.minor with an explicit partial/unknown-patch marker) instead of silently collapsing partially known firmware to `Unknown`. Keep model identification separate from firmware inference.
+
+### A5 — Coverage is good but below current Silver criteria
+
+**FACT:** baseline total coverage is 90.78%, and multiple integration modules are below 95%.
+
+**RECOMMENDATION:** raise coverage by risk, not by line-count gaming. Prioritize transport selection/read paths, firmware/device identification, config-flow edge cases, time handling, switches/selects, and maintenance service handlers. Only claim a higher Quality Scale tier after auditing every rule for that tier.
+
+### A6 — Codecov was a false-green signal
+
+**FACT:** baseline Tests job `93778480635` succeeded while the Codecov upload failed with `Token required - not valid tokenless upload` because the step was non-blocking.
+
+**FACT:** PR #1765 then proved GitHub OIDC token issuance works, but Codecov rejected the authenticated upload with `Repository not found`.
+
+**INFERENCE:** the remaining blocker is external Codecov repository onboarding/authorization rather than GitHub Actions token issuance.
+
+**ACTION:** this audit cleanup removes the non-functional non-blocking upload and retains the local pytest coverage gate. Reintroduce Codecov only after its repository-side configuration exists and the result is a deliberately verified signal.
+
+### A7 — Published version metadata and post-release main differ
+
+**FACT:** tag `v2.8.3` declares `pymodbus>=3.6.0,<4.0`; current `main` declares `pymodbus>=3.6.1,<4.0` in both `manifest.json` and `pyproject.toml`, while all three still use integration/package version `2.8.3`.
+
+**RECOMMENDATION:** select a new semantic version before the next release and synchronize manifest, package metadata, changelog, release notes, and tag. Do not treat the installed `2.8.3` device evidence as proof of the post-release main candidate.
+
+### A8 — Release workflow is well pinned but only loosely coupled to CI
+
+**FACT:** `.github/workflows/release.yaml` pins third-party actions by immutable commit SHA and validates version/tag state before publishing.
+
+**FACT:** the workflow is triggered by pushes to `main` affecting release metadata and does not itself verify that the exact release commit has completed the full CI matrix before creating the GitHub release.
+
+**RECOMMENDATION:** either keep release publication intentionally manual or add an explicit successful-CI dependency for the exact commit before publication. Do not add a complicated release gate unless it materially improves the current branch-protection/process model.
+
+## Deferred / external acceptance
+
+The following are intentionally not claimed complete by repository-only testing:
+
+- post-hardening AirPack TCP smoke test;
+- representative safe write plus confirmed read-back on the candidate;
+- network interruption and reconnect behavior;
+- RTU/USB validation if RTU is claimed for the next release;
+- 24–72 hour soak on the post-hardening candidate.
+
+These checks require the physical device and are the correct gate before high-risk polling/cache restructuring.
+
+## Recommended execution order
+
+1. Merge the audit/CI/documentation cleanup after all PR checks are green.
+2. Remove redundant sensor translation loads with a focused regression test; remeasure the live setup warning.
+3. Build a benchmark/evidence harness for request count, polling-cycle duration, startup scan duration, and reconnect/write behavior.
+4. Design fast/slow/on-demand polling from measurements and implement it behind tests, then validate on the physical AirPack.
+5. Introduce a versioned/TTL device-scan cache only with explicit invalidation and force-rescan behavior.
+6. Raise low-coverage, high-risk modules above 95% and then re-audit the complete current Home Assistant Quality Scale checklist.
+7. Resolve partial firmware/model identification and tighten release gating/version metadata before the next published release.

--- a/docs/ha_quality_scale_audit.md
+++ b/docs/ha_quality_scale_audit.md
@@ -1,6 +1,6 @@
 # Home Assistant Quality Scale Audit
 
-**Audit date:** 2026-08-10  
+**Audit date:** 2026-08-11  
 **Current released version:** `2.8.3`  
 **Integration:** `thessla_green_modbus`  
 **Canonical current status:** [`docs/quality/STATUS.md`](quality/STATUS.md)
@@ -15,21 +15,23 @@ The integration is a local-polling HACS custom integration for ThesslaGreen AirP
 
 ## Verified automated evidence
 
-PR #1762 merged to `main` as `088677385a179a0a02c14ddae3dd96d20c2534e0` after canonical CI #1146 completed successfully. That run verified:
+The 2026-08-10 hardening sequence is complete. PR #1762 merged the primary hardening work and PR #1763 merged the final follow-up. The durable follow-up checkpoint was finalized on `main` as `62e3cb10894767671c7aeb33a5e62b24c82c07ff`.
 
-- Ruff and import-order checks;
-- Ruff formatting;
-- Python compilation;
+The GitHub Actions run for `main@62e3cb1` completed all nine current checks successfully. It verifies:
+
+- Ruff/import-order/format and Python compilation;
 - vendor register comparison and AirPack 4 coverage;
-- translations;
-- repository maintainability gate;
-- durable agent checkpoint validation;
-- Hassfest;
-- HACS validation;
+- translations and maintainability;
+- durable checkpoint validation;
+- blocking `mypy` validation;
+- Hassfest and HACS validation;
 - entity mapping validation;
-- full pytest suite with 90.68% coverage against an 80% minimum.
+- full pytest on Home Assistant `2026.2.3`;
+- focused API contracts on minimum Home Assistant `2026.1.0`;
+- focused API contracts on current Home Assistant `2026.8.1` / Python `3.14`;
+- `pymodbus` compatibility suites for `3.6.1` and `3.14.0`.
 
-The follow-up hardening task adds mandatory mypy, declared-minimum Home Assistant API tests, immutable GitHub Action refs, repair-issue lifecycle, and cleanup of stale process-memory energy state. Those items are only marked verified after the follow-up PR's final CI run is green.
+The full suite reports **90.78%** total coverage against an 80% repository minimum.
 
 ## Quality-scale-oriented assessment
 
@@ -39,29 +41,23 @@ The follow-up hardening task adds mandatory mypy, declared-minimum Home Assistan
 
 Key evidence includes config flow, unique config entries, runtime data, entity unique IDs, integration-wide service registration from `async_setup()`, config-entry unloading, polling ownership through the coordinator/device client, and automated config-flow coverage.
 
-After PR #1762, service action schemas no longer depend on a loaded config entry. The follow-up also declares `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` because `async_setup()` exists only for process-lifetime service registration and YAML configuration is not supported.
+Service action schemas do not depend on a loaded config entry. `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` makes explicit that `async_setup()` exists for process-lifetime service registration while YAML configuration is not supported.
 
 ### Silver-oriented requirements
 
-**Status: substantially implemented, but not declared as the repository tier.**
+**Status: not fully satisfied by current evidence.**
 
-Evidence includes:
+The current Home Assistant Quality Scale `test-coverage` rule at Silver requires above 95% test coverage for **all integration modules**. The repository's current 90.78% aggregate coverage and several modules below 95% mean that rule is not met today, regardless of the repository's lower 80% CI threshold.
 
-- config-entry unload support;
-- translated/re-raised action failures (`HomeAssistantError` / `ServiceValidationError`);
-- unavailable-state/error handling;
-- reauthentication/reconfiguration support;
-- parallel-update limits;
-- test coverage above the repository threshold;
-- local polling and reconnect behavior covered by automated tests.
+Other Silver-oriented evidence is strong: config-entry unload support, translated/re-raised action failures (`HomeAssistantError` / `ServiceValidationError`), unavailable-state/error handling, reauthentication/reconfiguration support, explicit parallel-update limits, and local polling/reconnect test coverage.
 
-A higher declared tier should only be considered after the owner intentionally reviews the complete current Home Assistant Quality Scale checklist against this custom integration.
+A Silver declaration should only be considered after the complete current checklist is audited and every unmet rule, especially per-module test coverage, is closed.
 
 ### Gold-oriented requirements
 
 **Status: partial.**
 
-Implemented pieces include diagnostics with redaction, translated entities, device information, entity categories, disabled-by-default diagnostics/risky configuration entities, documented limitations, and Repairs support for actionable final Modbus write failures.
+Implemented pieces include diagnostics with redaction, translated entities, device information plumbing, entity categories, disabled-by-default diagnostics/risky configuration entities, documented limitations, and Repairs support for actionable final Modbus write failures.
 
 The principal unproven area is physical-device validation across the supported transport/model matrix. Existing AirPack 4 evidence predates the 2026-08-10 hardening changes.
 
@@ -69,7 +65,7 @@ The principal unproven area is physical-device validation across the supported t
 
 **Status: not claimed.**
 
-The follow-up adds strict typing as a blocking CI gate, but a Platinum claim would require an intentional audit of every current Platinum rule, not only successful mypy execution.
+Strict typing is a blocking CI gate, but a Platinum claim requires an intentional audit of every current Platinum rule, not only successful mypy execution.
 
 ## Safety-sensitive implementation notes
 
@@ -91,7 +87,7 @@ Final transport/write failures create an actionable Repairs issue scoped to the 
 
 ## External validation boundary
 
-GitHub CI cannot prove physical Modbus behavior. The following remain explicit external acceptance checks:
+GitHub CI cannot prove physical Modbus behavior. The following remain explicit external acceptance checks against the actual post-hardening candidate:
 
 - AirPack post-hardening smoke test;
 - RTU/USB validation using a stable `/dev/serial/by-id/...` path;

--- a/docs/quality/STATUS.md
+++ b/docs/quality/STATUS.md
@@ -26,7 +26,7 @@ The GitHub Actions run for `main@62e3cb1` completed all nine current checks succ
 
 The full suite reported **90.78%** total coverage against the repository's configured 80% minimum. This is a useful repository gate, but it is not sufficient by itself for Home Assistant's current Silver `test-coverage` rule, which requires above 95% coverage for every integration module.
 
-The 2026-08-11 audit also corrected the coverage-upload workflow to authenticate Codecov with GitHub OIDC rather than relying on an absent long-lived upload secret. This change must be considered verified only when its pull-request CI log confirms a successful upload.
+The 2026-08-11 audit verified two successive Codecov failure modes in otherwise-successful Tests jobs: the baseline upload lacked authentication, and an OIDC-authenticated retry obtained a valid short-lived token but Codecov returned `Repository not found`. Because Codecov repository onboarding/authorization is external to this repository and the upload was non-blocking, the broken upload step is removed rather than kept as a false-green signal. Pytest continues to enforce the local 80% coverage gate and print module-level coverage in CI. Codecov can be reintroduced later only after the repository is explicitly configured in Codecov and the upload is made a meaningful verified signal.
 
 ## Real-device evidence
 

--- a/docs/quality/STATUS.md
+++ b/docs/quality/STATUS.md
@@ -1,27 +1,32 @@
 # ThesslaGreen Modbus quality status
 
-**Status date:** 2026-08-10  
+**Status date:** 2026-08-11  
 **Current released version:** `2.8.3`  
 **Repository quality declaration:** Home Assistant `bronze`  
 **Minimum Home Assistant:** `2026.1.0`  
-**Runtime Modbus dependency:** `pymodbus>=3.6.1,<4.0`
+**Current `main` Modbus dependency:** `pymodbus>=3.6.1,<4.0`
 
 This file is the canonical snapshot for current quality, validation, and release-readiness status. Historical audit documents may describe older commits and must not be interpreted as the current state unless explicitly marked current.
 
 ## Automated verification
 
-The hardening change merged as PR #1762 (`088677385a179a0a02c14ddae3dd96d20c2534e0`). Its final canonical CI run #1146 passed all repository jobs: lint/format, compilation, vendor register coverage, translations, maintainability, checkpoint validation, Hassfest, HACS, entity mappings, and the full pytest suite. The full suite reported 90.68% coverage against the repository's 80% minimum.
+The 2026-08-10 hardening sequence is complete. PR #1762 merged the primary hardening work and PR #1763 merged the final follow-up. The follow-up checkpoint was finalized on `main` as `62e3cb10894767671c7aeb33a5e62b24c82c07ff`.
 
-The follow-up hardening task adds:
+The GitHub Actions run for `main@62e3cb1` completed all nine current checks successfully, including:
 
-- mandatory `mypy` validation using the repository's strict typing configuration;
-- a focused compatibility gate against the declared minimum Home Assistant `2026.1.0`;
-- commit-SHA pinning for third-party GitHub Actions used by CI and release workflows;
-- an explicit config-entry-only schema for the process-level `async_setup()` hook;
-- runtime Repairs issue lifecycle for final Modbus write failures;
-- removal of volatile in-memory `total_energy` accumulation and stale `estimated_power` aliases.
+- Ruff/import-order/format, compilation, vendor register coverage, translations, maintainability and checkpoint validation;
+- blocking `mypy` validation;
+- the full pytest suite on Home Assistant `2026.2.3`;
+- focused API-contract tests on the declared minimum Home Assistant `2026.1.0`;
+- focused API-contract tests on current Home Assistant `2026.8.1` / Python `3.14`;
+- `pymodbus` compatibility checks for `3.6.1` and `3.14.0`;
+- entity mapping validation;
+- Hassfest;
+- HACS validation.
 
-These follow-up items are considered complete only after the follow-up PR's final CI run is green.
+The full suite reported **90.78%** total coverage against the repository's configured 80% minimum. This is a useful repository gate, but it is not sufficient by itself for Home Assistant's current Silver `test-coverage` rule, which requires above 95% coverage for every integration module.
+
+The 2026-08-11 audit also corrected the coverage-upload workflow to authenticate Codecov with GitHub OIDC rather than relying on an absent long-lived upload secret. This change must be considered verified only when its pull-request CI log confirms a successful upload.
 
 ## Real-device evidence
 
@@ -35,7 +40,7 @@ Required external acceptance still includes:
 - safe write/read-back verification;
 - 24–72 hour polling soak with no transport desynchronization.
 
-GitHub CI cannot prove these hardware conditions. They must stay explicitly `PENDING` until measured on a real unit.
+GitHub CI cannot prove these hardware conditions. They must stay explicitly `PENDING` until measured on a real unit running the post-hardening candidate.
 
 ## Deliberately deferred work
 
@@ -43,4 +48,4 @@ Broad read-path/mixin/module consolidation is deliberately deferred. `docs/core_
 
 ## Release status
 
-`v2.8.3` is the current published GitHub release. The hardening work merged after that release and therefore belongs to a future version/release; no new release tag should be created until the repository owner intentionally selects the next version and the real-device acceptance level required for that release.
+`v2.8.3` is the current published GitHub release. Its tagged manifest declares `pymodbus>=3.6.0,<4.0`. Current `main` contains post-release hardening and declares `pymodbus>=3.6.1,<4.0` while the package version is still `2.8.3`; the next release must therefore select and apply a new version before tagging. No new release tag should be created until the repository owner intentionally selects that version and the real-device acceptance level required for the release.

--- a/docs/release_readiness.md
+++ b/docs/release_readiness.md
@@ -42,7 +42,7 @@ The GitHub Actions run for `main@62e3cb1` passed all nine current checks:
 
 The full suite reported **90.78%** total coverage against the configured 80% repository minimum. The current Home Assistant Silver quality-scale coverage rule is stricter: every integration module must be above 95%, so a Silver claim is not currently justified by coverage evidence.
 
-The 2026-08-11 audit found that the otherwise-green Tests job was not actually uploading `coverage.xml` to Codecov because no valid upload authentication was available. The audit cleanup switches that step to GitHub OIDC authentication and keeps the upload non-blocking; acceptance requires inspecting the pull-request CI log and confirming the upload succeeds.
+The 2026-08-11 audit verified that Codecov was not a functioning release signal. The baseline non-blocking upload failed without authentication; an OIDC-authenticated retry successfully obtained a short-lived token but Codecov returned `Repository not found`. The repository-side cleanup therefore removes the non-blocking Codecov upload. Coverage remains a blocking local pytest gate with module-level reporting in the CI log. Reintroducing external coverage reporting requires explicit Codecov repository onboarding/authorization and a separately verified upload.
 
 ## Real-device readiness
 
@@ -64,7 +64,7 @@ Recommended release gate for hardware-sensitive changes:
 
 CI and release workflows use immutable commit SHAs for third-party GitHub Actions. Version comments may be kept next to the SHA for readability. Moving `@main`, `@master`, or mutable major-version refs are not accepted in the release-ready state.
 
-Coverage upload authentication uses GitHub OIDC, avoiding a long-lived Codecov upload secret. The Tests job grants only the additional `id-token: write` permission required to mint the short-lived OIDC token, while retaining `contents: read` for checkout.
+External Codecov upload is deliberately not part of the current release gate because the repository is not yet available to the Codecov uploader. No extra OIDC permission or long-lived Codecov secret is retained merely to keep a non-blocking, non-functional step green.
 
 ## Documentation readiness
 

--- a/docs/release_readiness.md
+++ b/docs/release_readiness.md
@@ -1,8 +1,8 @@
 # Release Readiness
 
-**Status date:** 2026-08-10  
+**Status date:** 2026-08-11  
 **Current published release:** `v2.8.3`  
-**Current manifest/package version:** `2.8.3`  
+**Current `main` manifest/package version:** `2.8.3`  
 **Canonical quality status:** [`docs/quality/STATUS.md`](quality/STATUS.md)
 
 This file describes readiness for the **next** release. The old May 2026 `v2.8.0` pre-release checklist is obsolete: `v2.8.3` is already published.
@@ -11,49 +11,44 @@ This file describes readiness for the **next** release. The old May 2026 `v2.8.0
 
 | Source | Current value |
 |---|---|
-| `custom_components/thessla_green_modbus/manifest.json` | `2.8.3` |
-| `pyproject.toml` | `2.8.3` |
+| published tag `v2.8.3` manifest | version `2.8.3`, `pymodbus>=3.6.0,<4.0` |
+| `main` `custom_components/thessla_green_modbus/manifest.json` | version `2.8.3`, `pymodbus>=3.6.1,<4.0` |
+| `main` `pyproject.toml` | version `2.8.3`, `pymodbus>=3.6.1,<4.0` |
 | `hacs.json` minimum Home Assistant | `2026.1.0` |
-| runtime pymodbus constraint | `>=3.6.0,<4.0` |
 | repository quality declaration | `bronze` |
 
-Version metadata was synchronized by PR #1762. Do not increment it merely because development commits exist; select the next semantic version intentionally at release time.
+The identical `2.8.3` version string on the published tag and the post-release `main` branch is development-state metadata, not evidence that the published release contains the hardening changes. The next release must intentionally select and apply a new semantic version before tagging.
 
 ## Automated readiness
 
-PR #1762 merged to `main` as `088677385a179a0a02c14ddae3dd96d20c2534e0`. Canonical CI #1146 passed:
+The 2026-08-10 hardening sequence is complete: PR #1762 merged the primary hardening and PR #1763 merged the final follow-up. The durable follow-up checkpoint was finalized on `main` as `62e3cb10894767671c7aeb33a5e62b24c82c07ff`.
+
+The GitHub Actions run for `main@62e3cb1` passed all nine current checks:
 
 - Ruff and import order;
 - Ruff format;
 - compileall;
-- vendor register comparison;
-- AirPack 4 vendor coverage;
-- translation validation;
-- maintainability gate;
-- checkpoint validation;
-- full pytest suite;
+- `mypy`;
+- vendor register comparison and AirPack 4 vendor coverage;
+- translation and maintainability validation;
+- durable checkpoint validation;
+- full pytest suite on Home Assistant `2026.2.3`;
+- API-contract tests on minimum Home Assistant `2026.1.0`;
+- API-contract tests on current Home Assistant `2026.8.1` / Python `3.14`;
+- `pymodbus` `3.6.1` and `3.14.0` compatibility suites;
 - entity mapping validation;
 - Hassfest;
 - HACS validation.
 
-The full test suite reported 90.68% coverage, above the configured 80% minimum.
+The full suite reported **90.78%** total coverage against the configured 80% repository minimum. The current Home Assistant Silver quality-scale coverage rule is stricter: every integration module must be above 95%, so a Silver claim is not currently justified by coverage evidence.
 
-The 2026-08-10 follow-up hardening additionally requires a green final run with:
-
-- `mypy` as a blocking gate;
-- focused API-contract tests on minimum Home Assistant `2026.1.0`;
-- immutable commit SHAs for external GitHub Actions;
-- Hassfest with the config-entry-only schema warning removed;
-- Repairs write-failure lifecycle regression tests;
-- tests proving the removed volatile `total_energy` state does not return.
-
-Until that follow-up CI is green, those additions are `PENDING`, not assumed.
+The 2026-08-11 audit found that the otherwise-green Tests job was not actually uploading `coverage.xml` to Codecov because no valid upload authentication was available. The audit cleanup switches that step to GitHub OIDC authentication and keeps the upload non-blocking; acceptance requires inspecting the pull-request CI log and confirming the upload succeeds.
 
 ## Real-device readiness
 
 **Status: PARTIAL / external gate.**
 
-Historical evidence exists for an AirPack 4 over Modbus TCP, but it predates the 2026-08-10 hardening changes. The next release should not claim post-hardening hardware validation until the checks in [`docs/real_device_validation.md`](real_device_validation.md) are performed.
+Historical evidence exists for an AirPack 4 over Modbus TCP, but it predates the 2026-08-10 hardening changes. The next release should not claim post-hardening hardware validation until the checks in [`docs/real_device_validation.md`](real_device_validation.md) are performed against the actual post-hardening candidate.
 
 Recommended release gate for hardware-sensitive changes:
 
@@ -67,7 +62,9 @@ Recommended release gate for hardware-sensitive changes:
 
 ## Supply-chain readiness
 
-CI and release workflows must use immutable commit SHAs for third-party GitHub Actions. Version comments may be kept next to the SHA for readability. Moving `@main`, `@master`, or mutable major-version refs are not accepted in the final follow-up state.
+CI and release workflows use immutable commit SHAs for third-party GitHub Actions. Version comments may be kept next to the SHA for readability. Moving `@main`, `@master`, or mutable major-version refs are not accepted in the release-ready state.
+
+Coverage upload authentication uses GitHub OIDC, avoiding a long-lived Codecov upload secret. The Tests job grants only the additional `id-token: write` permission required to mint the short-lived OIDC token, while retaining `contents: read` for checkout.
 
 ## Documentation readiness
 
@@ -83,4 +80,4 @@ Before tagging the next release verify that all of these describe the candidate,
 
 ## Release decision
 
-A new GitHub release is **not** created by this audit follow-up. The repository owner should choose the next version after deciding how much real-device validation is required for that release. The existing release workflow reads the version from `manifest.json` and will skip creation when the corresponding tag already exists.
+A new GitHub release is **not** created by this audit cleanup. Select the next version only when the post-hardening candidate and the required real-device acceptance level are ready; then synchronize `manifest.json`, `pyproject.toml`, release notes, and tag metadata before publishing.


### PR DESCRIPTION
## Summary

- remove the non-blocking Codecov upload after proving it is not a functioning signal for this repository
- keep pytest coverage as a blocking local CI gate with module-level reporting
- add a durable deep-audit report with repository and read-only live Home Assistant evidence
- synchronize quality/release documentation with merged PR #1763 and current `main@62e3cb1`
- correct current test coverage to 90.78% and explicitly record the Home Assistant Silver >95%-per-module gap
- distinguish the published `v2.8.3` pymodbus requirement (`>=3.6.0,<4.0`) from post-release `main` (`>=3.6.1,<4.0`)

## Verified Codecov evidence

Baseline Tests job `93778480635` was green while Codecov rejected the upload with `Token required - not valid tokenless upload`.

An OIDC-authenticated retry in PR #1765 Tests job `93786147158` successfully obtained a short-lived GitHub OIDC token, but Codecov then returned `Repository not found`. The repository therefore does not keep a non-blocking external upload that can fail behind a green job. Codecov can be reintroduced after repository-side Codecov onboarding/authorization is explicitly configured and verified.

## Runtime audit highlights

Read-only diagnostics from the currently installed published `v2.8.3` show a stable sampled TCP connection (337 successful reads, 0 failed/connection/timeout errors) but expensive polling/startup: 336 registers accounted for per successful cycle, ~14.258 s average update-cycle duration at a 30 s interval, ~22.555 s device scan, and ~53.134 s config-entry setup. These measurements are evidence for the installed release only, not proof of post-release `main` behavior.

## External gate intentionally unchanged

Post-hardening AirPack smoke/reconnect/write/read-back/soak validation still requires the actual candidate on physical hardware and is not claimed by this PR.
