### PR TITLE
fix: close post-audit governance and sensor follow-ups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,11 +87,8 @@ jobs:
       - name: Maintainability gate
         run: python tools/check_maintainability.py
 
-      - name: Validate hardening checkpoint
-        run: python tools/agents/checkpoint.py docs/agents/tasks/TASK-20260810-ha-integration-hardening.md --require-checkpoint
-
-      - name: Validate follow-up checkpoint
-        run: python tools/agents/checkpoint.py docs/agents/tasks/TASK-20260810-ha-integration-10of10-followup.md --require-checkpoint
+      - name: Validate agent checkpoints
+        run: python tools/agents/checkpoint.py --tasks docs/agents/tasks --require-checkpoint
 
   tests:
     name: Tests

--- a/custom_components/thessla_green_modbus/sensor.py
+++ b/custom_components/thessla_green_modbus/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import translation
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -23,7 +22,6 @@ from .const import (
     AIRFLOW_UNIT_PERCENTAGE,
     CONF_AIRFLOW_UNIT,
     DEFAULT_AIRFLOW_UNIT,
-    DOMAIN,
     ERROR_REGISTER_PREFIX,
     SENSOR_UNAVAILABLE,
     STATUS_REGISTER_PREFIX,
@@ -65,7 +63,7 @@ def _error_status_description(key: str) -> str:
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    _hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
@@ -114,14 +112,7 @@ async def async_setup_entry(
         elif is_temp:
             temp_skipped += 1
 
-    try:
-        translations = await translation.async_get_translations(
-            hass, hass.config.language, f"component.{DOMAIN}"
-        )
-    except (KeyError, RuntimeError, AttributeError):
-        _LOGGER.debug("Translations unavailable during sensor setup; using empty mapping")
-        translations = {}
-    entities.append(ThesslaGreenErrorCodesSensor(coordinator, translations))
+    entities.append(ThesslaGreenErrorCodesSensor(coordinator))
 
     error_registers = [
         key
@@ -295,14 +286,9 @@ class ThesslaGreenErrorCodesSensor(ThesslaGreenEntity, SensorEntity):
     _attr_icon = "mdi:alert-circle"
     _register_name = "error_codes"
 
-    def __init__(
-        self,
-        coordinator: ThesslaGreenModbusCoordinator,
-        translations: dict[str, str],
-    ) -> None:
+    def __init__(self, coordinator: ThesslaGreenModbusCoordinator) -> None:
         """Initialize the aggregated error/status sensor."""
         super().__init__(coordinator, self._register_name, -2)
-        self._translations = translations
         self._attr_translation_key = self._register_name
 
     @property
@@ -340,13 +326,6 @@ class ThesslaGreenActiveErrorsSensor(ThesslaGreenEntity, SensorEntity):
     def __init__(self, coordinator: ThesslaGreenModbusCoordinator) -> None:
         """Initialize the active errors sensor."""
         super().__init__(coordinator, "active_errors", -3)
-        self._translations: dict[str, str] = {}
-
-    async def async_added_to_hass(self) -> None:
-        """Load translations when entity is added to Home Assistant."""
-        self._translations = await translation.async_get_translations(
-            self.hass, self.hass.config.language, f"component.{DOMAIN}"
-        )
 
     @property
     def available(self) -> bool:

--- a/docs/agents/tasks/TASK-20260810-ha-integration-hardening.md
+++ b/docs/agents/tasks/TASK-20260810-ha-integration-hardening.md
@@ -116,5 +116,5 @@ validation:
     result: PASS
     evidence: GitHub Actions run 31435299678 (#1145); lint, Hassfest, HACS, entity mappings, full pytest and 90.68% coverage all passed
 blockers: []
-next_action: Verify the checkpoint-only finalization CI, mark PR #1762 ready, and merge if all mandatory gates remain green.
+next_action: PR #1762 is merged; before any broad core/read-path consolidation, execute the physical AirPack soak/reconnect plan in docs/real_device_validation.md and record the hardware evidence.
 ```

--- a/docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
+++ b/docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
@@ -1,7 +1,7 @@
 ---
 task_id: TASK-20260811-deep-audit-cleanup
-status: done
-branch: codex/audit-cleanup-20260811
+status: ready
+branch: main
 base_branch: main
 created: 2026-08-11
 updated: 2026-08-11
@@ -30,14 +30,16 @@ optional_reads:
 
 ```yaml
 checkpoint_version: 1
-updated_at: 2026-08-11T13:15:00Z
-verified_head: daa9f814f472f6b51074c88692425b1d5d96cdf9
-branch: codex/audit-cleanup-20260811
+updated_at: 2026-08-11T13:25:10Z
+head: 025a36f78b3629e47421afe1d06b372c1df3aafb
+branch: main
 pr: 1765
-status: done
+status: ready
 context_routes:
   - GitHub connector
-  - Home Assistant connector (read-only audit)
+  - Home Assistant connector read-only audit
+  - docs/audits/deep_audit_2026-08-11.md
+  - docs/quality/STATUS.md
 owned_paths:
   - .github/workflows/ci.yaml
   - docs/audits/deep_audit_2026-08-11.md
@@ -46,35 +48,29 @@ owned_paths:
   - docs/ha_quality_scale_audit.md
   - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
 proven:
-  - main had no open pull requests or issues and no non-main branches before this task
-  - TASK-20260810-ha-integration-10of10-followup.md is status done and PR #1763 is merged
-  - main@62e3cb1 had nine successful GitHub Actions checks before this audit
-  - baseline Tests job 93778480635 reports total coverage 90.78 percent
-  - baseline Codecov upload failed with 'Token required - not valid tokenless upload' while the Tests job remained green
-  - PR #1765 Tests job 93786147158 successfully obtained a GitHub OIDC token but Codecov then failed with 'Repository not found'
-  - Codecov upload is therefore not a functioning CI/release signal for this repository today
-  - the non-blocking Codecov upload was removed while the blocking local pytest coverage gate was retained
-  - PR #1765 run 31494460377 on verified_head daa9f814 passed Lint, Hassfest, HACS, full Tests, minimum HA 2026.1.0 contracts, current HA 2026.8.1 contracts, pymodbus 3.6.1, pymodbus 3.14.0, and entity mappings validation
-  - PR #1765 Tests job 93789362227 confirms 90.78 percent total coverage and contains no Codecov upload step
-  - current quality/release docs now record merged follow-up PR #1763 and current dependency/version context
-  - manifest.json and pyproject.toml on current main require pymodbus>=3.6.1,<4.0 while tag v2.8.3 requires pymodbus>=3.6.0,<4.0
-  - physical AirPack post-hardening validation remains an external acceptance gate
-  - read-only live HA diagnostics show the installed v2.8.3 integration connected with 337 successful and 0 failed sampled reads, 336 available registers, about 14.258 seconds average update-cycle duration, about 22.555 seconds scan duration, and about 53.134 seconds config-entry setup duration
-  - live runtime is the published v2.8.3 build and is not evidence for post-release main behavior
+  - PR #1765 was merged to main as 025a36f78b3629e47421afe1d06b372c1df3aafb.
+  - No unfinished implementation branch, open pull request, or open issue existed at the start of the audit.
+  - Baseline main Tests job 93778480635 kept a non-blocking failed Codecov upload green.
+  - PR #1765 Tests job 93786147158 obtained a GitHub OIDC token and Codecov returned Repository not found.
+  - The non-functional Codecov upload was removed while the blocking local pytest coverage gate was retained.
+  - PR #1765 pre-merge Actions run 31494460377 passed the complete repository matrix after Codecov removal.
+  - Final main Actions run 31496065204 passed and the Python 3.13 suite reported 1402 tests passing.
+  - Current main and package metadata require pymodbus>=3.6.1,<4.0 while published v2.8.3 requires >=3.6.0,<4.0.
+  - Physical AirPack post-hardening validation remains an external acceptance gate.
 derived:
-  - remove the non-blocking Codecov upload rather than retain a false-green external signal
-  - prioritize measured polling/startup optimization over broad speculative refactoring
+  - Removing the non-blocking Codecov step eliminates a false-green external signal without weakening the local coverage gate.
+  - Hardware-sensitive polling and startup restructuring should remain measurement-driven and separately gated.
 unknown:
-  - post-hardening behavior on a physical AirPack during reconnect and 24-72 hour soak
-  - whether removing redundant sensor translation loading alone removes the live >10 second sensor-platform setup warning
+  - Post-hardening behavior on a physical AirPack during reconnect and a 24-72 hour soak.
+  - Whether removing redundant sensor translation loading eliminates the historical sensor-platform setup warning.
 conflicts: []
 first_failure:
-  marker: external Codecov repository availability
-  evidence: PR #1765 Tests job 93786147158 obtains OIDC token then receives 'Repository not found'
+  marker: none-after-final-validation
+  evidence: PR #1765 is merged and final main Actions run 31496065204 completed successfully.
 rejected_hypotheses:
-  - an unfinished implementation branch existed before this audit
-  - an open PR or issue was waiting to be completed before this audit
-  - GitHub OIDC token issuance was the remaining Codecov blocker
+  - An unfinished implementation branch existed before this audit.
+  - An open pull request or issue was waiting to be completed before this audit.
+  - GitHub OIDC token issuance was the remaining Codecov blocker.
 changed_paths:
   - .github/workflows/ci.yaml
   - docs/audits/deep_audit_2026-08-11.md
@@ -83,15 +79,18 @@ changed_paths:
   - docs/ha_quality_scale_audit.md
   - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
 validation:
-  - command: baseline main GitHub Actions inspection
-    result: PASS_WITH_NONBLOCKING_CODECOV_FAILURE
-    evidence: main@62e3cb1, Tests job 93778480635
-  - command: PR #1765 first Tests job inspection
-    result: PASS_WITH_EXTERNAL_CODECOV_REPOSITORY_NOT_FOUND
-    evidence: Tests job 93786147158
-  - command: PR #1765 full GitHub Actions matrix after Codecov removal
+  - command: inspect baseline main Tests job 93778480635
     result: PASS
-    evidence: run 31494460377 on daa9f814, Tests job 93789362227
+    evidence: Inspection confirmed the Codecov upload failed non-blockingly while the Tests job remained green.
+  - command: inspect PR #1765 Tests job 93786147158
+    result: PASS
+    evidence: Inspection confirmed successful OIDC token issuance followed by Codecov Repository not found.
+  - command: inspect PR #1765 Actions run 31494460377 after Codecov removal
+    result: PASS
+    evidence: Complete pre-merge repository matrix passed on the audited cleanup head.
+  - command: inspect final main Actions run 31496065204
+    result: PASS
+    evidence: Complete main matrix passed and the Python 3.13 suite reported 1402 passing tests.
 blockers: []
-next_action: merge PR #1765 after the final documentation-only synchronization check; post-hardening physical AirPack acceptance remains external
+next_action: Complete the repository-local A3 and checkpoint-governance follow-ups tracked in TASK-20260811-post-audit-closure.md, then use physical AirPack reconnect and soak evidence for the remaining hardware gate.
 ```

--- a/docs/agents/tasks/TASK-20260811-post-audit-closure.md
+++ b/docs/agents/tasks/TASK-20260811-post-audit-closure.md
@@ -11,8 +11,8 @@ scope: close verified post-audit follow-ups
 
 ```yaml
 checkpoint_version: 1
-updated_at: 2026-08-11T14:06:01Z
-head: e66d4a3e6510f7db2ddc4133fb27edae6f9ec466
+updated_at: 2026-08-11T14:16:53Z
+head: 22aaf191d4fd6a883678abfffaf076d2af9214ac
 branch: fix/close-audit-followups-20260811
 pr: 1766
 status: validating
@@ -26,6 +26,7 @@ owned_paths:
   - .github/workflows/ci.yaml
   - custom_components/thessla_green_modbus/sensor.py
   - tests/test_sensor_platform.py
+  - tests/test_all_entity_creation.py
   - docs/agents/tasks/
   - docs/audits/deep_audit_2026-08-11.md
   - docs/real_device_validation.md
@@ -36,45 +37,53 @@ proven:
   - The completed TASK-20260811-deep-audit-cleanup.md checkpoint violated the shared checkpoint contract.
   - manifest.json and pyproject.toml both require pymodbus>=3.6.1,<4.0; canonical quality/release docs match that bound.
   - sensor platform setup fetched translation data that the inspected error sensor classes stored but did not consume.
-  - PR #1766 removes both unused translation fetch/storage paths and adds a regression assertion that setup does not call the translation loader.
+  - PR #1766 removes both unused translation fetch/storage paths and adds focused regression coverage requiring sensor setup not to call the translation loader.
+  - GitHub Actions run 31499787197 passed Lint, Hassfest, and HACS on candidate 88e142cc761073194c71e7b169904ec751d0754d.
+  - The Lint job in run 31499787197 passed Ruff, Ruff import order, Ruff format, compileall, mypy, register-reference checks, AirPack4 vendor coverage, translation checks, maintainability, and full-directory agent-checkpoint validation.
+  - Tests job 93808188092 in run 31499787197 collected 1402 tests and failed exactly two tests with 1400 passing.
+  - Both failures occurred in tests/test_all_entity_creation.py while resolving a stale mock target for the removed sensor.translation import; platform setup did not execute in those failing contexts.
+  - Commit 22aaf191d4fd6a883678abfffaf076d2af9214ac removes only the stale translation mock/scaffolding from tests/test_all_entity_creation.py.
   - docs/real_device_validation.md previously described the already-merged follow-up as future work.
 derived:
   - The bounded repository-local fixes do not change public Home Assistant, entity, service, Modbus register, or transport contracts.
+  - The first CI failure is test-scaffolding drift caused by the intended import removal, not evidence of a runtime entity-creation regression.
   - Real-device startup timing remains external evidence even after the redundant translation calls are removed.
 unknown:
-  - Whether the complete PR #1766 CI matrix passes on the final candidate head.
+  - Whether the complete PR #1766 CI matrix passes on the candidate containing commit 22aaf191d4fd6a883678abfffaf076d2af9214ac.
   - Post-hardening reconnect and 24-72 hour soak behavior on a physical AirPack.
   - Whether the historical sensor-platform setup warning disappears on the exact deployed candidate.
 conflicts: []
 first_failure:
-  marker: checkpoint-governance-coverage
-  evidence: The previous CI command named only two 2026-08-10 task files, allowing the invalid 2026-08-11 checkpoint to remain unchecked.
+  marker: tests/test_all_entity_creation.py::stale-translation-patch
+  evidence: GitHub Actions run 31499787197 Tests job 93808188092 reported 2 failed and 1400 passed; both failures raised AttributeError because custom_components.thessla_green_modbus.sensor no longer exposes translation.
 rejected_hypotheses:
   - An open pull request or issue was waiting to be completed before this task.
   - Canonical pymodbus dependency documentation is stale relative to current main.
   - The error sensor translation mappings are consumed by the current state or attribute logic.
+  - The first failed CI run proves a runtime entity-creation regression; both failures occurred while resolving the stale test patch before platform setup.
 changed_paths:
   - .github/workflows/ci.yaml
   - custom_components/thessla_green_modbus/sensor.py
   - tests/test_sensor_platform.py
+  - tests/test_all_entity_creation.py
   - docs/agents/tasks/TASK-20260810-ha-integration-hardening.md
   - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
   - docs/agents/tasks/TASK-20260811-post-audit-closure.md
   - docs/audits/deep_audit_2026-08-11.md
   - docs/real_device_validation.md
 validation:
-  - command: python tools/agents/checkpoint.py --tasks docs/agents/tasks --require-checkpoint
+  - command: GitHub Actions run 31499787197 - Lint
+    result: PASS
+    evidence: Ruff, import order, format, compileall, mypy, register checks, AirPack4 coverage, translations, maintainability, and all-task checkpoint validation passed on 88e142cc761073194c71e7b169904ec751d0754d.
+  - command: GitHub Actions run 31499787197 - Hassfest and HACS
+    result: PASS
+    evidence: Both independent validation jobs completed successfully on 88e142cc761073194c71e7b169904ec751d0754d.
+  - command: GitHub Actions run 31499787197 - Tests job 93808188092
+    result: FAIL
+    evidence: 2 failed, 1400 passed; both failures were stale sensor.translation mock targets in tests/test_all_entity_creation.py.
+  - command: Complete GitHub Actions matrix after commit 22aaf191d4fd6a883678abfffaf076d2af9214ac
     result: NOT_RUN
-    evidence: The final candidate CI run has not completed yet.
-  - command: pre-commit run --all-files
-    result: NOT_RUN
-    evidence: GitHub Actions is the authoritative validation environment because the local sandbox cannot resolve GitHub.
-  - command: pylint custom_components/thessla_green_modbus
-    result: NOT_RUN
-    evidence: The repository CI lint and static-analysis job is the available equivalent gate in this environment.
-  - command: pytest -q
-    result: NOT_RUN
-    evidence: The final candidate full Tests job has not completed yet.
+    evidence: A fresh candidate run is required after the focused test-scaffolding correction.
 blockers: []
-next_action: Run the complete GitHub Actions matrix for PR #1766, fix any failure, then record final green evidence and merge only if every mandatory job passes.
+next_action: Run the complete GitHub Actions matrix on the candidate containing 22aaf191d4fd6a883678abfffaf076d2af9214ac, fix only evidenced failures, then record final green evidence and merge only if every mandatory job passes.
 ```

--- a/docs/agents/tasks/TASK-20260811-post-audit-closure.md
+++ b/docs/agents/tasks/TASK-20260811-post-audit-closure.md
@@ -1,6 +1,6 @@
 ---
 task_id: TASK-20260811-post-audit-closure
-status: validating
+status: ready
 owner: codex
 scope: close verified post-audit follow-ups
 ---
@@ -11,11 +11,11 @@ scope: close verified post-audit follow-ups
 
 ```yaml
 checkpoint_version: 1
-updated_at: 2026-08-11T14:16:53Z
-head: 22aaf191d4fd6a883678abfffaf076d2af9214ac
+updated_at: 2026-08-11T14:34:41Z
+head: 1eb289c2ad9f939a2deec439e767d3634e22cfbd
 branch: fix/close-audit-followups-20260811
 pr: 1766
-status: validating
+status: ready
 context_routes:
   - AGENTS.md
   - docs/agents/CONTEXT_HANDOFF.md
@@ -32,30 +32,30 @@ owned_paths:
   - docs/real_device_validation.md
 proven:
   - main head was 025a36f78b3629e47421afe1d06b372c1df3aafb when this branch was created.
-  - PR #1765 is merged and its final main CI completed successfully with 1402 tests passing on Python 3.13.
+  - PR #1765 is merged and its final main CI completed successfully.
   - Prior CI validated two task checkpoints explicitly instead of the complete task directory.
   - The completed TASK-20260811-deep-audit-cleanup.md checkpoint violated the shared checkpoint contract.
   - manifest.json and pyproject.toml both require pymodbus>=3.6.1,<4.0; canonical quality/release docs match that bound.
   - sensor platform setup fetched translation data that the inspected error sensor classes stored but did not consume.
   - PR #1766 removes both unused translation fetch/storage paths and adds focused regression coverage requiring sensor setup not to call the translation loader.
-  - GitHub Actions run 31499787197 passed Lint, Hassfest, and HACS on candidate 88e142cc761073194c71e7b169904ec751d0754d.
-  - The Lint job in run 31499787197 passed Ruff, Ruff import order, Ruff format, compileall, mypy, register-reference checks, AirPack4 vendor coverage, translation checks, maintainability, and full-directory agent-checkpoint validation.
-  - Tests job 93808188092 in run 31499787197 collected 1402 tests and failed exactly two tests with 1400 passing.
-  - Both failures occurred in tests/test_all_entity_creation.py while resolving a stale mock target for the removed sensor.translation import; platform setup did not execute in those failing contexts.
-  - Commit 22aaf191d4fd6a883678abfffaf076d2af9214ac removes only the stale translation mock/scaffolding from tests/test_all_entity_creation.py.
-  - docs/real_device_validation.md previously described the already-merged follow-up as future work.
+  - GitHub Actions run 31499787197 passed Lint, Hassfest, and HACS but its Tests job failed exactly two stale test mocks after the intended translation import removal; 1400 tests passed and 3 were skipped in that run.
+  - Commit 22aaf191d4fd6a883678abfffaf076d2af9214ac removed only the stale sensor.translation mock/scaffolding from tests/test_all_entity_creation.py.
+  - GitHub Actions run 31500880807 completed successfully on candidate 1eb289c2ad9f939a2deec439e767d3634e22cfbd.
+  - Run 31500880807 passed Lint, Hassfest, HACS, minimum Home Assistant 2026.1.0 contracts, current Home Assistant 2026.8.1 contracts, pymodbus 3.6.1 and 3.14.0 compatibility, entity mappings, and the full pytest coverage job.
+  - The Tests job in run 31500880807 completed successfully with 3 known skips and total coverage 90.78%, above the repository 80% gate.
+  - The Lint job in run 31500880807 passed Ruff, import order, format, compileall, mypy, register-reference checks, AirPack4 vendor coverage, translation checks, maintainability, and full-directory agent-checkpoint validation.
+  - docs/real_device_validation.md now requires every physical validation session to record the exact candidate commit and no longer describes already-merged #1763 as future work.
 derived:
   - The bounded repository-local fixes do not change public Home Assistant, entity, service, Modbus register, or transport contracts.
-  - The first CI failure is test-scaffolding drift caused by the intended import removal, not evidence of a runtime entity-creation regression.
+  - The first CI failure was test-scaffolding drift caused by the intended import removal, not a runtime entity-creation regression.
   - Real-device startup timing remains external evidence even after the redundant translation calls are removed.
 unknown:
-  - Whether the complete PR #1766 CI matrix passes on the candidate containing commit 22aaf191d4fd6a883678abfffaf076d2af9214ac.
   - Post-hardening reconnect and 24-72 hour soak behavior on a physical AirPack.
   - Whether the historical sensor-platform setup warning disappears on the exact deployed candidate.
 conflicts: []
 first_failure:
   marker: tests/test_all_entity_creation.py::stale-translation-patch
-  evidence: GitHub Actions run 31499787197 Tests job 93808188092 reported 2 failed and 1400 passed; both failures raised AttributeError because custom_components.thessla_green_modbus.sensor no longer exposes translation.
+  evidence: GitHub Actions run 31499787197 Tests job 93808188092 reported 2 failed, 1400 passed and 3 skipped; both failures raised AttributeError because custom_components.thessla_green_modbus.sensor no longer exposed translation.
 rejected_hypotheses:
   - An open pull request or issue was waiting to be completed before this task.
   - Canonical pymodbus dependency documentation is stale relative to current main.
@@ -72,18 +72,18 @@ changed_paths:
   - docs/audits/deep_audit_2026-08-11.md
   - docs/real_device_validation.md
 validation:
-  - command: GitHub Actions run 31499787197 - Lint
-    result: PASS
-    evidence: Ruff, import order, format, compileall, mypy, register checks, AirPack4 coverage, translations, maintainability, and all-task checkpoint validation passed on 88e142cc761073194c71e7b169904ec751d0754d.
-  - command: GitHub Actions run 31499787197 - Hassfest and HACS
-    result: PASS
-    evidence: Both independent validation jobs completed successfully on 88e142cc761073194c71e7b169904ec751d0754d.
   - command: GitHub Actions run 31499787197 - Tests job 93808188092
     result: FAIL
-    evidence: 2 failed, 1400 passed; both failures were stale sensor.translation mock targets in tests/test_all_entity_creation.py.
-  - command: Complete GitHub Actions matrix after commit 22aaf191d4fd6a883678abfffaf076d2af9214ac
-    result: NOT_RUN
-    evidence: A fresh candidate run is required after the focused test-scaffolding correction.
+    evidence: 2 failed, 1400 passed and 3 skipped; both failures were stale sensor.translation mock targets in tests/test_all_entity_creation.py.
+  - command: GitHub Actions run 31500880807 - Lint
+    result: PASS
+    evidence: Ruff, import order, format, compileall, mypy, register checks, AirPack4 coverage, translations, maintainability, and all-task checkpoint validation passed on 1eb289c2ad9f939a2deec439e767d3634e22cfbd.
+  - command: GitHub Actions run 31500880807 - Tests
+    result: PASS
+    evidence: The full pytest coverage job completed successfully with 3 known skips and 90.78% total coverage.
+  - command: GitHub Actions run 31500880807 - compatibility and ecosystem matrix
+    result: PASS
+    evidence: Hassfest, HACS, Home Assistant 2026.1.0 and 2026.8.1 contracts, pymodbus 3.6.1 and 3.14.0 compatibility, and entity mappings all completed successfully.
 blockers: []
-next_action: Run the complete GitHub Actions matrix on the candidate containing 22aaf191d4fd6a883678abfffaf076d2af9214ac, fix only evidenced failures, then record final green evidence and merge only if every mandatory job passes.
+next_action: Merge PR #1766 after the final checkpoint-only commit passes the complete required CI, then verify the exact resulting main commit before starting hardware-sensitive polling or scan-cache work.
 ```

--- a/docs/agents/tasks/TASK-20260811-post-audit-closure.md
+++ b/docs/agents/tasks/TASK-20260811-post-audit-closure.md
@@ -1,0 +1,57 @@
+---
+task_id: TASK-20260811-post-audit-closure
+status: implementing
+owner: codex
+scope: close verified post-audit follow-ups
+---
+
+# TASK-20260811-post-audit-closure
+
+## Objective
+
+Close verified repository-local follow-ups discovered while re-auditing `main`: repair agent checkpoint validation coverage/state, synchronize canonical dependency documentation, and remove redundant sensor translation setup work without changing Home Assistant or Modbus contracts.
+
+## Scope
+
+- `.github/workflows/ci.yaml`
+- `custom_components/thessla_green_modbus/sensor.py`
+- `tests/test_sensor_platform.py`
+- `docs/agents/tasks/`
+- `docs/audits/deep_audit_2026-08-11.md`
+- `docs/quality/STATUS.md`
+- `docs/release_readiness.md`
+
+## Checkpoint
+
+```yaml
+task_id: TASK-20260811-post-audit-closure
+objective: Close verified repository-local post-audit follow-ups without changing public Home Assistant or Modbus contracts.
+parent_objective: Complete safe repository-local follow-ups from the 2026-08-11 deep audit
+branch: fix/close-audit-followups-20260811
+base: main
+head: 025a36f78b3629e47421afe1d06b372c1df3aafb
+status: implementing
+owned_paths:
+  - .github/workflows/ci.yaml
+  - custom_components/thessla_green_modbus/sensor.py
+  - tests/test_sensor_platform.py
+  - docs/agents/tasks/
+  - docs/audits/deep_audit_2026-08-11.md
+  - docs/quality/STATUS.md
+  - docs/release_readiness.md
+validation:
+  - command: python tools/agents/checkpoint.py --tasks docs/agents/tasks --require-checkpoint
+    result: NOT_RUN
+  - command: pre-commit run --all-files
+    result: NOT_RUN
+  - command: pylint custom_components/thessla_green_modbus
+    result: NOT_RUN
+  - command: pytest -q
+    result: NOT_RUN
+blocked_on: []
+last_verified_commit: 025a36f78b3629e47421afe1d06b372c1df3aafb
+first_failure:
+  marker: none
+  evidence: none
+next_action: Repair checkpoint governance/state and the verified sensor/documentation follow-ups, then run the mandated validation stack in CI.
+```

--- a/docs/agents/tasks/TASK-20260811-post-audit-closure.md
+++ b/docs/agents/tasks/TASK-20260811-post-audit-closure.md
@@ -12,7 +12,7 @@ scope: close verified post-audit follow-ups
 ```yaml
 checkpoint_version: 1
 updated_at: 2026-08-11T13:30:00Z
-head: a1ba9f18772f002386bc82c51782c0e3947c181a
+head: 94dd5021d5126bc99cffc79e208d0093d9525bb0
 branch: fix/close-audit-followups-20260811
 pr: none
 status: implementing
@@ -27,17 +27,15 @@ owned_paths:
   - tests/test_sensor_platform.py
   - docs/agents/tasks/
   - docs/audits/deep_audit_2026-08-11.md
-  - docs/quality/STATUS.md
-  - docs/release_readiness.md
 proven:
   - main head was 025a36f78b3629e47421afe1d06b372c1df3aafb when this branch was created.
   - PR #1765 is merged and its final main CI completed successfully with 1402 tests passing on Python 3.13.
   - CI currently validates two task checkpoints explicitly instead of the complete task directory.
   - TASK-20260811-deep-audit-cleanup.md does not satisfy the current shared checkpoint contract.
-  - manifest.json and pyproject.toml require pymodbus>=3.7.0,<4.0 while canonical quality/release docs still say >=3.6.1,<4.0.
-  - sensor platform setup loads translation dictionaries that ThesslaGreenErrorCodesSensor stores but does not consume.
+  - manifest.json and pyproject.toml both require pymodbus>=3.6.1,<4.0; canonical quality/release docs match that bound.
+  - sensor platform setup loads translation data that the inspected error sensor classes store but do not consume.
 derived:
-  - The remaining repository-local follow-ups can be closed with bounded governance, documentation, and sensor setup changes.
+  - The remaining repository-local follow-ups can be closed with bounded governance and sensor setup changes.
 unknown:
   - Post-hardening reconnect and 24-72 hour soak behavior on a physical AirPack.
 conflicts: []
@@ -46,6 +44,7 @@ first_failure:
   evidence: .github/workflows/ci.yaml names only the two 2026-08-10 task files, leaving the 2026-08-11 checkpoint unchecked.
 rejected_hypotheses:
   - An open pull request or issue was waiting to be completed before this task.
+  - Canonical dependency documentation is stale relative to current main.
 changed_paths:
   - docs/agents/tasks/TASK-20260811-post-audit-closure.md
 validation:
@@ -62,5 +61,5 @@ validation:
     result: NOT_RUN
     evidence: Validation will run after the bounded implementation is committed.
 blockers: []
-next_action: Repair the invalid historical checkpoint, expand CI checkpoint coverage, synchronize dependency documentation, and remove the redundant sensor translation setup path with regression coverage.
+next_action: Repair the invalid historical checkpoint, expand CI checkpoint coverage, and remove the redundant sensor translation setup path with regression coverage.
 ```

--- a/docs/agents/tasks/TASK-20260811-post-audit-closure.md
+++ b/docs/agents/tasks/TASK-20260811-post-audit-closure.md
@@ -1,6 +1,6 @@
 ---
 task_id: TASK-20260811-post-audit-closure
-status: implementing
+status: validating
 owner: codex
 scope: close verified post-audit follow-ups
 ---
@@ -11,55 +11,70 @@ scope: close verified post-audit follow-ups
 
 ```yaml
 checkpoint_version: 1
-updated_at: 2026-08-11T13:30:00Z
-head: 94dd5021d5126bc99cffc79e208d0093d9525bb0
+updated_at: 2026-08-11T14:06:01Z
+head: e66d4a3e6510f7db2ddc4133fb27edae6f9ec466
 branch: fix/close-audit-followups-20260811
-pr: none
-status: implementing
+pr: 1766
+status: validating
 context_routes:
   - AGENTS.md
   - docs/agents/CONTEXT_HANDOFF.md
   - docs/agents/GOVERNANCE_CONTRACT.json
   - docs/audits/deep_audit_2026-08-11.md
+  - docs/real_device_validation.md
 owned_paths:
   - .github/workflows/ci.yaml
   - custom_components/thessla_green_modbus/sensor.py
   - tests/test_sensor_platform.py
   - docs/agents/tasks/
   - docs/audits/deep_audit_2026-08-11.md
+  - docs/real_device_validation.md
 proven:
   - main head was 025a36f78b3629e47421afe1d06b372c1df3aafb when this branch was created.
   - PR #1765 is merged and its final main CI completed successfully with 1402 tests passing on Python 3.13.
-  - CI currently validates two task checkpoints explicitly instead of the complete task directory.
-  - TASK-20260811-deep-audit-cleanup.md does not satisfy the current shared checkpoint contract.
+  - Prior CI validated two task checkpoints explicitly instead of the complete task directory.
+  - The completed TASK-20260811-deep-audit-cleanup.md checkpoint violated the shared checkpoint contract.
   - manifest.json and pyproject.toml both require pymodbus>=3.6.1,<4.0; canonical quality/release docs match that bound.
-  - sensor platform setup loads translation data that the inspected error sensor classes store but do not consume.
+  - sensor platform setup fetched translation data that the inspected error sensor classes stored but did not consume.
+  - PR #1766 removes both unused translation fetch/storage paths and adds a regression assertion that setup does not call the translation loader.
+  - docs/real_device_validation.md previously described the already-merged follow-up as future work.
 derived:
-  - The remaining repository-local follow-ups can be closed with bounded governance and sensor setup changes.
+  - The bounded repository-local fixes do not change public Home Assistant, entity, service, Modbus register, or transport contracts.
+  - Real-device startup timing remains external evidence even after the redundant translation calls are removed.
 unknown:
+  - Whether the complete PR #1766 CI matrix passes on the final candidate head.
   - Post-hardening reconnect and 24-72 hour soak behavior on a physical AirPack.
+  - Whether the historical sensor-platform setup warning disappears on the exact deployed candidate.
 conflicts: []
 first_failure:
   marker: checkpoint-governance-coverage
-  evidence: .github/workflows/ci.yaml names only the two 2026-08-10 task files, leaving the 2026-08-11 checkpoint unchecked.
+  evidence: The previous CI command named only two 2026-08-10 task files, allowing the invalid 2026-08-11 checkpoint to remain unchecked.
 rejected_hypotheses:
   - An open pull request or issue was waiting to be completed before this task.
-  - Canonical dependency documentation is stale relative to current main.
+  - Canonical pymodbus dependency documentation is stale relative to current main.
+  - The error sensor translation mappings are consumed by the current state or attribute logic.
 changed_paths:
+  - .github/workflows/ci.yaml
+  - custom_components/thessla_green_modbus/sensor.py
+  - tests/test_sensor_platform.py
+  - docs/agents/tasks/TASK-20260810-ha-integration-hardening.md
+  - docs/agents/tasks/TASK-20260811-deep-audit-cleanup.md
   - docs/agents/tasks/TASK-20260811-post-audit-closure.md
+  - docs/audits/deep_audit_2026-08-11.md
+  - docs/real_device_validation.md
 validation:
   - command: python tools/agents/checkpoint.py --tasks docs/agents/tasks --require-checkpoint
     result: NOT_RUN
-    evidence: Full-directory checkpoint validation is not yet wired into CI on this branch.
+    evidence: The final candidate CI run has not completed yet.
   - command: pre-commit run --all-files
     result: NOT_RUN
-    evidence: Validation will run after the bounded implementation is committed.
+    evidence: GitHub Actions is the authoritative validation environment because the local sandbox cannot resolve GitHub.
   - command: pylint custom_components/thessla_green_modbus
     result: NOT_RUN
-    evidence: Validation will run after the bounded implementation is committed.
+    evidence: The repository CI lint and static-analysis job is the available equivalent gate in this environment.
   - command: pytest -q
     result: NOT_RUN
-    evidence: Validation will run after the bounded implementation is committed.
+    evidence: The final candidate full Tests job has not completed yet.
 blockers: []
-next_action: Repair the invalid historical checkpoint, expand CI checkpoint coverage, and remove the redundant sensor translation setup path with regression coverage.
+next_action: Run the complete GitHub Actions matrix for PR #1766, fix any failure, then record final green evidence and merge only if every mandatory job passes.
 ```

--- a/docs/agents/tasks/TASK-20260811-post-audit-closure.md
+++ b/docs/agents/tasks/TASK-20260811-post-audit-closure.md
@@ -5,32 +5,22 @@ owner: codex
 scope: close verified post-audit follow-ups
 ---
 
-# TASK-20260811-post-audit-closure
+# Post-audit closure
 
-## Objective
-
-Close verified repository-local follow-ups discovered while re-auditing `main`: repair agent checkpoint validation coverage/state, synchronize canonical dependency documentation, and remove redundant sensor translation setup work without changing Home Assistant or Modbus contracts.
-
-## Scope
-
-- `.github/workflows/ci.yaml`
-- `custom_components/thessla_green_modbus/sensor.py`
-- `tests/test_sensor_platform.py`
-- `docs/agents/tasks/`
-- `docs/audits/deep_audit_2026-08-11.md`
-- `docs/quality/STATUS.md`
-- `docs/release_readiness.md`
-
-## Checkpoint
+## Context checkpoint
 
 ```yaml
-task_id: TASK-20260811-post-audit-closure
-objective: Close verified repository-local post-audit follow-ups without changing public Home Assistant or Modbus contracts.
-parent_objective: Complete safe repository-local follow-ups from the 2026-08-11 deep audit
+checkpoint_version: 1
+updated_at: 2026-08-11T13:30:00Z
+head: a1ba9f18772f002386bc82c51782c0e3947c181a
 branch: fix/close-audit-followups-20260811
-base: main
-head: 025a36f78b3629e47421afe1d06b372c1df3aafb
+pr: none
 status: implementing
+context_routes:
+  - AGENTS.md
+  - docs/agents/CONTEXT_HANDOFF.md
+  - docs/agents/GOVERNANCE_CONTRACT.json
+  - docs/audits/deep_audit_2026-08-11.md
 owned_paths:
   - .github/workflows/ci.yaml
   - custom_components/thessla_green_modbus/sensor.py
@@ -39,19 +29,38 @@ owned_paths:
   - docs/audits/deep_audit_2026-08-11.md
   - docs/quality/STATUS.md
   - docs/release_readiness.md
+proven:
+  - main head was 025a36f78b3629e47421afe1d06b372c1df3aafb when this branch was created.
+  - PR #1765 is merged and its final main CI completed successfully with 1402 tests passing on Python 3.13.
+  - CI currently validates two task checkpoints explicitly instead of the complete task directory.
+  - TASK-20260811-deep-audit-cleanup.md does not satisfy the current shared checkpoint contract.
+  - manifest.json and pyproject.toml require pymodbus>=3.7.0,<4.0 while canonical quality/release docs still say >=3.6.1,<4.0.
+  - sensor platform setup loads translation dictionaries that ThesslaGreenErrorCodesSensor stores but does not consume.
+derived:
+  - The remaining repository-local follow-ups can be closed with bounded governance, documentation, and sensor setup changes.
+unknown:
+  - Post-hardening reconnect and 24-72 hour soak behavior on a physical AirPack.
+conflicts: []
+first_failure:
+  marker: checkpoint-governance-coverage
+  evidence: .github/workflows/ci.yaml names only the two 2026-08-10 task files, leaving the 2026-08-11 checkpoint unchecked.
+rejected_hypotheses:
+  - An open pull request or issue was waiting to be completed before this task.
+changed_paths:
+  - docs/agents/tasks/TASK-20260811-post-audit-closure.md
 validation:
   - command: python tools/agents/checkpoint.py --tasks docs/agents/tasks --require-checkpoint
     result: NOT_RUN
+    evidence: Full-directory checkpoint validation is not yet wired into CI on this branch.
   - command: pre-commit run --all-files
     result: NOT_RUN
+    evidence: Validation will run after the bounded implementation is committed.
   - command: pylint custom_components/thessla_green_modbus
     result: NOT_RUN
+    evidence: Validation will run after the bounded implementation is committed.
   - command: pytest -q
     result: NOT_RUN
-blocked_on: []
-last_verified_commit: 025a36f78b3629e47421afe1d06b372c1df3aafb
-first_failure:
-  marker: none
-  evidence: none
-next_action: Repair checkpoint governance/state and the verified sensor/documentation follow-ups, then run the mandated validation stack in CI.
+    evidence: Validation will run after the bounded implementation is committed.
+blockers: []
+next_action: Repair the invalid historical checkpoint, expand CI checkpoint coverage, synchronize dependency documentation, and remove the redundant sensor translation setup path with regression coverage.
 ```

--- a/docs/audits/deep_audit_2026-08-11.md
+++ b/docs/audits/deep_audit_2026-08-11.md
@@ -65,13 +65,15 @@ Read-only diagnostics from the running Home Assistant instance showed:
 
 ### A3 — Sensor platform startup warning and redundant translation loads
 
-**FACT:** the running Home Assistant log contains `Setup of sensor platform thessla_green_modbus is taking over 10 seconds.`
+**FACT:** the audit-time Home Assistant log contained `Setup of sensor platform thessla_green_modbus is taking over 10 seconds.`
 
-**FACT:** `sensor.py::async_setup_entry` loads translations once. `ThesslaGreenActiveErrorsSensor.async_added_to_hass` loads translations again, while the inspected entity logic uses `_error_status_description` for its state/attributes. The stored `_translations` values in `ThesslaGreenErrorCodesSensor` / `ThesslaGreenActiveErrorsSensor` are not used by the inspected class logic.
+**FACT:** before the post-audit closure, `sensor.py::async_setup_entry` loaded translations once and `ThesslaGreenActiveErrorsSensor.async_added_to_hass` loaded them again, while the inspected entity logic used `_error_status_description` for state attributes and never consumed either stored translation mapping.
 
-**INFERENCE:** removing the redundant translation calls is a safe cleanup candidate and may reduce platform setup overhead, but it cannot by itself explain or guarantee elimination of the full >10 s warning because device I/O/startup work is also expensive.
+**ACTION:** PR #1766 removes both unused translation fetch/storage paths and adds focused regression coverage requiring sensor setup not to call Home Assistant's translation loader. This is a repository-local cleanup only; CI validation and merge evidence are recorded in `TASK-20260811-post-audit-closure.md`.
 
-**RECOMMENDATION:** remove the unused translation fetch/storage under a focused test, then remeasure platform setup time. Do not claim the warning fixed until the real HA log confirms it.
+**UNKNOWN:** whether this cleanup removes the historical >10 second platform warning on a physical AirPack candidate. Device I/O and restart-time scanning remain much larger startup costs and can only be separated by remeasurement after deployment.
+
+**RECOMMENDATION:** remeasure platform setup time and the Home Assistant log on the exact post-hardening candidate. Do not claim the warning fixed until that real runtime evidence is recorded.
 
 ### A4 — Device identity remains incomplete
 
@@ -125,8 +127,8 @@ These checks require the physical device and are the correct gate before high-ri
 
 ## Recommended execution order
 
-1. Merge the audit/CI/documentation cleanup after all PR checks are green.
-2. Remove redundant sensor translation loads with a focused regression test; remeasure the live setup warning.
+1. Merge the post-audit repository cleanup only after its complete PR checks are green.
+2. Remeasure sensor-platform setup time and the historical >10 second warning on the exact merged candidate.
 3. Build a benchmark/evidence harness for request count, polling-cycle duration, startup scan duration, and reconnect/write behavior.
 4. Design fast/slow/on-demand polling from measurements and implement it behind tests, then validate on the physical AirPack.
 5. Introduce a versioned/TTL device-scan cache only with explicit invalidation and force-rescan behavior.

--- a/docs/real_device_validation.md
+++ b/docs/real_device_validation.md
@@ -3,7 +3,7 @@
 **Status:** `PARTIAL`  
 **Last historical physical evidence:** 2026-07-08  
 **Post-hardening validation:** `PENDING`  
-**Current code baseline requiring revalidation:** PR #1762 / `088677385a179a0a02c14ddae3dd96d20c2534e0` plus the 2026-08-10 follow-up when merged.
+**Current code baseline requiring revalidation:** current `main`; every physical validation session must record the exact tested commit before execution.
 
 This document is the source of truth for physical ThesslaGreen validation. Automated CI results must not be recorded as physical-device evidence.
 
@@ -51,7 +51,7 @@ PR #1762 hardened behavior that directly affects hardware validation:
 - safe classification of transport failures as `indeterminate` rather than unsupported;
 - removal of redundant entity initial reads.
 
-The follow-up task additionally removes the volatile process-memory energy accumulator and adds a Repairs issue lifecycle for final Modbus write failures.
+PR #1763 added the bounded hardening follow-up, including removal of the volatile process-memory energy accumulator and a Repairs issue lifecycle for final Modbus write failures. Subsequent `main` changes also remain outside the historical hardware evidence unless their exact candidate commit is explicitly tested and recorded below.
 
 Because these changes touch runtime behavior, old hardware evidence remains historical evidence only.
 

--- a/tests/test_all_entity_creation.py
+++ b/tests/test_all_entity_creation.py
@@ -8,7 +8,6 @@ Design:
 - Adds missing HA component stubs that conftest does not provide (fan, switch,
   number, select, and the missing BinarySensorEntity on binary_sensor).
 - Patches ``capability_block_reason`` to always return ``None`` (allow).
-- Patches ``translation.async_get_translations`` (sensor platform).
 - Sets ``force_full_register_list = True`` for register-driven platforms.
 - Adds ``basic_control = True`` to capabilities for the climate platform.
 - Ensures ``air_flow_rate_manual`` is in holding_registers for the fan.
@@ -17,7 +16,7 @@ Design:
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from custom_components.thessla_green_modbus.const import DOMAIN
@@ -61,13 +60,9 @@ def _make_full_capabilities() -> SimpleNamespace:
 
 
 def _all_patches():
-    """Return a list of patch objects covering all 5 capability-filtered platforms."""
+    """Return patch objects covering all 5 capability-filtered platforms."""
     _cap = "custom_components.thessla_green_modbus.{mod}.capability_block_reason"
     return [
-        patch(
-            "custom_components.thessla_green_modbus.sensor.translation.async_get_translations",
-            new=AsyncMock(return_value={}),
-        ),
         patch(_cap.format(mod="sensor"), return_value=None),
         patch(_cap.format(mod="binary_sensor"), return_value=None),
         patch(_cap.format(mod="switch"), return_value=None),
@@ -126,7 +121,7 @@ async def test_all_platforms_create_at_least_one_entity(
     results: dict[str, list] = {}
 
     patches = _all_patches()
-    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
         for platform_name, platform_module in platforms:
             add_entities = MagicMock()
             await platform_module.async_setup_entry(hass, mock_config_entry, add_entities)
@@ -211,7 +206,7 @@ async def test_entity_counts_per_platform(
 
     counts: dict[str, int] = {}
     patches = _all_patches()
-    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
         for platform_name, platform_module in platforms:
             add_entities = MagicMock()
             await platform_module.async_setup_entry(hass, mock_config_entry, add_entities)

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -1,7 +1,6 @@
 """Tests for ThesslaGreen sensor platform setup."""
 
 import asyncio
-import types
 from unittest.mock import MagicMock, patch
 
 import custom_components.thessla_green_modbus.select as select_module
@@ -84,8 +83,8 @@ def test_sensors_have_native_units(mock_coordinator, mock_config_entry):
     asyncio.run(run_test())
 
 
-def test_error_codes_sensor_translates_active_registers(mock_coordinator, mock_config_entry):
-    """Error sensor returns translated active codes."""
+def test_error_codes_sensor_setup_does_not_load_translations(mock_coordinator, mock_config_entry):
+    """Error sensor setup does not fetch unused translation dictionaries."""
 
     async def run_test() -> None:
         hass = MagicMock()
@@ -98,11 +97,9 @@ def test_error_codes_sensor_translates_active_registers(mock_coordinator, mock_c
             "holding_registers", set()
         ).add("s_2")
         add_entities = MagicMock()
-        with patch(
-            "custom_components.thessla_green_modbus.sensor.translation.async_get_translations",
-            return_value={"entity.sensor.error_codes.state.s_2": "Device status S 2"},
-        ):
+        with patch("homeassistant.helpers.translation.async_get_translations") as get_translations:
             await async_setup_entry(hass, mock_config_entry, add_entities)
+        get_translations.assert_not_called()
         entities = add_entities.call_args[0][0]
         sensor = next(e for e in entities if isinstance(e, ThesslaGreenErrorCodesSensor))
         assert sensor.native_value == "S2"  # nosec B101
@@ -304,14 +301,12 @@ def test_select_and_sensor_share_register(mock_coordinator, mock_config_entry):
 
 
 def test_active_errors_sensor(mock_coordinator, mock_config_entry):
-    """Sensor aggregates active error and status codes with translations."""
+    """Sensor aggregates active error and status codes with register descriptions."""
 
     async def run_test() -> None:
         hass = MagicMock()
         hass.data = {DOMAIN: {mock_config_entry.entry_id: mock_coordinator}}
         mock_config_entry.runtime_data = mock_coordinator
-
-        hass.config = types.SimpleNamespace(language="en")
 
         mock_coordinator.device_client.available_registers = {
             "input_registers": set(),
@@ -320,23 +315,15 @@ def test_active_errors_sensor(mock_coordinator, mock_config_entry):
         mock_coordinator.data["e_100"] = 1
 
         add_entities = MagicMock()
-        with patch(
-            "homeassistant.helpers.translation.async_get_translations",
-            return_value={"entity.sensor.error_codes.state.e_100": "Outside temp sensor missing"},
-        ):
-            await async_setup_entry(hass, mock_config_entry, add_entities)
-            entities = add_entities.call_args[0][0]
-            assert any(isinstance(ent, ThesslaGreenActiveErrorsSensor) for ent in entities)
-            sensor = next(
-                ent for ent in entities if isinstance(ent, ThesslaGreenActiveErrorsSensor)
-            )
-            sensor.hass = hass
-            await sensor.async_added_to_hass()
-            assert sensor.native_value == "E100"
-            assert sensor.extra_state_attributes["errors"] == {
-                "E100": "No reading from outdoor air temperature sensor – air intake (TZ1)"
-            }
-            assert sensor.extra_state_attributes["codes"] == ["E100"]
+        await async_setup_entry(hass, mock_config_entry, add_entities)
+        entities = add_entities.call_args[0][0]
+        assert any(isinstance(ent, ThesslaGreenActiveErrorsSensor) for ent in entities)
+        sensor = next(ent for ent in entities if isinstance(ent, ThesslaGreenActiveErrorsSensor))
+        assert sensor.native_value == "E100"
+        assert sensor.extra_state_attributes["errors"] == {
+            "E100": "No reading from outdoor air temperature sensor – air intake (TZ1)"
+        }
+        assert sensor.extra_state_attributes["codes"] == ["E100"]
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Scope

Close verified repository-local follow-ups from the 2026-08-11 deep audit without changing public Home Assistant, entity, service, or Modbus register contracts.

- validate every canonical agent task checkpoint in CI instead of two hard-coded task files
- repair the completed deep-audit checkpoint so it conforms to `docs/agents/GOVERNANCE_CONTRACT.json`
- remove unused translation fetch/storage from sensor setup and active-error entities
- add focused regression coverage proving sensor setup no longer requests translation dictionaries
- track the work in `TASK-20260811-post-audit-closure.md`

## Safety boundary

No Modbus addresses, register names, entity IDs/unique IDs, service IDs, translation keys, write semantics, scan policy, or transport behavior are changed. Physical AirPack reconnect/soak validation remains an explicit external gate.

## Validation

GitHub Actions is the authoritative validation environment for this branch because the local sandbox cannot resolve GitHub. The PR should pass the complete CI matrix before merge.