### PR TITLE
fix: preserve partial firmware identity and harden scanner coverage

### DIFF
--- a/custom_components/thessla_green_modbus/scanner/firmware.py
+++ b/custom_components/thessla_green_modbus/scanner/firmware.py
@@ -98,25 +98,30 @@ def _apply_firmware_version_to_device(
             if missing_value is None and name in INPUT_REGISTERS:
                 missing_regs.append(f"{name} ({INPUT_REGISTERS[name]})")
 
-    if None not in (major, minor, patch):
-        device.firmware = f"{major}.{minor}.{patch}"
-    else:
-        details: list[str] = []
-        if missing_regs:
-            details.append("missing " + ", ".join(missing_regs))
-        if firmware_err is not None:
-            details.append(str(firmware_err))
-        msg = "Failed to read firmware version registers"
-        if details:
-            msg += ": " + "; ".join(details)
-        # version_patch (input register 4) is absent on some older firmware —
-        # that is expected.  Only escalate to WARNING when major or minor is
-        # also missing, which indicates a real communication problem.
-        if patch is None and major is not None and minor is not None:
-            _LOGGER.debug(msg)
-        else:
-            _LOGGER.warning(msg)
-        device.firmware_available = False
+    if major is not None and minor is not None:
+        # version_patch (input register 4) is absent on some older firmware.
+        # Preserve the verified major.minor identity rather than collapsing the
+        # whole firmware value to Unknown.  Callers can still distinguish the
+        # partial form because it contains two components instead of three.
+        device.firmware = f"{major}.{minor}" if patch is None else f"{major}.{minor}.{patch}"
+        device.firmware_available = True
+        if patch is None:
+            details = "missing " + ", ".join(missing_regs) if missing_regs else "patch unavailable"
+            if firmware_err is not None:
+                details += f"; {firmware_err}"
+            _LOGGER.debug("Firmware patch unavailable; using partial version %s: %s", device.firmware, details)
+        return
+
+    details: list[str] = []
+    if missing_regs:
+        details.append("missing " + ", ".join(missing_regs))
+    if firmware_err is not None:
+        details.append(str(firmware_err))
+    msg = "Failed to read firmware version registers"
+    if details:
+        msg += ": " + "; ".join(details)
+    _LOGGER.warning(msg)
+    device.firmware_available = False
 
 
 async def scan_firmware_info(scanner: Any, info_regs: list[int], device: ScannerDeviceInfo) -> None:

--- a/custom_components/thessla_green_modbus/scanner/firmware.py
+++ b/custom_components/thessla_green_modbus/scanner/firmware.py
@@ -106,11 +106,15 @@ def _apply_firmware_version_to_device(
         device.firmware = f"{major}.{minor}" if patch is None else f"{major}.{minor}.{patch}"
         device.firmware_available = True
         if patch is None:
-            details = "missing " + ", ".join(missing_regs) if missing_regs else "patch unavailable"
+            partial_details = (
+                "missing " + ", ".join(missing_regs) if missing_regs else "patch unavailable"
+            )
             if firmware_err is not None:
-                details += f"; {firmware_err}"
+                partial_details += f"; {firmware_err}"
             _LOGGER.debug(
-                "Firmware patch unavailable; using partial version %s: %s", device.firmware, details
+                "Firmware patch unavailable; using partial version %s: %s",
+                device.firmware,
+                partial_details,
             )
         return
 

--- a/custom_components/thessla_green_modbus/scanner/firmware.py
+++ b/custom_components/thessla_green_modbus/scanner/firmware.py
@@ -109,7 +109,9 @@ def _apply_firmware_version_to_device(
             details = "missing " + ", ".join(missing_regs) if missing_regs else "patch unavailable"
             if firmware_err is not None:
                 details += f"; {firmware_err}"
-            _LOGGER.debug("Firmware patch unavailable; using partial version %s: %s", device.firmware, details)
+            _LOGGER.debug(
+                "Firmware patch unavailable; using partial version %s: %s", device.firmware, details
+            )
         return
 
     details: list[str] = []

--- a/docs/agents/tasks/TASK-20260811-firmware-coverage.md
+++ b/docs/agents/tasks/TASK-20260811-firmware-coverage.md
@@ -1,0 +1,57 @@
+---
+task_id: TASK-20260811-firmware-coverage
+status: implementing
+owner: codex
+scope: improve firmware identity semantics and scanner coverage without changing Modbus transport contracts
+---
+
+# Firmware identity and coverage hardening
+
+## Context checkpoint
+
+```yaml
+checkpoint_version: 1
+updated_at: 2026-08-11T14:49:00Z
+head: ae3cdd7195088f207f5e87c74c519bb799676233
+branch: feat/firmware-coverage-20260811
+pr: null
+status: implementing
+context_routes:
+  - AGENTS.md
+  - docs/agents/CONTEXT_HANDOFF.md
+  - docs/agents/GOVERNANCE_CONTRACT.json
+  - docs/audits/deep_audit_2026-08-11.md
+owned_paths:
+  - custom_components/thessla_green_modbus/scanner/firmware.py
+  - tests/test_device_scanner_firmware.py
+  - docs/agents/tasks/TASK-20260811-firmware-coverage.md
+proven:
+  - main baseline is ae3cdd7195088f207f5e87c74c519bb799676233 and post-merge CI run 31503102829 passed all mandatory jobs.
+  - scanner/firmware.py treats a missing version_patch as expected on some older firmware but still leaves firmware Unknown and firmware_available false.
+  - tests/test_device_scanner_firmware.py covers fully unavailable, full fallback, and partial bulk fallback cases but not the expected older-device case where major and minor exist and patch is absent.
+  - the prior audit measured scanner/firmware.py among the lowest-covered integration modules.
+derived:
+  - major and minor together provide useful verified firmware identity when patch is genuinely unavailable on an older unit.
+  - a conservative partial-version representation can improve identity without altering Modbus addresses, transport behavior, write semantics, entity IDs, or services.
+unknown:
+  - exact physical AirPack behavior of the newest main candidate; no live Home Assistant connector is currently exposed in this session.
+  - whether repository-wide coverage will reach Silver thresholds from this bounded task alone.
+conflicts: []
+first_failure:
+  marker: firmware-partial-version-semantics
+  evidence: _apply_firmware_version_to_device logs missing patch at DEBUG as expected hardware behavior but sets firmware_available false and leaves firmware Unknown.
+rejected_hypotheses:
+  - missing version_patch always indicates a communication failure.
+  - hardware-sensitive polling or restart-scan defaults should be changed without new physical-device measurements.
+changed_paths:
+  - docs/agents/tasks/TASK-20260811-firmware-coverage.md
+validation:
+  - command: GitHub inspection of main and post-merge CI 31503102829
+    result: PASS
+    evidence: baseline main and all mandatory CI jobs are green before this task.
+  - command: focused firmware tests after implementation
+    result: NOT_RUN
+    evidence: implementation not yet committed.
+blockers: []
+next_action: Implement and test explicit major.minor partial firmware identity, then run the complete GitHub Actions matrix before merge.
+```

--- a/docs/agents/tasks/TASK-20260811-firmware-coverage.md
+++ b/docs/agents/tasks/TASK-20260811-firmware-coverage.md
@@ -1,6 +1,6 @@
 ---
 task_id: TASK-20260811-firmware-coverage
-status: implementing
+status: validating
 owner: codex
 scope: improve firmware identity semantics and scanner coverage without changing Modbus transport contracts
 ---
@@ -11,11 +11,11 @@ scope: improve firmware identity semantics and scanner coverage without changing
 
 ```yaml
 checkpoint_version: 1
-updated_at: 2026-08-11T14:49:00Z
-head: ae3cdd7195088f207f5e87c74c519bb799676233
+updated_at: 2026-08-11T15:10:00Z
+head: 8eb38e7875bc554ae7aa9045c32de985924c3331
 branch: feat/firmware-coverage-20260811
-pr: null
-status: implementing
+pr: 1767
+status: validating
 context_routes:
   - AGENTS.md
   - docs/agents/CONTEXT_HANDOFF.md
@@ -27,31 +27,44 @@ owned_paths:
   - docs/agents/tasks/TASK-20260811-firmware-coverage.md
 proven:
   - main baseline is ae3cdd7195088f207f5e87c74c519bb799676233 and post-merge CI run 31503102829 passed all mandatory jobs.
-  - scanner/firmware.py treats a missing version_patch as expected on some older firmware but still leaves firmware Unknown and firmware_available false.
-  - tests/test_device_scanner_firmware.py covers fully unavailable, full fallback, and partial bulk fallback cases but not the expected older-device case where major and minor exist and patch is absent.
-  - the prior audit measured scanner/firmware.py among the lowest-covered integration modules.
+  - scanner/firmware.py previously collapsed a missing version_patch to Unknown even though that register is absent on some older firmware.
+  - PR #1767 preserves verified major.minor identity when patch is unavailable while missing major or minor remains an unavailable firmware condition.
+  - PR #1767 does not change Modbus addresses, transport behavior, writes, entity IDs, services, or polling policy.
+  - tests/test_device_scanner_firmware.py now contains 8 focused tests covering unavailable firmware, full and partial fallback, partial major.minor identity, probe-error context, missing major/minor, legacy read signature fallback, serial parsing, and ASCII device-name parsing.
+  - CI run 31505010765 on head 8eb38e7875bc554ae7aa9045c32de985924c3331 passed HACS, Hassfest, Lint including mypy/checkpoint validation, entity mappings, pymodbus 3.6.1, pymodbus 3.14.0, minimum HA 2026.1.0, and the full Tests job.
+  - Tests job 93824694593 completed successfully with total coverage 90.82 percent and scanner/firmware.py coverage 83 percent, up from about 68 percent in the prior audit baseline.
+  - the Current HA 2026.8.1 job 93824694371 in run 31505010765 is stuck in GitHub as in_progress with a runner assigned but zero steps and no downloadable log.
 derived:
   - major and minor together provide useful verified firmware identity when patch is genuinely unavailable on an older unit.
-  - a conservative partial-version representation can improve identity without altering Modbus addresses, transport behavior, write semantics, entity IDs, or services.
+  - the bounded scanner change materially improves risk-focused firmware coverage but does not by itself satisfy Home Assistant Silver per-module coverage expectations.
+  - the zero-step Current HA job state is runner/workflow infrastructure evidence, not a passing or failing code result, so a fresh complete run is required.
 unknown:
-  - exact physical AirPack behavior of the newest main candidate; no live Home Assistant connector is currently exposed in this session.
-  - whether repository-wide coverage will reach Silver thresholds from this bounded task alone.
+  - whether a fresh complete CI run passes the Current HA 2026.8.1 contract job on the final candidate.
+  - exact physical AirPack behavior of the newest candidate; no live Home Assistant connector is currently exposed in this session.
+  - post-hardening reconnect and 24-72 hour physical soak behavior.
 conflicts: []
 first_failure:
-  marker: firmware-partial-version-semantics
-  evidence: _apply_firmware_version_to_device logs missing patch at DEBUG as expected hardware behavior but sets firmware_available false and leaves firmware Unknown.
+  marker: candidate-ci-hygiene
+  evidence: CI #1282 first failed Ruff formatting only; CI #1283 then passed formatting but failed mypy because one local variable name was reused with incompatible str and list[str] types. Both issues were corrected without expanding runtime scope.
 rejected_hypotheses:
   - missing version_patch always indicates a communication failure.
+  - the first two red CI runs proved a runtime scanner regression; they failed formatter/type gates before functional validation.
+  - the zero-step Current HA job can be counted as PASS.
   - hardware-sensitive polling or restart-scan defaults should be changed without new physical-device measurements.
 changed_paths:
+  - custom_components/thessla_green_modbus/scanner/firmware.py
+  - tests/test_device_scanner_firmware.py
   - docs/agents/tasks/TASK-20260811-firmware-coverage.md
 validation:
-  - command: GitHub inspection of main and post-merge CI 31503102829
+  - command: GitHub Actions run 31505010765 - HACS, Hassfest, Lint, entity mappings, pymodbus bounds, minimum HA and Tests
     result: PASS
-    evidence: baseline main and all mandatory CI jobs are green before this task.
-  - command: focused firmware tests after implementation
+    evidence: all listed jobs completed successfully on head 8eb38e7875bc554ae7aa9045c32de985924c3331; Tests job 93824694593 reports total coverage 90.82 percent and scanner/firmware.py 83 percent.
+  - command: GitHub Actions run 31505010765 - Current HA API contracts 2026.8.1
     result: NOT_RUN
-    evidence: implementation not yet committed.
+    evidence: job 93824694371 remains in_progress with zero steps and no log, so it cannot be treated as executed evidence.
+  - command: fresh complete GitHub Actions matrix after this checkpoint commit
+    result: NOT_RUN
+    evidence: required to replace the unusable zero-step Current HA job with exact final-head evidence.
 blockers: []
-next_action: Implement and test explicit major.minor partial firmware identity, then run the complete GitHub Actions matrix before merge.
+next_action: Run the complete GitHub Actions matrix on the checkpointed candidate, fix only evidenced failures, mark ready only after every mandatory job including Current HA 2026.8.1 passes, then merge PR #1767 and verify post-merge main CI.
 ```

--- a/docs/agents/tasks/TASK-20260811-firmware-coverage.md
+++ b/docs/agents/tasks/TASK-20260811-firmware-coverage.md
@@ -1,6 +1,6 @@
 ---
 task_id: TASK-20260811-firmware-coverage
-status: validating
+status: ready
 owner: codex
 scope: improve firmware identity semantics and scanner coverage without changing Modbus transport contracts
 ---
@@ -11,11 +11,11 @@ scope: improve firmware identity semantics and scanner coverage without changing
 
 ```yaml
 checkpoint_version: 1
-updated_at: 2026-08-11T15:10:00Z
-head: 8eb38e7875bc554ae7aa9045c32de985924c3331
+updated_at: 2026-08-11T15:16:00Z
+head: 8305b482de0868698338737107f7af2d397e7e6f
 branch: feat/firmware-coverage-20260811
 pr: 1767
-status: validating
+status: ready
 context_routes:
   - AGENTS.md
   - docs/agents/CONTEXT_HANDOFF.md
@@ -31,15 +31,15 @@ proven:
   - PR #1767 preserves verified major.minor identity when patch is unavailable while missing major or minor remains an unavailable firmware condition.
   - PR #1767 does not change Modbus addresses, transport behavior, writes, entity IDs, services, or polling policy.
   - tests/test_device_scanner_firmware.py now contains 8 focused tests covering unavailable firmware, full and partial fallback, partial major.minor identity, probe-error context, missing major/minor, legacy read signature fallback, serial parsing, and ASCII device-name parsing.
-  - CI run 31505010765 on head 8eb38e7875bc554ae7aa9045c32de985924c3331 passed HACS, Hassfest, Lint including mypy/checkpoint validation, entity mappings, pymodbus 3.6.1, pymodbus 3.14.0, minimum HA 2026.1.0, and the full Tests job.
-  - Tests job 93824694593 completed successfully with total coverage 90.82 percent and scanner/firmware.py coverage 83 percent, up from about 68 percent in the prior audit baseline.
-  - the Current HA 2026.8.1 job 93824694371 in run 31505010765 is stuck in GitHub as in_progress with a runner assigned but zero steps and no downloadable log.
+  - CI run 31505010765 passed every completed mandatory job on head 8eb38e7875bc554ae7aa9045c32de985924c3331; its first Current HA job was an unusable zero-step runner state and was not counted as PASS.
+  - Tests job 93824694593 in run 31505010765 completed successfully with total coverage 90.82 percent and scanner/firmware.py coverage 83 percent, up from about 68 percent in the prior audit baseline.
+  - fresh CI run 31505638599 on checkpointed head 8305b482de0868698338737107f7af2d397e7e6f completed with conclusion success.
+  - CI run 31505638599 passed Lint including Ruff, format, compile, mypy and checkpoint validation, Hassfest, HACS, full Tests, entity mappings, minimum HA 2026.1.0, current HA 2026.8.1, pymodbus 3.6.1, and pymodbus 3.14.0.
 derived:
   - major and minor together provide useful verified firmware identity when patch is genuinely unavailable on an older unit.
   - the bounded scanner change materially improves risk-focused firmware coverage but does not by itself satisfy Home Assistant Silver per-module coverage expectations.
-  - the zero-step Current HA job state is runner/workflow infrastructure evidence, not a passing or failing code result, so a fresh complete run is required.
+  - the earlier zero-step Current HA state was transient GitHub Actions runner behavior because the fresh run executed the same contract job successfully.
 unknown:
-  - whether a fresh complete CI run passes the Current HA 2026.8.1 contract job on the final candidate.
   - exact physical AirPack behavior of the newest candidate; no live Home Assistant connector is currently exposed in this session.
   - post-hardening reconnect and 24-72 hour physical soak behavior.
 conflicts: []
@@ -56,15 +56,15 @@ changed_paths:
   - tests/test_device_scanner_firmware.py
   - docs/agents/tasks/TASK-20260811-firmware-coverage.md
 validation:
-  - command: GitHub Actions run 31505010765 - HACS, Hassfest, Lint, entity mappings, pymodbus bounds, minimum HA and Tests
+  - command: GitHub Actions run 31505010765 - completed mandatory jobs and coverage
     result: PASS
-    evidence: all listed jobs completed successfully on head 8eb38e7875bc554ae7aa9045c32de985924c3331; Tests job 93824694593 reports total coverage 90.82 percent and scanner/firmware.py 83 percent.
-  - command: GitHub Actions run 31505010765 - Current HA API contracts 2026.8.1
+    evidence: HACS, Hassfest, Lint, entity mappings, pymodbus bounds, minimum HA and Tests passed on 8eb38e7875bc554ae7aa9045c32de985924c3331; Tests job 93824694593 reports total coverage 90.82 percent and scanner/firmware.py 83 percent.
+  - command: GitHub Actions run 31505638599 - complete matrix
+    result: PASS
+    evidence: workflow conclusion success on 8305b482de0868698338737107f7af2d397e7e6f including executed Current HA 2026.8.1 contracts.
+  - command: complete GitHub Actions matrix after this ready checkpoint commit
     result: NOT_RUN
-    evidence: job 93824694371 remains in_progress with zero steps and no log, so it cannot be treated as executed evidence.
-  - command: fresh complete GitHub Actions matrix after this checkpoint commit
-    result: NOT_RUN
-    evidence: required to replace the unusable zero-step Current HA job with exact final-head evidence.
+    evidence: required because this ready checkpoint changes the PR head.
 blockers: []
-next_action: Run the complete GitHub Actions matrix on the checkpointed candidate, fix only evidenced failures, mark ready only after every mandatory job including Current HA 2026.8.1 passes, then merge PR #1767 and verify post-merge main CI.
+next_action: Run the complete GitHub Actions matrix on the final ready-checkpoint head, merge PR #1767 only if every mandatory job passes, then verify the resulting main commit and post-merge CI.
 ```

--- a/tests/test_device_scanner_firmware.py
+++ b/tests/test_device_scanner_firmware.py
@@ -7,6 +7,19 @@ import pytest
 from custom_components.thessla_green_modbus.const import CONNECTION_MODE_TCP
 from custom_components.thessla_green_modbus.registers.loader import get_registers_by_function
 from custom_components.thessla_green_modbus.scanner.core import ThesslaGreenDeviceScanner
+from custom_components.thessla_green_modbus.scanner.device_info import ScannerDeviceInfo
+from custom_components.thessla_green_modbus.scanner.firmware import (
+    _apply_firmware_version_to_device,
+    _probe_missing_version_parts,
+    scan_device_identity,
+)
+from custom_components.thessla_green_modbus.scanner.register_maps import (
+    HOLDING_REGISTERS as SCANNER_HOLDING_REGISTERS,
+)
+from custom_components.thessla_green_modbus.scanner.register_maps import (
+    INPUT_REGISTERS as SCANNER_INPUT_REGISTERS,
+)
+from custom_components.thessla_green_modbus.scanner.register_maps import REGISTER_DEFINITIONS
 
 INPUT_REGISTERS = {r.name: r.address for r in get_registers_by_function(4)}
 
@@ -14,7 +27,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_scan_device_firmware_unavailable(caplog):
-    """Missing firmware registers should log info and report unknown firmware."""
+    """Missing firmware registers should log warning and report unknown firmware."""
     empty_regs = {4: {}, 3: {}, 1: {}, 2: {}}
     with patch.object(
         ThesslaGreenDeviceScanner, "_load_registers", AsyncMock(return_value=(empty_regs, {}))
@@ -75,6 +88,7 @@ async def test_scan_device_firmware_unavailable(caplog):
             result = await scanner.scan_device()
 
     assert result["device_info"]["firmware"] == "Unknown"
+    assert result["device_info"]["firmware_available"] is False
     assert "Failed to read firmware version registers" in caplog.text
 
 
@@ -139,6 +153,7 @@ async def test_scan_device_firmware_bulk_fallback():
             result = await scanner.scan_device()
 
     assert result["device_info"]["firmware"] == "4.85.0"
+    assert result["device_info"]["firmware_available"] is True
 
 
 async def test_scan_device_firmware_partial_bulk_fallback():
@@ -204,3 +219,93 @@ async def test_scan_device_firmware_partial_bulk_fallback():
             result = await scanner.scan_device()
 
     assert result["device_info"]["firmware"] == "4.85.0"
+
+
+async def test_partial_firmware_without_patch_is_preserved(caplog):
+    """An older unit without patch register should expose verified major.minor."""
+    device = ScannerDeviceInfo()
+
+    caplog.set_level(logging.DEBUG)
+    _apply_firmware_version_to_device(device, 4, 85, None, None)
+
+    assert device.firmware == "4.85"
+    assert device.firmware_available is True
+    assert "Firmware patch unavailable; using partial version 4.85" in caplog.text
+    assert "Failed to read firmware version registers" not in caplog.text
+
+
+async def test_partial_firmware_keeps_probe_error_as_debug_context(caplog):
+    """Expected patch absence should stay usable even when probing reports an error."""
+    device = ScannerDeviceInfo()
+
+    caplog.set_level(logging.DEBUG)
+    _apply_firmware_version_to_device(device, 4, 85, None, ValueError("unsupported register"))
+
+    assert device.firmware == "4.85"
+    assert device.firmware_available is True
+    assert "unsupported register" in caplog.text
+
+
+async def test_missing_major_or_minor_stays_unavailable(caplog):
+    """Major/minor loss remains a real identity failure."""
+    device = ScannerDeviceInfo()
+
+    caplog.set_level(logging.WARNING)
+    _apply_firmware_version_to_device(device, 4, None, 1, ValueError("bad minor"))
+
+    assert device.firmware == "Unknown"
+    assert device.firmware_available is False
+    assert "Failed to read firmware version registers" in caplog.text
+    assert "bad minor" in caplog.text
+
+
+async def test_probe_missing_version_parts_supports_legacy_read_signature():
+    """Probe should retry readers that do not accept the explicit client argument."""
+    scanner = AsyncMock()
+    scanner._client = object()
+
+    async def legacy_reader(*args, **kwargs):
+        if len(args) == 3:
+            raise TypeError("legacy signature")
+        address, count = args
+        assert count == 1
+        values = {
+            SCANNER_INPUT_REGISTERS["version_major"]: [4],
+            SCANNER_INPUT_REGISTERS["version_minor"]: [85],
+            SCANNER_INPUT_REGISTERS["version_patch"]: [2],
+        }
+        return values[address]
+
+    scanner._read_input = AsyncMock(side_effect=legacy_reader)
+    result = await _probe_missing_version_parts(scanner, None, None, None, None)
+
+    assert result[:3] == (4, 85, 2)
+    assert result[3] is None
+
+
+async def test_scan_device_identity_parses_serial_and_ascii_name():
+    """Identity helper should decode serial words and device-name words."""
+    serial_start = SCANNER_INPUT_REGISTERS["serial_number"]
+    serial_length = REGISTER_DEFINITIONS["serial_number"].length
+    info_regs = [0] * (serial_start + serial_length)
+    serial_words = [0x1234 + index for index in range(serial_length)]
+    info_regs[serial_start : serial_start + serial_length] = serial_words
+
+    name = b"AirPack Test"
+    if len(name) % 2:
+        name += b"\x00"
+    name_words = [(name[index] << 8) | name[index + 1] for index in range(0, len(name), 2)]
+    expected_length = REGISTER_DEFINITIONS["device_name"].length
+    name_words.extend([0] * max(0, expected_length - len(name_words)))
+
+    scanner = AsyncMock()
+    scanner._read_holding_block = AsyncMock(return_value=name_words[:expected_length])
+    device = ScannerDeviceInfo()
+
+    await scan_device_identity(scanner, info_regs, device)
+
+    assert device.serial_number == "".join(f"{word:04X}" for word in serial_words)
+    assert device.device_name == "AirPack Test"
+    scanner._read_holding_block.assert_awaited_once_with(
+        SCANNER_HOLDING_REGISTERS["device_name"], expected_length
+    )


### PR DESCRIPTION
## Scope

Continue the verified 2026-08-11 audit follow-ups with a bounded scanner hardening change.

- preserve a verified `major.minor` firmware identity when `version_patch` is absent on older units
- keep missing `major` or `minor` as an unavailable/unknown firmware condition
- add focused tests for partial firmware semantics, legacy probe fallback, serial parsing, and ASCII device-name parsing
- do not change Modbus addresses, transport behavior, writes, entity IDs, services, or polling policy

## Evidence boundary

This PR is repository-verifiable. Physical AirPack validation of the newest `main` remains external because no live Home Assistant connector is currently exposed in this session.

## Validation

Merge only after the complete GitHub Actions matrix passes on the final head commit.