### PR TITLE
docs(agents): forbid unapproved owner-funded AI usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Global Codex Agent Baseline
 
+## Owner-funded AI and credential budget — highest priority
+
+- Agents MUST NOT invoke Codex, OpenAI API, paid/limited AI review services, or any other mechanism that consumes the repository owner's personal AI quota, credits, tokens, subscription limits, or metered allowance unless the owner gives explicit permission for that specific use.
+- Agents MUST NOT use, export, copy, inspect, forward, or authenticate with owner-supplied API keys, access tokens, session tokens, personal credentials, or secrets for AI/model services unless the owner explicitly authorizes that exact credential/service use.
+- Availability of a credential, environment variable, CLI login, browser session, connector, MCP/plugin, or previously granted access does NOT constitute permission to consume owner-funded AI resources.
+- Prior permission is not standing permission. Authorization must be explicit for the current task/use; if scope, provider, model, or expected consumption materially changes, ask again.
+- If a workflow, policy, review gate, script, or tool would normally invoke Codex or another owner-funded AI service, skip that invocation and use a non-owner-funded alternative when one is genuinely available. If the requirement cannot be satisfied without such use, stop and report the exact blocker instead of consuming quota.
+- Never weaken, bypass, or falsely mark a review/validation gate as satisfied merely because owner-funded AI use is forbidden.
+
 ## Context efficiency
 
 - Work autonomously until the bounded task is complete or a real blocker or required decision is reached.


### PR DESCRIPTION
Adds a highest-priority rule forbidding Codex and any other owner-funded AI quota, credits, tokens, or owner AI credentials unless explicitly authorized for the specific use.